### PR TITLE
Pull request  nullpointer bugfixes

### DIFF
--- a/com.ibm.wala.core.testdata/src/cfg/exc/inter/CallFieldAccess.java
+++ b/com.ibm.wala.core.testdata/src/cfg/exc/inter/CallFieldAccess.java
@@ -12,7 +12,12 @@ public class CallFieldAccess {
     callIfNoException();
     callDynamicIfException();
     callDynamicIfNoException();
-
+    callIf2Exception();
+    callIf2NoException();
+    callDynamicIf2Exception();
+    callDynamicIf2NoException();
+    callGetException();
+    callDynamicGetException();
   }
   
   static B callIfException() {
@@ -29,6 +34,33 @@ public class CallFieldAccess {
   static B callDynamicIfNoException() {
     FieldAccessDynamic fad = new FieldAccessDynamic();
     return fad.testIf(unknown, new B(), new B());
+  }
+  
+  static B callIf2Exception() {
+    return FieldAccess.testIf2(unknown, null, null);
+  }
+  static B callIf2NoException() {
+    return FieldAccess.testIf2(unknown, new B(), null);
+  }
+  
+  static B callDynamicIf2Exception() {
+    FieldAccessDynamic fad = new FieldAccessDynamic();
+    return fad.testIf2(unknown, null, null);
+  }
+  static B callDynamicIf2NoException() {
+    FieldAccessDynamic fad = new FieldAccessDynamic();
+    return fad.testIf2(unknown, new B(), null);
+  }
+  
+  static B callGetException() {
+    B b = new B();
+    return FieldAccess.testGet(unknown, b);
+  }
+  
+  static B callDynamicGetException() {
+    FieldAccessDynamic fad = new FieldAccessDynamic();
+    B b = new B();
+    return fad.testGet(unknown, b);
   }
 
 }

--- a/com.ibm.wala.core.testdata/src/cfg/exc/inter/CallFieldAccess.java
+++ b/com.ibm.wala.core.testdata/src/cfg/exc/inter/CallFieldAccess.java
@@ -1,0 +1,34 @@
+package cfg.exc.inter;
+
+import cfg.exc.intra.B;
+import cfg.exc.intra.FieldAccess;
+import cfg.exc.intra.FieldAccessDynamic;
+
+public class CallFieldAccess {
+  static boolean unknown;
+  public static void main(String[] args) {
+    unknown = (args.length == 0);
+    callIfException();
+    callIfNoException();
+    callDynamicIfException();
+    callDynamicIfNoException();
+
+  }
+  
+  static B callIfException() {
+    return FieldAccess.testIf(unknown, new B(), null);
+  }
+  static B callIfNoException() {
+    return FieldAccess.testIf(unknown, new B(), new B());
+  }
+  
+  static B callDynamicIfException() {
+    FieldAccessDynamic fad = new FieldAccessDynamic();
+    return fad.testIf(unknown, new B(), null);
+  }
+  static B callDynamicIfNoException() {
+    FieldAccessDynamic fad = new FieldAccessDynamic();
+    return fad.testIf(unknown, new B(), new B());
+  }
+
+}

--- a/com.ibm.wala.core.testdata/src/cfg/exc/intra/B.java
+++ b/com.ibm.wala.core.testdata/src/cfg/exc/intra/B.java
@@ -1,0 +1,10 @@
+package cfg.exc.intra;
+
+/**
+ * @author Martin Hecker
+ */
+
+
+class B {
+	int f;
+}

--- a/com.ibm.wala.core.testdata/src/cfg/exc/intra/B.java
+++ b/com.ibm.wala.core.testdata/src/cfg/exc/intra/B.java
@@ -7,4 +7,5 @@ package cfg.exc.intra;
 
 public class B {
 	int f;
+	B b;
 }

--- a/com.ibm.wala.core.testdata/src/cfg/exc/intra/B.java
+++ b/com.ibm.wala.core.testdata/src/cfg/exc/intra/B.java
@@ -6,6 +6,6 @@ package cfg.exc.intra;
 
 
 public class B {
-	int f;
-	B b;
+	public int f;
+	public B b;
 }

--- a/com.ibm.wala.core.testdata/src/cfg/exc/intra/B.java
+++ b/com.ibm.wala.core.testdata/src/cfg/exc/intra/B.java
@@ -5,6 +5,6 @@ package cfg.exc.intra;
  */
 
 
-class B {
+public class B {
 	int f;
 }

--- a/com.ibm.wala.core.testdata/src/cfg/exc/intra/FieldAccess.java
+++ b/com.ibm.wala.core.testdata/src/cfg/exc/intra/FieldAccess.java
@@ -1,0 +1,83 @@
+/**
+ * This file is part of the Joana IFC project. It is developed at the
+ * Programming Paradigms Group of the Karlsruhe Institute of Technology.
+ *
+ * For further details on licensing please read the information at
+ * http://joana.ipd.kit.edu or contact the authors.
+ */
+package cfg.exc.intra;
+
+
+public class FieldAccess {
+  
+  
+  static B testIf(boolean unknown, B b1, B b2) {
+    b1.f = 42;
+    b2.f = 17;
+
+    B b3;
+    if (unknown) {
+      b3 = b1;
+    } else {
+      b3 = b2;
+    }
+    
+    return b3;
+  }
+
+  static B testIf2(boolean unknown, B b1, B b2) {
+    b1.f = 42;
+
+    B b3;
+    if (unknown) {
+      b3 = b1;
+    } else {
+      b3 = b2;
+    }
+    
+    return b3;
+  }
+  
+  static B testIf3(boolean unknown, B b1) {
+    if (unknown) {
+      b1.f = 42;
+    } else {
+      System.out.println("rofl");
+    }
+    
+    return b1;
+  }
+  
+  static B testWhile(boolean unknown, B b1) {
+    b1.f = 42;
+
+    B b3 = null;
+    while (unknown) {
+      b3 = b1;
+    }
+    
+    return b3;
+  }
+  
+  static B testWhile2(boolean unknown, B b1) {
+    b1.f = 42;
+
+    B b3 = new B();
+    b3.f = 17;
+    
+    while (unknown) {
+      b3 = b1;
+    }
+    
+    return b3;
+  }
+
+	public static void main(String[] args) {
+
+		B b1 = new B();
+		B b2 = new B();
+		final boolean unknown = (args.length == 0);
+
+		testIf(unknown, b1, b2);
+	}
+}

--- a/com.ibm.wala.core.testdata/src/cfg/exc/intra/FieldAccess.java
+++ b/com.ibm.wala.core.testdata/src/cfg/exc/intra/FieldAccess.java
@@ -11,6 +11,17 @@ package cfg.exc.intra;
 public class FieldAccess {
   
   
+  static B testParam(boolean unknown, B b1, B b2) {
+    b1 = null;
+    return b1;
+  }
+
+  static B testParam2(boolean unknown, B b1, B b2) {
+    b1.f = 42;
+    return b1;
+  }
+  
+  
   static B testIf(boolean unknown, B b1, B b2) {
     b1.f = 42;
     b2.f = 17;
@@ -36,6 +47,24 @@ public class FieldAccess {
     }
     
     return b3;
+  }
+  
+  static B testIfContinued(boolean unknown, B b1, B b2, B b4) {
+    b1.f = 42;
+
+    B b3;
+    if (unknown) {
+      b3 = b1;
+    } else {
+      b3 = b2;
+    }
+    
+    if (unknown) {
+      b1.f = 42;
+    }
+    
+    b3.f = 17;
+    return b2;
   }
   
   static B testIf3(boolean unknown, B b1) {
@@ -71,6 +100,7 @@ public class FieldAccess {
     
     return b3;
   }
+  
 
 	public static void main(String[] args) {
 

--- a/com.ibm.wala.core.testdata/src/cfg/exc/intra/FieldAccess.java
+++ b/com.ibm.wala.core.testdata/src/cfg/exc/intra/FieldAccess.java
@@ -101,6 +101,20 @@ public class FieldAccess {
     return b3;
   }
   
+  public static B testGet(boolean unknown, B b1) {
+    b1.f = 42;
+
+    B b3 = b1.b;
+
+    if (unknown) {
+      b3.f = 17;
+    } else {
+      System.out.println();
+    }
+    
+    return b3;
+  }
+  
 
 	public static void main(String[] args) {
 

--- a/com.ibm.wala.core.testdata/src/cfg/exc/intra/FieldAccess.java
+++ b/com.ibm.wala.core.testdata/src/cfg/exc/intra/FieldAccess.java
@@ -108,8 +108,6 @@ public class FieldAccess {
 
     if (unknown) {
       b3.f = 17;
-    } else {
-      System.out.println();
     }
     
     return b3;

--- a/com.ibm.wala.core.testdata/src/cfg/exc/intra/FieldAccessDynamic.java
+++ b/com.ibm.wala.core.testdata/src/cfg/exc/intra/FieldAccessDynamic.java
@@ -101,6 +101,20 @@ public class FieldAccessDynamic {
     return b3;
   }
   
+  public B testGet(boolean unknown, B b1) {
+    b1.f = 42;
+
+    B b3 = b1.b;
+
+    if (unknown) {
+      b3.f = 17;
+    } else {
+      System.out.println();
+    }
+    
+    return b3;
+  }
+  
 
 	public static void main(String[] args) {
 

--- a/com.ibm.wala.core.testdata/src/cfg/exc/intra/FieldAccessDynamic.java
+++ b/com.ibm.wala.core.testdata/src/cfg/exc/intra/FieldAccessDynamic.java
@@ -8,21 +8,21 @@
 package cfg.exc.intra;
 
 
-public class FieldAccess {
+public class FieldAccessDynamic {
   
   
-  public static B testParam(boolean unknown, B b1, B b2) {
+  public B testParam(boolean unknown, B b1, B b2) {
     b1 = null;
     return b1;
   }
 
-  public static B testParam2(boolean unknown, B b1, B b2) {
+  public B testParam2(boolean unknown, B b1, B b2) {
     b1.f = 42;
     return b1;
   }
   
   
-  public static B testIf(boolean unknown, B b1, B b2) {
+  public B testIf(boolean unknown, B b1, B b2) {
     b1.f = 42;
     b2.f = 17;
 
@@ -36,7 +36,7 @@ public class FieldAccess {
     return b3;
   }
 
-  public static B testIf2(boolean unknown, B b1, B b2) {
+  public B testIf2(boolean unknown, B b1, B b2) {
     b1.f = 42;
 
     B b3;
@@ -49,7 +49,7 @@ public class FieldAccess {
     return b3;
   }
   
-  public static B testIfContinued(boolean unknown, B b1, B b2, B b4) {
+  public B testIfContinued(boolean unknown, B b1, B b2, B b4) {
     b1.f = 42;
 
     B b3;
@@ -67,7 +67,7 @@ public class FieldAccess {
     return b2;
   }
   
-  public static B testIf3(boolean unknown, B b1) {
+  public B testIf3(boolean unknown, B b1) {
     if (unknown) {
       b1.f = 42;
     } else {
@@ -77,7 +77,7 @@ public class FieldAccess {
     return b1;
   }
   
-  public static B testWhile(boolean unknown, B b1) {
+  public B testWhile(boolean unknown, B b1) {
     b1.f = 42;
 
     B b3 = null;
@@ -88,7 +88,7 @@ public class FieldAccess {
     return b3;
   }
   
-  public static B testWhile2(boolean unknown, B b1) {
+  public B testWhile2(boolean unknown, B b1) {
     b1.f = 42;
 
     B b3 = new B();
@@ -108,6 +108,7 @@ public class FieldAccess {
 		B b2 = new B();
 		final boolean unknown = (args.length == 0);
 
-		testIf(unknown, b1, b2);
+		FieldAccessDynamic fa = new FieldAccessDynamic();
+		fa.testIf(unknown, b1, b2);
 	}
 }

--- a/com.ibm.wala.core.testdata/src/cfg/exc/intra/FieldAccessDynamic.java
+++ b/com.ibm.wala.core.testdata/src/cfg/exc/intra/FieldAccessDynamic.java
@@ -108,8 +108,6 @@ public class FieldAccessDynamic {
 
     if (unknown) {
       b3.f = 17;
-    } else {
-      System.out.println();
     }
     
     return b3;

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cfg/exc/inter/NullPointerExceptionInterTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cfg/exc/inter/NullPointerExceptionInterTest.java
@@ -23,6 +23,7 @@ import com.ibm.wala.cfg.exc.intra.IntraprocNullPointerAnalysis;
 import com.ibm.wala.classLoader.ClassLoaderFactory;
 import com.ibm.wala.classLoader.ClassLoaderFactoryImpl;
 import com.ibm.wala.classLoader.IMethod;
+import com.ibm.wala.core.tests.callGraph.CallGraphTestUtil;
 import com.ibm.wala.core.tests.util.TestConstants;
 import com.ibm.wala.core.tests.util.WalaTestCase;
 import com.ibm.wala.ipa.callgraph.AnalysisCache;
@@ -66,14 +67,14 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
   public static void beforeClass() throws Exception {
     cache = new AnalysisCache();
     scope = AnalysisScopeReader.readJavaScope(TestConstants.WALA_TESTDATA,
-        (new FileProvider()).getFile("J2SEClassHierarchyExclusions.txt"), NullPointerExceptionInterTest.class.getClassLoader());
+        (new FileProvider()).getFile(CallGraphTestUtil.REGRESSION_EXCLUSIONS), NullPointerExceptionInterTest.class.getClassLoader());
     ClassLoaderFactory factory = new ClassLoaderFactoryImpl(scope.getExclusions());
     try {
       cha = ClassHierarchy.make(scope, factory);
       Iterable<Entrypoint> entrypoints = com.ibm.wala.ipa.callgraph.impl.Util.makeMainEntrypoints(scope, cha, "Lcfg/exc/inter/CallFieldAccess");
       AnalysisOptions options = new AnalysisOptions(scope, entrypoints);
       
-      CallGraphBuilder builder = Util.makeVanillaNCFABuilder(3, options, cache, cha, scope);
+      CallGraphBuilder builder = Util.makeNCFABuilder(1, options, cache, cha, scope);
       cg = builder.makeCallGraph(options, null);
     } catch (ClassHierarchyException e) {
       throw new Exception();
@@ -160,5 +161,111 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
 
     ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG = interExplodedCFG.getResult(callNode);
     Assert.assertFalse(intraExplodedCFG.hasExceptions());
+  }
+  
+  @Test
+  public void testIf2Exception() throws UnsoundGraphException, CancelException, WalaException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callIf2Exception()Lcfg/exc/intra/B");
+
+    IMethod m = cha.resolveMethod(mr);
+    IR ir = cache.getIR(m);
+    InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG = 
+        NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
+
+    Assert.assertEquals(1, cg.getNodes(mr).size());
+    final CGNode callNode = cg.getNodes(mr).iterator().next();
+
+    ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG = interExplodedCFG.getResult(callNode);
+
+    Assert.assertTrue(intraExplodedCFG.hasExceptions());
+  }
+  
+  @Test
+  public void testDynamicIf2Exception() throws UnsoundGraphException, CancelException, WalaException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callDynamicIf2Exception()Lcfg/exc/intra/B");
+
+    IMethod m = cha.resolveMethod(mr);
+    
+    Assert.assertEquals(1, cg.getNodes(mr).size());
+    final CGNode callNode = cg.getNodes(mr).iterator().next();
+
+    IR ir = cache.getIR(m);
+    InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG = 
+        NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
+
+
+    ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG = interExplodedCFG.getResult(callNode);
+
+    Assert.assertTrue(intraExplodedCFG.hasExceptions());
+  }
+
+  
+  @Test
+  public void testIf2NoException() throws UnsoundGraphException, CancelException, WalaException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callIf2NoException()Lcfg/exc/intra/B");
+
+    IMethod m = cha.resolveMethod(mr);
+    IR ir = cache.getIR(m);
+    InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG = 
+        NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
+
+    Assert.assertEquals(1, cg.getNodes(mr).size());
+    final CGNode callNode = cg.getNodes(mr).iterator().next();
+
+    ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG = interExplodedCFG.getResult(callNode);
+    Assert.assertFalse(intraExplodedCFG.hasExceptions());
+  }
+  
+  @Test
+  public void testDynamicIf2NoException() throws UnsoundGraphException, CancelException, WalaException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callDynamicIf2NoException()Lcfg/exc/intra/B");
+
+    IMethod m = cha.resolveMethod(mr);
+    IR ir = cache.getIR(m);
+    InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG = 
+        NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
+
+    Assert.assertEquals(1, cg.getNodes(mr).size());
+    final CGNode callNode = cg.getNodes(mr).iterator().next();
+
+    ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG = interExplodedCFG.getResult(callNode);
+    Assert.assertFalse(intraExplodedCFG.hasExceptions());
+  }
+  
+
+  @Test
+  public void testGetException() throws UnsoundGraphException, CancelException, WalaException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callGetException()Lcfg/exc/intra/B");
+
+    IMethod m = cha.resolveMethod(mr);
+    IR ir = cache.getIR(m);
+    InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG = 
+        NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
+
+    Assert.assertEquals(1, cg.getNodes(mr).size());
+    final CGNode callNode = cg.getNodes(mr).iterator().next();
+
+    ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG = interExplodedCFG.getResult(callNode);
+
+    Assert.assertTrue(intraExplodedCFG.hasExceptions());
+  }
+  
+  @Test
+  public void testDynamicGetException() throws UnsoundGraphException, CancelException, WalaException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callDynamicGetException()Lcfg/exc/intra/B");
+
+    IMethod m = cha.resolveMethod(mr);
+    
+    Assert.assertEquals(1, cg.getNodes(mr).size());
+    final CGNode callNode = cg.getNodes(mr).iterator().next();
+
+    IR ir = cache.getIR(m);
+    InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG = 
+        NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
+
+
+    ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG = interExplodedCFG.getResult(callNode);
+
+    Assert.assertTrue(intraExplodedCFG.hasExceptions());
   }
 }

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cfg/exc/inter/NullPointerExceptionInterTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cfg/exc/inter/NullPointerExceptionInterTest.java
@@ -1,0 +1,173 @@
+/*******************************************************************************
+ * Copyright (c) 2002 - 2006 IBM Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.wala.core.tests.cfg.exc.inter;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.wala.cfg.ControlFlowGraph;
+import com.ibm.wala.cfg.exc.ExceptionPruningAnalysis;
+import com.ibm.wala.cfg.exc.InterprocAnalysisResult;
+import com.ibm.wala.cfg.exc.NullPointerAnalysis;
+import com.ibm.wala.cfg.exc.intra.IntraprocNullPointerAnalysis;
+import com.ibm.wala.cfg.exc.intra.NullPointerState;
+import com.ibm.wala.cfg.exc.intra.NullPointerState.State;
+import com.ibm.wala.classLoader.ClassLoaderFactory;
+import com.ibm.wala.classLoader.ClassLoaderFactoryImpl;
+import com.ibm.wala.classLoader.IMethod;
+import com.ibm.wala.core.tests.callGraph.CallGraphTestUtil;
+import com.ibm.wala.core.tests.cfg.exc.intra.NullPointerExceptionIntraTest;
+import com.ibm.wala.core.tests.util.TestConstants;
+import com.ibm.wala.core.tests.util.WalaTestCase;
+import com.ibm.wala.ipa.callgraph.AnalysisCache;
+import com.ibm.wala.ipa.callgraph.AnalysisOptions;
+import com.ibm.wala.ipa.callgraph.AnalysisScope;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.CallGraph;
+import com.ibm.wala.ipa.callgraph.CallGraphBuilder;
+import com.ibm.wala.ipa.callgraph.Entrypoint;
+import com.ibm.wala.ipa.callgraph.impl.Util;
+import com.ibm.wala.ipa.cha.ClassHierarchy;
+import com.ibm.wala.ipa.cha.ClassHierarchyException;
+import com.ibm.wala.ssa.IR;
+import com.ibm.wala.ssa.ISSABasicBlock;
+import com.ibm.wala.ssa.SSAInstruction;
+import com.ibm.wala.ssa.SSAReturnInstruction;
+import com.ibm.wala.ssa.analysis.IExplodedBasicBlock;
+import com.ibm.wala.types.MethodReference;
+import com.ibm.wala.util.CancelException;
+import com.ibm.wala.util.NullProgressMonitor;
+import com.ibm.wala.util.WalaException;
+import com.ibm.wala.util.config.AnalysisScopeReader;
+import com.ibm.wala.util.graph.GraphIntegrity.UnsoundGraphException;
+import com.ibm.wala.util.io.FileProvider;
+import com.ibm.wala.util.strings.StringStuff;
+import com.ibm.wala.util.warnings.Warnings;
+
+/**
+ * Test validity and precision of inter-procedural NullpointerException-Analysis {@link IntraprocNullPointerAnalysis}
+ * 
+ */
+public class NullPointerExceptionInterTest extends WalaTestCase {
+
+  private static AnalysisScope scope;
+
+  private static ClassHierarchy cha;
+  
+  private static CallGraph cg;
+  
+  private static AnalysisCache cache;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    cache = new AnalysisCache();
+    scope = AnalysisScopeReader.readJavaScope(TestConstants.WALA_TESTDATA,
+        (new FileProvider()).getFile("J2SEClassHierarchyExclusions.txt"), NullPointerExceptionInterTest.class.getClassLoader());
+    ClassLoaderFactory factory = new ClassLoaderFactoryImpl(scope.getExclusions());
+    try {
+      cha = ClassHierarchy.make(scope, factory);
+      Iterable<Entrypoint> entrypoints = com.ibm.wala.ipa.callgraph.impl.Util.makeMainEntrypoints(scope, cha, "Lcfg/exc/inter/CallFieldAccess");
+      AnalysisOptions options = new AnalysisOptions(scope, entrypoints);
+      
+      CallGraphBuilder builder = Util.makeVanillaNCFABuilder(3, options, cache, cha, scope);
+      cg = builder.makeCallGraph(options, null);
+    } catch (ClassHierarchyException e) {
+      throw new Exception();
+    }
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    Warnings.clear();
+    scope = null;
+    cha = null;
+    cg = null;
+    cache = null;
+  }
+
+  public static void main(String[] args) {
+    justThisTest(NullPointerExceptionInterTest.class);
+  }
+
+  @Test
+  public void testIfException() throws UnsoundGraphException, CancelException, WalaException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callIfException()Lcfg/exc/intra/B");
+
+    IMethod m = cha.resolveMethod(mr);
+    IR ir = cache.getIR(m);
+    InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG = 
+        NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
+
+    Assert.assertEquals(1, cg.getNodes(mr).size());
+    final CGNode callNode = cg.getNodes(mr).iterator().next();
+
+    ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG = interExplodedCFG.getResult(callNode);
+
+    Assert.assertTrue(intraExplodedCFG.hasExceptions());
+  }
+  
+  @Test
+  public void testDynamicIfException() throws UnsoundGraphException, CancelException, WalaException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callDynamicIfException()Lcfg/exc/intra/B");
+
+    IMethod m = cha.resolveMethod(mr);
+    
+    Assert.assertEquals(1, cg.getNodes(mr).size());
+    final CGNode callNode = cg.getNodes(mr).iterator().next();
+
+    IR ir = cache.getIR(m);
+    InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG = 
+        NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
+
+
+    ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG = interExplodedCFG.getResult(callNode);
+
+    Assert.assertTrue(intraExplodedCFG.hasExceptions());
+  }
+
+  
+  @Test
+  public void testIfNoException() throws UnsoundGraphException, CancelException, WalaException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callIfNoException()Lcfg/exc/intra/B");
+
+    IMethod m = cha.resolveMethod(mr);
+    IR ir = cache.getIR(m);
+    InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG = 
+        NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
+
+    Assert.assertEquals(1, cg.getNodes(mr).size());
+    final CGNode callNode = cg.getNodes(mr).iterator().next();
+
+    ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG = interExplodedCFG.getResult(callNode);
+    Assert.assertFalse(intraExplodedCFG.hasExceptions());
+  }
+  
+  @Test
+  public void testDynamicIfNoException() throws UnsoundGraphException, CancelException, WalaException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callDynamicIfNoException()Lcfg/exc/intra/B");
+
+    IMethod m = cha.resolveMethod(mr);
+    IR ir = cache.getIR(m);
+    InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG = 
+        NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
+
+    Assert.assertEquals(1, cg.getNodes(mr).size());
+    final CGNode callNode = cg.getNodes(mr).iterator().next();
+
+    ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG = interExplodedCFG.getResult(callNode);
+    Assert.assertFalse(intraExplodedCFG.hasExceptions());
+  }
+}

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cfg/exc/inter/NullPointerExceptionInterTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cfg/exc/inter/NullPointerExceptionInterTest.java
@@ -10,26 +10,19 @@
  *******************************************************************************/
 package com.ibm.wala.core.tests.cfg.exc.inter;
 
-import java.util.Collection;
-import java.util.Iterator;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.ibm.wala.cfg.ControlFlowGraph;
 import com.ibm.wala.cfg.exc.ExceptionPruningAnalysis;
 import com.ibm.wala.cfg.exc.InterprocAnalysisResult;
 import com.ibm.wala.cfg.exc.NullPointerAnalysis;
 import com.ibm.wala.cfg.exc.intra.IntraprocNullPointerAnalysis;
-import com.ibm.wala.cfg.exc.intra.NullPointerState;
-import com.ibm.wala.cfg.exc.intra.NullPointerState.State;
 import com.ibm.wala.classLoader.ClassLoaderFactory;
 import com.ibm.wala.classLoader.ClassLoaderFactoryImpl;
 import com.ibm.wala.classLoader.IMethod;
-import com.ibm.wala.core.tests.callGraph.CallGraphTestUtil;
-import com.ibm.wala.core.tests.cfg.exc.intra.NullPointerExceptionIntraTest;
 import com.ibm.wala.core.tests.util.TestConstants;
 import com.ibm.wala.core.tests.util.WalaTestCase;
 import com.ibm.wala.ipa.callgraph.AnalysisCache;
@@ -43,9 +36,7 @@ import com.ibm.wala.ipa.callgraph.impl.Util;
 import com.ibm.wala.ipa.cha.ClassHierarchy;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.ssa.IR;
-import com.ibm.wala.ssa.ISSABasicBlock;
 import com.ibm.wala.ssa.SSAInstruction;
-import com.ibm.wala.ssa.SSAReturnInstruction;
 import com.ibm.wala.ssa.analysis.IExplodedBasicBlock;
 import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.util.CancelException;

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cfg/exc/intra/NullPointerExceptionIntraTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cfg/exc/intra/NullPointerExceptionIntraTest.java
@@ -86,6 +86,75 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
   }
 
   @Test
+  public void testParam() throws UnsoundGraphException, CancelException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccess.testParam(ZLcfg/exc/intra/B;Lcfg/exc/intra/B;)Lcfg/exc/intra/B");
+
+    IMethod m = cha.resolveMethod(mr);
+    AnalysisCache cache = new AnalysisCache();
+    IR ir = cache.getIR(m);
+    final ISSABasicBlock returnNode = returnNode(ir.getControlFlowGraph());
+    final int returnVal = returnVal(returnNode);
+
+    {
+      ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
+          NullPointerAnalysis.createIntraproceduralExplodedCFGAnalysis(ir);
+      intraExplodedCFG.compute(new NullProgressMonitor());
+        
+      final IExplodedBasicBlock returnNodeExploded = returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
+      final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
+
+      Assert.assertEquals(State.NULL, returnState.getState(returnVal));
+    }
+    {
+      ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
+          NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
+      intraSSACFG.compute(new NullProgressMonitor());
+      
+      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      Assert.assertEquals(returnNode,           returnNode(intraSSACFG.getCFG()));
+        
+      final NullPointerState returnState = intraSSACFG.getState(returnNode);
+
+      Assert.assertEquals(State.NULL, returnState.getState(returnVal));
+    }    
+  }
+  
+  @Test
+  public void testParam2() throws UnsoundGraphException, CancelException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccess.testParam2(ZLcfg/exc/intra/B;Lcfg/exc/intra/B;)Lcfg/exc/intra/B");
+
+    IMethod m = cha.resolveMethod(mr);
+    AnalysisCache cache = new AnalysisCache();
+    IR ir = cache.getIR(m);
+    final ISSABasicBlock returnNode = returnNode(ir.getControlFlowGraph());
+    final int returnVal = returnVal(returnNode);
+
+    {
+      ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
+          NullPointerAnalysis.createIntraproceduralExplodedCFGAnalysis(ir);
+      intraExplodedCFG.compute(new NullProgressMonitor());
+        
+      final IExplodedBasicBlock returnNodeExploded = returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
+      final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
+
+      Assert.assertEquals(State.NOT_NULL, returnState.getState(returnVal));
+    }
+    {
+      ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
+          NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
+      intraSSACFG.compute(new NullProgressMonitor());
+      
+      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      Assert.assertEquals(returnNode,           returnNode(intraSSACFG.getCFG()));
+        
+      final NullPointerState returnState = intraSSACFG.getState(returnNode);
+
+      Assert.assertEquals(State.NOT_NULL, returnState.getState(returnVal));
+    }    
+  }
+  
+  
+  @Test
   public void testIf() throws UnsoundGraphException, CancelException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccess.testIf(ZLcfg/exc/intra/B;Lcfg/exc/intra/B;)Lcfg/exc/intra/B");
 
@@ -154,7 +223,42 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
       Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
     }    
   }
+  
+  @Test
+  public void testIfContinued() throws UnsoundGraphException, CancelException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccess.testIfContinued(ZLcfg/exc/intra/B;Lcfg/exc/intra/B;Lcfg/exc/intra/B;)Lcfg/exc/intra/B");
 
+    IMethod m = cha.resolveMethod(mr);
+    AnalysisCache cache = new AnalysisCache();
+    IR ir = cache.getIR(m);
+    final ISSABasicBlock returnNode = returnNode(ir.getControlFlowGraph());
+    final int returnVal = returnVal(returnNode);
+
+    {
+      ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
+          NullPointerAnalysis.createIntraproceduralExplodedCFGAnalysis(ir);
+      intraExplodedCFG.compute(new NullProgressMonitor());
+        
+      final IExplodedBasicBlock returnNodeExploded = returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
+      final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
+
+      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+    }
+    {
+      ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
+          NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
+      intraSSACFG.compute(new NullProgressMonitor());
+      
+      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      Assert.assertEquals(returnNode,           returnNode(intraSSACFG.getCFG()));
+        
+      final NullPointerState returnState = intraSSACFG.getState(returnNode);
+
+      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+    }    
+  }
   @Test
   public void testIf3() throws UnsoundGraphException, CancelException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccess.testIf3(ZLcfg/exc/intra/B;)Lcfg/exc/intra/B");

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cfg/exc/intra/NullPointerExceptionIntraTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cfg/exc/intra/NullPointerExceptionIntraTest.java
@@ -648,6 +648,77 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
     }    
   }
 
+  @Test
+  public void testGet() throws UnsoundGraphException, CancelException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccess.testGet(ZLcfg/exc/intra/B;)Lcfg/exc/intra/B");
+
+    IMethod m = cha.resolveMethod(mr);
+    AnalysisCache cache = new AnalysisCache();
+    IR ir = cache.getIR(m);
+    final ISSABasicBlock returnNode = returnNode(ir.getControlFlowGraph());
+    final int returnVal = returnVal(returnNode);
+
+    {
+      ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
+          NullPointerAnalysis.createIntraproceduralExplodedCFGAnalysis(ir);
+      intraExplodedCFG.compute(new NullProgressMonitor());
+        
+      final IExplodedBasicBlock returnNodeExploded = returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
+      final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
+
+      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+    }
+    {
+      ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
+          NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
+      intraSSACFG.compute(new NullProgressMonitor());
+      
+      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      Assert.assertEquals(returnNode,           returnNode(intraSSACFG.getCFG()));
+        
+      final NullPointerState returnState = intraSSACFG.getState(returnNode);
+
+      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+    }    
+  }
+  
+  @Test
+  public void testDynamicGet() throws UnsoundGraphException, CancelException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccessDynamic.testGet(ZLcfg/exc/intra/B;)Lcfg/exc/intra/B");
+
+    IMethod m = cha.resolveMethod(mr);
+    AnalysisCache cache = new AnalysisCache();
+    IR ir = cache.getIR(m);
+    final ISSABasicBlock returnNode = returnNode(ir.getControlFlowGraph());
+    final int returnVal = returnVal(returnNode);
+
+    {
+      ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
+          NullPointerAnalysis.createIntraproceduralExplodedCFGAnalysis(ir);
+      intraExplodedCFG.compute(new NullProgressMonitor());
+        
+      final IExplodedBasicBlock returnNodeExploded = returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
+      final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
+
+      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+    }
+    {
+      ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
+          NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
+      intraSSACFG.compute(new NullProgressMonitor());
+      
+      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      Assert.assertEquals(returnNode,           returnNode(intraSSACFG.getCFG()));
+        
+      final NullPointerState returnState = intraSSACFG.getState(returnNode);
+
+      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+    }    
+  }
 
   public static ISSABasicBlock returnNode(ControlFlowGraph<SSAInstruction, ISSABasicBlock> cfg) {
       Collection<ISSABasicBlock> returnNodes = cfg.getNormalPredecessors(cfg.exit());

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cfg/exc/intra/NullPointerExceptionIntraTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cfg/exc/intra/NullPointerExceptionIntraTest.java
@@ -1,0 +1,289 @@
+/*******************************************************************************
+ * Copyright (c) 2002 - 2006 IBM Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package com.ibm.wala.core.tests.cfg.exc.intra;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.ibm.wala.cfg.ControlFlowGraph;
+import com.ibm.wala.cfg.exc.ExceptionPruningAnalysis;
+import com.ibm.wala.cfg.exc.NullPointerAnalysis;
+import com.ibm.wala.cfg.exc.intra.IntraprocNullPointerAnalysis;
+import com.ibm.wala.cfg.exc.intra.NullPointerState;
+import com.ibm.wala.cfg.exc.intra.NullPointerState.State;
+import com.ibm.wala.classLoader.ClassLoaderFactory;
+import com.ibm.wala.classLoader.ClassLoaderFactoryImpl;
+import com.ibm.wala.classLoader.IMethod;
+import com.ibm.wala.core.tests.util.TestConstants;
+import com.ibm.wala.core.tests.util.WalaTestCase;
+import com.ibm.wala.ipa.callgraph.AnalysisCache;
+import com.ibm.wala.ipa.callgraph.AnalysisScope;
+import com.ibm.wala.ipa.cha.ClassHierarchy;
+import com.ibm.wala.ipa.cha.ClassHierarchyException;
+import com.ibm.wala.ssa.IR;
+import com.ibm.wala.ssa.ISSABasicBlock;
+import com.ibm.wala.ssa.SSACFG;
+import com.ibm.wala.ssa.SSAInstruction;
+import com.ibm.wala.ssa.SSAReturnInstruction;
+import com.ibm.wala.ssa.analysis.IExplodedBasicBlock;
+import com.ibm.wala.types.MethodReference;
+import com.ibm.wala.util.CancelException;
+import com.ibm.wala.util.NullProgressMonitor;
+import com.ibm.wala.util.config.AnalysisScopeReader;
+import com.ibm.wala.util.graph.GraphIntegrity.UnsoundGraphException;
+import com.ibm.wala.util.io.FileProvider;
+import com.ibm.wala.util.strings.StringStuff;
+import com.ibm.wala.util.warnings.Warnings;
+
+/**
+ * Test validity and precision of intra-procedurel NullpointerException-Analysis {@link IntraprocNullPointerAnalysis}
+ * 
+ */
+public class NullPointerExceptionIntraTest extends WalaTestCase {
+
+  private static AnalysisScope scope;
+
+  private static ClassHierarchy cha;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+
+    scope = AnalysisScopeReader.readJavaScope(TestConstants.WALA_TESTDATA,
+        (new FileProvider()).getFile("J2SEClassHierarchyExclusions.txt"), NullPointerExceptionIntraTest.class.getClassLoader());
+    ClassLoaderFactory factory = new ClassLoaderFactoryImpl(scope.getExclusions());
+
+    try {
+      cha = ClassHierarchy.make(scope, factory);
+    } catch (ClassHierarchyException e) {
+      throw new Exception();
+    }
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    Warnings.clear();
+    scope = null;
+    cha = null;
+  }
+
+  public static void main(String[] args) {
+    justThisTest(NullPointerExceptionIntraTest.class);
+  }
+
+  @Test
+  public void testIf() throws UnsoundGraphException, CancelException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccess.testIf(ZLcfg/exc/intra/B;Lcfg/exc/intra/B;)Lcfg/exc/intra/B");
+
+    IMethod m = cha.resolveMethod(mr);
+    AnalysisCache cache = new AnalysisCache();
+    IR ir = cache.getIR(m);
+    final ISSABasicBlock returnNode = returnNode(ir.getControlFlowGraph());
+    final int returnVal = returnVal(returnNode);
+
+    {
+      ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
+          NullPointerAnalysis.createIntraproceduralExplodedCFGAnalysis(ir);
+      intraExplodedCFG.compute(new NullProgressMonitor());
+        
+      final IExplodedBasicBlock returnNodeExploded = returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
+      final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
+
+      Assert.assertEquals(State.NOT_NULL, returnState.getState(returnVal));
+    }
+    {
+      ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
+          NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
+      intraSSACFG.compute(new NullProgressMonitor());
+      
+      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      Assert.assertEquals(returnNode,           returnNode(intraSSACFG.getCFG()));
+        
+      final NullPointerState returnState = intraSSACFG.getState(returnNode);
+
+      Assert.assertEquals(State.NOT_NULL, returnState.getState(returnVal));
+    }    
+  }
+  
+  @Test
+  public void testIf2() throws UnsoundGraphException, CancelException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccess.testIf2(ZLcfg/exc/intra/B;Lcfg/exc/intra/B;)Lcfg/exc/intra/B");
+
+    IMethod m = cha.resolveMethod(mr);
+    AnalysisCache cache = new AnalysisCache();
+    IR ir = cache.getIR(m);
+    final ISSABasicBlock returnNode = returnNode(ir.getControlFlowGraph());
+    final int returnVal = returnVal(returnNode);
+
+    {
+      ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
+          NullPointerAnalysis.createIntraproceduralExplodedCFGAnalysis(ir);
+      intraExplodedCFG.compute(new NullProgressMonitor());
+        
+      final IExplodedBasicBlock returnNodeExploded = returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
+      final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
+
+      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+    }
+    {
+      ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
+          NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
+      intraSSACFG.compute(new NullProgressMonitor());
+      
+      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      Assert.assertEquals(returnNode,           returnNode(intraSSACFG.getCFG()));
+        
+      final NullPointerState returnState = intraSSACFG.getState(returnNode);
+
+      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+    }    
+  }
+
+  @Test
+  public void testIf3() throws UnsoundGraphException, CancelException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccess.testIf3(ZLcfg/exc/intra/B;)Lcfg/exc/intra/B");
+
+    IMethod m = cha.resolveMethod(mr);
+    AnalysisCache cache = new AnalysisCache();
+    IR ir = cache.getIR(m);
+    final ISSABasicBlock returnNode = returnNode(ir.getControlFlowGraph());
+    final int returnVal = returnVal(returnNode);
+
+    {
+      ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
+          NullPointerAnalysis.createIntraproceduralExplodedCFGAnalysis(ir);
+      intraExplodedCFG.compute(new NullProgressMonitor());
+        
+      final IExplodedBasicBlock returnNodeExploded = returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
+      final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
+
+      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+    }
+    {
+      ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
+          NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
+      intraSSACFG.compute(new NullProgressMonitor());
+      
+      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      Assert.assertEquals(returnNode,           returnNode(intraSSACFG.getCFG()));
+        
+      final NullPointerState returnState = intraSSACFG.getState(returnNode);
+
+      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+    }    
+  }
+
+  
+  
+  @Test
+  public void testWhile() throws UnsoundGraphException, CancelException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccess.testWhile(ZLcfg/exc/intra/B;)Lcfg/exc/intra/B");
+
+    IMethod m = cha.resolveMethod(mr);
+    AnalysisCache cache = new AnalysisCache();
+    IR ir = cache.getIR(m);
+    final ISSABasicBlock returnNode = returnNode(ir.getControlFlowGraph());
+    final int returnVal = returnVal(returnNode);
+
+    {
+      ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
+          NullPointerAnalysis.createIntraproceduralExplodedCFGAnalysis(ir);
+      intraExplodedCFG.compute(new NullProgressMonitor());
+        
+      final IExplodedBasicBlock returnNodeExploded = returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
+      final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
+
+      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+    }
+    {
+      ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
+          NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
+      intraSSACFG.compute(new NullProgressMonitor());
+      
+      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      Assert.assertEquals(returnNode,           returnNode(intraSSACFG.getCFG()));
+        
+      final NullPointerState returnState = intraSSACFG.getState(returnNode);
+
+      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+    }    
+  }
+  
+  @Test
+  public void testWhile2() throws UnsoundGraphException, CancelException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccess.testWhile2(ZLcfg/exc/intra/B;)Lcfg/exc/intra/B");
+
+    IMethod m = cha.resolveMethod(mr);
+    AnalysisCache cache = new AnalysisCache();
+    IR ir = cache.getIR(m);
+    final ISSABasicBlock returnNode = returnNode(ir.getControlFlowGraph());
+    final int returnVal = returnVal(returnNode);
+
+    {
+      ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
+          NullPointerAnalysis.createIntraproceduralExplodedCFGAnalysis(ir);
+      intraExplodedCFG.compute(new NullProgressMonitor());
+        
+      final IExplodedBasicBlock returnNodeExploded = returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
+      final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
+
+      Assert.assertEquals(State.NOT_NULL, returnState.getState(returnVal));
+    }
+    {
+      ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
+          NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
+      intraSSACFG.compute(new NullProgressMonitor());
+      
+      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      Assert.assertEquals(returnNode,           returnNode(intraSSACFG.getCFG()));
+        
+      final NullPointerState returnState = intraSSACFG.getState(returnNode);
+
+      Assert.assertEquals(State.NOT_NULL, returnState.getState(returnVal));
+    }    
+  }
+
+  private static ISSABasicBlock returnNode(ControlFlowGraph<SSAInstruction, ISSABasicBlock> cfg) {
+      Collection<ISSABasicBlock> returnNodes = cfg.getNormalPredecessors(cfg.exit());
+      Assert.assertEquals(1, returnNodes.size());
+      return (ISSABasicBlock) returnNodes.toArray()[0];
+  }
+  
+  private static int returnVal(ISSABasicBlock returnNode) {
+    final SSAReturnInstruction returnInst = (SSAReturnInstruction) returnNode.getLastInstruction();
+    Assert.assertEquals(1, returnInst.getNumberOfUses());
+    return returnInst.getUse(0);
+  }
+  
+  private static IExplodedBasicBlock returnNodeExploded(ISSABasicBlock returnNode, ControlFlowGraph<SSAInstruction, IExplodedBasicBlock> explodedCfg) {
+    final IExplodedBasicBlock exit = explodedCfg.exit();
+    for (Iterator<IExplodedBasicBlock> it = explodedCfg.getPredNodes(exit); it.hasNext();) {
+      IExplodedBasicBlock candidate  = it.next();
+      if (candidate.getInstruction() == returnNode.getLastInstruction()) {
+        return candidate;
+      }
+    }
+    Assert.assertTrue(false);
+    return null;
+  }
+}

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cfg/exc/intra/NullPointerExceptionIntraTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cfg/exc/intra/NullPointerExceptionIntraTest.java
@@ -120,8 +120,75 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
   }
   
   @Test
+  public void testDynamicParam() throws UnsoundGraphException, CancelException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccessDynamic.testParam(ZLcfg/exc/intra/B;Lcfg/exc/intra/B;)Lcfg/exc/intra/B");
+
+    IMethod m = cha.resolveMethod(mr);
+    AnalysisCache cache = new AnalysisCache();
+    IR ir = cache.getIR(m);
+    final ISSABasicBlock returnNode = returnNode(ir.getControlFlowGraph());
+    final int returnVal = returnVal(returnNode);
+
+    {
+      ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
+          NullPointerAnalysis.createIntraproceduralExplodedCFGAnalysis(ir);
+      intraExplodedCFG.compute(new NullProgressMonitor());
+        
+      final IExplodedBasicBlock returnNodeExploded = returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
+      final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
+
+      Assert.assertEquals(State.NULL, returnState.getState(returnVal));
+    }
+    {
+      ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
+          NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
+      intraSSACFG.compute(new NullProgressMonitor());
+      
+      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      Assert.assertEquals(returnNode,           returnNode(intraSSACFG.getCFG()));
+        
+      final NullPointerState returnState = intraSSACFG.getState(returnNode);
+
+      Assert.assertEquals(State.NULL, returnState.getState(returnVal));
+    }    
+  }
+  
+  @Test
   public void testParam2() throws UnsoundGraphException, CancelException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccess.testParam2(ZLcfg/exc/intra/B;Lcfg/exc/intra/B;)Lcfg/exc/intra/B");
+
+    IMethod m = cha.resolveMethod(mr);
+    AnalysisCache cache = new AnalysisCache();
+    IR ir = cache.getIR(m);
+    final ISSABasicBlock returnNode = returnNode(ir.getControlFlowGraph());
+    final int returnVal = returnVal(returnNode);
+
+    {
+      ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
+          NullPointerAnalysis.createIntraproceduralExplodedCFGAnalysis(ir);
+      intraExplodedCFG.compute(new NullProgressMonitor());
+        
+      final IExplodedBasicBlock returnNodeExploded = returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
+      final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
+
+      Assert.assertEquals(State.NOT_NULL, returnState.getState(returnVal));
+    }
+    {
+      ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
+          NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
+      intraSSACFG.compute(new NullProgressMonitor());
+      
+      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      Assert.assertEquals(returnNode,           returnNode(intraSSACFG.getCFG()));
+        
+      final NullPointerState returnState = intraSSACFG.getState(returnNode);
+
+      Assert.assertEquals(State.NOT_NULL, returnState.getState(returnVal));
+    }    
+  }
+  
+  public void testDynamicParam2() throws UnsoundGraphException, CancelException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccess.testDynamicParam2(ZLcfg/exc/intra/B;Lcfg/exc/intra/B;)Lcfg/exc/intra/B");
 
     IMethod m = cha.resolveMethod(mr);
     AnalysisCache cache = new AnalysisCache();
@@ -157,6 +224,40 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
   @Test
   public void testIf() throws UnsoundGraphException, CancelException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccess.testIf(ZLcfg/exc/intra/B;Lcfg/exc/intra/B;)Lcfg/exc/intra/B");
+
+    IMethod m = cha.resolveMethod(mr);
+    AnalysisCache cache = new AnalysisCache();
+    IR ir = cache.getIR(m);
+    final ISSABasicBlock returnNode = returnNode(ir.getControlFlowGraph());
+    final int returnVal = returnVal(returnNode);
+
+    {
+      ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
+          NullPointerAnalysis.createIntraproceduralExplodedCFGAnalysis(ir);
+      intraExplodedCFG.compute(new NullProgressMonitor());
+        
+      final IExplodedBasicBlock returnNodeExploded = returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
+      final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
+
+      Assert.assertEquals(State.NOT_NULL, returnState.getState(returnVal));
+    }
+    {
+      ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
+          NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
+      intraSSACFG.compute(new NullProgressMonitor());
+      
+      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      Assert.assertEquals(returnNode,           returnNode(intraSSACFG.getCFG()));
+        
+      final NullPointerState returnState = intraSSACFG.getState(returnNode);
+
+      Assert.assertEquals(State.NOT_NULL, returnState.getState(returnVal));
+    }    
+  }
+  
+  @Test
+  public void testDynamicIf() throws UnsoundGraphException, CancelException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccessDynamic.testIf(ZLcfg/exc/intra/B;Lcfg/exc/intra/B;)Lcfg/exc/intra/B");
 
     IMethod m = cha.resolveMethod(mr);
     AnalysisCache cache = new AnalysisCache();
@@ -225,6 +326,43 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
   }
   
   @Test
+  public void testDynamicIf2() throws UnsoundGraphException, CancelException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccessDynamic.testIf2(ZLcfg/exc/intra/B;Lcfg/exc/intra/B;)Lcfg/exc/intra/B");
+
+    IMethod m = cha.resolveMethod(mr);
+    AnalysisCache cache = new AnalysisCache();
+    IR ir = cache.getIR(m);
+    final ISSABasicBlock returnNode = returnNode(ir.getControlFlowGraph());
+    final int returnVal = returnVal(returnNode);
+
+    {
+      ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
+          NullPointerAnalysis.createIntraproceduralExplodedCFGAnalysis(ir);
+      intraExplodedCFG.compute(new NullProgressMonitor());
+        
+      final IExplodedBasicBlock returnNodeExploded = returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
+      final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
+
+      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+    }
+    {
+      ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
+          NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
+      intraSSACFG.compute(new NullProgressMonitor());
+      
+      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      Assert.assertEquals(returnNode,           returnNode(intraSSACFG.getCFG()));
+        
+      final NullPointerState returnState = intraSSACFG.getState(returnNode);
+
+      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+    }    
+  }
+
+  
+  @Test
   public void testIfContinued() throws UnsoundGraphException, CancelException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccess.testIfContinued(ZLcfg/exc/intra/B;Lcfg/exc/intra/B;Lcfg/exc/intra/B;)Lcfg/exc/intra/B");
 
@@ -259,6 +397,43 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
       Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
     }    
   }
+  
+  @Test
+  public void testDynamicIfContinued() throws UnsoundGraphException, CancelException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccessDynamic.testIfContinued(ZLcfg/exc/intra/B;Lcfg/exc/intra/B;Lcfg/exc/intra/B;)Lcfg/exc/intra/B");
+
+    IMethod m = cha.resolveMethod(mr);
+    AnalysisCache cache = new AnalysisCache();
+    IR ir = cache.getIR(m);
+    final ISSABasicBlock returnNode = returnNode(ir.getControlFlowGraph());
+    final int returnVal = returnVal(returnNode);
+
+    {
+      ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
+          NullPointerAnalysis.createIntraproceduralExplodedCFGAnalysis(ir);
+      intraExplodedCFG.compute(new NullProgressMonitor());
+        
+      final IExplodedBasicBlock returnNodeExploded = returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
+      final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
+
+      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+    }
+    {
+      ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
+          NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
+      intraSSACFG.compute(new NullProgressMonitor());
+      
+      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      Assert.assertEquals(returnNode,           returnNode(intraSSACFG.getCFG()));
+        
+      final NullPointerState returnState = intraSSACFG.getState(returnNode);
+
+      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+    }    
+  }
+
   @Test
   public void testIf3() throws UnsoundGraphException, CancelException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccess.testIf3(ZLcfg/exc/intra/B;)Lcfg/exc/intra/B");
@@ -296,10 +471,82 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
   }
 
   
+  @Test
+  public void testDynamicIf3() throws UnsoundGraphException, CancelException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccessDynamic.testIf3(ZLcfg/exc/intra/B;)Lcfg/exc/intra/B");
+
+    IMethod m = cha.resolveMethod(mr);
+    AnalysisCache cache = new AnalysisCache();
+    IR ir = cache.getIR(m);
+    final ISSABasicBlock returnNode = returnNode(ir.getControlFlowGraph());
+    final int returnVal = returnVal(returnNode);
+
+    {
+      ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
+          NullPointerAnalysis.createIntraproceduralExplodedCFGAnalysis(ir);
+      intraExplodedCFG.compute(new NullProgressMonitor());
+        
+      final IExplodedBasicBlock returnNodeExploded = returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
+      final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
+
+      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+    }
+    {
+      ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
+          NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
+      intraSSACFG.compute(new NullProgressMonitor());
+      
+      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      Assert.assertEquals(returnNode,           returnNode(intraSSACFG.getCFG()));
+        
+      final NullPointerState returnState = intraSSACFG.getState(returnNode);
+
+      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+    }    
+  }
+  
   
   @Test
   public void testWhile() throws UnsoundGraphException, CancelException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccess.testWhile(ZLcfg/exc/intra/B;)Lcfg/exc/intra/B");
+
+    IMethod m = cha.resolveMethod(mr);
+    AnalysisCache cache = new AnalysisCache();
+    IR ir = cache.getIR(m);
+    final ISSABasicBlock returnNode = returnNode(ir.getControlFlowGraph());
+    final int returnVal = returnVal(returnNode);
+
+    {
+      ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
+          NullPointerAnalysis.createIntraproceduralExplodedCFGAnalysis(ir);
+      intraExplodedCFG.compute(new NullProgressMonitor());
+        
+      final IExplodedBasicBlock returnNodeExploded = returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
+      final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
+
+      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+    }
+    {
+      ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
+          NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
+      intraSSACFG.compute(new NullProgressMonitor());
+      
+      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      Assert.assertEquals(returnNode,           returnNode(intraSSACFG.getCFG()));
+        
+      final NullPointerState returnState = intraSSACFG.getState(returnNode);
+
+      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+    }    
+  }
+  
+  @Test
+  public void testWhileDynamic() throws UnsoundGraphException, CancelException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccessDynamic.testWhile(ZLcfg/exc/intra/B;)Lcfg/exc/intra/B");
 
     IMethod m = cha.resolveMethod(mr);
     AnalysisCache cache = new AnalysisCache();
@@ -366,20 +613,55 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
       Assert.assertEquals(State.NOT_NULL, returnState.getState(returnVal));
     }    
   }
+  
+  @Test
+  public void testDynamicWhile2() throws UnsoundGraphException, CancelException {
+    MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccessDynamic.testWhile2(ZLcfg/exc/intra/B;)Lcfg/exc/intra/B");
 
-  private static ISSABasicBlock returnNode(ControlFlowGraph<SSAInstruction, ISSABasicBlock> cfg) {
+    IMethod m = cha.resolveMethod(mr);
+    AnalysisCache cache = new AnalysisCache();
+    IR ir = cache.getIR(m);
+    final ISSABasicBlock returnNode = returnNode(ir.getControlFlowGraph());
+    final int returnVal = returnVal(returnNode);
+
+    {
+      ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
+          NullPointerAnalysis.createIntraproceduralExplodedCFGAnalysis(ir);
+      intraExplodedCFG.compute(new NullProgressMonitor());
+        
+      final IExplodedBasicBlock returnNodeExploded = returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
+      final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
+
+      Assert.assertEquals(State.NOT_NULL, returnState.getState(returnVal));
+    }
+    {
+      ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
+          NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
+      intraSSACFG.compute(new NullProgressMonitor());
+      
+      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      Assert.assertEquals(returnNode,           returnNode(intraSSACFG.getCFG()));
+        
+      final NullPointerState returnState = intraSSACFG.getState(returnNode);
+
+      Assert.assertEquals(State.NOT_NULL, returnState.getState(returnVal));
+    }    
+  }
+
+
+  public static ISSABasicBlock returnNode(ControlFlowGraph<SSAInstruction, ISSABasicBlock> cfg) {
       Collection<ISSABasicBlock> returnNodes = cfg.getNormalPredecessors(cfg.exit());
       Assert.assertEquals(1, returnNodes.size());
       return (ISSABasicBlock) returnNodes.toArray()[0];
   }
   
-  private static int returnVal(ISSABasicBlock returnNode) {
+  public static int returnVal(ISSABasicBlock returnNode) {
     final SSAReturnInstruction returnInst = (SSAReturnInstruction) returnNode.getLastInstruction();
     Assert.assertEquals(1, returnInst.getNumberOfUses());
     return returnInst.getUse(0);
   }
   
-  private static IExplodedBasicBlock returnNodeExploded(ISSABasicBlock returnNode, ControlFlowGraph<SSAInstruction, IExplodedBasicBlock> explodedCfg) {
+  public static IExplodedBasicBlock returnNodeExploded(ISSABasicBlock returnNode, ControlFlowGraph<SSAInstruction, IExplodedBasicBlock> explodedCfg) {
     final IExplodedBasicBlock exit = explodedCfg.exit();
     for (Iterator<IExplodedBasicBlock> it = explodedCfg.getPredNodes(exit); it.hasNext();) {
       IExplodedBasicBlock candidate  = it.next();

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/nullpointer/IntraproceduralNullPointerAnalysis.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/nullpointer/IntraproceduralNullPointerAnalysis.java
@@ -7,6 +7,7 @@ import com.ibm.wala.cfg.exc.intra.NullPointerState;
 import com.ibm.wala.cfg.exc.intra.NullPointerState.State;
 import com.ibm.wala.ssa.IR;
 import com.ibm.wala.ssa.ISSABasicBlock;
+import com.ibm.wala.ssa.SSACFG;
 import com.ibm.wala.ssa.SSAInstruction;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.CancelException;
@@ -35,10 +36,11 @@ public class IntraproceduralNullPointerAnalysis {
 
 		final int maxVarNum = ir.getSymbolTable().getMaxValueNumber();
 		final int[] paramValNum = ir.getParameterValueNumbers();
+		SSACFG cfg = ir.getControlFlowGraph();
 		final NullPointerFrameWork<ISSABasicBlock> problem = new NullPointerFrameWork<ISSABasicBlock>(
-				ir.getControlFlowGraph(), ir);
+				cfg, ir);
 		this.solver = new NullPointerSolver<ISSABasicBlock>(problem, maxVarNum,
-				paramValNum, ir);
+				paramValNum, ir, cfg.entry());
 		try {
 			this.solver.solve(NO_PROGRESS_MONITOR);
 		} catch (final CancelException e) {

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/IntraprocNullPointerAnalysis.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/IntraprocNullPointerAnalysis.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Set;
 
 import com.ibm.wala.cfg.ControlFlowGraph;
+import com.ibm.wala.cfg.exc.intra.NullPointerState.State;
 import com.ibm.wala.dataflow.graph.DataflowSolver;
 import com.ibm.wala.ipa.cfg.PrunedCFG;
 import com.ibm.wala.ssa.IR;
@@ -138,7 +139,7 @@ public class IntraprocNullPointerAnalysis<T extends ISSABasicBlock> {
         final NullPointerFrameWork<T> problem = new NullPointerFrameWork<T>(cfg, ir);
         final int[] paramValNum = ir.getParameterValueNumbers();
       
-        solver = new NullPointerSolver<T>(problem, maxVarNum, paramValNum, initialState, ir);
+        solver = new NullPointerSolver<T>(problem, maxVarNum, paramValNum, cfg.entry(), ir, initialState);
         
         solver.solve(progress);
         
@@ -195,7 +196,7 @@ public class IntraprocNullPointerAnalysis<T extends ISSABasicBlock> {
       // empty IR ... so states have not changed and we can return the initial state as a save approximation 
       return new NullPointerState(maxVarNum, ir.getSymbolTable(), initialState);
     } else {
-      return solver.getIn(block);
+      return solver.getOut(block);
     }
   }
   
@@ -225,7 +226,7 @@ public class IntraprocNullPointerAnalysis<T extends ISSABasicBlock> {
       SSAInstruction instr = NullPointerTransferFunctionProvider.getRelevantInstruction(bb);
       
       if (instr != null) {
-        currentState = solver.getIn(bb);
+        currentState = getState(bb);
         currentBlock = bb;
         instr.visit(this);
         currentState = null;
@@ -260,6 +261,7 @@ public class IntraprocNullPointerAnalysis<T extends ISSABasicBlock> {
       assert instr.isPEI();
       
       if (instr instanceof SSAAbstractInvokeInstruction) {
+        assert ((SSAAbstractInvokeInstruction) instr).isStatic();
         return mState != null && !mState.throwsException((SSAAbstractInvokeInstruction) instr); 
       } else {
         Collection<TypeReference> exc = instr.getExceptionTypes();

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/NullPointerSolver.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/NullPointerSolver.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.wala.cfg.exc.intra;
 
+import com.ibm.wala.cfg.exc.intra.NullPointerState.State;
 import com.ibm.wala.dataflow.graph.DataflowSolver;
 import com.ibm.wala.ssa.IR;
 import com.ibm.wala.ssa.ISSABasicBlock;
@@ -24,16 +25,18 @@ public class NullPointerSolver<B extends ISSABasicBlock> extends DataflowSolver<
 
   private final int maxVarNum;
   private final ParameterState parameterState;
+  private final B entry;
   private final IR ir;
 
-  public NullPointerSolver(NullPointerFrameWork<B> problem, int maxVarNum, int[] paramVarNum, IR ir) {
-    this(problem, maxVarNum, paramVarNum, ParameterState.createDefault(ir.getMethod()), ir);
+  public NullPointerSolver(NullPointerFrameWork<B> problem, int maxVarNum, int[] paramVarNum, IR ir, B entry) {
+    this(problem, maxVarNum, paramVarNum, entry, ir, ParameterState.createDefault(ir.getMethod()));
   }
   
-  public NullPointerSolver(NullPointerFrameWork<B> problem, int maxVarNum, int[] paramVarNum, ParameterState initialState, IR ir) {
+  public NullPointerSolver(NullPointerFrameWork<B> problem, int maxVarNum, int[] paramVarNum, B entry, IR ir, ParameterState initialState) {
     super(problem);
     this.maxVarNum = maxVarNum;
     this.parameterState = initialState;
+    this.entry = entry;
     this.ir = ir;
   }
   
@@ -50,7 +53,11 @@ public class NullPointerSolver<B extends ISSABasicBlock> extends DataflowSolver<
    */
   @Override
   protected NullPointerState makeNodeVariable(B n, boolean IN) {
-    return new NullPointerState(maxVarNum, ir.getSymbolTable(), parameterState);
+    if (IN && n.equals(entry)) {
+      return new NullPointerState(maxVarNum, ir.getSymbolTable(), parameterState, State.BOTH);
+    } else {
+      return new NullPointerState(maxVarNum, ir.getSymbolTable(), parameterState, State.UNKNOWN);
+    }
   }
 
   @Override

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/NullPointerState.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/NullPointerState.java
@@ -11,6 +11,8 @@
 
 package com.ibm.wala.cfg.exc.intra;
 
+import java.util.Collection;
+
 import com.ibm.wala.dataflow.graph.AbstractMeetOperator;
 import com.ibm.wala.fixpoint.AbstractVariable;
 import com.ibm.wala.fixpoint.FixedPointConstants;
@@ -27,7 +29,7 @@ public class NullPointerState extends AbstractVariable<NullPointerState> {
   
   /*
    * Inital state is UNKNOWN.
-   * Lattice: UNKNOWN < { NULL, NOT_NULL } < BOTH
+   * Lattice: BOTH < { NULL, NOT_NULL } < UNKNOWN
    */
   public enum State { UNKNOWN, BOTH, NULL, NOT_NULL };
   
@@ -35,6 +37,10 @@ public class NullPointerState extends AbstractVariable<NullPointerState> {
   private final State[] vars;
   
   NullPointerState(int maxVarNum, SymbolTable symbolTable, ParameterState parameterState) {
+    this(maxVarNum, symbolTable, parameterState, State.UNKNOWN);
+  }
+
+  NullPointerState(int maxVarNum, SymbolTable symbolTable, ParameterState parameterState, State defaultState) {
     this.vars = new State[maxVarNum + 1];
     
     // Initialize the states
@@ -46,7 +52,7 @@ public class NullPointerState extends AbstractVariable<NullPointerState> {
           vars[i] = State.NOT_NULL;
         }
       } else {
-        vars[i] = State.UNKNOWN;
+        vars[i] = defaultState;
       }
     }
     
@@ -95,6 +101,10 @@ public class NullPointerState extends AbstractVariable<NullPointerState> {
     return IndentityFunction.INSTANCE;
   }
   
+  static UnaryOperator<NullPointerState> phisFunction(Collection<UnaryOperator<NullPointerState>> phiFunctions) {
+    return new PhiValueMeets(phiFunctions);
+  }
+
   boolean isNeverNull(int varNum) {
     assert varNum > 0 && varNum < vars.length;
     
@@ -167,42 +177,6 @@ public class NullPointerState extends AbstractVariable<NullPointerState> {
     return changed;
   }
   
-  /**
-   * This is a intersect operator for the NullPointerState variables. It is used by the
-   * phi values.
-   * <pre>
-   * ? == unknown, 1 == not null, 0 == null, * == both
-   * 
-   * meet | ? | 0 | 1 | * |  <- rhs
-   * -----|---|---|---|---|
-   *    ? | ? | ? | ? | * |
-   * -----|---|---|---|---|
-   *    0 | ? | 0 | * | * |
-   * -----|---|---|---|---|
-   *    1 | ? | * | 1 | * |
-   * -----|---|---|---|---|
-   *    * | * | * | * | * |
-   * ----------------------
-   *    ^
-   *    |
-   *   lhs
-   * </pre> 
-   */
-  boolean intersect(final int varNum, final State state) {
-    final State lhs = vars[varNum];
-    
-    if (lhs != State.BOTH && state != lhs) {
-      if (state != State.BOTH && (lhs == State.UNKNOWN || state == State.UNKNOWN)){
-        vars[varNum] = State.UNKNOWN;
-        return true;
-      } else {
-        vars[varNum] = State.BOTH;
-        return true;
-      }
-    } else {
-      return false;
-    }
-  }
 
   boolean nullify(int varNum) {
     if (vars[varNum] != State.NULL) {
@@ -336,15 +310,12 @@ public class NullPointerState extends AbstractVariable<NullPointerState> {
     
     @Override
     public byte evaluate(NullPointerState lhs, NullPointerState rhs) {
-      byte state = FixedPointConstants.NOT_CHANGED;
-      
+      boolean changed = false;
       for (int from : fromVars) {
-        if (lhs.intersect(varNum, rhs.vars[from])) {
-          state = FixedPointConstants.CHANGED;
-        }
+          changed |= lhs.meet(varNum, rhs.vars[from]);
       }
-        
-      return state;
+      
+      return (changed ? FixedPointConstants.CHANGED : FixedPointConstants.NOT_CHANGED);
     }
 
     /* (non-Javadoc)
@@ -398,6 +369,52 @@ public class NullPointerState extends AbstractVariable<NullPointerState> {
     }
 
   }
+  
+  private static class PhiValueMeets extends UnaryOperator<NullPointerState> {
+    
+    final Collection<UnaryOperator<NullPointerState>> phiTransferFunctions;
+    
+    public PhiValueMeets(Collection<UnaryOperator<NullPointerState>> phiTransferFunctions) {
+      this.phiTransferFunctions = phiTransferFunctions;
+    }
+  
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null) return false;
+      if (getClass() != o.getClass()) return false;
+      
+      PhiValueMeets other = (PhiValueMeets) o;
+      return phiTransferFunctions.equals(other. phiTransferFunctions);
+    }
+  
+    @Override
+    public int hashCode() {
+      return phiTransferFunctions.hashCode();
+    }
+    
+    @Override
+    public String toString() {
+      return phiTransferFunctions.toString();
+    }
+    
+    @Override
+    public byte evaluate(NullPointerState lhs, NullPointerState rhs) {
+      byte changed = FixedPointConstants.NOT_CHANGED;
+      
+      for (UnaryOperator<NullPointerState> phiTransferFunction : phiTransferFunctions) {
+        byte changedPhi = phiTransferFunction.evaluate(lhs, rhs);
+        
+        assert (changedPhi == FixedPointConstants.NOT_CHANGED || changedPhi == FixedPointConstants.CHANGED);
+        if (changedPhi == FixedPointConstants.CHANGED) {
+          changed = FixedPointConstants.CHANGED;
+        }
+      }
+      
+      return changed;
+    }
+  }
+
   
   private static class NullifyFunction extends UnaryOperator<NullPointerState> {
 
@@ -551,5 +568,6 @@ public class NullPointerState extends AbstractVariable<NullPointerState> {
     }
     
   }
+
 
 }

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/OperatorUtil.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/OperatorUtil.java
@@ -1,0 +1,73 @@
+package com.ibm.wala.cfg.exc.intra;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import com.ibm.wala.fixpoint.FixedPointConstants;
+import com.ibm.wala.fixpoint.IVariable;
+import com.ibm.wala.fixpoint.UnaryOperator;
+
+/**
+ * Combinators for {@link UnaryOperator}
+ * 
+ * @author Martin Hecker, martin.hecker@kit.edu 
+ */
+public class OperatorUtil {
+  
+  /**
+   * An operator of the form lhs = op_1(op_2(..op_n(rhs)..))
+   * 
+   * @author Martin Hecker, martin.hecker@kit.edu 
+   */
+  public static class UnaryOperatorSequence<T extends IVariable> extends UnaryOperator<T> {
+    
+    final UnaryOperator<T>[] operators;
+    
+    @SuppressWarnings("unchecked")
+    public UnaryOperatorSequence(Collection<UnaryOperator<T>> operators) {
+      if (operators.size() == 0 ) throw new IllegalArgumentException("Empty Operator-Sequence");
+      this.operators = operators.toArray(new UnaryOperator[operators.size()]);
+    }
+    
+    public UnaryOperatorSequence(UnaryOperator<T>... operators) {
+      if (operators.length == 0 ) throw new IllegalArgumentException("Empty Operator-Sequence");
+      this.operators = Arrays.copyOf(operators, operators.length);
+    }
+  
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null) return false;
+      if (getClass() != o.getClass()) return false;
+      
+      UnaryOperatorSequence other = (UnaryOperatorSequence) o;
+      return operators.equals(other.operators);
+    }
+  
+    @Override
+    public int hashCode() {
+      return operators.hashCode();
+    }
+    
+    @Override
+    public String toString() {
+      return Arrays.toString(operators);
+    }
+    
+    @Override
+    public byte evaluate(T lhs, T rhs) {
+      assert (operators.length > 0);
+      int result = operators[0].evaluate(lhs, rhs);
+      
+      for (int i = 1 ; i < operators.length; i++) {
+        byte changed = operators[i].evaluate(lhs, lhs);
+        result =   ((result | changed) & FixedPointConstants.CHANGED_MASK)
+                 | ((result | changed) & FixedPointConstants.SIDE_EFFECT_MASK)
+                 | ((result & changed) & FixedPointConstants.FIXED_MASK);
+      }
+      
+      return (byte) result;
+    }
+  }
+
+}

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/ParameterState.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/ParameterState.java
@@ -27,7 +27,7 @@ import com.ibm.wala.fixpoint.AbstractVariable;
 public class ParameterState extends AbstractVariable<ParameterState> {
   /*
    * Inital state is UNKNOWN.
-   * Lattice: UNKNOWN < { NULL, NOT_NULL } < BOTH
+   * Lattice: BOTH < { NULL, NOT_NULL } < UNKNOWN 
    * 
    * public enum State { UNKNOWN, BOTH, NULL, NOT_NULL }; as defined in NullPointerState
    * 

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/ParameterState.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/ParameterState.java
@@ -60,7 +60,7 @@ public class ParameterState extends AbstractVariable<ParameterState> {
    */
   public ParameterState(NullPointerState state, int[] parameterNumbers) {
     //by convention the first ssa vars are the parameters
-    for (int i=1; i < parameterNumbers.length; i++){
+    for (int i=0; i < parameterNumbers.length; i++){
       params.put(i, state.getState(parameterNumbers[i]));
     }
   }
@@ -69,8 +69,8 @@ public class ParameterState extends AbstractVariable<ParameterState> {
     State prev = params.get(varNum);
     if (prev != null) {
       switch (prev) {
-      case BOTH:
-        if (state != State.BOTH) {
+      case UNKNOWN:
+        if (state != State.UNKNOWN) {
           throw new IllegalArgumentException("Try to set " + prev + " to " + state);
         }
         break;
@@ -101,7 +101,10 @@ public class ParameterState extends AbstractVariable<ParameterState> {
    */
   public State getState(int varNum) {
     State state = params.get(varNum);
-    return (state == null ? State.UNKNOWN : state);
+    if (state == null) {
+      throw new IllegalArgumentException("No mapping for variable " + varNum + "in ParameterState " + this.toString());
+    }
+    return state;
   }
 
   @Override


### PR DESCRIPTION
This pull requests fixes intraprocedural Nullpointer analysis by respecting phi-nodes, and correctly initializing entry variables.

Since the changes are non-trivial, i do not expect you to blindly merge them.
Instead, I suggest you to look at the tests added in 1b74b906fc03a1e04678ec513c3db9213c3d05e5, and observe that some of these *fail* with the current implementation.

Specifically w.r.t. soundness, the test `testIf3()` asserts that if a value is returned from the method

```Java
  static B testIf3(boolean unknown, B b1) {
    if (unknown) {
      b1.f = 42;
    } else {
      System.out.println("rofl");
    }
    
    return b1;
  }
```

, it cannot be statically to be known `==null`, nor can it statically be known to be `!=null`

This is so because (even though for calls with `unknown == true`, if a value is returned, we know know that b1 must've been null) we cannot assert anything about b1 for calls with `unknown == false`.

The existing analysis, however, claims it to be definitely `!=null`.

Do we agree that this and the other tests actually represent the expected behaviour?

The subsequent commit then proceed to make these tests pass.

