### PR TITLE
Use Arrays.toString() instead of the default array toString() method.

### DIFF
--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/FilteredPointerKey.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/FilteredPointerKey.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.ibm.wala.ipa.callgraph.propagation;
 
+import java.util.Arrays;
+
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.ipa.callgraph.ContextItem;
@@ -90,7 +92,7 @@ public interface FilteredPointerKey extends PointerKey {
 
     @Override
     public String toString() {
-      return "SingleClassFilter: " + concreteType;
+      return "MultipleClassesFilter: " + Arrays.toString(concreteType);
     }
 
     public IClass[] getConcreteTypes() {

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PropagationSystem.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PropagationSystem.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.wala.ipa.callgraph.propagation;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -578,7 +579,7 @@ public class PropagationSystem extends DefaultFixedPointSolver<PointsToSetVariab
       throw new IllegalArgumentException("null arg0");
     }
     if (DEBUG) {
-      System.err.println("add constraint D: " + op + " " + arg0);
+      System.err.println("add constraint D: " + op + " " + Arrays.toString(arg0));
     }
     PointsToSetVariable[] vs = new PointsToSetVariable[ arg0.length ];
     for(int i = 0; i < arg0.length; i++) {

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/SSAPhiInstruction.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/SSAPhiInstruction.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.wala.ssa;
 
+import java.util.Arrays;
 import java.util.Iterator;
 
 import com.ibm.wala.analysis.stackMachine.AbstractIntStackMachine;
@@ -140,7 +141,7 @@ public class SSAPhiInstruction extends SSAInstruction {
    */
   public void setValues(int[] i) {
     if (i == null || i.length < 1) {
-      throw new IllegalArgumentException("illegal i: " + i);
+      throw new IllegalArgumentException("illegal i: " + Arrays.toString(i));
     }
     this.params = i;
   }


### PR DESCRIPTION
The former will include the contents of the array, while the latter only includes the object's identity.

This will allow WALA to be compiled using Google's error-prone compiler (https://github.com/google/error-prone).