### PR TITLE
Add Hamcrest dependency

### DIFF
--- a/com.ibm.wala.core.tests/META-INF/MANIFEST.MF
+++ b/com.ibm.wala.core.tests/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Require-Bundle: com.ibm.wala.shrike,
  org.eclipse.core.runtime,
  com.ibm.wala.core.testdata,
  org.junit;bundle-version="4.0.0",
- org.apache.ant
+ org.apache.ant,
+ org.hamcrest.core;bundle-version="1.3.0"
 Bundle-Localization: plugin
 Export-Package: com.ibm.wala.core.tests.basic,
  com.ibm.wala.core.tests.callGraph,


### PR DESCRIPTION
Some source files in `com.ibm.wala.core.tests` use [Hamcrest](http://hamcrest.org/), so listing it as a dependency seems reasonable.  What I find confusing is the inconsistency among my Eclipse installations.  On some of my various machines, Eclipse reports an error if this dependency is not listed.  On others, Eclipse finds the required jar and reports no error, even if this dependency is not listed.  I don’t know why the latter works, or why the inconsistency exists at all.  Eclipse is a complex, subtle beast.  What I can say is that this change fixes the error for my Eclipses that were reporting an error, and does not introduce any new errors for my Eclipses that were already happy before this change.