### PR TITLE
display which classes each handler catches when outputting IR

### DIFF
--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/IR.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/IR.java
@@ -154,7 +154,17 @@ public abstract class IR {
       int end = bb.getLastInstructionIndex();
       result.append("BB").append(bb.getNumber());
       if (bb instanceof ExceptionHandlerBasicBlock) {
-        result.append("<Handler>");
+
+        result.append("<Handler> (");
+        Iterator<TypeReference> catchIter = ((ExceptionHandlerBasicBlock) bb).getCaughtExceptionTypes();
+        while (catchIter.hasNext()) {
+          TypeReference next = catchIter.next();
+          result.append(next);
+          if (catchIter.hasNext()) {
+            result.append(",");
+          }
+        }
+        result.append(")");
       }
       result.append("\n");
       for (Iterator it = bb.iteratePhis(); it.hasNext();) {


### PR DESCRIPTION
This is a small but handy improvement when debugging exceptional control-flow.