### PR TITLE
Check class of parent variable directly rather than using instanceof che...

### DIFF
--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/BypassMethodTargetSelector.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/BypassMethodTargetSelector.java
@@ -126,6 +126,9 @@ public class BypassMethodTargetSelector implements MethodTargetSelector {
         return findOrCreateSyntheticMethod(site.getDeclaredTarget(), site.isStatic());
       }
 
+      // not using if (instanceof ClassHierarchyMethodTargetSelector) because
+      // we want to make sure that getCalleeTarget() is still called if 
+      // parent is a subclass of ClassHierarchyMethodTargetSelector
       if (parent.getClass() == ClassHierarchyMethodTargetSelector.class) {
         // already checked this case and decided not to bypass
         return chaTarget;


### PR DESCRIPTION
...ck. Needed to get correct behavior for subclasses of ClassHierarchyMethodTargetSelector. Fixes #42.
