### PR TITLE
Resolve all Eclipse warnings about deprecated APIs

### DIFF
--- a/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/AbstractFieldBasedTest.java
+++ b/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/AbstractFieldBasedTest.java
@@ -20,8 +20,6 @@ import com.ibm.wala.util.NullProgressMonitor;
 import com.ibm.wala.util.ProgressMaster;
 import com.ibm.wala.util.WalaException;
 
-import junit.framework.AssertionFailedError;
-
 public abstract class AbstractFieldBasedTest extends TestJSCallGraphShape {
 
   protected FieldBasedCGUtil util;
@@ -48,8 +46,8 @@ public abstract class AbstractFieldBasedTest extends TestJSCallGraphShape {
         cg = util.buildCG(url, builderType, monitor, false, DefaultSourceExtractor.factory).fst;
         System.err.println(cg);
         verifyGraphAssertions(cg, assertions);
-      } catch(AssertionFailedError afe) {
-        throw new AssertionFailedError(builderType + ": " + afe.getMessage());
+      } catch(AssertionError afe) {
+        throw new AssertionError(builderType + ": " + afe.getMessage());
       } 
     }
     return cg;

--- a/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/FieldBasedComparisonTest.java
+++ b/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/FieldBasedComparisonTest.java
@@ -11,8 +11,6 @@ import com.ibm.wala.cast.js.test.TestSimplePageCallGraphShape;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.WalaException;
 
-import junit.framework.AssertionFailedError;
-
 public class FieldBasedComparisonTest extends AbstractFieldBasedTest {
 
   private void test(String file, Object[][] assertions, BuilderType builderType) throws IOException, WalaException, Error, CancelException {
@@ -25,7 +23,7 @@ public class FieldBasedComparisonTest extends AbstractFieldBasedTest {
     }
   }
 
-  @Test(expected = AssertionFailedError.class)
+  @Test(expected = AssertionError.class)
   public void testSkeletonPessimistic() throws IOException, WalaException, Error, CancelException {
     test("pages/skeleton.html", TestSimplePageCallGraphShape.assertionsForSkeleton, BuilderType.PESSIMISTIC);
   }
@@ -40,7 +38,7 @@ public class FieldBasedComparisonTest extends AbstractFieldBasedTest {
     test("pages/skeleton.html", TestSimplePageCallGraphShape.assertionsForSkeleton, BuilderType.OPTIMISTIC_WORKLIST);
   }
 
-  @Test(expected = AssertionFailedError.class)
+  @Test(expected = AssertionError.class)
   public void testSkeleton2Pessimistic() throws IOException, WalaException, Error, CancelException {
     test("pages/skeleton2.html", TestSimplePageCallGraphShape.assertionsForSkeleton2, BuilderType.PESSIMISTIC);
   }

--- a/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/rhino/test/HTMLCGBuilder.java
+++ b/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/rhino/test/HTMLCGBuilder.java
@@ -17,6 +17,8 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Properties;
 
+import org.junit.Assert;
+
 import com.ibm.wala.cast.js.html.DefaultSourceExtractor;
 import com.ibm.wala.cast.js.html.JSSourceExtractor;
 import com.ibm.wala.cast.js.ipa.callgraph.JSCFABuilder;
@@ -37,8 +39,6 @@ import com.ibm.wala.util.functions.Function;
 import com.ibm.wala.util.io.CommandLine;
 import com.ibm.wala.util.io.FileProvider;
 import com.ibm.wala.util.io.FileUtil;
-
-import junit.framework.Assert;
 
 /**
  * Utility class for building call graphs of HTML pages.

--- a/com.ibm.wala.cast.test/harness-src/com/ibm/wala/cast/test/TestCAstPattern.java
+++ b/com.ibm.wala.cast.test/harness-src/com/ibm/wala/cast/test/TestCAstPattern.java
@@ -16,6 +16,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.ibm.wala.cast.tree.CAstNode;
@@ -24,8 +25,6 @@ import com.ibm.wala.cast.util.CAstPattern;
 import com.ibm.wala.cast.util.CAstPattern.Segments;
 import com.ibm.wala.cast.util.CAstPrinter;
 import com.ibm.wala.core.tests.util.WalaTestCase;
-
-import junit.framework.Assert;
 
 public class TestCAstPattern extends WalaTestCase {
 

--- a/com.ibm.wala.cast.test/harness-src/com/ibm/wala/cast/test/TestCAstTranslator.java
+++ b/com.ibm.wala.cast.test/harness-src/com/ibm/wala/cast/test/TestCAstTranslator.java
@@ -18,6 +18,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
+import org.junit.Assert;
+
 import com.ibm.wala.cast.ipa.callgraph.CAstCallGraphUtil;
 import com.ibm.wala.cast.ir.ssa.AstIRFactory;
 import com.ibm.wala.cast.loader.SingleClassLoaderFactory;
@@ -35,8 +37,6 @@ import com.ibm.wala.ssa.IRFactory;
 import com.ibm.wala.ssa.SSAOptions;
 import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.collections.Pair;
-
-import junit.framework.Assert;
 
 public abstract class TestCAstTranslator extends WalaTestCase {
 

--- a/com.ibm.wala.cast.test/harness-src/com/ibm/wala/cast/test/TestCallGraphShape.java
+++ b/com.ibm.wala.cast.test/harness-src/com/ibm/wala/cast/test/TestCallGraphShape.java
@@ -13,6 +13,8 @@ package com.ibm.wala.cast.test;
 import java.util.Collection;
 import java.util.Iterator;
 
+import org.junit.Assert;
+
 import com.ibm.wala.cast.loader.AstMethod;
 import com.ibm.wala.cast.tree.CAstSourcePositionMap.Position;
 import com.ibm.wala.classLoader.CallSiteReference;
@@ -23,8 +25,6 @@ import com.ibm.wala.ssa.IR;
 import com.ibm.wala.ssa.SSACFG;
 import com.ibm.wala.ssa.SSAInstruction;
 import com.ibm.wala.util.collections.NonNullSingletonIterator;
-
-import junit.framework.Assert;
 
 public abstract class TestCallGraphShape extends WalaTestCase {
 

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cha/ExclusionsTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cha/ExclusionsTest.java
@@ -12,6 +12,7 @@ package com.ibm.wala.core.tests.cha;
 
 import java.io.IOException;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.ibm.wala.core.tests.util.TestConstants;
@@ -21,8 +22,6 @@ import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.config.AnalysisScopeReader;
 import com.ibm.wala.util.io.FileProvider;
 import com.ibm.wala.util.strings.StringStuff;
-
-import junit.framework.Assert;
 
 public class ExclusionsTest {
 

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ir/CFGSanitizerTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ir/CFGSanitizerTest.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.ibm.wala.cfg.CFGSanitizer;
@@ -36,8 +37,6 @@ import com.ibm.wala.util.WalaException;
 import com.ibm.wala.util.config.AnalysisScopeReader;
 import com.ibm.wala.util.graph.Graph;
 import com.ibm.wala.util.io.FileProvider;
-
-import junit.framework.Assert;
 
 /**
  * Test integrity of CFGs

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ptrs/ZeroLengthArrayTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ptrs/ZeroLengthArrayTest.java
@@ -12,6 +12,7 @@ package com.ibm.wala.core.tests.ptrs;
 
 import java.io.IOException;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.ibm.wala.core.tests.callGraph.CallGraphTestUtil;
@@ -37,8 +38,6 @@ import com.ibm.wala.types.Selector;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.intset.OrdinalSet;
-
-import junit.framework.Assert;
 
 public class ZeroLengthArrayTest {
 

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/examples/analysis/dataflow/DataflowTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/examples/analysis/dataflow/DataflowTest.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -53,8 +54,6 @@ import com.ibm.wala.util.config.AnalysisScopeReader;
 import com.ibm.wala.util.config.FileOfClasses;
 import com.ibm.wala.util.intset.IntIterator;
 import com.ibm.wala.util.intset.IntSet;
-
-import junit.framework.Assert;
 
 /**
  * Tests of various flow analysis engines.

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/examples/analysis/dataflow/InitializerTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/examples/analysis/dataflow/InitializerTest.java
@@ -13,6 +13,8 @@ package com.ibm.wala.examples.analysis.dataflow;
 
 import java.io.IOException;
 
+import org.junit.Assert;
+
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.core.tests.callGraph.CallGraphTestUtil;
 import com.ibm.wala.core.tests.util.TestConstants;
@@ -37,8 +39,6 @@ import com.ibm.wala.util.config.AnalysisScopeReader;
 import com.ibm.wala.util.intset.IntIterator;
 import com.ibm.wala.util.intset.IntSet;
 import com.ibm.wala.util.io.FileProvider;
-
-import junit.framework.Assert;
 
 public class InitializerTest {
 

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/cha/CHACallGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/cha/CHACallGraph.java
@@ -110,6 +110,7 @@ public class CHACallGraph extends BasicCallGraph<CHAContextInterpreter> {
     setInterpreter(new ContextInsensitiveCHAContextInterpreter());
   }
 
+  @SuppressWarnings("deprecation")
   public void init(Iterable<Entrypoint> entrypoints) throws CancelException {
     super.init();
 
@@ -213,6 +214,7 @@ public class CHACallGraph extends BasicCallGraph<CHAContextInterpreter> {
   private int clinitPC = 0;
   
   @Override
+  @SuppressWarnings("deprecation")
   public CGNode findOrCreateNode(IMethod method, Context C) throws CancelException {
     assert C.equals(Everywhere.EVERYWHERE);
     assert !method.isAbstract();

--- a/com.ibm.wala.ide.jdt.test/source/com/ibm/wala/cast/java/test/JDTJavaTest.java
+++ b/com.ibm.wala.ide.jdt.test/source/com/ibm/wala/cast/java/test/JDTJavaTest.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
+import org.junit.Assert;
 
 import com.ibm.wala.cast.java.client.JDTJavaSourceAnalysisEngine;
 import com.ibm.wala.cast.java.ipa.callgraph.JavaSourceAnalysisScope;
@@ -28,8 +29,6 @@ import com.ibm.wala.ipa.callgraph.impl.Util;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.util.io.TemporaryFile;
-
-import junit.framework.Assert;
 
 public abstract class JDTJavaTest extends IRTests {
 

--- a/com.ibm.wala.ide.jdt/source/com/ibm/wala/ide/util/JdtUtil.java
+++ b/com.ibm.wala.ide.jdt/source/com/ibm/wala/ide/util/JdtUtil.java
@@ -578,6 +578,7 @@ public class JdtUtil {
   }
 
   public static ASTNode getAST(IFile javaSourceFile) {
+	  @SuppressWarnings("deprecation")
 	  ASTParser parser = ASTParser.newParser(AST.JLS3);
 	  parser.setSource(JavaCore.createCompilationUnitFrom(javaSourceFile));
 	  parser.setProject(JavaCore.create(javaSourceFile.getProject()));


### PR DESCRIPTION
The vast majority of these (about 92 in total) are fixed by replacing `junit.framework.Assert` and `junit.framework.AssertionFailedError` (from JUnit 3.*x*) with `org.junit.Assert` and `java.lang.AssertionError` (from JUnit 4.*x*).

Three other deprecation warnings were better suppressed than fixed. One involves WALA asking for a rather old AST JLS version; the other two involve presumed-safe use of an internal WALA API by other parts of WALA.