### PR TITLE
Optimize PDG to only check callers for number of callee params when n…

### DIFF
--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/loader/JavaScriptLoader.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/loader/JavaScriptLoader.java
@@ -668,6 +668,11 @@ public class JavaScriptLoader extends CAstAbstractModuleLoader {
       return false;
     }
 
+    @Override
+    public boolean canPassMismatchedNumberOfParameters() {
+      return true;
+    }
+
   };
 
   private static final Map<Selector, IMethod> emptyMap1 = Collections.emptyMap();

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/JavaLanguage.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/JavaLanguage.java
@@ -764,4 +764,9 @@ public class JavaLanguage extends LanguageImpl implements BytecodeLanguage, Cons
   public boolean methodsHaveDeclaredParameterTypes() {
     return true;
   }
+
+  @Override
+  public boolean canPassMismatchedNumberOfParameters() {
+    return false;
+  }
 }

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/Language.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/Language.java
@@ -106,7 +106,7 @@ public interface Language {
    * be the corresponding {@link TypeReference}. The returned object should be
    * appropriate for use as the token in an {@link SSALoadMetadataInstruction}
    * for the language
-   * 
+   *
    */
   Object getMetadataToken(Object value);
 
@@ -135,14 +135,21 @@ public interface Language {
 
   /**
    * get the abstraction of a primitive type to be used for type inference
-   * 
+   *
    * @see TypeInference
    */
   PrimitiveType getPrimitive(TypeReference reference);
-  
+
   /**
    * do MethodReference objects have declared parameter types?
    */
   boolean methodsHaveDeclaredParameterTypes();
-   
+
+  /**
+   * Given a function/method with k formal parameters, does
+   * the language allow for passing greater or fewer than k
+   * parameters at a call site?
+   */
+  boolean canPassMismatchedNumberOfParameters();
+
 }


### PR DESCRIPTION
…ecessary

This extra step should only be needed for languages that let you pass extra
parameters at call sites, like JavaScript.