### PR TITLE
Update SSAConditionalBranchInstruction.java

### DIFF
--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/SSAConditionalBranchInstruction.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/SSAConditionalBranchInstruction.java
@@ -92,7 +92,7 @@ public class SSAConditionalBranchInstruction extends SSAInstruction {
   }
 
   public boolean isObjectComparison() {
-    return type == TypeReference.JavaLangObject;
+    return type.isReferenceType();
   }
 
   public boolean isIntegerComparison() {


### PR DESCRIPTION
Changing SSAConditionalBranchInstruction.isObjectComparison(): previous definition returns true for comparisons of Primordial scope objects, but false for Application scope objects. The updated version returns true in both cases.
