### PR TITLE
Remove unnecessary `klass` argument and propagate back to callers

### DIFF
--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/slicer/SlicerTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/slicer/SlicerTest.java
@@ -137,7 +137,7 @@ public class SlicerTest {
     // compute a data slice
     final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
     Collection<Statement> computeBackwardSlice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis,
-        InstanceKey.class, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
+        DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     Collection<Statement> slice = computeBackwardSlice;
     dumpSlice(slice);
 
@@ -168,7 +168,7 @@ public class SlicerTest {
     // compute a data slice
     final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
     Collection<Statement> computeBackwardSlice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis,
-        InstanceKey.class, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
+        DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     Collection<Statement> slice = computeBackwardSlice;
     dumpSlice(slice);
 
@@ -192,7 +192,7 @@ public class SlicerTest {
     System.err.println("Statement: " + s);
     // compute a data slice
     final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL,
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, DataDependenceOptions.FULL,
         ControlDependenceOptions.NONE);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 1, countAllocations(slice));
@@ -216,7 +216,7 @@ public class SlicerTest {
     System.err.println("Statement: " + s);
     // compute a data slice
     final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-    Collection<Statement> slice = Slicer.computeForwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL,
+    Collection<Statement> slice = Slicer.computeForwardSlice(s, cg, pointerAnalysis, DataDependenceOptions.FULL,
         ControlDependenceOptions.NONE);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 4, slice.size());
@@ -240,7 +240,7 @@ public class SlicerTest {
     System.err.println("Statement: " + s);
     // compute a data slice
     final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-    Collection<Statement> slice = Slicer.computeForwardSlice(s, cg, pointerAnalysis, InstanceKey.class,
+    Collection<Statement> slice = Slicer.computeForwardSlice(s, cg, pointerAnalysis,
         DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 7, slice.size());
@@ -270,7 +270,7 @@ public class SlicerTest {
     System.err.println("Statement: " + s);
     // compute a data slice
     final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-    Collection<Statement> slice = Slicer.computeForwardSlice(s, cg, pointerAnalysis, InstanceKey.class,
+    Collection<Statement> slice = Slicer.computeForwardSlice(s, cg, pointerAnalysis,
         DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     dumpSlice(slice);
   }
@@ -299,12 +299,12 @@ public class SlicerTest {
     System.err.println("Statement: " + s);
     // compute a backward slice, with data dependence and no exceptional control dependence
     final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL,
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, DataDependenceOptions.FULL,
         ControlDependenceOptions.NO_EXCEPTIONAL_EDGES);
     dumpSlice(slice);
     Assert.assertEquals(4, countInvokes(slice));
     // should only get 4 statements total when ignoring control dependences completely
-    slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL,
+    slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, DataDependenceOptions.FULL,
         ControlDependenceOptions.NONE);
     Assert.assertEquals(slice.toString(), 4, slice.size());
   }
@@ -326,7 +326,7 @@ public class SlicerTest {
     System.err.println("Statement: " + s);
     // compute a backward slice, with data dependence and no exceptional control dependence
     final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL,
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, DataDependenceOptions.FULL,
         ControlDependenceOptions.NO_EXCEPTIONAL_EDGES);
     //dumpSlice(slice);
     Assert.assertEquals(/*slice.toString(), */5, countApplicationNormals(slice));
@@ -350,7 +350,7 @@ public class SlicerTest {
     System.err.println("Statement: " + s);
     // compute a data slice
     final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.NONE,
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, DataDependenceOptions.NONE,
         ControlDependenceOptions.FULL);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 2, countConditionals(slice));
@@ -374,7 +374,7 @@ public class SlicerTest {
     System.err.println("Statement: " + s);
     // compute a data slice
     final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.NONE,
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, DataDependenceOptions.NONE,
         ControlDependenceOptions.FULL);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 1, countConditionals(slice));
@@ -398,7 +398,7 @@ public class SlicerTest {
     System.err.println("Statement: " + s);
     // compute a data slice
     final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.NONE,
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, DataDependenceOptions.NONE,
         ControlDependenceOptions.FULL);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 0, countConditionals(slice));
@@ -423,13 +423,13 @@ public class SlicerTest {
 
     // compute a no-data slice
     final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.NONE,
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, DataDependenceOptions.NONE,
         ControlDependenceOptions.FULL);
     dumpSlice(slice);
     Assert.assertEquals(0, countConditionals(slice));
 
     // compute a full slice
-    slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class,
+    slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis,
         DataDependenceOptions.FULL, ControlDependenceOptions.FULL);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 1, countConditionals(slice));
@@ -454,7 +454,7 @@ public class SlicerTest {
 
     // compute a no-data slice
     final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-    Collection<Statement> slice = Slicer.computeForwardSlice(s, cg, pointerAnalysis, InstanceKey.class,
+    Collection<Statement> slice = Slicer.computeForwardSlice(s, cg, pointerAnalysis,
         DataDependenceOptions.NONE, ControlDependenceOptions.NO_EXCEPTIONAL_EDGES);
     dumpSlice(slice);
     Assert.assertTrue(slice.toString(), slice.size() > 1);
@@ -479,7 +479,7 @@ public class SlicerTest {
 
     // compute a no-data slice
     final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-    Collection<Statement> slice = Slicer.computeForwardSlice(s, cg, pointerAnalysis, InstanceKey.class,
+    Collection<Statement> slice = Slicer.computeForwardSlice(s, cg, pointerAnalysis,
         DataDependenceOptions.NONE, ControlDependenceOptions.NO_EXCEPTIONAL_EDGES);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 2, countInvokes(slice));
@@ -503,7 +503,7 @@ public class SlicerTest {
     System.err.println("Statement: " + s);
     // compute a data slice
     final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL,
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, DataDependenceOptions.FULL,
         ControlDependenceOptions.NONE);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 1, countAllocations(slice));
@@ -527,7 +527,7 @@ public class SlicerTest {
     System.err.println("Statement: " + s);
     // compute a data slice
     final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL,
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, DataDependenceOptions.FULL,
         ControlDependenceOptions.NONE);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 2, countAllocations(slice));
@@ -552,7 +552,7 @@ public class SlicerTest {
     System.err.println("Statement: " + s);
     // compute a data slice
     final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL,
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, DataDependenceOptions.FULL,
         ControlDependenceOptions.NONE);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 2, countAllocations(slice));
@@ -579,7 +579,7 @@ public class SlicerTest {
     // compute normal data slice
     // compute a data slice
     final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL,
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, DataDependenceOptions.FULL,
         ControlDependenceOptions.NONE);
     dumpSlice(slice);
     Assert.assertEquals(3, countAllocations(slice));
@@ -587,7 +587,7 @@ public class SlicerTest {
 
     // compute thin slice .. ignore base pointers
     Collection<Statement> computeBackwardSlice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis,
-        InstanceKey.class, DataDependenceOptions.NO_BASE_PTRS, ControlDependenceOptions.NONE);
+        DataDependenceOptions.NO_BASE_PTRS, ControlDependenceOptions.NONE);
     slice = computeBackwardSlice;
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 2, countAllocations(slice));
@@ -612,7 +612,7 @@ public class SlicerTest {
     System.err.println("Statement: " + s);
     // compute a data slice
     final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL,
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, DataDependenceOptions.FULL,
         ControlDependenceOptions.NONE);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 1, countAllocations(slice));
@@ -638,7 +638,7 @@ public class SlicerTest {
     System.err.println("Statement: " + s);
     // compute a data slice
     final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL,
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, DataDependenceOptions.FULL,
         ControlDependenceOptions.NONE);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 2, countAllocations(slice));
@@ -663,7 +663,7 @@ public class SlicerTest {
 
     // compute a data slice
     final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL,
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, DataDependenceOptions.FULL,
         ControlDependenceOptions.NONE);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 3, countAllocations(slice));
@@ -691,7 +691,7 @@ public class SlicerTest {
 
     // compute full slice
     final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, pcg, pointerAnalysis, InstanceKey.class,
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, pcg, pointerAnalysis,
         DataDependenceOptions.FULL, ControlDependenceOptions.FULL);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 0, countAllocations(slice));
@@ -733,7 +733,7 @@ public class SlicerTest {
     System.err.println("Statement: " + s);
 
     final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, pcg, pointerAnalysis, InstanceKey.class,
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, pcg, pointerAnalysis,
         DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 1, countAllocations(slice));
@@ -757,7 +757,7 @@ public class SlicerTest {
     System.err.println("Statement: " + s);
     // compute a data slice
     final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL,
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, DataDependenceOptions.FULL,
         ControlDependenceOptions.NONE);
     dumpSlice(slice);
     Assert.assertEquals(slice.toString(), 1, countApplicationAllocations(slice));
@@ -802,7 +802,7 @@ public class SlicerTest {
 
     CallGraphBuilder builder = Util.makeZeroOneCFABuilder(options, new AnalysisCacheImpl(), cha, scope);
     CallGraph cg = builder.makeCallGraph(options, null);
-    SDG<?> sdg = new SDG<>(cg, builder.getPointerAnalysis(), InstanceKey.class, DataDependenceOptions.NO_BASE_NO_HEAP, ControlDependenceOptions.FULL);
+    SDG<?> sdg = new SDG<>(cg, builder.getPointerAnalysis(), DataDependenceOptions.NO_BASE_NO_HEAP, ControlDependenceOptions.FULL);
     GraphIntegrity.check(sdg);
   }
 
@@ -824,7 +824,7 @@ public class SlicerTest {
     System.err.println("Statement: " + s);
 
     final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL,
+    Collection<Statement> slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, DataDependenceOptions.FULL,
         ControlDependenceOptions.NO_EXCEPTIONAL_EDGES);
     dumpSlice(slice);
   }

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/examples/drivers/PDFSDG.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/examples/drivers/PDFSDG.java
@@ -131,7 +131,7 @@ public class PDFSDG {
       CallGraphBuilder<InstanceKey> builder = Util.makeZeroOneCFABuilder(options, new AnalysisCacheImpl(), cha, scope);
       CallGraph cg = builder.makeCallGraph(options,null);
       final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-      SDG<?> sdg = new SDG<>(cg, pointerAnalysis, InstanceKey.class, dOptions, cOptions);
+      SDG<?> sdg = new SDG<>(cg, pointerAnalysis, dOptions, cOptions);
       try {
         GraphIntegrity.check(sdg);
       } catch (UnsoundGraphException e1) {

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/examples/drivers/PDFSlice.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/examples/drivers/PDFSlice.java
@@ -159,7 +159,7 @@ public class PDFSlice {
       // CallGraphBuilder builder = Util.makeZeroOneCFABuilder(options, new
       // AnalysisCache(), cha, scope);
       CallGraph cg = builder.makeCallGraph(options, null);
-      SDG<InstanceKey> sdg = new SDG<>(cg, builder.getPointerAnalysis(), InstanceKey.class, dOptions, cOptions);
+      SDG<InstanceKey> sdg = new SDG<>(cg, builder.getPointerAnalysis(), dOptions, cOptions);
 
       // find the call statement of interest
       CGNode callerNode = SlicerTest.findMethod(cg, srcCaller);
@@ -170,13 +170,13 @@ public class PDFSlice {
       Collection<Statement> slice = null;
       if (goBackward) {
         final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-        slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, dOptions, cOptions);
+        slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, dOptions, cOptions);
       } else {
         // for forward slices ... we actually slice from the return value of
         // calls.
         s = getReturnStatementForCall(s);
         final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-        slice = Slicer.computeForwardSlice(s, cg, pointerAnalysis, InstanceKey.class, dOptions, cOptions);
+        slice = Slicer.computeForwardSlice(s, cg, pointerAnalysis, dOptions, cOptions);
       }
       SlicerTest.dumpSlice(slice);
 

--- a/com.ibm.wala.core/src/com/ibm/wala/client/AbstractAnalysisEngine.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/client/AbstractAnalysisEngine.java
@@ -271,8 +271,8 @@ public abstract class AbstractAnalysisEngine<I extends InstanceKey> implements A
     return heapGraph;
   }
 
-  public SDG<I> getSDG(Class<I> instanceKeyClass, DataDependenceOptions data, ControlDependenceOptions ctrl) {
-    return new SDG<I>(getCallGraph(), getPointerAnalysis(), instanceKeyClass, data, ctrl);
+  public SDG<I> getSDG(DataDependenceOptions data, ControlDependenceOptions ctrl) {
+    return new SDG<I>(getCallGraph(), getPointerAnalysis(), data, ctrl);
   }
   
   public String getExclusionsFile() {

--- a/com.ibm.wala.core/src/com/ibm/wala/demandpa/util/PABasedMemoryAccessMap.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/demandpa/util/PABasedMemoryAccessMap.java
@@ -52,11 +52,11 @@ public class PABasedMemoryAccessMap implements MemoryAccessMap {
   private final Map<PointerKey, Set<Statement>> invRef;
 
   public PABasedMemoryAccessMap(CallGraph cg, PointerAnalysis<InstanceKey> pa) {
-    this(cg, pa, new SDG<InstanceKey>(cg, pa, InstanceKey.class, DataDependenceOptions.NO_BASE_NO_HEAP_NO_EXCEPTIONS, ControlDependenceOptions.NONE));
+    this(cg, pa, new SDG<InstanceKey>(cg, pa, DataDependenceOptions.NO_BASE_NO_HEAP_NO_EXCEPTIONS, ControlDependenceOptions.NONE));
   }
 
   public PABasedMemoryAccessMap(CallGraph cg, PointerAnalysis<InstanceKey> pa, SDG<InstanceKey> sdg) {
-    this(cg, pa, CISlicer.scanForMod(sdg, pa, true, ModRef.make(InstanceKey.class)), CISlicer.scanForRef(sdg, pa));
+    this(cg, pa, CISlicer.scanForMod(sdg, pa, true, ModRef.make()), CISlicer.scanForRef(sdg, pa));
   }
   
   public PABasedMemoryAccessMap(CallGraph cg, PointerAnalysis<InstanceKey> pa, Map<Statement, Set<PointerKey>> mod,

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/ReflectionHandler.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/ReflectionHandler.java
@@ -62,7 +62,7 @@ public class ReflectionHandler {
       if (VERBOSE) {
         System.err.println("Slice " + st);
       }
-      Collection<Statement> slice = Slicer.computeForwardSlice(st, builder.callGraph, null, null, DataDependenceOptions.REFLECTION, ControlDependenceOptions.NONE);
+      Collection<Statement> slice = Slicer.computeForwardSlice(st, builder.callGraph, null, DataDependenceOptions.REFLECTION, ControlDependenceOptions.NONE);
       if (VERBOSE) {
         for (Statement x : slice) {
           System.err.println(" " + x);

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/modref/ModRef.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/modref/ModRef.java
@@ -44,7 +44,7 @@ import com.ibm.wala.util.intset.OrdinalSet;
  */
 public class ModRef<T extends InstanceKey> {
 
-  public static <U extends InstanceKey> ModRef<U> make(Class<U> klass) {
+  public static <U extends InstanceKey> ModRef<U> make() {
     return new ModRef<U>();
   }
 

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/SDG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/SDG.java
@@ -122,8 +122,8 @@ public class SDG<T extends InstanceKey> extends AbstractNumberedGraph<Statement>
    */
   private boolean eagerComputed = false;
 
-  public SDG(final CallGraph cg, PointerAnalysis<T> pa, Class<T> instanceKeyClass, DataDependenceOptions dOptions, ControlDependenceOptions cOptions) {
-    this(cg, pa, ModRef.make(instanceKeyClass), dOptions, cOptions, null);
+  public SDG(final CallGraph cg, PointerAnalysis<T> pa, DataDependenceOptions dOptions, ControlDependenceOptions cOptions) {
+    this(cg, pa, ModRef.<T>make(), dOptions, cOptions, null);
   }
 
   public SDG(final CallGraph cg, PointerAnalysis<T> pa, ModRef<T> modRef, DataDependenceOptions dOptions,

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/Slicer.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/Slicer.java
@@ -131,8 +131,8 @@ public class Slicer {
    * @throws CancelException
    */
   public static <U extends InstanceKey> Collection<Statement> computeBackwardSlice(Statement s, CallGraph cg, PointerAnalysis<U> pa,
-      Class<U> instanceKeyClass, DataDependenceOptions dOptions, ControlDependenceOptions cOptions) throws IllegalArgumentException, CancelException {
-    return computeSlice(new SDG<U>(cg, pa, ModRef.make(instanceKeyClass), dOptions, cOptions), Collections.singleton(s), true);
+      DataDependenceOptions dOptions, ControlDependenceOptions cOptions) throws IllegalArgumentException, CancelException {
+    return computeSlice(new SDG<U>(cg, pa, ModRef.<U>make(), dOptions, cOptions), Collections.singleton(s), true);
   }
 
   /**
@@ -141,9 +141,9 @@ public class Slicer {
    * @throws CancelException
    */
   public static <U extends InstanceKey> Collection<Statement> computeForwardSlice(Statement s, CallGraph cg,
-      PointerAnalysis<U> pa, Class<U> instanceKeyClass,
+      PointerAnalysis<U> pa,
       DataDependenceOptions dOptions, ControlDependenceOptions cOptions) throws IllegalArgumentException, CancelException {
-    return computeSlice(new SDG<U>(cg, pa, ModRef.make(instanceKeyClass), dOptions, cOptions), Collections.singleton(s), false);
+    return computeSlice(new SDG<U>(cg, pa, ModRef.<U>make(), dOptions, cOptions), Collections.singleton(s), false);
   }
 
   /**
@@ -229,7 +229,7 @@ public class Slicer {
    */
   public static Collection<Statement> computeBackwardSlice(Statement s, CallGraph cg, PointerAnalysis<InstanceKey> pointerAnalysis)
       throws IllegalArgumentException, CancelException {
-    return computeBackwardSlice(s, cg, pointerAnalysis, InstanceKey.class, DataDependenceOptions.FULL, ControlDependenceOptions.FULL);
+    return computeBackwardSlice(s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.FULL);
   }
 
   /**

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/thin/CISlicer.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/thin/CISlicer.java
@@ -53,7 +53,7 @@ public class CISlicer {
   private final Graph<Statement> depGraph;
 
   public CISlicer(CallGraph cg, PointerAnalysis<InstanceKey> pa, DataDependenceOptions dOptions, ControlDependenceOptions cOptions) {
-    this(cg, pa, ModRef.make(InstanceKey.class), dOptions, cOptions);
+    this(cg, pa, ModRef.make(), dOptions, cOptions);
   }
 
   public CISlicer(CallGraph cg, PointerAnalysis<InstanceKey> pa, ModRef<InstanceKey> modRef, DataDependenceOptions dOptions, ControlDependenceOptions cOptions)
@@ -95,7 +95,7 @@ public class CISlicer {
    * Compute the set of pointer keys each statement mods
    */
   public static Map<Statement, Set<PointerKey>> scanForMod(SDG<InstanceKey> sdg, PointerAnalysis<InstanceKey> pa) {
-    return scanForMod(sdg, pa, false, ModRef.make(InstanceKey.class));
+    return scanForMod(sdg, pa, false, ModRef.make());
   }
 
   /**
@@ -105,7 +105,7 @@ public class CISlicer {
     if (sdg == null) {
       throw new IllegalArgumentException("null sdg");
     }
-    return scanForRef(sdg, pa, ModRef.make(InstanceKey.class));
+    return scanForRef(sdg, pa, ModRef.make());
   }
 
   /**

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/thin/ThinSlicer.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/thin/ThinSlicer.java
@@ -31,7 +31,7 @@ import com.ibm.wala.ipa.slicer.Slicer.DataDependenceOptions;
 public class ThinSlicer extends CISlicer {
 
   public ThinSlicer(CallGraph cg, PointerAnalysis<InstanceKey> pa) {
-    this(cg, pa, ModRef.make(InstanceKey.class));
+    this(cg, pa, ModRef.make());
   }
 
   public ThinSlicer(CallGraph cg, PointerAnalysis<InstanceKey> pa, ModRef<InstanceKey> modRef) {

--- a/com.ibm.wala.dalvik.test/source/com/ibm/wala/dalvik/drivers/APKCallGraphDriver.java
+++ b/com.ibm.wala.dalvik.test/source/com/ibm/wala/dalvik/drivers/APKCallGraphDriver.java
@@ -109,7 +109,7 @@ public class APKCallGraphDriver {
 	        CG = DalvikCallGraphTestBase.makeAPKCallGraph(libs(), null, apk.getAbsolutePath(), pm, ReflectionOptions.NONE);
 	        System.err.println("Analyzed " + apk + " in " + (System.currentTimeMillis() - time));
 
-	        System.err.println(new SDG<>(CG.fst, CG.snd, InstanceKey.class, DataDependenceOptions.NO_BASE_NO_HEAP_NO_EXCEPTIONS, ControlDependenceOptions.NONE));
+	        System.err.println(new SDG<>(CG.fst, CG.snd, DataDependenceOptions.NO_BASE_NO_HEAP_NO_EXCEPTIONS, ControlDependenceOptions.NONE));
 	        
 	        if (dumpIR) {
 	          for(CGNode n : CG.fst) {


### PR DESCRIPTION
Special thanks to @khatchad for [asking why this argument was needed](https://github.com/wala/WALA/pull/146#commitcomment-21999159). It isn't!