### PR TITLE
Fix Eclipse warnings about type safety and raw types

### DIFF
--- a/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/client/ECJJavaSourceAnalysisEngine.java
+++ b/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/client/ECJJavaSourceAnalysisEngine.java
@@ -15,7 +15,7 @@ import com.ibm.wala.classLoader.ClassLoaderFactory;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.util.config.SetOfClasses;
 
-public class ECJJavaSourceAnalysisEngine extends JavaSourceAnalysisEngine<InstanceKey> {
+public class ECJJavaSourceAnalysisEngine<I extends InstanceKey> extends JavaSourceAnalysisEngine<I> {
 
   @Override
   protected ClassLoaderFactory getClassLoaderFactory(SetOfClasses exclusions) {

--- a/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/ecj/util/SourceDirCallGraph.java
+++ b/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/ecj/util/SourceDirCallGraph.java
@@ -70,7 +70,7 @@ public class SourceDirCallGraph {
 //    options.setReflectionOptions(ReflectionOptions.NONE);
     AnalysisCache cache = new AnalysisCacheImpl(AstIRFactory.makeDefaultFactory());
     //CallGraphBuilder builder = new ZeroCFABuilderFactory().make(options, cache, cha, scope, false);
-    CallGraphBuilder builder = new ZeroOneContainerCFABuilderFactory().make(options, cache, cha, scope, false);
+    CallGraphBuilder<?> builder = new ZeroOneContainerCFABuilderFactory().make(options, cache, cha, scope, false);
     System.out.println("building call graph...");
     CallGraph cg = builder.makeCallGraph(options, null);
     long end = System.currentTimeMillis();

--- a/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
+++ b/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
@@ -348,7 +348,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
     }
 
     @Override
-    public Iterator getScopedEntities(CAstNode construct) {
+    public Iterator<CAstEntity> getScopedEntities(CAstNode construct) {
       Assertions.UNREACHABLE("Non-AST-bearing entity (ClassEntity) asked for scoped entities related to a given AST node");
       return null;
     }
@@ -387,7 +387,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
     }
 
     @Override
-    public Collection getQualifiers() {
+    public Collection<CAstQualifier> getQualifiers() {
       return fQuals;
     }
 
@@ -419,8 +419,8 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
    * @param context
    * @return
    */
-  private CAstEntity createClassDeclaration(ASTNode n, List/* <BodyDeclaration> */bodyDecls,
-      List/* EnumConstantDeclaration */enumConstants, ITypeBinding typeBinding, String name, int modifiers, 
+  private CAstEntity createClassDeclaration(ASTNode n, List<BodyDeclaration> bodyDecls,
+      List<EnumConstantDeclaration> enumConstants, ITypeBinding typeBinding, String name, int modifiers, 
       boolean isInterface, boolean isAnnotation, WalkContext context) {
     final List<CAstEntity> memberEntities = new ArrayList<>();
 
@@ -863,7 +863,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
     }
 
     @Override
-    public Iterator getScopedEntities(CAstNode construct) {
+    public Iterator<CAstEntity> getScopedEntities(CAstNode construct) {
       if (fEntities.containsKey(construct)) {
         return (fEntities.get(construct)).iterator();
       } else {
@@ -930,8 +930,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
 
       // from CodeBodyEntity
       fEntities = new LinkedHashMap<>();
-      for (Iterator keys = entities.keySet().iterator(); keys.hasNext();) {
-        CAstNode key = (CAstNode) keys.next();
+      for (CAstNode key : entities.keySet()) {
         fEntities.put(key, Collections.singleton(entities.get(key)));
       }
 
@@ -1038,7 +1037,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
     }
 
     @Override
-    public Collection getQualifiers() {
+    public Collection<CAstQualifier> getQualifiers() {
       if (fDecl == null)
         return JDT2CAstUtils.mapModifiersToQualifiers(Modifier.STATIC, false, false); // static init
       else
@@ -1208,7 +1207,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
     }
 
     @Override
-    public Iterator getScopedEntities(CAstNode construct) {
+    public Iterator<CAstEntity> getScopedEntities(CAstNode construct) {
       return EmptyIterator.instance();
     }
 
@@ -1251,7 +1250,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
     }
 
     @Override
-    public Collection getQualifiers() {
+    public Collection<CAstQualifier> getQualifiers() {
       return quals;
     }
 
@@ -1332,7 +1331,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
 
     eltNodes[idx++] = makeNode(context, fFactory, n, CAstNode.NEW, fFactory.makeConstant(newTypeRef), fFactory.makeConstant(n
         .expressions().size()));
-    for (Iterator iter = n.expressions().iterator(); iter.hasNext(); idx++) {
+    for (Iterator<CAstEntity> iter = n.expressions().iterator(); iter.hasNext(); idx++) {
       Expression element = (Expression) iter.next();
       eltNodes[idx] = visitNode(element, context);
       if (eltNodes[idx] == null)
@@ -1347,7 +1346,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
         .getAnonymousClassDeclaration(), context);
   }
 
-  private CAstNode createClassInstanceCreation(ASTNode nn, List/* Expression or CAstNode */arguments, IMethodBinding ctorBinding,
+  private CAstNode createClassInstanceCreation(ASTNode nn, List<?> arguments, IMethodBinding ctorBinding,
       Expression qual, AnonymousClassDeclaration anonDecl, WalkContext context) {
     // a new instruction is actually two things: a NEW object and a CALL to a constructor
     CAstNode newNode;
@@ -1419,7 +1418,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
     argNodes[idx++] = fFactory.makeConstant(callSiteRef);
 
     // rest of args
-    for (Iterator iter = arguments.iterator(); iter.hasNext();) {
+    for (Iterator<?> iter = arguments.iterator(); iter.hasNext();) {
       Object arg = iter.next();
       argNodes[idx++] = (arg instanceof CAstNode) ? ((CAstNode) arg) : visitNode((Expression) arg, context);
     }
@@ -1533,7 +1532,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
   }
 
   private CAstNode createMethodInvocation(ASTNode pos, IMethodBinding methodBinding, CAstNode target,
-      List/* Expression or CAstNode */arguments, WalkContext context) {
+      List<?> arguments, WalkContext context) {
     // MethodMethodInstance methodInstance = n.methodInstance();
     boolean isStatic = (methodBinding.getModifiers() & Modifier.STATIC) != 0;
     ITypeBinding methodOwner = methodBinding.getDeclaringClass();
@@ -1592,7 +1591,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
    * @param arguments
    * @param context
    */
-  private void populateArguments(CAstNode[] children, IMethodBinding methodBinding, List/* CAstNode or Expression */arguments,
+  private void populateArguments(CAstNode[] children, IMethodBinding methodBinding, List<?/* CAstNode or Expression */> arguments,
       WalkContext context) {
     int nFormals = methodBinding.getParameterTypes().length;
     assert children.length == nFormals + 2;

--- a/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/JDTTypeDictionary.java
+++ b/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/JDTTypeDictionary.java
@@ -161,7 +161,7 @@ public class JDTTypeDictionary extends CAstTypeDictionaryImpl {
 
     @Override
     @SuppressWarnings("unchecked")
-    public Collection getSupertypes() {
+    public Collection<CAstType> getSupertypes() {
       if (fSuperTypes == null) {
         buildSuperTypes();
       }

--- a/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/ecj/ECJSourceModuleTranslator.java
+++ b/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/ecj/ECJSourceModuleTranslator.java
@@ -90,7 +90,7 @@ public class ECJSourceModuleTranslator implements SourceModuleTranslator {
 
     @Override
     public void acceptAST(String source, CompilationUnit ast) {
-      JDTJava2CAstTranslator jdt2cast = makeCAstTranslator(ast, source);
+      JDTJava2CAstTranslator<Position> jdt2cast = makeCAstTranslator(ast, source);
       final Java2IRTranslator java2ir = makeIRTranslator();
       java2ir.translate(sourceMap.get(source), jdt2cast.translateToCAst());
  
@@ -188,7 +188,7 @@ public class ECJSourceModuleTranslator implements SourceModuleTranslator {
     final ASTParser parser = ASTParser.newParser(AST.JLS8);
     parser.setResolveBindings(true);
     parser.setEnvironment(libs, this.sources, null, false);
-    Hashtable options = JavaCore.getOptions();
+    Hashtable<String, String> options = JavaCore.getOptions();
     options.put(JavaCore.COMPILER_SOURCE, "1.8");
     parser.setCompilerOptions(options);
     parser.createASTs(sourceFiles, null, new String[0], new ECJAstToIR(sourceMap), new NullProgressMonitor());
@@ -198,7 +198,7 @@ public class ECJSourceModuleTranslator implements SourceModuleTranslator {
     return new Java2IRTranslator(sourceLoader);
   }
 
-  protected JDTJava2CAstTranslator makeCAstTranslator(CompilationUnit cu, String fullPath) {
+  protected JDTJava2CAstTranslator<Position> makeCAstTranslator(CompilationUnit cu, String fullPath) {
     return new JDTJava2CAstTranslator<Position>(sourceLoader, cu, fullPath, false, dump) {
       @Override
       public Position makePosition(int start, int end) {

--- a/com.ibm.wala.cast.java.test.data/src/javaonepointfive/AnonymousGenerics.java
+++ b/com.ibm.wala.cast.java.test.data/src/javaonepointfive/AnonymousGenerics.java
@@ -85,7 +85,7 @@ public class AnonymousGenerics {
 		globalEconomy = ops.nullary();
 		System.out.println(globalEconomy);
 		
-		Ops hack = ops;
+		Ops<String> hack = ops;
 		hack.unary("whatever");
 		hack.nullary();
 		hack = strQuadrupler;

--- a/com.ibm.wala.cast.java.test.data/src/javaonepointfive/BasicsGenerics.java
+++ b/com.ibm.wala.cast.java.test.data/src/javaonepointfive/BasicsGenerics.java
@@ -43,7 +43,7 @@ import java.util.Iterator;
 public class BasicsGenerics {
 	
 	static ArrayList<String> strs = new ArrayList<String>();
-	static ArrayList ints = new ArrayList();
+	static ArrayList<Integer> ints = new ArrayList<>();
 	
 	public BasicsGenerics() {
 		strs.add("Coucou, monde!");

--- a/com.ibm.wala.cast.java.test/src/com/ibm/wala/cast/java/test/IRTests.java
+++ b/com.ibm.wala.cast.java.test/src/com/ibm/wala/cast/java/test/IRTests.java
@@ -346,7 +346,7 @@ public abstract class IRTests {
     return new String[] { "L" + pkgName + "/" + getTestName().substring(4) };
   }
 
-  protected abstract AbstractAnalysisEngine getAnalysisEngine(String[] mainClassDescriptors, Collection<String> sources, List<String> libs);
+  protected abstract <I extends InstanceKey> AbstractAnalysisEngine<I> getAnalysisEngine(String[] mainClassDescriptors, Collection<String> sources, List<String> libs);
 
   public <I extends InstanceKey> Pair<CallGraph, PointerAnalysis<I>> runTest(Collection<String> sources, List<String> libs,
         String[] mainClassDescriptors, List<? extends IRAssertion> ca, boolean assertReachable) throws IllegalArgumentException, CancelException, IOException {

--- a/com.ibm.wala.cast.java.test/src/com/ibm/wala/cast/java/test/JavaIRTests.java
+++ b/com.ibm.wala.cast.java.test/src/com/ibm/wala/cast/java/test/JavaIRTests.java
@@ -615,7 +615,7 @@ public abstract class JavaIRTests extends IRTests {
     // test partial slice
     MethodReference sliceRootRef = getSliceRootReference("MiniaturSliceBug", "validNonDispatchedCall", "(LIntWrapper;)V");
     Set<CGNode> roots = cg.getNodes(sliceRootRef);
-    Pair<Collection<Statement>, SDG> y = AstJavaSlicer.computeAssertionSlice(cg, pa, roots, false);
+    Pair<Collection<Statement>,SDG<InstanceKey>> y = AstJavaSlicer.computeAssertionSlice(cg, pa, roots, false);
     Collection<Statement> slice = y.fst;
     SlicerTest.dumpSlice(slice);
     Assert.assertEquals(0, SlicerTest.countAllocations(slice));

--- a/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/client/JavaSourceAnalysisEngine.java
+++ b/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/client/JavaSourceAnalysisEngine.java
@@ -173,7 +173,7 @@ public abstract class JavaSourceAnalysisEngine<I extends InstanceKey> extends Ab
   }
 
   @Override
-  protected CallGraphBuilder getCallGraphBuilder(IClassHierarchy cha, AnalysisOptions options, IAnalysisCacheView cache) {
+  protected CallGraphBuilder<I> getCallGraphBuilder(IClassHierarchy cha, AnalysisOptions options, IAnalysisCacheView cache) {
     return new ZeroCFABuilderFactory().make(options, cache, cha, scope, false);
   }
 }

--- a/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/ipa/modref/AstJavaModRef.java
+++ b/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/ipa/modref/AstJavaModRef.java
@@ -48,7 +48,7 @@ public class AstJavaModRef<T extends InstanceKey> extends AstModRef<T> {
 
   @Override
   protected RefVisitor makeRefVisitor(CGNode n, Collection<PointerKey> result, PointerAnalysis<T> pa, ExtendedHeapModel h) {
-    return new AstJavaRefVisitor(n, result, pa, h);
+    return new AstJavaRefVisitor<>(n, result, pa, h);
   }
 
   protected static class AstJavaModVisitor<T extends InstanceKey> 

--- a/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/ipa/slicer/AstJavaSlicer.java
+++ b/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/ipa/slicer/AstJavaSlicer.java
@@ -108,10 +108,10 @@ public class AstJavaSlicer extends Slicer {
     });
   }
 
-  public static Pair<Collection<Statement>, SDG> computeAssertionSlice(CallGraph CG, PointerAnalysis<InstanceKey> pa,
+  public static Pair<Collection<Statement>, SDG<InstanceKey>> computeAssertionSlice(CallGraph CG, PointerAnalysis<InstanceKey> pa,
       Collection<CGNode> partialRoots, boolean multiThreadedCode) throws IllegalArgumentException, CancelException {
     CallGraph pcg = PartialCallGraph.make(CG, new LinkedHashSet<>(partialRoots));
-    SDG sdg = new SDG(pcg, pa, new AstJavaModRef(), DataDependenceOptions.FULL, ControlDependenceOptions.FULL);
+    SDG<InstanceKey> sdg = new SDG<>(pcg, pa, new AstJavaModRef<>(), DataDependenceOptions.FULL, ControlDependenceOptions.FULL);
     //System.err.println(("SDG:\n" + sdg));
     Set<Statement> stmts = gatherAssertions(CG, partialRoots);
     if (multiThreadedCode) {

--- a/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/TestJavaScriptSlicer.java
+++ b/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/TestJavaScriptSlicer.java
@@ -23,6 +23,7 @@ import com.ibm.wala.classLoader.CallSiteReference;
 import com.ibm.wala.core.tests.slicer.SlicerTest;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.CallGraph;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.slicer.NormalStatement;
 import com.ibm.wala.ipa.slicer.SDG;
 import com.ibm.wala.ipa.slicer.Slicer;
@@ -75,7 +76,7 @@ public abstract class TestJavaScriptSlicer extends TestJSCallGraphShape {
     JSCFABuilder B = JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", file);
     CallGraph CG = B.makeCallGraph(B.getOptions());
  
-    SDG sdg = new SDG(CG, B.getPointerAnalysis(), new JavaScriptModRef(), data, ctrl);
+    SDG sdg = new SDG<>(CG, B.getPointerAnalysis(), new JavaScriptModRef<>(), data, ctrl);
 
     final Collection<Statement> ss = findTargetStatement(CG);
     Collection<Statement> result = Slicer.computeBackwardSlice(sdg, ss);

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/client/JavaScriptAnalysisEngine.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/client/JavaScriptAnalysisEngine.java
@@ -194,7 +194,7 @@ public abstract class JavaScriptAnalysisEngine<I extends InstanceKey> extends Ab
   public static class PropagationJavaScriptAnalysisEngine extends JavaScriptAnalysisEngine<InstanceKey> {
   
     @Override
-    protected CallGraphBuilder getCallGraphBuilder(IClassHierarchy cha, AnalysisOptions options, IAnalysisCacheView cache) {
+    protected CallGraphBuilder<InstanceKey> getCallGraphBuilder(IClassHierarchy cha, AnalysisOptions options, IAnalysisCacheView cache) {
       return new ZeroCFABuilderFactory().make((JSAnalysisOptions) options, cache, cha, scope, false);
     }
   }

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/PropertyNameContextSelector.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/PropertyNameContextSelector.java
@@ -205,6 +205,7 @@ public class PropertyNameContextSelector implements ContextSelector {
     if (PROPNAME_MARKER.equals(caller.getContext().get(PROPNAME_KEY))) {
       if (!identifyDependentParameters(caller, site).isEmpty()) {
         // use a MarkerForInContext to clone based on the InstanceKey used in the caller context
+        @SuppressWarnings("unchecked")
         InstanceKey callerIk = ((ContextItem.Value<InstanceKey>)caller.getContext().get(INSTANCE_KEY_KEY)).getValue();
         return new MarkerForInContext(baseContext, callerIk);
       } else {

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/modref/JavaScriptModRef.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/modref/JavaScriptModRef.java
@@ -100,7 +100,7 @@ public class JavaScriptModRef<T extends InstanceKey> extends AstModRef<T> {
 
   @Override
   protected RefVisitor makeRefVisitor(CGNode n, Collection<PointerKey> result, PointerAnalysis<T> pa, ExtendedHeapModel h) {
-    return new JavaScriptRefVisitor(n, result, pa, h);
+    return new JavaScriptRefVisitor<>(n, result, pa, h);
   }
 
   protected static class JavaScriptModVisitor<T extends InstanceKey> extends AstModVisitor<T> implements JSInstructionVisitor {

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/vis/JsPaPanel.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/vis/JsPaPanel.java
@@ -43,7 +43,7 @@ public class JsPaPanel extends PaPanel {
 	}
 
 	private void initDataStructures(PointerAnalysis<InstanceKey> pa) {
-		HeapGraph heapGraph = pa.getHeapGraph();
+		HeapGraph<InstanceKey> heapGraph = pa.getHeapGraph();
 		OrdinalSetMapping<InstanceKey> instanceKeyMapping = pa.getInstanceKeyMapping();
 		for (Object n : heapGraph){
 			if (heapGraph.getPredNodeCount(n) == 0){

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/modref/AstModRef.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/modref/AstModRef.java
@@ -151,7 +151,7 @@ public class AstModRef<T extends InstanceKey> extends ModRef<T> {
 
   @Override
   protected ModVisitor makeModVisitor(CGNode n, Collection<PointerKey> result, PointerAnalysis<T> pa, ExtendedHeapModel h, boolean ignoreAllocHeapDefs) {
-    return new AstModVisitor(n, result, (AstHeapModel)h, pa);
+    return new AstModVisitor<>(n, result, (AstHeapModel)h, pa);
   }
 
 }

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/slicer/SlicerTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/slicer/SlicerTest.java
@@ -36,6 +36,8 @@ import com.ibm.wala.ipa.callgraph.ContextSelector;
 import com.ibm.wala.ipa.callgraph.Entrypoint;
 import com.ibm.wala.ipa.callgraph.impl.PartialCallGraph;
 import com.ibm.wala.ipa.callgraph.impl.Util;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis;
 import com.ibm.wala.ipa.callgraph.propagation.SSAContextInterpreter;
 import com.ibm.wala.ipa.callgraph.propagation.SSAPropagationCallGraphBuilder;
 import com.ibm.wala.ipa.callgraph.propagation.cfa.ZeroXInstanceKeys;
@@ -112,8 +114,9 @@ public class SlicerTest {
     Statement s = findCallTo(main, "println");
     System.err.println("Statement: " + s);
     // compute a data slice
-    Collection<Statement> computeBackwardSlice = Slicer.computeBackwardSlice(s, cg, builder.getPointerAnalysis(),
-        DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
+    final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
+    Collection<Statement> computeBackwardSlice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis,
+        InstanceKey.class, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     Collection<Statement> slice = computeBackwardSlice;
     dumpSlice(slice);
 
@@ -142,8 +145,9 @@ public class SlicerTest {
     Statement s = findCallTo(main, "println");
     System.err.println("Statement: " + s);
     // compute a data slice
-    Collection<Statement> computeBackwardSlice = Slicer.computeBackwardSlice(s, cg, builder.getPointerAnalysis(),
-        DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
+    final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
+    Collection<Statement> computeBackwardSlice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis,
+        InstanceKey.class, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     Collection<Statement> slice = computeBackwardSlice;
     dumpSlice(slice);
 
@@ -166,7 +170,8 @@ public class SlicerTest {
     Statement s = findCallTo(main, "doNothing");
     System.err.println("Statement: " + s);
     // compute a data slice
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, builder.getPointerAnalysis(), DataDependenceOptions.FULL,
+    final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL,
         ControlDependenceOptions.NONE);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 1, countAllocations(slice));
@@ -189,7 +194,8 @@ public class SlicerTest {
     s = PDFSlice.getReturnStatementForCall(s);
     System.err.println("Statement: " + s);
     // compute a data slice
-    Collection<Statement> slice = Slicer.computeForwardSlice(s, cg, builder.getPointerAnalysis(), DataDependenceOptions.FULL,
+    final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
+    Collection<Statement> slice = Slicer.computeForwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL,
         ControlDependenceOptions.NONE);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 4, slice.size());
@@ -212,8 +218,9 @@ public class SlicerTest {
     s = PDFSlice.getReturnStatementForCall(s);
     System.err.println("Statement: " + s);
     // compute a data slice
-    Collection<Statement> slice = Slicer.computeForwardSlice(s, cg, builder.getPointerAnalysis(), DataDependenceOptions.FULL,
-        ControlDependenceOptions.NONE);
+    final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
+    Collection<Statement> slice = Slicer.computeForwardSlice(s, cg, pointerAnalysis, InstanceKey.class,
+        DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 7, slice.size());
   }
@@ -241,8 +248,9 @@ public class SlicerTest {
     Statement s = findFirstAllocation(main);
     System.err.println("Statement: " + s);
     // compute a data slice
-    Collection<Statement> slice = Slicer.computeForwardSlice(s, cg, builder.getPointerAnalysis(), DataDependenceOptions.FULL,
-        ControlDependenceOptions.NONE);
+    final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
+    Collection<Statement> slice = Slicer.computeForwardSlice(s, cg, pointerAnalysis, InstanceKey.class,
+        DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     dumpSlice(slice);
   }
 
@@ -269,12 +277,13 @@ public class SlicerTest {
     Statement s = findCallToDoNothing(process);
     System.err.println("Statement: " + s);
     // compute a backward slice, with data dependence and no exceptional control dependence
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, builder.getPointerAnalysis(), DataDependenceOptions.FULL,
+    final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL,
         ControlDependenceOptions.NO_EXCEPTIONAL_EDGES);
     dumpSlice(slice);
     Assert.assertEquals(4, countInvokes(slice));
     // should only get 4 statements total when ignoring control dependences completely
-    slice = Slicer.computeBackwardSlice(s, cg, builder.getPointerAnalysis(), DataDependenceOptions.FULL,
+    slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL,
         ControlDependenceOptions.NONE);
     Assert.assertEquals(slice.toString(), 4, slice.size());
   }
@@ -296,7 +305,8 @@ public class SlicerTest {
     Statement s = findCallToDoNothing(main);
     System.err.println("Statement: " + s);
     // compute a data slice
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, builder.getPointerAnalysis(), DataDependenceOptions.NONE,
+    final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.NONE,
         ControlDependenceOptions.FULL);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 2, countConditionals(slice));
@@ -319,7 +329,8 @@ public class SlicerTest {
     Statement s = findCallToDoNothing(main);
     System.err.println("Statement: " + s);
     // compute a data slice
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, builder.getPointerAnalysis(), DataDependenceOptions.NONE,
+    final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.NONE,
         ControlDependenceOptions.FULL);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 1, countConditionals(slice));
@@ -342,7 +353,8 @@ public class SlicerTest {
     Statement s = findCallToDoNothing(main);
     System.err.println("Statement: " + s);
     // compute a data slice
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, builder.getPointerAnalysis(), DataDependenceOptions.NONE,
+    final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.NONE,
         ControlDependenceOptions.FULL);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 0, countConditionals(slice));
@@ -366,14 +378,15 @@ public class SlicerTest {
     System.err.println("Statement: " + s);
 
     // compute a no-data slice
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, builder.getPointerAnalysis(), DataDependenceOptions.NONE,
+    final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.NONE,
         ControlDependenceOptions.FULL);
     dumpSlice(slice);
     Assert.assertEquals(0, countConditionals(slice));
 
     // compute a full slice
-    slice = Slicer.computeBackwardSlice(s, cg, builder.getPointerAnalysis(), DataDependenceOptions.FULL,
-        ControlDependenceOptions.FULL);
+    slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class,
+        DataDependenceOptions.FULL, ControlDependenceOptions.FULL);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 1, countConditionals(slice));
   }
@@ -396,8 +409,9 @@ public class SlicerTest {
     System.err.println("Statement: " + s);
 
     // compute a no-data slice
-    Collection<Statement> slice = Slicer.computeForwardSlice(s, cg, builder.getPointerAnalysis(), DataDependenceOptions.NONE,
-        ControlDependenceOptions.NO_EXCEPTIONAL_EDGES);
+    final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
+    Collection<Statement> slice = Slicer.computeForwardSlice(s, cg, pointerAnalysis, InstanceKey.class,
+        DataDependenceOptions.NONE, ControlDependenceOptions.NO_EXCEPTIONAL_EDGES);
     dumpSlice(slice);
     Assert.assertTrue(slice.toString(), slice.size() > 1);
   }
@@ -420,8 +434,9 @@ public class SlicerTest {
     System.err.println("Statement: " + s);
 
     // compute a no-data slice
-    Collection<Statement> slice = Slicer.computeForwardSlice(s, cg, builder.getPointerAnalysis(), DataDependenceOptions.NONE,
-        ControlDependenceOptions.NO_EXCEPTIONAL_EDGES);
+    final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
+    Collection<Statement> slice = Slicer.computeForwardSlice(s, cg, pointerAnalysis, InstanceKey.class,
+        DataDependenceOptions.NONE, ControlDependenceOptions.NO_EXCEPTIONAL_EDGES);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 2, countInvokes(slice));
   }
@@ -443,7 +458,8 @@ public class SlicerTest {
     Statement s = findCallToDoNothing(main);
     System.err.println("Statement: " + s);
     // compute a data slice
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, builder.getPointerAnalysis(), DataDependenceOptions.FULL,
+    final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL,
         ControlDependenceOptions.NONE);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 1, countAllocations(slice));
@@ -466,7 +482,8 @@ public class SlicerTest {
     Statement s = findCallToDoNothing(main);
     System.err.println("Statement: " + s);
     // compute a data slice
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, builder.getPointerAnalysis(), DataDependenceOptions.FULL,
+    final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL,
         ControlDependenceOptions.NONE);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 2, countAllocations(slice));
@@ -490,7 +507,8 @@ public class SlicerTest {
     Statement s = findCallToDoNothing(main);
     System.err.println("Statement: " + s);
     // compute a data slice
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, builder.getPointerAnalysis(), DataDependenceOptions.FULL,
+    final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL,
         ControlDependenceOptions.NONE);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 2, countAllocations(slice));
@@ -516,15 +534,16 @@ public class SlicerTest {
 
     // compute normal data slice
     // compute a data slice
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, builder.getPointerAnalysis(), DataDependenceOptions.FULL,
+    final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL,
         ControlDependenceOptions.NONE);
     dumpSlice(slice);
     Assert.assertEquals(3, countAllocations(slice));
     Assert.assertEquals(2, countPutfields(slice));
 
     // compute thin slice .. ignore base pointers
-    Collection<Statement> computeBackwardSlice = Slicer.computeBackwardSlice(s, cg, builder.getPointerAnalysis(),
-        DataDependenceOptions.NO_BASE_PTRS, ControlDependenceOptions.NONE);
+    Collection<Statement> computeBackwardSlice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis,
+        InstanceKey.class, DataDependenceOptions.NO_BASE_PTRS, ControlDependenceOptions.NONE);
     slice = computeBackwardSlice;
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 2, countAllocations(slice));
@@ -548,7 +567,8 @@ public class SlicerTest {
     Statement s = findCallToDoNothing(main);
     System.err.println("Statement: " + s);
     // compute a data slice
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, builder.getPointerAnalysis(), DataDependenceOptions.FULL,
+    final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL,
         ControlDependenceOptions.NONE);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 1, countAllocations(slice));
@@ -573,7 +593,8 @@ public class SlicerTest {
     Statement s = findCallToDoNothing(main);
     System.err.println("Statement: " + s);
     // compute a data slice
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, builder.getPointerAnalysis(), DataDependenceOptions.FULL,
+    final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL,
         ControlDependenceOptions.NONE);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 2, countAllocations(slice));
@@ -597,7 +618,8 @@ public class SlicerTest {
     System.err.println("Statement: " + s);
 
     // compute a data slice
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, builder.getPointerAnalysis(), DataDependenceOptions.FULL,
+    final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL,
         ControlDependenceOptions.NONE);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 3, countAllocations(slice));
@@ -624,8 +646,9 @@ public class SlicerTest {
     System.err.println("Statement: " + s);
 
     // compute full slice
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, pcg, builder.getPointerAnalysis(), DataDependenceOptions.FULL,
-        ControlDependenceOptions.FULL);
+    final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, pcg, pointerAnalysis, InstanceKey.class,
+        DataDependenceOptions.FULL, ControlDependenceOptions.FULL);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 0, countAllocations(slice));
     Assert.assertEquals(slice.toString(), 1, countPutfields(slice));
@@ -665,8 +688,9 @@ public class SlicerTest {
     Statement s = findCallToDoNothing(test);
     System.err.println("Statement: " + s);
 
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, pcg, builder.getPointerAnalysis(), DataDependenceOptions.FULL,
-        ControlDependenceOptions.NONE);
+    final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, pcg, pointerAnalysis, InstanceKey.class,
+        DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 1, countAllocations(slice));
     Assert.assertEquals(slice.toString(), 1, countPutfields(slice));
@@ -688,7 +712,8 @@ public class SlicerTest {
     Statement s = findCallToDoNothing(main);
     System.err.println("Statement: " + s);
     // compute a data slice
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, builder.getPointerAnalysis(), DataDependenceOptions.FULL,
+    final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL,
         ControlDependenceOptions.NONE);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 1, countApplicationAllocations(slice));
@@ -733,7 +758,7 @@ public class SlicerTest {
 
     CallGraphBuilder builder = Util.makeZeroOneCFABuilder(options, new AnalysisCacheImpl(), cha, scope);
     CallGraph cg = builder.makeCallGraph(options, null);
-    SDG sdg = new SDG(cg, builder.getPointerAnalysis(), DataDependenceOptions.NO_BASE_NO_HEAP, ControlDependenceOptions.FULL);
+    SDG<?> sdg = new SDG<>(cg, builder.getPointerAnalysis(), InstanceKey.class, DataDependenceOptions.NO_BASE_NO_HEAP, ControlDependenceOptions.FULL);
     GraphIntegrity.check(sdg);
   }
 
@@ -754,7 +779,8 @@ public class SlicerTest {
     Statement s = findCallToDoNothing(main);
     System.err.println("Statement: " + s);
 
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, builder.getPointerAnalysis(), DataDependenceOptions.FULL,
+    final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL,
         ControlDependenceOptions.NO_EXCEPTIONAL_EDGES);
     dumpSlice(slice);
   }

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/examples/analysis/SimpleThreadEscapeAnalysis.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/examples/analysis/SimpleThreadEscapeAnalysis.java
@@ -76,7 +76,7 @@ import com.ibm.wala.util.intset.OrdinalSet;
  * 
  * @author Julian Dolby
  */
-public class SimpleThreadEscapeAnalysis extends AbstractAnalysisEngine {
+public class SimpleThreadEscapeAnalysis extends AbstractAnalysisEngine<InstanceKey> {
 
   private final Set<JarFile> applicationJarFiles;
 
@@ -91,7 +91,7 @@ public class SimpleThreadEscapeAnalysis extends AbstractAnalysisEngine {
   }
 
   @Override
-  protected CallGraphBuilder getCallGraphBuilder(IClassHierarchy cha, AnalysisOptions options, IAnalysisCacheView cache) {
+  protected CallGraphBuilder<InstanceKey> getCallGraphBuilder(IClassHierarchy cha, AnalysisOptions options, IAnalysisCacheView cache) {
     return Util.makeZeroCFABuilder(options, cache, cha, scope);
   }
 

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/pointers/BasicHeapGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/pointers/BasicHeapGraph.java
@@ -99,12 +99,12 @@ public class BasicHeapGraph<T extends InstanceKey> extends HeapGraphImpl<T> {
       @Override
       public int getNumber(Object N) {
         if (N instanceof PointerKey) {
-          return pointerKeys.getMappedIndex((PointerKey) N);
+          return pointerKeys.getMappedIndex(N);
         } else {
           if (!(N instanceof InstanceKey)) {
             Assertions.UNREACHABLE(N.getClass().toString());
           }
-          int inumber = P.getInstanceKeyMapping().getMappedIndex((InstanceKey) N);
+          int inumber = P.getInstanceKeyMapping().getMappedIndex(N);
           return (inumber == -1) ? -1 : inumber + pointerKeys.getMaximumIndex() + 1;
         }
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/OperatorUtil.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/OperatorUtil.java
@@ -29,6 +29,7 @@ public class OperatorUtil {
       this.operators = operators.toArray(new UnaryOperator[operators.size()]);
     }
     
+    @SafeVarargs
     public UnaryOperatorSequence(UnaryOperator<T>... operators) {
       if (operators.length == 0 ) throw new IllegalArgumentException("Empty Operator-Sequence");
       this.operators = Arrays.copyOf(operators, operators.length);

--- a/com.ibm.wala.core/src/com/ibm/wala/client/AbstractAnalysisEngine.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/client/AbstractAnalysisEngine.java
@@ -79,7 +79,7 @@ public abstract class AbstractAnalysisEngine<I extends InstanceKey> implements A
   /**
    * The modules to analyze
    */
-  protected Collection<Module> moduleFiles;
+  protected Collection<? extends Module> moduleFiles;
 
   /**
    * A representation of the analysis scope
@@ -133,11 +133,11 @@ public abstract class AbstractAnalysisEngine<I extends InstanceKey> implements A
     }
   };
 
-  protected abstract CallGraphBuilder getCallGraphBuilder(IClassHierarchy cha, AnalysisOptions options, IAnalysisCacheView cache2);
+  protected abstract CallGraphBuilder<I> getCallGraphBuilder(IClassHierarchy cha, AnalysisOptions options, IAnalysisCacheView cache2);
 
   protected CallGraphBuilder buildCallGraph(IClassHierarchy cha, AnalysisOptions options, boolean savePointerAnalysis,
       IProgressMonitor monitor) throws IllegalArgumentException, CancelException {
-    CallGraphBuilder builder = getCallGraphBuilder(cha, options, cache);
+    CallGraphBuilder<I> builder = getCallGraphBuilder(cha, options, cache);
 
     cg = builder.makeCallGraph(options, monitor);
 
@@ -149,7 +149,7 @@ public abstract class AbstractAnalysisEngine<I extends InstanceKey> implements A
   }
 
   @Override
-  public void setModuleFiles(Collection moduleFiles) {
+  public void setModuleFiles(Collection<? extends Module> moduleFiles) {
     this.moduleFiles = moduleFiles;
   }
 
@@ -272,8 +272,8 @@ public abstract class AbstractAnalysisEngine<I extends InstanceKey> implements A
     return heapGraph;
   }
 
-  public SDG<I> getSDG(DataDependenceOptions data, ControlDependenceOptions ctrl) {
-    return new SDG<I>(getCallGraph(), getPointerAnalysis(), data, ctrl);
+  public SDG<I> getSDG(Class<I> instanceKeyClass, DataDependenceOptions data, ControlDependenceOptions ctrl) {
+    return new SDG<I>(getCallGraph(), getPointerAnalysis(), instanceKeyClass, data, ctrl);
   }
   
   public String getExclusionsFile() {

--- a/com.ibm.wala.core/src/com/ibm/wala/client/AnalysisEngine.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/client/AnalysisEngine.java
@@ -26,7 +26,7 @@ public interface AnalysisEngine {
    * 
    * @param moduleFiles A non-null Collection of module files: (EARFile, WARFile, ApplicationClientFile, EJBJarFile).
    */
-  void setModuleFiles(Collection moduleFiles);
+  void setModuleFiles(Collection<? extends Module> moduleFiles);
 
   /**
    * Specify the jar files that represent the standard J2SE libraries

--- a/com.ibm.wala.core/src/com/ibm/wala/demandpa/util/PABasedMemoryAccessMap.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/demandpa/util/PABasedMemoryAccessMap.java
@@ -52,11 +52,11 @@ public class PABasedMemoryAccessMap implements MemoryAccessMap {
   private final Map<PointerKey, Set<Statement>> invRef;
 
   public PABasedMemoryAccessMap(CallGraph cg, PointerAnalysis<InstanceKey> pa) {
-    this(cg, pa, new SDG(cg, pa, DataDependenceOptions.NO_BASE_NO_HEAP_NO_EXCEPTIONS, ControlDependenceOptions.NONE));
+    this(cg, pa, new SDG<InstanceKey>(cg, pa, InstanceKey.class, DataDependenceOptions.NO_BASE_NO_HEAP_NO_EXCEPTIONS, ControlDependenceOptions.NONE));
   }
 
-  public PABasedMemoryAccessMap(CallGraph cg, PointerAnalysis<InstanceKey> pa, SDG sdg) {
-    this(cg, pa, CISlicer.scanForMod(sdg, pa, true, ModRef.make()), CISlicer.scanForRef(sdg, pa));
+  public PABasedMemoryAccessMap(CallGraph cg, PointerAnalysis<InstanceKey> pa, SDG<InstanceKey> sdg) {
+    this(cg, pa, CISlicer.scanForMod(sdg, pa, true, ModRef.make(InstanceKey.class)), CISlicer.scanForRef(sdg, pa));
   }
   
   public PABasedMemoryAccessMap(CallGraph cg, PointerAnalysis<InstanceKey> pa, Map<Statement, Set<PointerKey>> mod,

--- a/com.ibm.wala.core/src/com/ibm/wala/escape/FILiveObjectAnalysis.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/escape/FILiveObjectAnalysis.java
@@ -48,7 +48,7 @@ public class FILiveObjectAnalysis implements ILiveObjectAnalysis {
   /**
    * Graph view of pointer analysis results
    */
-  private final HeapGraph heapGraph;
+  private final HeapGraph<InstanceKey> heapGraph;
 
   /**
    * Cached map from InstanceKey -> Set<CGNode>
@@ -68,7 +68,7 @@ public class FILiveObjectAnalysis implements ILiveObjectAnalysis {
   /**
    * 
    */
-  public FILiveObjectAnalysis(CallGraph callGraph, HeapGraph heapGraph, boolean expensiveIntraproceduralAnalysis) {
+  public FILiveObjectAnalysis(CallGraph callGraph, HeapGraph<InstanceKey> heapGraph, boolean expensiveIntraproceduralAnalysis) {
     super();
     this.callGraph = callGraph;
     this.heapGraph = heapGraph;

--- a/com.ibm.wala.core/src/com/ibm/wala/escape/TrivialMethodEscape.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/escape/TrivialMethodEscape.java
@@ -40,7 +40,7 @@ public class TrivialMethodEscape implements IMethodEscapeAnalysis, INodeEscapeAn
   /**
    * Heap graph representation of pointer analysis
    */
-  private final HeapGraph hg;
+  private final HeapGraph<InstanceKey> hg;
 
   /**
    * Governing call graph
@@ -51,7 +51,7 @@ public class TrivialMethodEscape implements IMethodEscapeAnalysis, INodeEscapeAn
    * @param hg Heap graph representation of pointer analysis
    * @param cg governing call graph
    */
-  public TrivialMethodEscape(CallGraph cg, HeapGraph hg) {
+  public TrivialMethodEscape(CallGraph cg, HeapGraph<InstanceKey> hg) {
     this.hg = hg;
     this.cg = cg;
   }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/BasicCallGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/BasicCallGraph.java
@@ -136,8 +136,8 @@ public abstract class BasicCallGraph<T> extends AbstractNumberedGraph<CGNode> im
     return result;
   }
 
-  protected NodeImpl getNode(Key K) {
-    return (NodeImpl) nodes.get(K);
+  protected CGNode getNode(Key K) {
+    return nodes.get(K);
   }
 
   @Override

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/ExplicitCallGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/ExplicitCallGraph.java
@@ -121,7 +121,7 @@ public class ExplicitCallGraph extends BasicCallGraph<SSAContextInterpreter> imp
       throw new IllegalArgumentException("null context");
     }
     Key k = new Key(method, context);
-    NodeImpl result = getNode(k);
+    CGNode result = getNode(k);
     if (result == null) {
       if (maxNumberOfNodes == -1 || getNumberOfNodes() < maxNumberOfNodes) {
         result = makeNode(method, context);

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/AbstractPointerAnalysis.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/AbstractPointerAnalysis.java
@@ -27,7 +27,7 @@ public abstract class AbstractPointerAnalysis implements PointerAnalysis<Instanc
   /**
    * graph representation of pointer-analysis results
    */
-  private HeapGraph heapGraph;
+  private HeapGraph<InstanceKey> heapGraph;
   /**
    * Governing call graph.
    */
@@ -44,9 +44,9 @@ public abstract class AbstractPointerAnalysis implements PointerAnalysis<Instanc
   }
 
   @Override
-  public HeapGraph getHeapGraph() {
+  public HeapGraph<InstanceKey> getHeapGraph() {
     if (heapGraph == null) {
-      heapGraph = new BasicHeapGraph(this, cg);
+      heapGraph = new BasicHeapGraph<InstanceKey>(this, cg);
     }
     return heapGraph;
   }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PropagationCallGraphBuilder.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PropagationCallGraphBuilder.java
@@ -58,7 +58,7 @@ import com.ibm.wala.util.warnings.Warnings;
  * TODO: This implementation currently keeps all points to sets live ... even those for local variables that do not span
  * interprocedural boundaries. This may be too space-inefficient .. we can consider recomputing local sets on demand.
  */
-public abstract class PropagationCallGraphBuilder implements CallGraphBuilder {
+public abstract class PropagationCallGraphBuilder implements CallGraphBuilder<InstanceKey> {
   private final static boolean DEBUG_ALL = false;
 
   final static boolean DEBUG_ASSIGN = DEBUG_ALL | false;

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/ReflectionHandler.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/ReflectionHandler.java
@@ -62,8 +62,7 @@ public class ReflectionHandler {
       if (VERBOSE) {
         System.err.println("Slice " + st);
       }
-      Collection<Statement> slice = Slicer.computeForwardSlice(st, builder.callGraph, null, DataDependenceOptions.REFLECTION,
-          ControlDependenceOptions.NONE);
+      Collection<Statement> slice = Slicer.computeForwardSlice(st, builder.callGraph, null, null, DataDependenceOptions.REFLECTION, ControlDependenceOptions.NONE);
       if (VERBOSE) {
         for (Statement x : slice) {
           System.err.println(" " + x);

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/modref/ModRef.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/modref/ModRef.java
@@ -44,8 +44,8 @@ import com.ibm.wala.util.intset.OrdinalSet;
  */
 public class ModRef<T extends InstanceKey> {
 
-  public static ModRef make() {
-    return new ModRef();
+  public static <U extends InstanceKey> ModRef<U> make(Class<U> klass) {
+    return new ModRef<U>();
   }
 
   protected ModRef() {
@@ -344,7 +344,7 @@ public class ModRef<T extends InstanceKey> {
 
   protected ModVisitor makeModVisitor(CGNode n, Collection<PointerKey> result, PointerAnalysis<T> pa, ExtendedHeapModel h,
       boolean ignoreAllocHeapDefs) {
-    return new ModVisitor(n, result, h, pa, ignoreAllocHeapDefs);
+    return new ModVisitor<T, ExtendedHeapModel>(n, result, h, pa, ignoreAllocHeapDefs);
   }
 
   /**

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/HeapReachingDefs.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/HeapReachingDefs.java
@@ -71,11 +71,11 @@ public class HeapReachingDefs<T extends InstanceKey> {
 
   private static final boolean VERBOSE = false;
 
-  private final ModRef modRef;
+  private final ModRef<T> modRef;
 
   private final ExtendedHeapModel heapModel;
   
-  public HeapReachingDefs(ModRef modRef, ExtendedHeapModel heapModel) {
+  public HeapReachingDefs(ModRef<T> modRef, ExtendedHeapModel heapModel) {
     this.modRef = modRef;
     this.heapModel = heapModel;
   }
@@ -180,7 +180,7 @@ public class HeapReachingDefs<T extends InstanceKey> {
      * For each pointerKey, which statements may def it
      */
     private Map<PointerKey, MutableIntSet> initPointerKeyMod(OrdinalSetMapping<Statement> domain, CGNode node, ExtendedHeapModel h,
-        PointerAnalysis<? extends InstanceKey> pa) {
+        PointerAnalysis<T> pa) {
       Map<PointerKey, MutableIntSet> pointerKeyMod = HashMapFactory.make();
       for (Statement s : domain) {
         switch (s.getKind()) {
@@ -419,7 +419,7 @@ public class HeapReachingDefs<T extends InstanceKey> {
     return true;
   }
 
-  private Collection<PointerKey> getMod(Statement s, CGNode n, ExtendedHeapModel h, PointerAnalysis<? extends InstanceKey> pa, HeapExclusions exclusions) {
+  private Collection<PointerKey> getMod(Statement s, CGNode n, ExtendedHeapModel h, PointerAnalysis<T> pa, HeapExclusions exclusions) {
     switch (s.getKind()) {
     case NORMAL:
       NormalStatement ns = (NormalStatement) s;
@@ -480,7 +480,7 @@ public class HeapReachingDefs<T extends InstanceKey> {
 
     private final OrdinalSetMapping<Statement> domain;
 
-    private final PointerAnalysis<? extends InstanceKey> pa;
+    private final PointerAnalysis<T> pa;
 
     private final Map<Integer, NormalStatement> ssaInstructionIndex2Statement;
 
@@ -492,7 +492,7 @@ public class HeapReachingDefs<T extends InstanceKey> {
      */
     private final IBinaryNaturalRelation heapReturnCaller = new BasicNaturalRelation();
 
-    public RD(CGNode node, ExplodedControlFlowGraph cfg, PointerAnalysis<? extends InstanceKey> pa2, OrdinalSetMapping<Statement> domain,
+    public RD(CGNode node, ExplodedControlFlowGraph cfg, PointerAnalysis<T> pa2, OrdinalSetMapping<Statement> domain,
         Map<Integer, NormalStatement> ssaInstructionIndex2Statement, HeapExclusions exclusions) {
       this.node = node;
       this.cfg = cfg;

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/ISDG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/ISDG.java
@@ -13,6 +13,7 @@ package com.ibm.wala.ipa.slicer;
 import java.util.Iterator;
 
 import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.cha.IClassHierarchyDweller;
 import com.ibm.wala.ipa.slicer.Slicer.ControlDependenceOptions;
 import com.ibm.wala.util.graph.NumberedGraph;
@@ -31,7 +32,7 @@ public interface ISDG extends NumberedGraph<Statement>, IClassHierarchyDweller {
   /**
    * Get the program dependence graph constructed for a particular node.
    */
-  PDG getPDG(CGNode node);
+  PDG<? extends InstanceKey> getPDG(CGNode node);
 
   /**
    * Iterate over the nodes which have been discovered so far, but do <em>NOT</em> eagerly construct the entire graph.

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/PDG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/PDG.java
@@ -117,7 +117,7 @@ public class PDG<T extends InstanceKey> implements NumberedGraph<Statement> {
 
   private final CallGraph cg;
 
-  private final ModRef modRef;
+  private final ModRef<T> modRef;
 
   private final Map<CGNode, OrdinalSet<PointerKey>> ref;
 
@@ -133,7 +133,7 @@ public class PDG<T extends InstanceKey> implements NumberedGraph<Statement> {
    */
   public PDG(final CGNode node, PointerAnalysis<T> pa, Map<CGNode, OrdinalSet<PointerKey>> mod,
       Map<CGNode, OrdinalSet<PointerKey>> ref, DataDependenceOptions dOptions, ControlDependenceOptions cOptions,
-      HeapExclusions exclusions, CallGraph cg, ModRef modRef) {
+      HeapExclusions exclusions, CallGraph cg, ModRef<T> modRef) {
     this(node, pa, mod, ref, dOptions, cOptions, exclusions, cg, modRef, false);
   }
 
@@ -145,7 +145,7 @@ public class PDG<T extends InstanceKey> implements NumberedGraph<Statement> {
    */
   public PDG(final CGNode node, PointerAnalysis<T> pa, Map<CGNode, OrdinalSet<PointerKey>> mod,
       Map<CGNode, OrdinalSet<PointerKey>> ref, DataDependenceOptions dOptions, ControlDependenceOptions cOptions,
-      HeapExclusions exclusions, CallGraph cg, ModRef modRef, boolean ignoreAllocHeapDefs) {
+      HeapExclusions exclusions, CallGraph cg, ModRef<T> modRef, boolean ignoreAllocHeapDefs) {
 
     super();
     if (node == null) {

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/SDG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/SDG.java
@@ -83,7 +83,7 @@ public class SDG<T extends InstanceKey> extends AbstractNumberedGraph<Statement>
   /**
    * keeps track of PDG for each call graph node
    */
-  private final Map<CGNode, PDG> pdgMap = HashMapFactory.make();
+  private final Map<CGNode, PDG<T>> pdgMap = HashMapFactory.make();
 
   /**
    * governs data dependence edges in the graph
@@ -115,23 +115,23 @@ public class SDG<T extends InstanceKey> extends AbstractNumberedGraph<Statement>
    */
   private final HeapExclusions heapExclude;
 
-  private final ModRef modRef;
+  private final ModRef<T> modRef;
 
   /**
    * Have we eagerly populated all nodes of this SDG?
    */
   private boolean eagerComputed = false;
 
-  public SDG(final CallGraph cg, PointerAnalysis<T> pa, DataDependenceOptions dOptions, ControlDependenceOptions cOptions) {
-    this(cg, pa, ModRef.make(), dOptions, cOptions, null);
+  public SDG(final CallGraph cg, PointerAnalysis<T> pa, Class<T> instanceKeyClass, DataDependenceOptions dOptions, ControlDependenceOptions cOptions) {
+    this(cg, pa, ModRef.make(instanceKeyClass), dOptions, cOptions, null);
   }
 
-  public SDG(final CallGraph cg, PointerAnalysis<T> pa, ModRef modRef, DataDependenceOptions dOptions,
+  public SDG(final CallGraph cg, PointerAnalysis<T> pa, ModRef<T> modRef, DataDependenceOptions dOptions,
       ControlDependenceOptions cOptions) {
     this(cg, pa, modRef, dOptions, cOptions, null);
   }
 
-  public SDG(CallGraph cg, PointerAnalysis<T> pa, ModRef modRef, DataDependenceOptions dOptions, ControlDependenceOptions cOptions,
+  public SDG(CallGraph cg, PointerAnalysis<T> pa, ModRef<T> modRef, DataDependenceOptions dOptions, ControlDependenceOptions cOptions,
       HeapExclusions heapExclude) throws IllegalArgumentException {
     super();
     if (dOptions == null) {
@@ -179,7 +179,7 @@ public class SDG<T extends InstanceKey> extends AbstractNumberedGraph<Statement>
   private void addPDGStatementNodes(CGNode node) {
     if (!statementsAdded.contains(node)) {
       statementsAdded.add(node);
-      PDG pdg = getPDG(node);
+      PDG<?> pdg = getPDG(node);
       for (Iterator<? extends Statement> it = pdg.iterator(); it.hasNext();) {
         addNode(it.next());
       }
@@ -796,7 +796,7 @@ public class SDG<T extends InstanceKey> extends AbstractNumberedGraph<Statement>
 
   @Override
   public PDG<T> getPDG(CGNode node) {
-    PDG result = pdgMap.get(node);
+    PDG<T> result = pdgMap.get(node);
     if (result == null) {
       result = new PDG<T>(node, pa, mod, ref, dOptions, cOptions, heapExclude, cg, modRef);
       pdgMap.put(node, result);

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/Slicer.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/Slicer.java
@@ -130,9 +130,9 @@ public class Slicer {
    * @return the backward slice of s.
    * @throws CancelException
    */
-  public static Collection<Statement> computeBackwardSlice(Statement s, CallGraph cg, PointerAnalysis<? extends InstanceKey> pa,
-      DataDependenceOptions dOptions, ControlDependenceOptions cOptions) throws IllegalArgumentException, CancelException {
-    return computeSlice(new SDG(cg, pa, ModRef.make(), dOptions, cOptions), Collections.singleton(s), true);
+  public static <U extends InstanceKey> Collection<Statement> computeBackwardSlice(Statement s, CallGraph cg, PointerAnalysis<U> pa,
+      Class<U> instanceKeyClass, DataDependenceOptions dOptions, ControlDependenceOptions cOptions) throws IllegalArgumentException, CancelException {
+    return computeSlice(new SDG<U>(cg, pa, ModRef.make(instanceKeyClass), dOptions, cOptions), Collections.singleton(s), true);
   }
 
   /**
@@ -140,9 +140,10 @@ public class Slicer {
    * @return the forward slice of s.
    * @throws CancelException
    */
-  public static Collection<Statement> computeForwardSlice(Statement s, CallGraph cg, PointerAnalysis<? extends InstanceKey> pa,
+  public static <U extends InstanceKey> Collection<Statement> computeForwardSlice(Statement s, CallGraph cg,
+      PointerAnalysis<U> pa, Class<U> instanceKeyClass,
       DataDependenceOptions dOptions, ControlDependenceOptions cOptions) throws IllegalArgumentException, CancelException {
-    return computeSlice(new SDG(cg, pa, ModRef.make(), dOptions, cOptions), Collections.singleton(s), false);
+    return computeSlice(new SDG<U>(cg, pa, ModRef.make(instanceKeyClass), dOptions, cOptions), Collections.singleton(s), false);
   }
 
   /**
@@ -200,9 +201,9 @@ public class Slicer {
 
     SliceProblem p = makeSliceProblem(roots, sdg, backward);
 
-    PartiallyBalancedTabulationSolver<Statement, PDG, Object> solver = PartiallyBalancedTabulationSolver
+    PartiallyBalancedTabulationSolver<Statement, PDG<?>, Object> solver = PartiallyBalancedTabulationSolver
         .createPartiallyBalancedTabulationSolver(p, null);
-    TabulationResult<Statement, PDG, Object> tr = solver.solve();
+    TabulationResult<Statement, PDG<?>, Object> tr = solver.solve();
 
     Collection<Statement> slice = tr.getSupergraphNodesReached();
 
@@ -228,18 +229,18 @@ public class Slicer {
    */
   public static Collection<Statement> computeBackwardSlice(Statement s, CallGraph cg, PointerAnalysis<InstanceKey> pointerAnalysis)
       throws IllegalArgumentException, CancelException {
-    return computeBackwardSlice(s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.FULL);
+    return computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL, ControlDependenceOptions.FULL);
   }
 
   /**
    * Tabulation problem representing slicing
    * 
    */
-  public static class SliceProblem implements PartiallyBalancedTabulationProblem<Statement, PDG, Object> {
+  public static class SliceProblem implements PartiallyBalancedTabulationProblem<Statement, PDG<?>, Object> {
 
     private final Collection<Statement> roots;
 
-    private final ISupergraph<Statement, PDG> supergraph;
+    private final ISupergraph<Statement, PDG<?>> supergraph;
 
     private final SliceFunctions f;
 
@@ -282,7 +283,7 @@ public class Slicer {
      * @see com.ibm.wala.dataflow.IFDS.TabulationProblem#getSupergraph()
      */
     @Override
-    public ISupergraph<Statement, PDG> getSupergraph() {
+    public ISupergraph<Statement, PDG<?>> getSupergraph() {
       return supergraph;
     }
 

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/thin/CISDG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/thin/CISDG.java
@@ -123,7 +123,7 @@ public class CISDG implements ISDG {
   }
 
   @Override
-  public PDG getPDG(CGNode node) {
+  public PDG<InstanceKey> getPDG(CGNode node) {
     Assertions.UNREACHABLE();
     return noHeap.getPDG(node);
   }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/thin/CISlicer.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/thin/CISlicer.java
@@ -53,10 +53,10 @@ public class CISlicer {
   private final Graph<Statement> depGraph;
 
   public CISlicer(CallGraph cg, PointerAnalysis<InstanceKey> pa, DataDependenceOptions dOptions, ControlDependenceOptions cOptions) {
-    this(cg, pa, ModRef.make(), dOptions, cOptions);
+    this(cg, pa, ModRef.make(InstanceKey.class), dOptions, cOptions);
   }
 
-  public CISlicer(CallGraph cg, PointerAnalysis<InstanceKey> pa, ModRef modRef, DataDependenceOptions dOptions, ControlDependenceOptions cOptions)
+  public CISlicer(CallGraph cg, PointerAnalysis<InstanceKey> pa, ModRef<InstanceKey> modRef, DataDependenceOptions dOptions, ControlDependenceOptions cOptions)
       throws IllegalArgumentException {
     if (dOptions == null) {
       throw new IllegalArgumentException("dOptions == null");
@@ -65,7 +65,7 @@ public class CISlicer {
       throw new IllegalArgumentException("Heap data dependences requested in CISlicer!");
     }
 
-    SDG sdg = new SDG(cg, pa, modRef, dOptions, cOptions, null);
+    SDG<InstanceKey> sdg = new SDG<>(cg, pa, modRef, dOptions, cOptions, null);
 
     Map<Statement, Set<PointerKey>> mod = scanForMod(sdg, pa, modRef);
     Map<Statement, Set<PointerKey>> ref = scanForRef(sdg, pa, modRef);
@@ -74,7 +74,7 @@ public class CISlicer {
 
   }
 
-  public CISlicer(final SDG sdg, final PointerAnalysis<InstanceKey> pa, final ModRef modRef) {
+  public CISlicer(final SDG<InstanceKey> sdg, final PointerAnalysis<InstanceKey> pa, final ModRef<InstanceKey> modRef) {
     Map<Statement, Set<PointerKey>> mod = scanForMod(sdg, pa, modRef);
     Map<Statement, Set<PointerKey>> ref = scanForRef(sdg, pa, modRef);
 
@@ -94,24 +94,24 @@ public class CISlicer {
   /**
    * Compute the set of pointer keys each statement mods
    */
-  public static Map<Statement, Set<PointerKey>> scanForMod(SDG sdg, PointerAnalysis<InstanceKey> pa) {
-    return scanForMod(sdg, pa, false, ModRef.make());
+  public static Map<Statement, Set<PointerKey>> scanForMod(SDG<InstanceKey> sdg, PointerAnalysis<InstanceKey> pa) {
+    return scanForMod(sdg, pa, false, ModRef.make(InstanceKey.class));
   }
 
   /**
    * Compute the set of pointer keys each statement refs
    */
-  public static Map<Statement, Set<PointerKey>> scanForRef(SDG sdg, PointerAnalysis<InstanceKey> pa) {
+  public static Map<Statement, Set<PointerKey>> scanForRef(SDG<InstanceKey> sdg, PointerAnalysis<InstanceKey> pa) {
     if (sdg == null) {
       throw new IllegalArgumentException("null sdg");
     }
-    return scanForRef(sdg, pa, ModRef.make());
+    return scanForRef(sdg, pa, ModRef.make(InstanceKey.class));
   }
 
   /**
    * Compute the set of pointer keys each statement mods
    */
-  public static Map<Statement, Set<PointerKey>> scanForMod(SDG sdg, PointerAnalysis<InstanceKey> pa, ModRef modRef) {
+  public static Map<Statement, Set<PointerKey>> scanForMod(SDG<InstanceKey> sdg, PointerAnalysis<InstanceKey> pa, ModRef<InstanceKey> modRef) {
     return scanForMod(sdg, pa, false, modRef);
   }
 
@@ -119,7 +119,7 @@ public class CISlicer {
    * Compute the set of pointer keys each statement mods. Be careful to avoid eager PDG construction here! That means .. don't
    * iterate over SDG statements!
    */
-  public static Map<Statement, Set<PointerKey>> scanForMod(SDG sdg, PointerAnalysis<InstanceKey> pa, boolean ignoreAllocHeapDefs, ModRef modRef) {
+  public static Map<Statement, Set<PointerKey>> scanForMod(SDG<InstanceKey> sdg, PointerAnalysis<InstanceKey> pa, boolean ignoreAllocHeapDefs, ModRef<InstanceKey> modRef) {
     if (pa == null) {
       throw new IllegalArgumentException("null pa");
     }
@@ -147,7 +147,7 @@ public class CISlicer {
    * Compute the set of PointerKeys each statement refs.Be careful to avoid eager PDG construction here! That means .. don't iterate
    * over SDG statements!
    */
-  public static Map<Statement, Set<PointerKey>> scanForRef(SDG sdg, PointerAnalysis<InstanceKey> pa, ModRef modRef) {
+  public static Map<Statement, Set<PointerKey>> scanForRef(SDG<InstanceKey> sdg, PointerAnalysis<InstanceKey> pa, ModRef<InstanceKey> modRef) {
     if (pa == null) {
       throw new IllegalArgumentException("null pa");
     }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/thin/ThinSlicer.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/thin/ThinSlicer.java
@@ -31,10 +31,10 @@ import com.ibm.wala.ipa.slicer.Slicer.DataDependenceOptions;
 public class ThinSlicer extends CISlicer {
 
   public ThinSlicer(CallGraph cg, PointerAnalysis<InstanceKey> pa) {
-    this(cg, pa, ModRef.make());
+    this(cg, pa, ModRef.make(InstanceKey.class));
   }
 
-  public ThinSlicer(CallGraph cg, PointerAnalysis<InstanceKey> pa, ModRef modRef) {
+  public ThinSlicer(CallGraph cg, PointerAnalysis<InstanceKey> pa, ModRef<InstanceKey> modRef) {
     super(cg, pa, modRef, DataDependenceOptions.NO_HEAP, ControlDependenceOptions.NONE);
   }
 }

--- a/com.ibm.wala.core/src/com/ibm/wala/util/ssa/ParameterAccessor.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/ssa/ParameterAccessor.java
@@ -839,7 +839,7 @@ public class ParameterAccessor {
         }
 
         final List<Parameter> all = all();
-        final List<Parameter> allExctends = new ArrayList();
+        final List<Parameter> allExctends = new ArrayList<>();
         IClass searchType = null;
         final IClassLoader[] allLoaders = cha.getLoaders();
 
@@ -908,7 +908,7 @@ public class ParameterAccessor {
 
         final IClass searchType = cha.lookupClass(tRef);
         final List<Parameter> all = all();
-        final List<Parameter> allExctends = new ArrayList();
+        final List<Parameter> allExctends = new ArrayList<>();
             
         if (searchType == null) {
             throw new IllegalStateException("Could not find the IClass of " + tRef);

--- a/com.ibm.wala.core/src/com/ibm/wala/util/ssa/SSAValueManager.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/ssa/SSAValueManager.java
@@ -176,7 +176,7 @@ public class SSAValueManager {
             throw new IllegalStateException("The parameter " + value + " using Key " + value.key + " has already been allocated");
         } else {
             info("New variable in management: {}", value);
-            final Managed<SSAValue> param = new Managed(value, value.key);
+            final Managed<SSAValue> param = new Managed<>(value, value.key);
             param.status = ValueStatus.ALLOCATED;
             param.setInScope = currentScope;
             param.setBy = setBy;
@@ -276,7 +276,7 @@ public class SSAValueManager {
         }
 
         final SSAValue var = new SSAValue(nextLocal++, type, this.forMethod, key);
-        final Managed<SSAValue> param = new Managed(var, key);
+        final Managed<SSAValue> param = new Managed<>(var, key);
 
         param.status = ValueStatus.FREE;
         param.setInScope = currentScope;
@@ -321,7 +321,7 @@ public class SSAValueManager {
         }
 
         final SSAValue var = new SSAValue(nextLocal++, type, this.forMethod, key);
-        final Managed<SSAValue> param = new Managed(var, key);
+        final Managed<SSAValue> param = new Managed<>(var, key);
 
         param.status = ValueStatus.UNALLOCATED;
         param.setInScope = currentScope;

--- a/com.ibm.wala.core/src/com/ibm/wala/util/ssa/TypeSafeInstructionFactory.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/ssa/TypeSafeInstructionFactory.java
@@ -121,7 +121,7 @@ public class TypeSafeInstructionFactory {
             throw new IllegalArgumentException("The parameter exception may not be null");
         }
         if (params == null) {
-            params = Collections.EMPTY_LIST;
+            params = Collections.emptyList();
         }
         if (site == null) {
             throw new IllegalArgumentException("The CallSite may not be null");
@@ -230,7 +230,7 @@ public class TypeSafeInstructionFactory {
             throw new IllegalArgumentException("The parameter exception may not be null");
         }
         if (params == null) {
-            params = Collections.EMPTY_LIST;
+            params = Collections.emptyList();
         }
         if (site == null) {
             throw new IllegalArgumentException("The CallSite may not be null");

--- a/com.ibm.wala.core/src/com/ibm/wala/viz/viewer/ChaPanel.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/viz/viewer/ChaPanel.java
@@ -39,8 +39,8 @@ public class ChaPanel extends JSplitPane {
     JTree tree = buildTree();
     this.setLeftComponent(new JScrollPane(tree));
     
-    final DefaultListModel methodListModel = new DefaultListModel();
-    JList methodList = new JList(methodListModel);
+    final DefaultListModel<String> methodListModel = new DefaultListModel<>();
+    JList methodList = new JList<String>(methodListModel);
     this.setRightComponent(methodList);
     
     tree.addTreeSelectionListener(new TreeSelectionListener(){

--- a/com.ibm.wala.core/src/com/ibm/wala/viz/viewer/IrViewer.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/viz/viewer/IrViewer.java
@@ -33,8 +33,8 @@ import com.ibm.wala.util.collections.HashMapFactory;
 
 public class IrViewer extends JPanel{
   private JTextField methodName;
-  private DefaultListModel irLineList = new DefaultListModel();
-  private JList irLines;
+  private DefaultListModel<String> irLineList = new DefaultListModel<>();
+  private JList<String> irLines;
 
   // mapping from ir viewer list line to source code line number.
   private Map<Integer, Integer> lineToPosition = null;
@@ -50,7 +50,7 @@ public class IrViewer extends JPanel{
   
   public IrViewer() {
     super(new BorderLayout());
-    irLines = new JList(irLineList);
+    irLines = new JList<String>(irLineList);
     methodName = new JTextField("IR");
     this.add(methodName, BorderLayout.PAGE_START);
     this.add(new JScrollPane(irLines, ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,

--- a/com.ibm.wala.core/src/com/ibm/wala/viz/viewer/PaPanel.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/viz/viewer/PaPanel.java
@@ -167,7 +167,7 @@ public class PaPanel extends JSplitPane {
   }
 
   private void initDataStructures(PointerAnalysis<InstanceKey> pa) {
-    HeapGraph heapGraph = pa.getHeapGraph();
+    HeapGraph<InstanceKey> heapGraph = pa.getHeapGraph();
     OrdinalSetMapping<InstanceKey> instanceKeyMapping = pa.getInstanceKeyMapping();
     for (Object n : heapGraph){
       if (heapGraph.getPredNodeCount(n) == 0){ // considering only roots of the heap graph.

--- a/com.ibm.wala.core/src/com/ibm/wala/viz/viewer/SourceViewer.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/viz/viewer/SourceViewer.java
@@ -25,13 +25,13 @@ import javax.swing.JTextField;
 public class SourceViewer extends JPanel{
   private URL sourceURL;
   private JTextField sourceCodeLocation;
-  private DefaultListModel sourceCodeLinesList = new DefaultListModel();
-  private JList sourceCodeLines;
+  private DefaultListModel<String> sourceCodeLinesList = new DefaultListModel<>();
+  private JList<String> sourceCodeLines;
 
   public SourceViewer() {
     super(new BorderLayout());
     sourceURL = null;
-    sourceCodeLines = new JList(sourceCodeLinesList);
+    sourceCodeLines = new JList<String>(sourceCodeLinesList);
     sourceCodeLocation = new JTextField("Source code");
     this.add(sourceCodeLocation, BorderLayout.PAGE_START);
     this.add(new JScrollPane(sourceCodeLines), BorderLayout.CENTER);

--- a/com.ibm.wala.dalvik.test/source/com/ibm/wala/dalvik/drivers/APKCallGraphDriver.java
+++ b/com.ibm.wala.dalvik.test/source/com/ibm/wala/dalvik/drivers/APKCallGraphDriver.java
@@ -109,7 +109,7 @@ public class APKCallGraphDriver {
 	        CG = DalvikCallGraphTestBase.makeAPKCallGraph(libs(), null, apk.getAbsolutePath(), pm, ReflectionOptions.NONE);
 	        System.err.println("Analyzed " + apk + " in " + (System.currentTimeMillis() - time));
 
-	        System.err.println(new SDG(CG.fst, CG.snd, DataDependenceOptions.NO_BASE_NO_HEAP_NO_EXCEPTIONS, ControlDependenceOptions.NONE));
+	        System.err.println(new SDG<>(CG.fst, CG.snd, InstanceKey.class, DataDependenceOptions.NO_BASE_NO_HEAP_NO_EXCEPTIONS, ControlDependenceOptions.NONE));
 	        
 	        if (dumpIR) {
 	          for(CGNode n : CG.fst) {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/DefaultInstantiationBehavior.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/DefaultInstantiationBehavior.java
@@ -368,6 +368,7 @@ public class DefaultInstantiationBehavior extends IInstantiationBehavior impleme
      *  hard-coded behaviors don't get mixed with loaded ones. It may be deserialized but using a
      *  LoadedInstantiationBehavior instead may be a better way (as it starts in an empty state)
      */
+	@SuppressWarnings("unchecked")
 	private void readObject(java.io.ObjectInputStream stream) 
         throws IOException, ClassNotFoundException {
 

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/DefaultInstantiationBehavior.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/DefaultInstantiationBehavior.java
@@ -103,7 +103,7 @@ public class DefaultInstantiationBehavior extends IInstantiationBehavior impleme
         @Override
         public boolean equals(Object o) {
             if (o instanceof BehaviorKey) {
-                BehaviorKey other = (BehaviorKey) o;
+                BehaviorKey<?> other = (BehaviorKey<?>) o;
                 return base.equals(other.base);
             } else {
                 return false;
@@ -122,7 +122,7 @@ public class DefaultInstantiationBehavior extends IInstantiationBehavior impleme
     }
 
 
-    private final Map<BehaviorKey, BehviourValue> behaviours = new HashMap<>();
+    private final Map<BehaviorKey<?>, BehviourValue> behaviours = new HashMap<>();
     private final transient IClassHierarchy cha;
 
     public DefaultInstantiationBehavior(final IClassHierarchy cha) {
@@ -350,8 +350,8 @@ public class DefaultInstantiationBehavior extends IInstantiationBehavior impleme
         if (this.serializationIncludesCache) {
             stream.writeObject(this.behaviours);
         } else {
-            final Map<BehaviorKey, BehviourValue> strippedBehaviours = new HashMap<>();
-            for (final BehaviorKey key : this.behaviours.keySet()) {
+            final Map<BehaviorKey<?>, BehviourValue> strippedBehaviours = new HashMap<>();
+            for (final BehaviorKey<?> key : this.behaviours.keySet()) {
                 final BehviourValue val = this.behaviours.get(key);
                 if (! val.isCached() ) {
                     strippedBehaviours.put(key, val);
@@ -368,11 +368,11 @@ public class DefaultInstantiationBehavior extends IInstantiationBehavior impleme
      *  hard-coded behaviors don't get mixed with loaded ones. It may be deserialized but using a
      *  LoadedInstantiationBehavior instead may be a better way (as it starts in an empty state)
      */
-    private void readObject(java.io.ObjectInputStream stream) 
+	private void readObject(java.io.ObjectInputStream stream) 
         throws IOException, ClassNotFoundException {
 
         DefaultInstantiationBehavior.this.behaviours.clear();
-        this.behaviours.putAll((Map<BehaviorKey, BehviourValue>) stream.readObject());
+        this.behaviours.putAll((Map<BehaviorKey<?>, BehviourValue>) stream.readObject());
     }
 
 }

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/FlatInstantiator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/FlatInstantiator.java
@@ -662,6 +662,7 @@ public class FlatInstantiator implements IInstantiator {
     /**
      *  Satisfy the interface.
      */
+    @SuppressWarnings("unchecked")
     public int createInstance(TypeReference type, Object... instantiatorArgs) {
         // public SSAValue createInstance(final TypeReference T, final boolean asManaged, VariableKey key, Set<SSAValue> seen) {
         if (! (instantiatorArgs[0] instanceof Boolean)) {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/FlatInstantiator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/FlatInstantiator.java
@@ -683,7 +683,7 @@ public class FlatInstantiator implements IInstantiator {
             }
         }
         if (instantiatorArgs[2] != null) {
-            final Set seen = (Set) instantiatorArgs[2];
+            final Set<?> seen = (Set<?>) instantiatorArgs[2];
             if (! seen.isEmpty()) {
                 final Object o = seen.iterator().next();
                 if (! (o instanceof SSAValue)) {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/Instantiator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/Instantiator.java
@@ -676,7 +676,7 @@ public class Instantiator implements IInstantiator {
                     "got: " + instantiatorArgs[2].getClass()); 
         }
         if (instantiatorArgs[2] != null) {
-            final Set seen = (Set) instantiatorArgs[2];
+            final Set<?> seen = (Set<?>) instantiatorArgs[2];
             if (! seen.isEmpty()) {
                 final Object o = seen.iterator().next();
                 if (! (o instanceof SSAValue)) {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/Instantiator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/Instantiator.java
@@ -663,6 +663,7 @@ public class Instantiator implements IInstantiator {
     /**
      *  Satisfy the interface.
      */
+    @SuppressWarnings("unchecked")
     public int createInstance(TypeReference type, Object... instantiatorArgs) {
         // public SSAValue createInstance(final TypeReference T, final boolean asManaged, VariableKey key, Set<SSAValue> seen) {
         if (! (instantiatorArgs[0] instanceof Boolean)) {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/LoadedInstantiationBehavior.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/LoadedInstantiationBehavior.java
@@ -315,6 +315,7 @@ public class LoadedInstantiationBehavior extends IInstantiationBehavior implemen
         }
     }
 
+    @SuppressWarnings("unchecked")
     private void readObject(java.io.ObjectInputStream stream)
         throws IOException, ClassNotFoundException {
 

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/LoadedInstantiationBehavior.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/LoadedInstantiationBehavior.java
@@ -105,7 +105,7 @@ public class LoadedInstantiationBehavior extends IInstantiationBehavior implemen
         @Override
         public boolean equals(Object o) {
             if (o instanceof BehaviorKey) {
-                BehaviorKey other = (BehaviorKey) o;
+                BehaviorKey<?> other = (BehaviorKey<?>) o;
                 return base.equals(other.base);
             } else {
                 return false;
@@ -124,7 +124,7 @@ public class LoadedInstantiationBehavior extends IInstantiationBehavior implemen
     }
 
     private InstanceBehavior defaultBehavior = null;
-    private final Map<BehaviorKey, BehviourValue> behaviours = new HashMap<>();
+    private final Map<BehaviorKey<?>, BehviourValue> behaviours = new HashMap<>();
     private final IClassHierarchy cha;
 
     public LoadedInstantiationBehavior(IClassHierarchy cha) {
@@ -304,8 +304,8 @@ public class LoadedInstantiationBehavior extends IInstantiationBehavior implemen
         if (this.serializationIncludesCache) {
             stream.writeObject(this.behaviours);
         } else {
-            final Map<BehaviorKey, BehviourValue> strippedBehaviours = new HashMap<>();
-            for (final BehaviorKey key : this.behaviours.keySet()) {
+            final Map<BehaviorKey<?>, BehviourValue> strippedBehaviours = new HashMap<>();
+            for (final BehaviorKey<?> key : this.behaviours.keySet()) {
                 final BehviourValue val = this.behaviours.get(key);
                 if (! val.isCached() ) {
                     strippedBehaviours.put(key, val);
@@ -319,7 +319,7 @@ public class LoadedInstantiationBehavior extends IInstantiationBehavior implemen
         throws IOException, ClassNotFoundException {
 
         this.behaviours.clear();
-        this.behaviours.putAll( (Map<BehaviorKey, BehviourValue>) stream.readObject());
+        this.behaviours.putAll((Map<BehaviorKey<?>, BehviourValue>) stream.readObject());
     }
 
 

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/SpecializedInstantiator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/SpecializedInstantiator.java
@@ -260,6 +260,7 @@ public class SpecializedInstantiator extends FlatInstantiator {
     /**
      *  Satisfy the interface.
      */
+    @SuppressWarnings("unchecked")
     public int createInstance(TypeReference type, Object... instantiatorArgs) {
         // public SSAValue createInstance(final TypeReference T, final boolean asManaged, VariableKey key, Set<SSAValue> seen) {
         if (! (instantiatorArgs[0] instanceof Boolean)) {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/SpecializedInstantiator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/SpecializedInstantiator.java
@@ -281,7 +281,7 @@ public class SpecializedInstantiator extends FlatInstantiator {
             }
         }
         if (instantiatorArgs[2] != null) {
-            final Set seen = (Set) instantiatorArgs[2];
+            final Set<?> seen = (Set<?>) instantiatorArgs[2];
             if (! seen.isEmpty()) {
                 final Object o = seen.iterator().next();
                 if (! (o instanceof SSAValue)) {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentContextSelector.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentContextSelector.java
@@ -169,7 +169,7 @@ public class IntentContextSelector implements ContextSelector {
             final Intent intent;
             { // Extract target-Service as intent
                 if (param instanceof ConstantKey) {
-                    final String target = (String) ((ConstantKey)param).getValue();
+					final String target = (String) ((ConstantKey<?>)param).getValue();
                     intent = new Intent(target) {
                         @Override
                         public Intent.IntentType getType() {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentMap.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentMap.java
@@ -203,7 +203,7 @@ import com.ibm.wala.util.strings.StringStuff;
         final String action;
         {
             if (actionKey instanceof ConstantKey) {
-                final Object actionO = ((ConstantKey)actionKey).getValue();
+                final Object actionO = ((ConstantKey<?>) actionKey).getValue();
                 if (actionO instanceof String) {
                     action = StringStuff.deployment2CanonicalTypeString((String) actionO);
                 } else if (actionO instanceof IClass) {

--- a/com.ibm.wala.ide.jdt.test/source/com/ibm/wala/cast/java/test/ECJJavaIRTest.java
+++ b/com.ibm.wala.ide.jdt.test/source/com/ibm/wala/cast/java/test/ECJJavaIRTest.java
@@ -17,6 +17,7 @@ import com.ibm.wala.core.tests.callGraph.CallGraphTestUtil;
 import com.ibm.wala.ipa.callgraph.AnalysisScope;
 import com.ibm.wala.ipa.callgraph.Entrypoint;
 import com.ibm.wala.ipa.callgraph.impl.Util;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 
 public class ECJJavaIRTest extends JavaIRTests {
@@ -26,8 +27,8 @@ public class ECJJavaIRTest extends JavaIRTests {
   }
 
   @Override
-  protected AbstractAnalysisEngine getAnalysisEngine(final String[] mainClassDescriptors, Collection<String> sources, List<String> libs) {
-    JavaSourceAnalysisEngine engine = new ECJJavaSourceAnalysisEngine() {
+  protected <I extends InstanceKey> AbstractAnalysisEngine<I> getAnalysisEngine(final String[] mainClassDescriptors, Collection<String> sources, List<String> libs) {
+    JavaSourceAnalysisEngine<I> engine = new ECJJavaSourceAnalysisEngine<I>() {
       @Override
       protected Iterable<Entrypoint> makeDefaultEntrypoints(AnalysisScope scope, IClassHierarchy cha) {
         return Util.makeMainEntrypoints(JavaSourceAnalysisScope.SOURCE, cha, mainClassDescriptors);

--- a/com.ibm.wala.ide.jdt.test/source/com/ibm/wala/cast/java/test/JDTJavaIRTests.java
+++ b/com.ibm.wala.ide.jdt.test/source/com/ibm/wala/cast/java/test/JDTJavaIRTests.java
@@ -44,6 +44,7 @@ import java.util.List;
 import com.ibm.wala.cast.java.jdt.test.Activator;
 import com.ibm.wala.client.AbstractAnalysisEngine;
 import com.ibm.wala.ide.tests.util.EclipseTestUtil.ZippedProjectData;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 
 public class JDTJavaIRTests extends JavaIRTests {
   
@@ -72,7 +73,7 @@ public class JDTJavaIRTests extends JavaIRTests {
   }
 
   @Override
-  protected AbstractAnalysisEngine getAnalysisEngine(final String[] mainClassDescriptors, Collection<String> sources, List<String> libs) {
+  protected <I extends InstanceKey> AbstractAnalysisEngine<I> getAnalysisEngine(final String[] mainClassDescriptors, Collection<String> sources, List<String> libs) {
     return JDTJavaTest.makeAnalysisEngine(mainClassDescriptors, sources, libs, project);
   }
 }

--- a/com.ibm.wala.ide.jdt.test/source/com/ibm/wala/cast/java/test/JDTJavaTest.java
+++ b/com.ibm.wala.ide.jdt.test/source/com/ibm/wala/cast/java/test/JDTJavaTest.java
@@ -25,6 +25,7 @@ import com.ibm.wala.ide.tests.util.EclipseTestUtil.ZippedProjectData;
 import com.ibm.wala.ipa.callgraph.AnalysisScope;
 import com.ibm.wala.ipa.callgraph.Entrypoint;
 import com.ibm.wala.ipa.callgraph.impl.Util;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.util.io.TemporaryFile;
 
@@ -45,14 +46,14 @@ public abstract class JDTJavaTest extends IRTests {
    }
 
   @Override
-  protected AbstractAnalysisEngine getAnalysisEngine(final String[] mainClassDescriptors, Collection<String> sources, List<String> libs) {
+  protected <I extends InstanceKey> AbstractAnalysisEngine<I> getAnalysisEngine(final String[] mainClassDescriptors, Collection<String> sources, List<String> libs) {
     return makeAnalysisEngine(mainClassDescriptors, sources, libs, project);
   }
   
-  static AbstractAnalysisEngine makeAnalysisEngine(final String[] mainClassDescriptors, Collection<String> sources, List<String> libs, ZippedProjectData project) {
-    AbstractAnalysisEngine engine;
+  static <I extends InstanceKey> AbstractAnalysisEngine<I> makeAnalysisEngine(final String[] mainClassDescriptors, Collection<String> sources, List<String> libs, ZippedProjectData project) {
+    AbstractAnalysisEngine<I> engine;
     try {
-      engine = new JDTJavaSourceAnalysisEngine(project.projectName) {
+      engine = new JDTJavaSourceAnalysisEngine<I>(project.projectName) {
         {
           setDump(Boolean.parseBoolean(System.getProperty("wala.cast.dump", "false")));
         }

--- a/com.ibm.wala.ide.jdt/source/com/ibm/wala/cast/java/client/JDTJavaSourceAnalysisEngine.java
+++ b/com.ibm.wala.ide.jdt/source/com/ibm/wala/cast/java/client/JDTJavaSourceAnalysisEngine.java
@@ -107,7 +107,7 @@ public class JDTJavaSourceAnalysisEngine<I extends InstanceKey> extends EclipseP
   }
 
   @Override
-  protected CallGraphBuilder getCallGraphBuilder(IClassHierarchy cha,
+  protected CallGraphBuilder<I> getCallGraphBuilder(IClassHierarchy cha,
 		  AnalysisOptions options, IAnalysisCacheView cache) {
 	    return new ZeroCFABuilderFactory().make(options, cache, cha, scope, false);
   }

--- a/com.ibm.wala.ide.jsdt/source/com/ibm/wala/cast/js/client/EclipseJavaScriptAnalysisEngine.java
+++ b/com.ibm.wala.ide.jsdt/source/com/ibm/wala/cast/js/client/EclipseJavaScriptAnalysisEngine.java
@@ -114,7 +114,7 @@ public class EclipseJavaScriptAnalysisEngine<I extends InstanceKey> extends Ecli
   }
 
   @Override
-  protected CallGraphBuilder getCallGraphBuilder(IClassHierarchy cha,
+  protected CallGraphBuilder<I> getCallGraphBuilder(IClassHierarchy cha,
 		AnalysisOptions options, IAnalysisCacheView cache) {
 	    return new ZeroCFABuilderFactory().make((JSAnalysisOptions)options, cache, cha, scope, false);
   }

--- a/com.ibm.wala.ide.jsdt/source/com/ibm/wala/cast/js/client/EclipseWebAnalysisEngine.java
+++ b/com.ibm.wala.ide.jsdt/source/com/ibm/wala/cast/js/client/EclipseWebAnalysisEngine.java
@@ -22,13 +22,14 @@ import com.ibm.wala.ide.util.EclipseWebProjectPath;
 import com.ibm.wala.ide.util.JavaScriptEclipseProjectPath;
 import com.ibm.wala.ipa.callgraph.AnalysisScope;
 import com.ibm.wala.ipa.callgraph.Entrypoint;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.util.config.SetOfClasses;
 
-public class EclipseWebAnalysisEngine extends EclipseJavaScriptAnalysisEngine {
+public class EclipseWebAnalysisEngine extends EclipseJavaScriptAnalysisEngine<InstanceKey> {
 
   private final Set<Pair<String, Plugin>> models = HashSetFactory.make();
   

--- a/com.ibm.wala.ide.tests/src/com/ibm/wala/examples/drivers/SWTPointsTo.java
+++ b/com.ibm.wala.ide.tests/src/com/ibm/wala/examples/drivers/SWTPointsTo.java
@@ -98,6 +98,6 @@ public class SWTPointsTo {
     
     System.err.println(pointerAnalysis);
     
-    return new BasicHeapGraph(pointerAnalysis, cg);
+    return new BasicHeapGraph<>(pointerAnalysis, cg);
   }
 }

--- a/com.ibm.wala.ide/src/com/ibm/wala/ide/client/EclipseProjectAnalysisEngine.java
+++ b/com.ibm.wala.ide/src/com/ibm/wala/ide/client/EclipseProjectAnalysisEngine.java
@@ -50,7 +50,7 @@ abstract public class EclipseProjectAnalysisEngine<P, I extends InstanceKey> ext
   abstract protected EclipseProjectPath<?,P> createProjectPath(P project) throws IOException, CoreException;
 
   @Override
-  abstract protected CallGraphBuilder getCallGraphBuilder(IClassHierarchy cha, AnalysisOptions options, IAnalysisCacheView cache);
+  abstract protected CallGraphBuilder<I> getCallGraphBuilder(IClassHierarchy cha, AnalysisOptions options, IAnalysisCacheView cache);
 
   abstract protected AnalysisScope makeAnalysisScope();
   

--- a/com.ibm.wala.ide/src/com/ibm/wala/ide/ui/IFDSExplorer.java
+++ b/com.ibm.wala.ide/src/com/ibm/wala/ide/ui/IFDSExplorer.java
@@ -52,7 +52,7 @@ public class IFDSExplorer {
     viewIFDS(r, roots, null);
   }
 
-  public static <T, P, F> void viewIFDS(TabulationResult<T, P, F> r, Collection<? extends P> roots, NodeDecorator labels)
+  public static <T, P, F> void viewIFDS(TabulationResult<T, P, F> r, Collection<? extends P> roots, NodeDecorator<T> labels)
       throws WalaException {
     Properties p = null;
     try {
@@ -65,7 +65,7 @@ public class IFDSExplorer {
     viewIFDS(r, roots, labels, scratch);
   }
 
-  public static <T, P, F> void viewIFDS(TabulationResult<T, P, F> r, Collection<? extends P> roots, NodeDecorator labels,
+  public static <T, P, F> void viewIFDS(TabulationResult<T, P, F> r, Collection<? extends P> roots, NodeDecorator<T> labels,
       String scratchDirectory) throws WalaException {
     if (r == null) {
       throw new IllegalArgumentException("r is null");

--- a/com.ibm.wala.ide/src/com/ibm/wala/ide/ui/ViewIFDSLocalAction.java
+++ b/com.ibm.wala.ide/src/com/ibm/wala/ide/ui/ViewIFDSLocalAction.java
@@ -69,10 +69,10 @@ public class ViewIFDSLocalAction<T, P, F> extends Action {
    */
   private final String pdfViewExe;
 
-  private final NodeDecorator labels;
+  private final NodeDecorator<T> labels;
 
   public ViewIFDSLocalAction(SWTTreeViewer viewer, TabulationResult<T, P, F> result, String pdfFile, String dotFile, String dotExe,
-      String pdfViewExe, NodeDecorator labels) {
+      String pdfViewExe, NodeDecorator<T> labels) {
     if (result == null) {
       throw new IllegalArgumentException("null result");
     }
@@ -101,7 +101,7 @@ public class ViewIFDSLocalAction<T, P, F> extends Action {
     setText("View Local Supergraph");
   }
 
-  private static class Labels<T, P, F> implements NodeDecorator {
+  private static class Labels<T, P, F> implements NodeDecorator<T> {
     private TabulationResult<T, P, F> result;
 
     Labels(TabulationResult<T, P, F> result) {


### PR DESCRIPTION
Previously, Eclipse reported 140 warnings in the “Type Safety and Raw Types” category. The commits in this pull request bring that count to zero.