### PR TITLE
Build fixes for Eclipse Neon

### DIFF
--- a/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/FakeExceptionTypeBinding.java
+++ b/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/FakeExceptionTypeBinding.java
@@ -297,6 +297,12 @@ public class FakeExceptionTypeBinding implements ITypeBinding {
     return false;
   }
 
+  // add @Override here once Eclipse Mars is no longer supported
+  public boolean isIntersectionType() {
+    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
+    return false;
+  }
+
   @Override
   public boolean isLocal() {
     Assertions.UNREACHABLE("FakeExceptionTypeBinding ");


### PR DESCRIPTION
The fixes needed for Eclipse Neon are very similar to those previously added for Luna (c9ad359d656463eccea08417d9855d4eb8f4478b + 0e55cd2eecdd830428a4fa16ab99ef7ca98f9df4, fixing #56) and Mars (6df8d1b32d1b6a9750bdb368efaecab8c1edca8c, fixing #98).