### PR TITLE
use WeakReference so that CGNode.getIR() doesn't hit the cache too often

### DIFF
--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/ExplicitCallGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/ExplicitCallGraph.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.wala.ipa.callgraph.impl;
 
+import java.lang.ref.WeakReference;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -139,6 +140,9 @@ public class ExplicitCallGraph extends BasicCallGraph implements BytecodeConstan
     protected final SparseVector<Object> targets = new SparseVector<Object>();
 
     private final MutableSharedBitVectorIntSet allTargets = new MutableSharedBitVectorIntSet();
+    
+    private WeakReference<IR> ir = new WeakReference<IR>(null);
+    private WeakReference<DefUse> du = new WeakReference<DefUse>(null);
 
     /**
      * @param method
@@ -293,11 +297,21 @@ public class ExplicitCallGraph extends BasicCallGraph implements BytecodeConstan
     }
 
     public IR getIR() {
-      return getCallGraph().getInterpreter(this).getIR(this);
+      IR ir = this.ir.get();
+      if (ir == null) {
+        ir = getCallGraph().getInterpreter(this).getIR(this);
+        this.ir = new WeakReference<IR>(ir);
+      }
+      return ir;
     }
 
     public DefUse getDU() {
-      return getCallGraph().getInterpreter(this).getDU(this);
+      DefUse du = this.du.get();
+      if (du == null) {
+        du = getCallGraph().getInterpreter(this).getDU(this);
+        this.du = new WeakReference<DefUse>(du);
+      }
+      return du;
     }
 
     public ExplicitCallGraph getCallGraph() {


### PR DESCRIPTION
regarding wala/WALA#9

does not fast-forward but should apply cleanly
