### PR TITLE
Added build script step to copy dx.jar from Android SDK.

### DIFF
--- a/com.ibm.wala.dalvik.test/build.xml
+++ b/com.ibm.wala.dalvik.test/build.xml
@@ -35,6 +35,8 @@
 	<property name="bundleJavacTarget" value="${javacTarget}"/>
 	<property name="bundleBootClasspath" value="${bootclasspath}"/>
 
+	<property environment="env"/>
+
      <target name="sampleLexPresent" depends="init">
         <available file="${plugin.destination}/data/sample.lex" property="sample.lex.present"/>
      </target>
@@ -59,7 +61,20 @@
      <available file="${plugin.destination}/data/android.jar" property="android.jar.present"/>
    </target>
 
-   <target name="getJars" depends="fetchSampleLex,fetchSampleCup,fetchAndroidJar" />
+   <target name="copyDxJar" depends="dxJarPresent" unless="dx.jar.present">
+	<fail unless="env.ANDROID_HOME" message="ANDROID_HOME is not set! Set the environment variable or copy dx.jar manually." />
+	<copy tofile="${basedir}/lib/dx.jar">
+		<first>
+			<fileset dir="${env.ANDROID_HOME}" includes="build-tools/*/lib/dx.jar"/>
+		</first>
+	</copy>
+   </target>
+
+   <target name="dxJarPresent" depends="init">
+	<available file="${basedir}/lib/dx.jar" property="dx.jar.present"/>
+   </target>
+
+   <target name="getJars" depends="fetchSampleLex,fetchSampleCup,fetchAndroidJar,copyDxJar" />
 
 	<target name="init" depends="properties">
 		<condition property="pluginTemp" value="${buildTempFolder}/plugins">


### PR DESCRIPTION
The proposed additions to the ant script automatically copy the dx.jar from the local Android SDK folder into the `com.ibm.wala.dalvik.test/lib` folder, if ANDROID_HOME is set. This is basically the procedure from [here](https://groups.google.com/forum/#!msg/wala-sourceforge-net/cBYsfEvYVG0/Ua52dyQQU-YJ). As the dx.jar is needed for a clean compile of the whole project, the user does not have to copy it manually anymore.