### PR TITLE
Pull request  exception pruning for safe array creation

### DIFF
--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/JavaLanguage.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/JavaLanguage.java
@@ -423,6 +423,9 @@ public class JavaLanguage extends LanguageImpl implements BytecodeLanguage, Cons
   private static final Collection<TypeReference> newArrayExceptions = Collections.unmodifiableCollection(Arrays
       .asList(new TypeReference[] { TypeReference.JavaLangOutOfMemoryError, TypeReference.JavaLangNegativeArraySizeException }));
 
+  private static final Collection<TypeReference> newSafeArrayExceptions = Collections.unmodifiableCollection(Arrays
+      .asList(new TypeReference[] { TypeReference.JavaLangOutOfMemoryError}));
+
   private static final Collection<TypeReference> exceptionInInitializerError = Collections
       .singleton(TypeReference.JavaLangExceptionInInitializerError);
 
@@ -464,7 +467,9 @@ public class JavaLanguage extends LanguageImpl implements BytecodeLanguage, Cons
   public static Collection<TypeReference> getNewArrayExceptions() {
     return newArrayExceptions;
   }
-
+  public static Collection<TypeReference> getNewSafeArrayExceptions() {
+    return newSafeArrayExceptions;
+  }
   public static Collection<TypeReference> getNewScalarExceptions() {
     return newScalarExceptions;
   }


### PR DESCRIPTION
These commits allow pruning of exceptional control flow for JavaLangNegativeArraySizeException  during array creation for cases like

```
int a[] = new int[42]; // 42 is constant, >=0
int b[] = new int[a.length] // if a!=null, we know that a.length >=0, hence no JavaLangNegativeArraySizeException will ever be thrown
```