### PR TITLE
Fix warnings about unset javacProjectSettings build entries

### DIFF
--- a/com.ibm.wala.cast.java.test/build.properties
+++ b/com.ibm.wala.cast.java.test/build.properties
@@ -2,3 +2,4 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .
+javacProjectSettings = true

--- a/com.ibm.wala.cast.java/build.properties
+++ b/com.ibm.wala.cast.java/build.properties
@@ -2,3 +2,4 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .
+javacProjectSettings = true

--- a/com.ibm.wala.cast.js.html.nu_validator/build.properties
+++ b/com.ibm.wala.cast.js.html.nu_validator/build.properties
@@ -4,4 +4,5 @@ bin.includes = META-INF/,\
                .,\
                lib/htmlparser-1.4.jar
 jars.extra.classpath = lib/htmlparser-1.4.jar
+javacProjectSettings = true
                

--- a/com.ibm.wala.cast.js.nodejs.test/build.properties
+++ b/com.ibm.wala.cast.js.nodejs.test/build.properties
@@ -2,3 +2,4 @@ source.. = src/,\
            testdata/
 bin.includes = META-INF/,\
                .
+javacProjectSettings = true

--- a/com.ibm.wala.cast.js.nodejs/build.properties
+++ b/com.ibm.wala.cast.js.nodejs/build.properties
@@ -3,3 +3,4 @@ source.. = src/,\
 bin.includes = META-INF/,\
                .,\
                lib/json-20160212.jar
+javacProjectSettings = true

--- a/com.ibm.wala.cast.js.rhino.test/build.properties
+++ b/com.ibm.wala.cast.js.rhino.test/build.properties
@@ -3,3 +3,4 @@ output.. = bin/,\
            /com.ibm.wala.cast.js.test.data/examples-src/
 bin.includes = META-INF/,\
                .
+javacProjectSettings = true

--- a/com.ibm.wala.cast.js.rhino/build.properties
+++ b/com.ibm.wala.cast.js.rhino/build.properties
@@ -4,3 +4,4 @@ bin.includes = META-INF/,\
                .,\
                lib/rhino-1.7.6.jar
 jars.extra.classpath = lib/rhino-1.7.6.jar
+javacProjectSettings = true

--- a/com.ibm.wala.cast.js.test/build.properties
+++ b/com.ibm.wala.cast.js.test/build.properties
@@ -2,3 +2,4 @@ source.. =  harness-src
 output.. = bin/
 bin.includes = META-INF/,\
                .
+javacProjectSettings = true

--- a/com.ibm.wala.cast.js/build.properties
+++ b/com.ibm.wala.cast.js/build.properties
@@ -4,3 +4,4 @@ bin.includes = .,\
                lib/jericho-html-3.2.jar
 source.. = source/,\
            dat/
+javacProjectSettings = true

--- a/com.ibm.wala.cast.test/build.properties
+++ b/com.ibm.wala.cast.test/build.properties
@@ -2,3 +2,4 @@ source.. =  harness-src
 output.. = bin/
 bin.includes = META-INF/,\
                .
+javacProjectSettings = true

--- a/com.ibm.wala.cast/build.properties
+++ b/com.ibm.wala.cast/build.properties
@@ -3,3 +3,4 @@ output.. = bin/
 bin.includes = META-INF/,\
 	           lib/commons-io-2.4.jar,\
                .
+javacProjectSettings = true

--- a/com.ibm.wala.core.tests/build.properties
+++ b/com.ibm.wala.core.tests/build.properties
@@ -5,3 +5,4 @@ bin.includes = META-INF/,\
                .,\
                plugin.xml,\
                plugin.properties
+javacProjectSettings = true

--- a/com.ibm.wala.core/build.properties
+++ b/com.ibm.wala.core/build.properties
@@ -8,3 +8,4 @@ output.. = bin/
 source.. = dat/,\
            src/,\
            lib/
+javacProjectSettings = true

--- a/com.ibm.wala.dalvik.test/build.properties
+++ b/com.ibm.wala.dalvik.test/build.properties
@@ -5,3 +5,4 @@ bin.includes = META-INF/,\
 	       lib/dx.jar
 jars.extra.classpath = lib/dx.jar
 jre.compilation.profile = JavaSE-1.7
+javacProjectSettings = true

--- a/com.ibm.wala.ide.jdt.test/build.properties
+++ b/com.ibm.wala.ide.jdt.test/build.properties
@@ -4,3 +4,4 @@ output.. = bin/
 bin.includes = META-INF/,\
                .
 jre.compilation.profile = JavaSE-1.7
+javacProjectSettings = true

--- a/com.ibm.wala.ide.jdt/build.properties
+++ b/com.ibm.wala.ide.jdt/build.properties
@@ -2,3 +2,4 @@ source.. = source/
 output.. = bin/
 bin.includes = META-INF/,\
                .
+javacProjectSettings = true

--- a/com.ibm.wala.ide.jsdt.tests/build.properties
+++ b/com.ibm.wala.ide.jsdt.tests/build.properties
@@ -1,3 +1,4 @@
 source.. = src/
 bin.includes = META-INF/,\
                .
+javacProjectSettings = true

--- a/com.ibm.wala.ide.jsdt/build.properties
+++ b/com.ibm.wala.ide.jsdt/build.properties
@@ -2,3 +2,4 @@ source.. = source/
 output.. = bin/
 bin.includes = META-INF/,\
                .
+javacProjectSettings = true

--- a/com.ibm.wala.ide.tests/build.properties
+++ b/com.ibm.wala.ide.tests/build.properties
@@ -4,3 +4,4 @@ bin.includes = META-INF/,\
                .,\
                plugin.xml,\
                plugin.properties
+javacProjectSettings = true

--- a/com.ibm.wala.ide/build.properties
+++ b/com.ibm.wala.ide/build.properties
@@ -4,3 +4,4 @@ bin.includes = META-INF/,\
 jars.compile.order = .
 source.. = src/
 output.. = bin/
+javacProjectSettings = true

--- a/com.ibm.wala.shrike/build.properties
+++ b/com.ibm.wala.shrike/build.properties
@@ -4,3 +4,4 @@ bin.includes = META-INF/,\
 jars.compile.order = .
 source.. = src/
 output.. = bin/
+javacProjectSettings = true

--- a/com.ibm.wala.util/build.properties
+++ b/com.ibm.wala.util/build.properties
@@ -3,3 +3,4 @@ bin.includes = META-INF/,\
 jars.compile.order = .
 source.. = src/
 output.. = bin/
+javacProjectSettings = true


### PR DESCRIPTION
Specifically, these are all warnings of the form "The 'javacProjectSettings' build entry should be set when there are project specific compiler settings".