### PR TITLE
Off by one error in toString, the last node is at index maxNumber-1.

### DIFF
--- a/com.ibm.wala.util/src/com/ibm/wala/util/graph/impl/DelegatingNumberedNodeManager.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/graph/impl/DelegatingNumberedNodeManager.java
@@ -180,7 +180,7 @@ public class DelegatingNumberedNodeManager<T extends INodeWithNumber> implements
   @Override
   public String toString() {
     StringBuffer result = new StringBuffer("Nodes:\n");
-    for (int i = 0; i < maxNumber; i++) {
+    for (int i = 0; i <= maxNumber; i++) {
       result.append(i).append(" ");
       if (nodes[i] != null) {
         result.append(nodes[i].toString());


### PR DESCRIPTION
Since `maxNumber` is initially set to `-1` and it is incremented with each added node, the first node will be at index `0` and the last node will be at `maxNumber-1`. This commit fixes a bug that would result in an index out of bounds exception by attempting to access `nodes[maxNumber]` when printing the nodes.
