### PR TITLE
Publish source features on update site

### DIFF
--- a/com.ibm.wala-feature/feature.xml
+++ b/com.ibm.wala-feature/feature.xml
@@ -5,14 +5,6 @@
       version="1.3.4.qualifier"
       provider-name="%providerName">
 
-   <copyright url="%copyrightURL">
-      %copyright
-   </copyright>
-
-   <license url="%licenseURL">
-      %license
-   </license>
-
    <plugin
          id="com.ibm.wala.core"
          download-size="0"

--- a/com.ibm.wala-repository/category.xml
+++ b/com.ibm.wala-repository/category.xml
@@ -3,6 +3,9 @@
     <feature id="com.ibm.wala-feature">
         <category name="main"/>
     </feature>
+    <feature id="com.ibm.wala-feature.source">
+        <category name="main"/>
+    </feature>
     <feature id="com.ibm.wala.ide-feature">
         <category name="main"/>
     </feature>

--- a/com.ibm.wala.ide-feature/feature.xml
+++ b/com.ibm.wala.ide-feature/feature.xml
@@ -5,14 +5,6 @@
       version="1.3.4.qualifier"
       provider-name="%providerName">
 
-   <copyright url="%copyrightURL">
-      %copyright
-   </copyright>
-
-   <license url="%licenseURL">
-      %license
-   </license>
-
    <plugin
          id="com.ibm.wala.ide"
          download-size="0"

--- a/com.ibm.wala.tests-feature/feature.xml
+++ b/com.ibm.wala.tests-feature/feature.xml
@@ -5,14 +5,6 @@
       version="1.3.4.qualifier"
       provider-name="%providerName">
 
-   <copyright url="%copyrightURL">
-      %copyright
-   </copyright>
-
-   <license url="%licenseURL">
-      %license
-   </license>
-
    <plugin
          id="com.ibm.wala.cast.java.test"
          download-size="0"

--- a/com.ibm.wala.tests.ide-feature/feature.xml
+++ b/com.ibm.wala.tests.ide-feature/feature.xml
@@ -5,14 +5,6 @@
       version="1.3.4.qualifier"
       provider-name="%providerName">
 
-   <copyright url="%copyrightURL">
-      %copyright
-   </copyright>
-
-   <license url="%licenseURL">
-      %license
-   </license>
-
    <plugin
          id="com.ibm.wala.ide.tests"
          download-size="0"

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 		<project-version>1.3.4-SNAPSHOT</project-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<build-alias>b000</build-alias>
-		<tycho-version>0.17.0</tycho-version>
+		<tycho-version>0.18.0</tycho-version>
 		<tycho.scmUrl>scm:git:ssh://github.com:wala/WALA.git</tycho.scmUrl>
 	</properties>
 
@@ -112,10 +112,41 @@
 					<argLine>${tycho.test.jvmArgs}</argLine>
 				</configuration>
 			</plugin>
+			<!-- The tycho-source-feature-plugin needs to be place before the tycho-p2-plugin, as both plugins' goals bind to the same phase -->
+			<plugin>
+				<groupId>org.eclipse.tycho.extras</groupId>
+				<artifactId>tycho-source-feature-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<executions>
+					<execution>
+						<id>generate-source-feature</id>
+						<goals>
+							<goal>source-feature</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-p2-plugin</artifactId>
 				<version>${tycho-version}</version>
+				<executions>
+					<execution>
+						<!-- Don't attach (default) metadata before the "generate-source-feature" execution. -->
+						<id>default-p2-metadata-default</id>
+						<configuration>
+							<attachP2Metadata>false</attachP2Metadata>
+						</configuration>
+					</execution>
+					<execution>
+						<!-- Do attach metadata after the "generate-source-feature" execution. -->
+						<id>attach-p2-metadata</id>
+						<phase>package</phase>
+						<goals>
+							<goal>p2-metadata</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
@@ -129,11 +160,6 @@
 				<configuration>
 					<includeAllDependencies>false</includeAllDependencies>
 				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho.extras</groupId>
-				<artifactId>tycho-source-feature-plugin</artifactId>
-				<version>${tycho-version}</version>
 			</plugin>
 			<plugin>
 				<groupId>com.googlecode.maven-download-plugin</groupId>


### PR DESCRIPTION
I noticed that the current build only creates source bundles but no source features, despite the fact that the `tycho-source-feature-plugin` is mentioned in the POM. Alas, that plugin is missing an execution.

I fixed this together with an update to Tycho 0.18. After a `mvn clean verify` you can find an update site with source bundles in `com.ibm.wala-repository/target/repository`.

I am afraid, however, that the relevant part in the POM (`tycho-source-feature-plugin` and `tycho-p2-plugin`) is a bit verbose. Alas, this is the shortest way I know to make sure that the `p2-metadata` goal is executed after the `source-feature` goal when both are bound to the same phase. (This kind of subtle order dependency was exactlu what phases were designed to avoid originally, but apparently a typically Tycho build contains more steps than Maven has phases...) That being said, a dedicated "features" parent POM might help. See https://git.eclipse.org/c/recommenders/org.eclipse.recommenders.git/tree/features/pom.xml for an example.
