### PR TITLE
fix for Maven build

### DIFF
--- a/com.ibm.wala.util/build.properties
+++ b/com.ibm.wala.util/build.properties
@@ -1,3 +1,7 @@
 bin.includes = META-INF/,\
+               .,\
                walaUtil.jar
 source.walaUtil.jar = src/
+jars.compile.order = .
+source.. = src/
+output.. = bin/


### PR DESCRIPTION
The jar file with the binaries for com.ibm.wala.util doesn't contain the code directly. It only contains another jar file that contains the code, i.e., the classes are double-wrapped in jars. 

This breaks the build for any project that relies on util.

The patch below should fix it.
