### PR TITLE
Generalize a generic type parameter even more

### DIFF
--- a/com.ibm.wala.core/src/com/ibm/wala/escape/FILiveObjectAnalysis.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/escape/FILiveObjectAnalysis.java
@@ -48,7 +48,7 @@ public class FILiveObjectAnalysis implements ILiveObjectAnalysis {
   /**
    * Graph view of pointer analysis results
    */
-  private final HeapGraph<? super InstanceKey> heapGraph;
+  private final HeapGraph<?> heapGraph;
 
   /**
    * Cached map from InstanceKey -> Set<CGNode>
@@ -68,7 +68,7 @@ public class FILiveObjectAnalysis implements ILiveObjectAnalysis {
   /**
    * 
    */
-  public FILiveObjectAnalysis(CallGraph callGraph, HeapGraph<? super InstanceKey> heapGraph, boolean expensiveIntraproceduralAnalysis) {
+  public FILiveObjectAnalysis(CallGraph callGraph, HeapGraph<?> heapGraph, boolean expensiveIntraproceduralAnalysis) {
     super();
     this.callGraph = callGraph;
     this.heapGraph = heapGraph;


### PR DESCRIPTION
As it turns out, I should have been using "`? extends InstanceKey`" rather than "`? super InstanceKey`".  But really, we can just use "`?`" here since `HeapGraph` itself constrains its own type parameter appropriately.

This should fix WALA bug #151, which was first introduced by [this change](https://github.com/wala/WALA/commit/fde65340d22f153914343a33bbaf6f5497ce67f4#diff-6f505606d6841bf44858283ce76371ceL71) in commit fde65340d22f153914343a33bbaf6f5497ce67f4.