### PR TITLE
Fix or suppress 373 Eclipse Code Style warnings relating to static declarations

### DIFF
--- a/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
+++ b/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
@@ -396,7 +396,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
 
   }
 
-  private boolean isInterface(AbstractTypeDeclaration decl) {
+  private static boolean isInterface(AbstractTypeDeclaration decl) {
     return decl instanceof AnnotationTypeDeclaration ||
       (decl instanceof TypeDeclaration && ((TypeDeclaration)decl).isInterface());
   }
@@ -640,7 +640,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
     return visit(fakeCtor, classBinding, oldContext, inits);
   }
 
-  private IMethodBinding findDefaultCtor(ITypeBinding superClass) {
+  private static IMethodBinding findDefaultCtor(ITypeBinding superClass) {
     for (IMethodBinding met : superClass.getDeclaredMethods()) {
       if (met.isConstructor() && met.getParameterTypes().length == 0)
         return met;
@@ -1832,7 +1832,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
    * @param isPrivate
    * @return
    */
-  private ITypeBinding findClosestEnclosingClassSubclassOf(ITypeBinding typeOfThis, ITypeBinding owningType, boolean isPrivate) {
+  private static ITypeBinding findClosestEnclosingClassSubclassOf(ITypeBinding typeOfThis, ITypeBinding owningType, boolean isPrivate) {
     // GENERICS
 //    if (owningType.isParameterizedType())
 //      owningType = owningType.getTypeDeclaration();

--- a/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/ecj/ECJSourceModuleTranslator.java
+++ b/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/ecj/ECJSourceModuleTranslator.java
@@ -128,7 +128,7 @@ public class ECJSourceModuleTranslator implements SourceModuleTranslator {
     libs = paths.snd;
   }
 
-  private Pair<String[],String[]> computeClassPath(AnalysisScope scope) {
+  private static Pair<String[],String[]> computeClassPath(AnalysisScope scope) {
     List<String> sources = new LinkedList<>();
     List<String> libs = new LinkedList<>();
     for (ClassLoaderReference cl : scope.getLoaders()) {

--- a/com.ibm.wala.cast.java.test.data/src/foo/bar/hello/world/MethodMadness.java
+++ b/com.ibm.wala.cast.java.test.data/src/foo/bar/hello/world/MethodMadness.java
@@ -99,6 +99,7 @@ public class MethodMadness {
 			return 233 + x;
 		}
 		
+		@SuppressWarnings("static-access")
 		public void hello() {
 			System.out.println(privateInteger()); // inner function, inner this, 200013
 			System.out.println(MethodMadness.this.privateInteger()); // outer function, outer this, 100007 

--- a/com.ibm.wala.cast.java.test/src/com/ibm/wala/cast/java/test/JavaIRTests.java
+++ b/com.ibm.wala.cast.java.test/src/com/ibm/wala/cast/java/test/JavaIRTests.java
@@ -596,7 +596,7 @@ public abstract class JavaIRTests extends IRTests {
     runTest(singleTestSrc(), rtJar, simpleTestEntryPoint(), emptyList, true);
   }
 
-  private MethodReference getSliceRootReference(String className, String methodName, String methodDescriptor) {
+  private static MethodReference getSliceRootReference(String className, String methodName, String methodDescriptor) {
     TypeName clsName = TypeName.string2TypeName("L" + className.replace('.', '/'));
     TypeReference clsRef = TypeReference.findOrCreate(JavaSourceAnalysisScope.SOURCE, clsName);
 

--- a/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/examples/ast/SynchronizedBlockDuplicator.java
+++ b/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/examples/ast/SynchronizedBlockDuplicator.java
@@ -164,7 +164,7 @@ public class SynchronizedBlockDuplicator extends
     return oldTarget;
   }
 
-  private boolean contains(RewriteContext<UnwindKey> c, CAstNode n) {
+  private static boolean contains(RewriteContext<UnwindKey> c, CAstNode n) {
     if (c instanceof SyncContext) {
       return ((SyncContext) c).containsNode(n);
     } else {
@@ -176,7 +176,7 @@ public class SynchronizedBlockDuplicator extends
    * does root represent a synchronized block? if so, return the variable whose
    * lock is acquired. otherwise, return <code>null</code>
    */
-  private String isSynchronizedOnVar(CAstNode root) {
+  private static String isSynchronizedOnVar(CAstNode root) {
     if (root.getKind() == CAstNode.UNWIND) {
       CAstNode unwindBody = root.getChild(0);
       if (unwindBody.getKind() == CAstNode.BLOCK_STMT) {

--- a/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/loader/JavaSourceLoaderImpl.java
+++ b/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/loader/JavaSourceLoaderImpl.java
@@ -535,7 +535,7 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
     ((JavaClass) owner).addField(n);
   }
 
-  private TypeName toWALATypeName(CAstType type) {
+  private static TypeName toWALATypeName(CAstType type) {
     return TypeName.string2TypeName(type.getName());
   }
   

--- a/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/translator/JavaCAst2IRTranslator.java
+++ b/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/translator/JavaCAst2IRTranslator.java
@@ -167,7 +167,7 @@ public class JavaCAst2IRTranslator extends AstTranslator {
     processExceptions(newNode, context);
   }
 
-  private void processExceptions(CAstNode n, WalkContext context) {
+  private static void processExceptions(CAstNode n, WalkContext context) {
     context.cfg().addPreNode(n, context.getUnwindState());
     context.cfg().newBlock(true);
 
@@ -412,7 +412,7 @@ public class JavaCAst2IRTranslator extends AstTranslator {
     }
   }
 
-  private CAstType getType(final String name) {
+  private static CAstType getType(final String name) {
     return new CAstType.Class() {
       
       @Override

--- a/com.ibm.wala.cast.js.nodejs/src/com/ibm/wala/cast/js/nodejs/NodejsRequireTargetSelector.java
+++ b/com.ibm.wala.cast.js.nodejs/src/com/ibm/wala/cast/js/nodejs/NodejsRequireTargetSelector.java
@@ -24,8 +24,8 @@ import org.json.JSONObject;
 import com.ibm.wala.cast.js.ipa.callgraph.JSCallGraphUtil;
 import com.ibm.wala.cast.js.loader.JavaScriptLoader;
 import com.ibm.wala.cast.js.ssa.JavaScriptInvoke;
-import com.ibm.wala.cast.js.types.JavaScriptMethods;
 import com.ibm.wala.cast.js.types.JavaScriptTypes;
+import com.ibm.wala.cast.types.AstMethodReference;
 import com.ibm.wala.classLoader.CallSiteReference;
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IMethod;
@@ -118,7 +118,7 @@ public class NodejsRequireTargetSelector implements MethodTargetSelector {
 					
 					System.err.println(builder.getClassHierarchy());
 					
-					IMethod method = script.getMethod(JavaScriptMethods.fnSelector);
+					IMethod method = script.getMethod(AstMethodReference.fnSelector);
 					previouslyRequired.put(sourceModule.getClassName(), method);
 					
 					return method;

--- a/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/examples/hybrid/Driver.java
+++ b/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/examples/hybrid/Driver.java
@@ -12,7 +12,6 @@ import com.ibm.wala.cast.js.ipa.callgraph.JSCallGraphUtil;
 import com.ibm.wala.cast.js.ipa.callgraph.JavaScriptConstructTargetSelector;
 import com.ibm.wala.cast.js.ipa.callgraph.JavaScriptEntryPoints;
 import com.ibm.wala.cast.js.loader.JavaScriptLoader;
-import com.ibm.wala.cast.js.test.JSCallGraphBuilderUtil;
 import com.ibm.wala.cast.js.translator.CAstRhinoTranslatorFactory;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.classLoader.Language;
@@ -57,7 +56,7 @@ public class Driver {
 
     scope.addToScope(
         scope.getJavaScriptLoader(),
-        JSCallGraphBuilderUtil.getPrologueFile("prologue.js"));
+        JSCallGraphUtil.getPrologueFile("prologue.js"));
     for(int i = 1; i < args.length; i++) {
       URL script = Driver.class.getClassLoader().getResource(args[i]);
       scope.addToScope(

--- a/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/test/TestCPA.java
+++ b/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/test/TestCPA.java
@@ -31,7 +31,7 @@ public class TestCPA {
     com.ibm.wala.cast.js.ipa.callgraph.JSCallGraphUtil.setTranslatorFactory(new CAstRhinoTranslatorFactory());
   }
 
-  @SuppressWarnings("static-access")
+  @SuppressWarnings({ "static-access", "static-method" })
   @Test public void testCPA() throws IOException, IllegalArgumentException, CancelException, WalaException {
     JSCFABuilder builder = JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "cpa.js");
     builder.setContextSelector(new CPAContextSelector(builder.getContextSelector()));

--- a/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/test/TestRhinoSourceMap.java
+++ b/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/test/TestRhinoSourceMap.java
@@ -154,7 +154,7 @@ public class TestRhinoSourceMap {
 		  checkFunctionBodies("jquery_spec_test.js", jquery_spec_testSource);
 	  }
 
-	  private void checkFunctionBodies(String fileName, String[][] assertions) throws IOException, ClassHierarchyException {
+	  private static void checkFunctionBodies(String fileName, String[][] assertions) throws IOException, ClassHierarchyException {
 		  Map<String, String> sources = HashMapFactory.make();
 		  for(String[] assertion : assertions) {
 			  sources.put(assertion[0], assertion[1]);

--- a/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/test/TestRhinoSourceMap.java
+++ b/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/test/TestRhinoSourceMap.java
@@ -148,6 +148,7 @@ public class TestRhinoSourceMap {
 "        }"}
 	  };
 	  
+	  @SuppressWarnings("static-method")
 	  @Test
 	  public void testJquerySpecTestSourceMappings() throws IllegalArgumentException, IOException, CancelException, ClassHierarchyException {
 		  checkFunctionBodies("jquery_spec_test.js", jquery_spec_testSource);

--- a/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/test/TestSimpleCallGraphShapeRhino.java
+++ b/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/test/TestSimpleCallGraphShapeRhino.java
@@ -34,6 +34,7 @@ public class TestSimpleCallGraphShapeRhino extends TestSimpleCallGraphShape {
     com.ibm.wala.cast.js.ipa.callgraph.JSCallGraphUtil.setTranslatorFactory(new CAstRhinoTranslatorFactory());
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void test214631() throws IOException, IllegalArgumentException, CancelException, WalaException {
     JSCFABuilder b = JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "214631.js");
@@ -42,42 +43,50 @@ public class TestSimpleCallGraphShapeRhino extends TestSimpleCallGraphShape {
     // just make sure this does not crash
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testRewriterDoesNotChangeLabelsBug() throws IOException, IllegalArgumentException, CancelException, WalaException {
     JSCallGraphBuilderUtil.makeScriptCG("tests", "rewrite_does_not_change_lables_bug.js");
     // all we need is for it to finish building CG successfully.
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testRepr() throws IllegalArgumentException, IOException, CancelException, WalaException {
     JSCallGraphBuilderUtil.makeScriptCG("tests", "repr.js");
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testTranslateToCAstCrash1() throws IllegalArgumentException, IOException, CancelException, WalaException {
     JSCallGraphBuilderUtil.makeScriptCG("tests", "rhino_crash1.js");
   }
   
+  @SuppressWarnings("static-method")
   @Test
   public void testTranslateToCAstCrash2() throws IllegalArgumentException, IOException, CancelException, WalaException {
     JSCallGraphBuilderUtil.makeScriptCG("tests", "rhino_crash2.js");
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testTranslateToCAstCrash3() throws IllegalArgumentException, IOException, CancelException, WalaException {
     JSCallGraphBuilderUtil.makeScriptCG("tests", "rhino_crash3.js");
   }
   
+  @SuppressWarnings("static-method")
   @Test
   public void testNonLoopBreakLabel() throws IllegalArgumentException, IOException, CancelException, WalaException {
 	  JSCallGraphBuilderUtil.makeScriptCG("tests", "non_loop_break.js");
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testForInName() throws IllegalArgumentException, IOException, CancelException, WalaException {
     JSCallGraphBuilderUtil.makeScriptCG("tests", "for_in_name.js");
   }
 
+  @SuppressWarnings("static-method")
   @Test(expected = WalaException.class)
   public void testParseError() throws IllegalArgumentException, IOException, CancelException, WalaException {
     PropagationCallGraphBuilder B = JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "portal-example-simple.html");

--- a/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/vis/JsViewerDriver.java
+++ b/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/vis/JsViewerDriver.java
@@ -25,6 +25,7 @@ import com.ibm.wala.cast.js.html.WebPageLoaderFactory;
 import com.ibm.wala.cast.js.html.WebUtil;
 import com.ibm.wala.cast.js.html.jericho.JerichoHtmlParser;
 import com.ibm.wala.cast.js.ipa.callgraph.JSCFABuilder;
+import com.ibm.wala.cast.js.ipa.callgraph.JSCallGraphUtil;
 import com.ibm.wala.cast.js.loader.JavaScriptLoader;
 import com.ibm.wala.cast.js.test.JSCallGraphBuilderUtil;
 import com.ibm.wala.cast.js.translator.CAstRhinoTranslatorFactory;
@@ -49,7 +50,7 @@ public class JsViewerDriver extends JSCallGraphBuilderUtil {
 		URL url = new URL(args[0]); 
 		
 		// computing CG + PA
-		JSCallGraphBuilderUtil.setTranslatorFactory(new CAstRhinoTranslatorFactory());
+		JSCallGraphUtil.setTranslatorFactory(new CAstRhinoTranslatorFactory());
 		JavaScriptLoader.addBootstrapFile(WebUtil.preamble);
 
 		SourceModule[] sources = getSources(domless, url);

--- a/com.ibm.wala.cast.js.rhino/source/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
+++ b/com.ibm.wala.cast.js.rhino/source/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
@@ -213,7 +213,7 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
 
   }
 
-  private String operationReceiverName(int operationIndex) {
+  private static String operationReceiverName(int operationIndex) {
     return "$$destructure$rcvr" + operationIndex;
   }
 
@@ -221,7 +221,7 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
     return Ast.makeNode(CAstNode.VAR, Ast.makeConstant(operationReceiverName(operationIndex)));
   }
   
-  private String operationElementName(int operationIndex) {
+  private static String operationElementName(int operationIndex) {
     return "$$destructure$elt" + operationIndex;
   }
 
@@ -229,7 +229,7 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
     return Ast.makeNode(CAstNode.VAR, Ast.makeConstant(operationElementName(operationIndex)));
   }
 
-  private CAstNode translateOpcode(int nodeType) {
+  private static CAstNode translateOpcode(int nodeType) {
     switch (nodeType) {
     case Token.POS:
     case Token.ADD:
@@ -311,26 +311,26 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
     return makeCtorCall(value, arguments, context);
   }
 
-  private boolean isPrologueScript(WalkContext context) {
+  private static boolean isPrologueScript(WalkContext context) {
     return JavaScriptLoader.bootstrapFileNames.contains(context.script());
   }
 
-  private Node getCallTarget(FunctionCall n) {
+  private static Node getCallTarget(FunctionCall n) {
 	  return n.getTarget();
   }
   /**
    * is n a call to "primitive" within our synthetic modeling code?
    */
-  private boolean isPrimitiveCall(WalkContext context, FunctionCall n) {
+  private static boolean isPrimitiveCall(WalkContext context, FunctionCall n) {
     return isPrologueScript(context) && n.getType() == Token.CALL && getCallTarget(n).getType() == Token.NAME
         && getCallTarget(n).getString().equals("primitive");
   }
 
-  private Node getNewTarget(NewExpression n) {
+  private static Node getNewTarget(NewExpression n) {
 	  return n.getTarget();
   }
   
-  private boolean isPrimitiveCreation(WalkContext context, NewExpression n) {
+  private static boolean isPrimitiveCreation(WalkContext context, NewExpression n) {
 	  Node target = getNewTarget(n);
     return isPrologueScript(context) && n.getType() == Token.NEW && target.getType() == Token.NAME
         && target.getString().equals("Primitives");
@@ -585,14 +585,14 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
     return cn;
   }
   
-  private List<Label> getLabels(AstNode node) {
+  private static List<Label> getLabels(AstNode node) {
 	  if (node instanceof LabeledStatement || ((node = node.getParent()) instanceof LabeledStatement)) {
 		  return ((LabeledStatement)node).getLabels();
 	  } else {
 		  return null;
 	  }
   }
-  private AstNode makeEmptyLabelStmt(String label) {
+  private static AstNode makeEmptyLabelStmt(String label) {
 	  Label l = new Label();
 	  l.setName(label);
 	  LabeledStatement st = new LabeledStatement();
@@ -603,7 +603,7 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
 	  return st;
   }
   
-  private WalkContext makeLoopContext(AstNode node, WalkContext arg,
+  private static WalkContext makeLoopContext(AstNode node, WalkContext arg,
 			AstNode breakStmt, AstNode contStmt) {
 	  WalkContext loopContext = arg;
 	  List<Label> labels = getLabels(node);
@@ -617,7 +617,7 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
 	  return loopContext;
   }
 
-  private WalkContext makeBreakContext(AstNode node, WalkContext arg,
+  private static WalkContext makeBreakContext(AstNode node, WalkContext arg,
       AstNode breakStmt) {
     WalkContext loopContext = arg;
     List<Label> labels = getLabels(node);

--- a/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/FieldBasedCGUtil.java
+++ b/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/FieldBasedCGUtil.java
@@ -78,7 +78,7 @@ public class FieldBasedCGUtil {
     JavaScriptLoaderFactory loaders = new JavaScriptLoaderFactory(translatorFactory);
     Module[] scripts = new Module[]{
         new SourceURLModule(url),
-        JSCallGraphBuilderUtil.getPrologueFile("prologue.js")
+        JSCallGraphUtil.getPrologueFile("prologue.js")
     };
     return buildCG(loaders, scripts, builderType, monitor, supportFullPointerAnalysis);
 	}

--- a/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/TestForInLoopHack.java
+++ b/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/TestForInLoopHack.java
@@ -156,6 +156,7 @@ public abstract class TestForInLoopHack extends TestJSCallGraphShape {
     verifyGraphAssertions(CG, assertionsForbadforin2HackPrecision);
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testForInRecursion() throws IOException, IllegalArgumentException, CancelException, WalaException {
     JSCFABuilder B = JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "badforin3.js");
     addHackedForInLoopSensitivity(B);

--- a/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/TestForInLoopHack.java
+++ b/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/TestForInLoopHack.java
@@ -173,7 +173,7 @@ public abstract class TestForInLoopHack extends TestJSCallGraphShape {
   }
   */
   
-  private void addHackedForInLoopSensitivity(JSCFABuilder builder) {
+  private static void addHackedForInLoopSensitivity(JSCFABuilder builder) {
     final ContextSelector orig = builder.getContextSelector();
     builder.setContextSelector(new PropertyNameContextSelector(builder.getAnalysisCache(), orig));
   }

--- a/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/TestLexicalModRef.java
+++ b/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/TestLexicalModRef.java
@@ -27,6 +27,7 @@ import com.ibm.wala.util.intset.OrdinalSet;
 
 public abstract class TestLexicalModRef {
 
+  @SuppressWarnings("static-method")
   @Test
   public void testSimpleLexical() throws IOException, IllegalArgumentException, CancelException, WalaException {
     JSCFABuilder b = JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "simple-lexical.js");

--- a/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/TestPointerAnalyses.java
+++ b/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/TestPointerAnalyses.java
@@ -93,7 +93,7 @@ public abstract class TestPointerAnalyses {
     JSCallGraphUtil.setTranslatorFactory(factory);
   }
 
-  private Pair<CGNode, NewSiteReference> map(CallGraph CG, Pair<CGNode, NewSiteReference> ptr) {
+  private static Pair<CGNode, NewSiteReference> map(CallGraph CG, Pair<CGNode, NewSiteReference> ptr) {
     CGNode n = ptr.fst;
     
     if (! (n.getMethod() instanceof JavaScriptConstructor)) {
@@ -116,7 +116,7 @@ public abstract class TestPointerAnalyses {
     return Pair.make(caller, new NewSiteReference(site.getProgramCounter(), ptr.snd.getDeclaredType()));
   }
   
-  private Set<Pair<CGNode, NewSiteReference>> map(CallGraph CG, Set<Pair<CGNode, NewSiteReference>> ptrs) {
+  private static Set<Pair<CGNode, NewSiteReference>> map(CallGraph CG, Set<Pair<CGNode, NewSiteReference>> ptrs) {
     Set<Pair<CGNode, NewSiteReference>> result = HashSetFactory.make();
     for(Pair<CGNode, NewSiteReference> ptr : ptrs) {
       result.add(map(CG, ptr));
@@ -124,7 +124,7 @@ public abstract class TestPointerAnalyses {
     return result;
   }
   
-  private Set<Pair<CGNode, NewSiteReference>> ptrs(Set<CGNode> functions, int local, CallGraph CG, PointerAnalysis<? extends InstanceKey> pa) {
+  private static Set<Pair<CGNode, NewSiteReference>> ptrs(Set<CGNode> functions, int local, CallGraph CG, PointerAnalysis<? extends InstanceKey> pa) {
     Set<Pair<CGNode, NewSiteReference>> result = HashSetFactory.make();
 
     for(CGNode n : functions) {
@@ -144,7 +144,7 @@ public abstract class TestPointerAnalyses {
     return result;
   }
   
-  private boolean isGlobal(Set<CGNode> functions, int local, PointerAnalysis<? extends InstanceKey> pa) {
+  private static boolean isGlobal(Set<CGNode> functions, int local, PointerAnalysis<? extends InstanceKey> pa) {
     for(CGNode n : functions) {
       PointerKey l = pa.getHeapModel().getPointerKeyForLocal(n, local);
       if (l != null) {

--- a/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/TestSimpleCallGraphShape.java
+++ b/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/TestSimpleCallGraphShape.java
@@ -188,6 +188,7 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
     verifyGraphAssertions(CG, assertionsForSimpleLexical);
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testRecursiveLexical() throws IOException, IllegalArgumentException, CancelException, WalaException {
     // just checking that we have a sufficient bailout to ensure termination
@@ -346,12 +347,14 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
     verifyNoEdges(CG, "suffix:test2", "suffix:foo_of_A");
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testStackOverflowOnSsaConversionBug() throws IOException, IllegalArgumentException, CancelException, WalaException {
     JSCallGraphBuilderUtil.makeScriptCG("tests", "stack_overflow_on_ssa_conversion.js");
     // all we need is for it to finish building CG successfully.
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testExtJSSwitch() throws IOException, IllegalArgumentException, CancelException, WalaException {
     JSCallGraphBuilderUtil.makeScriptCG("tests", "extjs_switch.js");
@@ -359,6 +362,7 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
   }
 
 
+  @SuppressWarnings("static-method")
   @Test
   public void testFunctionDotCall() throws IOException, IllegalArgumentException, CancelException, WalaException {
     CallGraph cg = JSCallGraphBuilderUtil.makeScriptCG("tests", "function_call.js");
@@ -537,6 +541,7 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
     verifyGraphAssertions(CG, assertionsForLexicalBroken);
   }
   
+  @SuppressWarnings("static-method")
   @Test
   public void testDeadPhi() throws IllegalArgumentException, IOException, CancelException, WalaException {
     JSCallGraphBuilderUtil.makeScriptCG("tests", "dead_phi.js");
@@ -695,16 +700,19 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
       verifyGraphAssertions(cg, assertionsForExtend);
     }
 
+    @SuppressWarnings("static-method")
     @Test
     public void testDeadCatch() throws IllegalArgumentException, IOException, CancelException, WalaException {
       JSCallGraphBuilderUtil.makeScriptCG("tests", "dead_catch.js");
     }
 
+    @SuppressWarnings("static-method")
     @Test
     public void testUglyLoopCrash() throws IllegalArgumentException, IOException, CancelException, WalaException {
       JSCallGraphBuilderUtil.makeScriptCG("tests", "ssa-crash.js");
     }
 
+    @SuppressWarnings("static-method")
     @Test
     public void testTryFinallyCrash() throws IllegalArgumentException, IOException, CancelException, WalaException {      
       JSCFABuilder B = JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "try-finally-crash.js");
@@ -716,6 +724,7 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
     }
 
 
+    @SuppressWarnings("static-method")
     @Test(expected = CallGraphBuilderCancelException.class)
     public void testManyStrings() throws IllegalArgumentException, IOException, CancelException, WalaException {
       SSAPropagationCallGraphBuilder B = JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "many-strings.js");
@@ -727,6 +736,7 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
       CAstCallGraphUtil.dumpCG(B.getCFAContextInterpreter(), B.getPointerAnalysis(), CG);
     }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testTutorialExample() throws IllegalArgumentException, IOException, CancelException, WalaException {
     SSAPropagationCallGraphBuilder B = JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "tutorial-example.js");

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/callgraph/fieldbased/FieldBasedCallGraphBuilder.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/callgraph/fieldbased/FieldBasedCallGraphBuilder.java
@@ -87,7 +87,7 @@ public abstract class FieldBasedCallGraphBuilder {
 		this.supportFullPointerAnalysis = supportFullPointerAnalysis;
 	}
 
-  private MethodTargetSelector setupMethodTargetSelector(IClassHierarchy cha, JavaScriptConstructorFunctions constructors2, AnalysisOptions options) {
+  private static MethodTargetSelector setupMethodTargetSelector(IClassHierarchy cha, JavaScriptConstructorFunctions constructors2, AnalysisOptions options) {
     MethodTargetSelector result = new JavaScriptConstructTargetSelector(constructors2, options.getMethodTargetSelector());
     if (options instanceof JSAnalysisOptions && ((JSAnalysisOptions)options).handleCallApply()) {
       result = new JavaScriptFunctionApplyTargetSelector(new JavaScriptFunctionDotCallTargetSelector(result));
@@ -243,7 +243,7 @@ public abstract class FieldBasedCallGraphBuilder {
   
   Everywhere targetContext = Everywhere.EVERYWHERE;
   @SuppressWarnings("deprecation")
-  private boolean addCGEdgeWithContext(final JSCallGraph cg, CallSiteReference site, IMethod target, CGNode caller,
+  private static boolean addCGEdgeWithContext(final JSCallGraph cg, CallSiteReference site, IMethod target, CGNode caller,
       Context targetContext) throws CancelException {
     boolean ret = false;
     if(target != null) {
@@ -266,14 +266,14 @@ public abstract class FieldBasedCallGraphBuilder {
    * FuncVertex nodes for the reflectively-invoked methods
    * @throws CancelException 
    */
-	private OrdinalSet<FuncVertex> getReflectiveTargets(FlowGraph flowGraph, CallVertex callVertex, IProgressMonitor monitor) throws CancelException {
+	private static OrdinalSet<FuncVertex> getReflectiveTargets(FlowGraph flowGraph, CallVertex callVertex, IProgressMonitor monitor) throws CancelException {
 	  SSAAbstractInvokeInstruction invoke = callVertex.getInstruction();
 	  VarVertex functionParam = flowGraph.getVertexFactory().makeVarVertex(callVertex.getCaller(), invoke.getUse(1));
 	  return flowGraph.getReachingSet(functionParam, monitor);
   }
 
   @SuppressWarnings("unused")
-  private OrdinalSet<FuncVertex> getConstructorTargets(FlowGraph flowGraph, CallVertex callVertex, IProgressMonitor monitor) throws CancelException {
+  private static OrdinalSet<FuncVertex> getConstructorTargets(FlowGraph flowGraph, CallVertex callVertex, IProgressMonitor monitor) throws CancelException {
     SSAAbstractInvokeInstruction invoke = callVertex.getInstruction();
     assert invoke.getDeclaredTarget().getName().equals(JavaScriptMethods.ctorAtom);
     VarVertex objectParam = flowGraph.getVertexFactory().makeVarVertex(callVertex.getCaller(), invoke.getUse(0));

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/callgraph/fieldbased/FieldBasedCallGraphBuilder.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/callgraph/fieldbased/FieldBasedCallGraphBuilder.java
@@ -283,6 +283,7 @@ public abstract class FieldBasedCallGraphBuilder {
   /**
 	 * Extract call edges from the flow graph into high-level representation.
 	 */
+	@SuppressWarnings("static-method")
 	public Set<Pair<CallVertex, FuncVertex>> extractCallGraphEdges(FlowGraph flowgraph, IProgressMonitor monitor) throws CancelException {
 		VertexFactory factory = flowgraph.getVertexFactory();
 		final Set<Pair<CallVertex, FuncVertex>> result = HashSetFactory.make();

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/callgraph/fieldbased/OptimisticCallgraphBuilder.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/callgraph/fieldbased/OptimisticCallgraphBuilder.java
@@ -93,7 +93,7 @@ public class OptimisticCallgraphBuilder extends FieldBasedCallGraphBuilder {
 	}
 
 	// add flow corresponding to a new call edge
-	private void addEdge(FlowGraph flowgraph, CallVertex c, FuncVertex callee, IProgressMonitor monitor) throws CancelException {
+	private static void addEdge(FlowGraph flowgraph, CallVertex c, FuncVertex callee, IProgressMonitor monitor) throws CancelException {
 	  VertexFactory factory = flowgraph.getVertexFactory();
 	  JavaScriptInvoke invk = c.getInstruction();
 	  FuncVertex caller = c.getCaller();
@@ -116,7 +116,7 @@ public class OptimisticCallgraphBuilder extends FieldBasedCallGraphBuilder {
 	
 	// add data flow corresponding to a reflective invocation via Function.prototype.call
 	// NB: for f.call(...), f will _not_ appear as a call target, but the appropriate argument and return data flow will be set up
-	private void addReflectiveCallEdge(FlowGraph flowgraph, CallVertex c, IProgressMonitor monitor) throws CancelException {
+	private static void addReflectiveCallEdge(FlowGraph flowgraph, CallVertex c, IProgressMonitor monitor) throws CancelException {
 	  VertexFactory factory = flowgraph.getVertexFactory();
 	  FuncVertex caller = c.getCaller();
 	  JavaScriptInvoke invk = c.getInstruction();

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/callgraph/fieldbased/PessimisticCallGraphBuilder.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/callgraph/fieldbased/PessimisticCallGraphBuilder.java
@@ -51,6 +51,7 @@ public class PessimisticCallGraphBuilder extends FieldBasedCallGraphBuilder {
 		return flowgraph;
 	}
 
+	@SuppressWarnings("static-method")
 	protected boolean filterFunction(IMethod function) {
 	  return function.getDescriptor().equals(AstMethodReference.fnDesc);
 	}

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/FlowGraph.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/FlowGraph.java
@@ -104,7 +104,7 @@ public class FlowGraph implements Iterable<Vertex> {
 		optimistic_closure = computeClosure(graph, monitor, FuncVertex.class);
 	}
 	
-	private <T> GraphReachability<Vertex, T> computeClosure(NumberedGraph<Vertex> graph, IProgressMonitor monitor, final Class<?> type) throws CancelException {
+	private static <T> GraphReachability<Vertex, T> computeClosure(NumberedGraph<Vertex> graph, IProgressMonitor monitor, final Class<?> type) throws CancelException {
 		// prune flowgraph by taking out 'unknown' vertex
 		Graph<Vertex> pruned_flowgraph = GraphSlicer.prune(graph, new Predicate<Vertex>() {
 			@Override

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/html/DefaultSourceExtractor.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/html/DefaultSourceExtractor.java
@@ -100,7 +100,7 @@ public class DefaultSourceExtractor extends DomLessSourceExtractor{
       domRegion.println("");
     }
 
-    private String makeRef(String object, String property) {
+    private static String makeRef(String object, String property) {
       assert object != null && property != null;
       return object + "[\"" + property + "\"]";
     }

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/html/DomLessSourceExtractor.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/html/DomLessSourceExtractor.java
@@ -140,7 +140,7 @@ public class DomLessSourceExtractor extends JSSourceExtractor {
       handleDOM(tag);
     }
 
-    private boolean isUsableIdentifier(String x) {
+    private static boolean isUsableIdentifier(String x) {
       return x != null &&
           LEGAL_JS_IDENTIFIER_REGEXP.matcher(x).matches() &&
           !LEGAL_JS_KEYWORD_REGEXP.matcher(x).matches();
@@ -217,7 +217,7 @@ public class DomLessSourceExtractor extends JSSourceExtractor {
       return Pair.make(value, quote);
     }
     
-    private String extructJS(String attValue) {
+    private static String extructJS(String attValue) {
       if (attValue == null){
         return "";
       }
@@ -351,7 +351,7 @@ public class DomLessSourceExtractor extends JSSourceExtractor {
     return new HtmlCallback(entrypointUrl, urlResolver);
   }
 
-  private File createOutputFile(URL url, boolean delete, boolean useTempName) throws IOException {
+  private static File createOutputFile(URL url, boolean delete, boolean useTempName) throws IOException {
     File outputFile;
     String fileName = new File(url.getFile()).getName();
     if (fileName.length() < 5) {

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/html/DomLessSourceExtractor.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/html/DomLessSourceExtractor.java
@@ -346,6 +346,7 @@ public class DomLessSourceExtractor extends JSSourceExtractor {
     return Collections.singleton(singleFileModule);
   }
 
+  @SuppressWarnings("static-method")
   protected IGeneratorCallback createHtmlCallback(URL entrypointUrl, IUrlResolver urlResolver) {
     return new HtmlCallback(entrypointUrl, urlResolver);
   }

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionApplyContextInterpreter.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionApplyContextInterpreter.java
@@ -61,7 +61,7 @@ public class JavaScriptFunctionApplyContextInterpreter extends AstContextInsensi
     }
   }
 
-  private IR makeIRForArgList(CGNode node) {
+  private static IR makeIRForArgList(CGNode node) {
     // we have: v1 is dummy apply method
     // v2 is function to be invoked
     // v3 is argument to be passed as 'this'
@@ -121,7 +121,7 @@ public class JavaScriptFunctionApplyContextInterpreter extends AstContextInsensi
   }
 
   @SuppressWarnings("unused")
-  private int passArbitraryPropertyValAsParams(JSInstructionFactory insts, int nargs, JavaScriptSummary S, int[] paramsToPassToInvoked) {
+  private static int passArbitraryPropertyValAsParams(JSInstructionFactory insts, int nargs, JavaScriptSummary S, int[] paramsToPassToInvoked) {
     // read an arbitrary property name via EachElementGet
     int curValNum = nargs + 2;
     int eachElementGetResult = curValNum++;
@@ -139,7 +139,7 @@ public class JavaScriptFunctionApplyContextInterpreter extends AstContextInsensi
     return curValNum;
   }
   
-  private int passActualPropertyValsAsParams(JSInstructionFactory insts, int nargs, JavaScriptSummary S, int[] paramsToPassToInvoked) {
+  private static int passActualPropertyValsAsParams(JSInstructionFactory insts, int nargs, JavaScriptSummary S, int[] paramsToPassToInvoked) {
     // read an arbitrary property name via EachElementGet
     int nullVn = nargs + 2;
     S.addConstant(nullVn, new ConstantValue(null));
@@ -165,7 +165,7 @@ public class JavaScriptFunctionApplyContextInterpreter extends AstContextInsensi
     return curValNum;
   }
 
-  private IR makeIRForNoArgList(CGNode node) {
+  private static IR makeIRForNoArgList(CGNode node) {
     // kind of a hack; re-use the summarized function infrastructure
     MethodReference ref = node.getMethod().getReference();
     IClass declaringClass = node.getMethod().getDeclaringClass();

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionApplyTargetSelector.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionApplyTargetSelector.java
@@ -42,7 +42,7 @@ public class JavaScriptFunctionApplyTargetSelector implements MethodTargetSelect
     this.base = base;
   }
 
-  private IMethod createApplyDummyMethod(IClass declaringClass) {
+  private static IMethod createApplyDummyMethod(IClass declaringClass) {
     final MethodReference ref = genSyntheticMethodRef(declaringClass);
     // number of args doesn't matter
     JavaScriptSummary S = new JavaScriptSummary(ref, 1);
@@ -51,7 +51,7 @@ public class JavaScriptFunctionApplyTargetSelector implements MethodTargetSelect
 
   public static final String SYNTHETIC_APPLY_METHOD_PREFIX = "$$ apply_dummy";
 
-  private MethodReference genSyntheticMethodRef(IClass receiver) {
+  private static MethodReference genSyntheticMethodRef(IClass receiver) {
     Atom atom = Atom.findOrCreateUnicodeAtom(SYNTHETIC_APPLY_METHOD_PREFIX);
     Descriptor desc = Descriptor.findOrCreateUTF8(JavaScriptLoader.JS, "()LRoot;");
     MethodReference ref = MethodReference.findOrCreate(receiver.getReference(), atom, desc);

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionDotCallTargetSelector.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionDotCallTargetSelector.java
@@ -174,14 +174,14 @@ public class JavaScriptFunctionDotCallTargetSelector implements MethodTargetSele
 
   public static final String SYNTHETIC_CALL_METHOD_PREFIX = "$$ call_";
 
-  private MethodReference genSyntheticMethodRef(IClass receiver, int nargs, String key) {
+  private static MethodReference genSyntheticMethodRef(IClass receiver, int nargs, String key) {
     Atom atom = Atom.findOrCreateUnicodeAtom(SYNTHETIC_CALL_METHOD_PREFIX + key);
     Descriptor desc = Descriptor.findOrCreateUTF8(JavaScriptLoader.JS, "()LRoot;");
     MethodReference ref = MethodReference.findOrCreate(receiver.getReference(), atom, desc);
     return ref;
   }
 
-  private String getKey(int nargs, CGNode caller, CallSiteReference site) {
+  private static String getKey(int nargs, CGNode caller, CallSiteReference site) {
     if (SEPARATE_SYNTHETIC_METHOD_PER_SITE) {
       return JSCallGraphUtil.getShortName(caller) + "_" + caller.getGraphNodeId() + "_" + site.getProgramCounter();
     } else {
@@ -189,7 +189,7 @@ public class JavaScriptFunctionDotCallTargetSelector implements MethodTargetSele
     }
   }
 
-  private int getNumberOfArgsPassed(CGNode caller, CallSiteReference site) {
+  private static int getNumberOfArgsPassed(CGNode caller, CallSiteReference site) {
     IR callerIR = caller.getIR();
     SSAAbstractInvokeInstruction callStmts[] = callerIR.getCalls(site);
     assert callStmts.length == 1;

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionDotCallTargetSelector.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionDotCallTargetSelector.java
@@ -12,6 +12,7 @@ package com.ibm.wala.cast.js.ipa.callgraph;
 
 import java.util.Map;
 
+import com.ibm.wala.cast.ipa.callgraph.CAstCallGraphUtil;
 import com.ibm.wala.cast.js.ipa.summaries.JavaScriptSummarizedFunction;
 import com.ibm.wala.cast.js.ipa.summaries.JavaScriptSummary;
 import com.ibm.wala.cast.js.loader.JSCallSiteReference;
@@ -183,7 +184,7 @@ public class JavaScriptFunctionDotCallTargetSelector implements MethodTargetSele
 
   private static String getKey(int nargs, CGNode caller, CallSiteReference site) {
     if (SEPARATE_SYNTHETIC_METHOD_PER_SITE) {
-      return JSCallGraphUtil.getShortName(caller) + "_" + caller.getGraphNodeId() + "_" + site.getProgramCounter();
+      return CAstCallGraphUtil.getShortName(caller) + "_" + caller.getGraphNodeId() + "_" + site.getProgramCounter();
     } else {
       return ""+nargs;
     }

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/LoadFileTargetSelector.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/LoadFileTargetSelector.java
@@ -18,7 +18,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import com.ibm.wala.cast.js.loader.JavaScriptLoader;
-import com.ibm.wala.cast.js.types.JavaScriptMethods;
 import com.ibm.wala.cast.js.types.JavaScriptTypes;
 import com.ibm.wala.cast.types.AstMethodReference;
 import com.ibm.wala.classLoader.CallSiteReference;
@@ -79,7 +78,7 @@ public class LoadFileTargetSelector implements MethodTargetSelector {
               JSCallGraphUtil.loadAdditionalFile(builder.getClassHierarchy() , cl, url);
               loadedFiles.add(url);
               IClass script = builder.getClassHierarchy().lookupClass(TypeReference.findOrCreate(cl.getReference(), "L" + url.getFile()));
-              return script.getMethod(JavaScriptMethods.fnSelector);
+              return script.getMethod(AstMethodReference.fnSelector);
             }
           } catch (MalformedURLException e1) {
             // do nothing, fall through and return 'target'

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/RecursionCheckContextSelector.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/RecursionCheckContextSelector.java
@@ -61,7 +61,7 @@ public class RecursionCheckContextSelector implements ContextSelector {
     return baseContext;
   }
 
-  private boolean recursiveContext(Context baseContext, IMethod callee) {
+  private static boolean recursiveContext(Context baseContext, IMethod callee) {
     if (!recursionPossible(callee)) {
       return false;
     }
@@ -100,7 +100,7 @@ public class RecursionCheckContextSelector implements ContextSelector {
     return false;
   }
 
-  private boolean updateForNode(Context baseContext, Collection<IMethod> curEncountered, LinkedList<Pair<Context, Collection<IMethod>>> worklist, CGNode callerNode) {
+  private static boolean updateForNode(Context baseContext, Collection<IMethod> curEncountered, LinkedList<Pair<Context, Collection<IMethod>>> worklist, CGNode callerNode) {
     final IMethod method = callerNode.getMethod();
     if (!recursionPossible(method)) {
       assert !curEncountered.contains(method);
@@ -132,7 +132,7 @@ public class RecursionCheckContextSelector implements ContextSelector {
    * @param m
    * @return
    */
-  private boolean recursionPossible(IMethod m) {
+  private static boolean recursionPossible(IMethod m) {
     // object or array constructors cannot be involved
     if (m.getReference().getName().equals(JavaScriptMethods.ctorAtom)) {
       TypeReference declaringClass = m.getReference().getDeclaringClass();

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/correlations/CorrelationFinder.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/correlations/CorrelationFinder.java
@@ -244,7 +244,7 @@ public class CorrelationFinder {
     printCorrelatedAccesses(findCorrelatedAccesses(url));
   }
 
-  private void printCorrelatedAccesses(Map<IMethod, CorrelationSummary> summaries) {
+  private static void printCorrelatedAccesses(Map<IMethod, CorrelationSummary> summaries) {
     List<Pair<Position, String>> correlations = new ArrayList<>();
     for(CorrelationSummary summary : summaries.values())
       correlations.addAll(summary.pp());

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/ClosureExtractor.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/ClosureExtractor.java
@@ -666,7 +666,7 @@ public class ClosureExtractor extends CAstRewriterExt {
     return stmts;
   }
   
-  private CAstNode addSpuriousExnFlow(CAstNode node, CAstControlFlowMap cfg) {
+  private static CAstNode addSpuriousExnFlow(CAstNode node, CAstControlFlowMap cfg) {
     CAstControlFlowRecorder flow = (CAstControlFlowRecorder)cfg;
     if(node.getKind() == ASSIGN) {
       if(node.getChild(0).getKind() == VAR) {

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/CorrelatedPairExtractionPolicy.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/CorrelatedPairExtractionPolicy.java
@@ -179,7 +179,7 @@ public class CorrelatedPairExtractionPolicy extends ExtractionPolicy {
     return true;
   }
   
-  private void filterNames(Set<ChildPos> nodes, String indexName) {
+  private static void filterNames(Set<ChildPos> nodes, String indexName) {
     for(Iterator<ChildPos> iter=nodes.iterator();iter.hasNext();) {
       CAstNode node = iter.next().getChild();
       if(node.getKind() == CAstNode.OBJECT_REF) {
@@ -191,7 +191,7 @@ public class CorrelatedPairExtractionPolicy extends ExtractionPolicy {
     }
   }
 
-  private Pair<CAstNode, ? extends ExtractionRegion> findClosestContainingBlock(CAstEntity entity, ChildPos startNode, ChildPos endNode, String parmName, List<String> locals) {
+  private static Pair<CAstNode, ? extends ExtractionRegion> findClosestContainingBlock(CAstEntity entity, ChildPos startNode, ChildPos endNode, String parmName, List<String> locals) {
     ChildPos pos = startNode;
     CAstNode block = null;
     int start = -1, end = 0;

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/summaries/JavaScriptConstructorFunctions.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/summaries/JavaScriptConstructorFunctions.java
@@ -88,7 +88,7 @@ public class JavaScriptConstructorFunctions {
     return m;
   }
 
-  private IMethod makeNullaryValueConstructor(IClass cls, Object value) {
+  private static IMethod makeNullaryValueConstructor(IClass cls, Object value) {
     JSInstructionFactory insts = (JSInstructionFactory)cls.getClassLoader().getInstructionFactory();
     MethodReference ref = JavaScriptMethods.makeCtorReference(cls.getReference());
     JavaScriptSummary S = new JavaScriptSummary(ref, 1);
@@ -118,7 +118,7 @@ public class JavaScriptConstructorFunctions {
     return new JavaScriptConstructor(ref, S, cls, cls);
   }
 
-  private IMethod makeUnaryValueConstructor(IClass cls) {
+  private static IMethod makeUnaryValueConstructor(IClass cls) {
     JSInstructionFactory insts = (JSInstructionFactory)cls.getClassLoader().getInstructionFactory();
    MethodReference ref = JavaScriptMethods.makeCtorReference(cls.getReference());
     JavaScriptSummary S = new JavaScriptSummary(ref, 2);

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/translator/JSAstTranslator.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/translator/JSAstTranslator.java
@@ -54,7 +54,7 @@ public class JSAstTranslator extends AstTranslator {
     super(loader);
   }
 
-  private boolean isPrologueScript(WalkContext context) {
+  private static boolean isPrologueScript(WalkContext context) {
     return JavaScriptLoader.bootstrapFileNames.contains( context.getModule().getName() );
   }
 

--- a/com.ibm.wala.cast.test/harness-src/com/ibm/wala/cast/test/TestCAstPattern.java
+++ b/com.ibm.wala.cast.test/harness-src/com/ibm/wala/cast/test/TestCAstPattern.java
@@ -60,7 +60,7 @@ public class TestCAstPattern extends WalaTestCase {
 
   }
 
-  private void test(CAstPattern p, CAstNode n, Map names) {
+  private static void test(CAstPattern p, CAstNode n, Map names) {
     System.err.println(("testing pattern " + p));
     System.err.println(("testing with input " + CAstPrinter.print(n)));
 

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/callgraph/AstSSAPropagationCallGraphBuilder.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/callgraph/AstSSAPropagationCallGraphBuilder.java
@@ -358,7 +358,7 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
       return ((AstPointerKeyFactory) getBuilder().getPointerKeyFactory()).getPointerKeysForReflectedFieldWrite(I, F);
     }
 
-    private void visitLexical(AstLexicalAccess instruction, final LexicalOperator op) {
+    private static void visitLexical(AstLexicalAccess instruction, final LexicalOperator op) {
       op.doLexicalPointerKeys(false);
       // I have no idea what the code below does, but commenting it out doesn't
       // break any regression tests. --MS

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/callgraph/AstSSAPropagationCallGraphBuilder.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/callgraph/AstSSAPropagationCallGraphBuilder.java
@@ -102,6 +102,7 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
    * each language can specify whether a particular field name should be stored
    * in object catalogs or not. By default, always return false.
    */
+  @SuppressWarnings("static-method")
   protected boolean isUncataloguedField(IClass type, String fieldName) {
     return false;
   }

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/callgraph/DelegatingAstPointerKeys.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/callgraph/DelegatingAstPointerKeys.java
@@ -96,6 +96,7 @@ public class DelegatingAstPointerKeys implements AstPointerKeyFactory {
    * @param F
    * @return
    */
+  @SuppressWarnings("static-method")
   protected IClass getFieldNameType(InstanceKey F) {
     return F.getConcreteType();
   }

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/AbstractSSAConversion.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/AbstractSSAConversion.java
@@ -306,15 +306,15 @@ public abstract class AbstractSSAConversion {
     }
   }
 
-   private <T> void push(ArrayList<T> stack, T elt) {
+   private static <T> void push(ArrayList<T> stack, T elt) {
     stack.add(elt);
   }
   
-  private <T> T peek(ArrayList<T> stack) {
+  private static <T> T peek(ArrayList<T> stack) {
     return stack.get(stack.size()-1); 
   }
   
-  private <T> T pop(ArrayList<T> stack) {
+  private static <T> T pop(ArrayList<T> stack) {
     T e = stack.get(stack.size()-1);
     stack.remove(stack.size()-1);
     return e;

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/SSAConversion.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/SSAConversion.java
@@ -332,11 +332,11 @@ public class SSAConversion extends AbstractSSAConversion {
     return null;
   }
 
-  private <T> void push(ArrayList<T> stack, T elt) {
+  private static <T> void push(ArrayList<T> stack, T elt) {
     stack.add(elt);
   }
   
-  private <T> T peek(ArrayList<T> stack) {
+  private static <T> T peek(ArrayList<T> stack) {
     return stack.get(stack.size()-1); 
   }
 

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
@@ -3158,7 +3158,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
     return map;
   }
 
-  protected final CAstType getTypeForNode(WalkContext context, CAstNode node) {
+  protected final static CAstType getTypeForNode(WalkContext context, CAstNode node) {
     if (context.top().getNodeTypeMap() != null) {
       return context.top().getNodeTypeMap().getNodeType(node);
     } else {

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
@@ -227,6 +227,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
    * to access a non-existent variable (believe it or not, JavaScript actually
    * does this!)
    */
+  @SuppressWarnings("static-method")
   protected boolean hasImplicitGlobals() {
     return false;
   }
@@ -333,6 +334,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
    * @param name A variable name
    * @return is this name safe to overwrite, i.e. it's synthetic from the translator?
    */
+  @SuppressWarnings("static-method")
   protected boolean ignoreName(String name) {
     return false;
   }
@@ -450,6 +452,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   /**
    * generate instructions to check if ref has field, storing answer in result
    */
+  @SuppressWarnings("static-method")
   protected void doIsFieldDefined(WalkContext context, int result, int ref, CAstNode field) {
     Assertions.UNREACHABLE();
   }
@@ -1785,10 +1788,12 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
     };
   }
 
+  @SuppressWarnings("static-method")
   protected int getArgumentCount(CAstEntity f) {
     return f.getArgumentCount();
   }
   
+  @SuppressWarnings("static-method")
   protected String[] getArgumentNames(CAstEntity f) {
     return f.getArgumentNames();
   }

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
@@ -344,7 +344,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
    * call sites, as would be required for
    * {@link #doLexicallyScopedRead(CAstNode, WalkContext, String)}
    */
-  private int doLexReadHelper(WalkContext context, final String name, TypeReference type) {
+  private static int doLexReadHelper(WalkContext context, final String name, TypeReference type) {
     Symbol S = context.currentScope().lookup(name);
     Scope definingScope = S.getDefiningScope();
     CAstEntity E = definingScope.getEntity();
@@ -371,7 +371,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
    * @param entityName
    * @param isWrite
    */
-  private void markExposedInEnclosingEntities(WalkContext context, final String name, Scope definingScope, TypeReference type, CAstEntity E,
+  private static void markExposedInEnclosingEntities(WalkContext context, final String name, Scope definingScope, TypeReference type, CAstEntity E,
       final String entityName, boolean isWrite) {
     Scope curScope = context.currentScope();
     while (!curScope.equals(definingScope)) {
@@ -1161,7 +1161,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
       }
     }
     
-    private boolean checkBlockBoundaries(IncipientCFG icfg) {
+    private static boolean checkBlockBoundaries(IncipientCFG icfg) {
       MutableIntSet boundaries = IntSetUtil.make();
       for(PreBasicBlock b : icfg) {
         if (b.getFirstInstructionIndex() >= 0) {
@@ -2803,7 +2803,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
       readOnlyNames = original.readOnlyNames;
     }
 
-    private int[] buildLexicalUseArray(Pair<Pair<String, String>, Integer>[] exposedNames, String entityName) {
+    private static int[] buildLexicalUseArray(Pair<Pair<String, String>, Integer>[] exposedNames, String entityName) {
       if (exposedNames != null) {
         int[] lexicalUses = new int[exposedNames.length];
         for (int j = 0; j < exposedNames.length; j++) {
@@ -2820,7 +2820,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
       }
     }
 
-    private Pair<String, String>[] buildLexicalNamesArray(Pair<Pair<String, String>, Integer>[] exposedNames) {
+    private static Pair<String, String>[] buildLexicalNamesArray(Pair<Pair<String, String>, Integer>[] exposedNames) {
       if (exposedNames != null) {
         @SuppressWarnings("unchecked")
         Pair<String, String>[] lexicalNames = new Pair[exposedNames.length];
@@ -2998,7 +2998,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
    * used to update an instruction that performs all the accesses at the
    * beginning of the method and defines the locals.
    */
-  private void addAccess(WalkContext context, CAstEntity e, Access access) {
+  private static void addAccess(WalkContext context, CAstEntity e, Access access) {
     context.getAccesses(e).add(access);
   }
 
@@ -3021,7 +3021,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
    * @param valueNumber
    *          the name's value number in the scope of entity
    */
-  private void addExposedName(CAstEntity entity, CAstEntity declaration, String name, int valueNumber, boolean isWrite, WalkContext context) {
+  private static void addExposedName(CAstEntity entity, CAstEntity declaration, String name, int valueNumber, boolean isWrite, WalkContext context) {
     Pair<Pair<String, String>, Integer> newVal = Pair.make(Pair.make(name, context.getEntityName(declaration)), valueNumber);
     context.exposeNameSet(entity, isWrite).add(newVal);
   }
@@ -3629,7 +3629,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
     return false;
   }
 
-  private boolean handleBinaryOpThrow(CAstNode n, CAstNode op, WalkContext context) {
+  private static boolean handleBinaryOpThrow(CAstNode n, CAstNode op, WalkContext context) {
     // currently, only integer / and % throw exceptions
     boolean mayBeInteger = false;
     Collection labels = context.getControlFlow().getTargetLabels(n);
@@ -4002,7 +4002,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
     }
   }
 
-  private int[] gatherArrayDims(WalkContext c, CAstNode n) {
+  private static int[] gatherArrayDims(WalkContext c, CAstNode n) {
     int numDims = n.getChildCount() - 2;
     int[] dims = new int[numDims];
     for (int i = 0; i < numDims; i++)
@@ -4180,7 +4180,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
     }
   }
 
-  private boolean isSimpleSwitch(CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
+  private static boolean isSimpleSwitch(CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
     CAstControlFlowMap ctrl = context.getControlFlow();
     Collection caseLabels = ctrl.getTargetLabels(n);
     for (Iterator kases = caseLabels.iterator(); kases.hasNext();) {

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/util/CAstPrinter.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/util/CAstPrinter.java
@@ -192,7 +192,7 @@ public class CAstPrinter {
       instance.doXmlTo(top, pos, w);
   }
 
-  private void doXmlTo(CAstNode top, CAstSourcePositionMap pos, Writer w) {
+  private static void doXmlTo(CAstNode top, CAstSourcePositionMap pos, Writer w) {
     printTo(top, pos, w, 0, true);
   }
 

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/basic/ExtensionGraphTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/basic/ExtensionGraphTest.java
@@ -66,6 +66,7 @@ public class ExtensionGraphTest {
     base.addEdge("H", "A");
   }
   
+  @SuppressWarnings("static-method")
   @Test
   public void testAugment() {
     NumberedGraph<String> base = makeBaseGraph();

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/basic/GraphDataflowTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/basic/GraphDataflowTest.java
@@ -56,6 +56,7 @@ public class GraphDataflowTest extends WalaTestCase {
    * A simple test of the GraphBitVectorDataflow system
    * @throws CancelException 
    */
+  @SuppressWarnings("static-method")
   @Test public void testSolverNodeEdge() throws CancelException {
     Graph<String> G = buildGraph();
     String result = solveNodeEdge(G);
@@ -67,6 +68,7 @@ public class GraphDataflowTest extends WalaTestCase {
     Assert.assertEquals(expectedStringNodeEdge(), result);
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testSolverNodeOnly() throws CancelException {
     Graph<String> G = buildGraph();
     String result = solveNodeOnly(G);

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/basic/OrdinalSetTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/basic/OrdinalSetTest.java
@@ -20,6 +20,7 @@ import com.ibm.wala.util.intset.OrdinalSet;
  */
 public class OrdinalSetTest extends WalaTestCase {
 
+  @SuppressWarnings("static-method")
   @Test public void test1() {
     OrdinalSet.unify(OrdinalSet.empty(), OrdinalSet.empty());
   }

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/basic/PathFinderTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/basic/PathFinderTest.java
@@ -60,6 +60,7 @@ public class PathFinderTest {
   
   private static final String edges1 = "ABBCBDCECFDGDHEIFIGJHJJKIKKL";
 
+  @SuppressWarnings("static-method")
   @Test
   public void testPaths1() {
     Graph<String> g = createGraph(edges1);
@@ -69,6 +70,7 @@ public class PathFinderTest {
 
   private static final String edges2 = "ABBCBDCECFDGDHEIFIGJHJJKIKKCKL";
 
+  @SuppressWarnings("static-method")
   @Test
   public void testPaths2() {
     Graph<String> g = createGraph(edges2);
@@ -78,6 +80,7 @@ public class PathFinderTest {
 
   private static final String edges3 = "ABBHBCBDCECFDGDHEIFIGJHJJKIKKCKL";
 
+  @SuppressWarnings("static-method")
   @Test
   public void testPaths3() {
     Graph<String> g = createGraph(edges3);
@@ -87,6 +90,7 @@ public class PathFinderTest {
 
   private static final String edges4 = "ABACADAEBABCBDBECACBCDCEDADBDCDEEAEBECED";
 
+  @SuppressWarnings("static-method")
   @Test
   public void testPaths4() {
     Graph<String> g = createGraph(edges4);

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/basic/PrimitivesTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/basic/PrimitivesTest.java
@@ -64,7 +64,7 @@ public class PrimitivesTest extends WalaTestCase {
   /**
    * Test the MutableSparseIntSet implementation
    */
-  private void doMutableIntSet(MutableIntSetFactory factory) {
+  private static void doMutableIntSet(MutableIntSetFactory factory) {
     MutableIntSet v = factory.parse("{9,17}");
     MutableIntSet w = factory.make(new int[] {});
     MutableIntSet x = factory.make(new int[] { 7, 4, 2, 4, 2, 2 });
@@ -356,7 +356,7 @@ public class PrimitivesTest extends WalaTestCase {
   /**
    * Test the MutableSparseIntSet implementation
    */
-  private void doMutableLongSet(MutableLongSetFactory factory) {
+  private static void doMutableLongSet(MutableLongSetFactory factory) {
     MutableLongSet v = factory.parse("{9,17}");
     MutableLongSet w = factory.make(new long[] {});
     MutableLongSet x = factory.make(new long[] { 7, 4, 2, 4, 2, 2 });
@@ -717,7 +717,7 @@ public class PrimitivesTest extends WalaTestCase {
     Assert.assertTrue(c.size() == 10);
   }
 
-  private NumberedGraph<Integer> makeBFSTestGraph() {
+  private static NumberedGraph<Integer> makeBFSTestGraph() {
     // test graph
     NumberedGraph<Integer> G = SlowSparseNumberedGraph.make();
 
@@ -872,7 +872,7 @@ public class PrimitivesTest extends WalaTestCase {
     Assert.assertTrue("Got count " + count, count == 2);
   }
 
-  private int countEquivalenceClasses(IntegerUnionFind uf) {
+  private static int countEquivalenceClasses(IntegerUnionFind uf) {
     HashSet<Integer> s = HashSetFactory.make();
     for (int i = 0; i < uf.size(); i++) {
       s.add(new Integer(uf.find(i)));
@@ -910,7 +910,7 @@ public class PrimitivesTest extends WalaTestCase {
     testSingleBitVector(new OffsetBitVector(100, 10));
   }
 
-  private void testSingleBitVector(BitVectorBase bv) {
+  private static void testSingleBitVector(BitVectorBase bv) {
     // does the following not automatically scale the bitvector to
     // a reasonable size?
     bv.set(55);
@@ -984,7 +984,7 @@ public class PrimitivesTest extends WalaTestCase {
   }
 
   @SuppressWarnings("unchecked")
-  private <T extends BitVectorBase> void testBitVectors(T v1, T v2) {
+  private static <T extends BitVectorBase> void testBitVectors(T v1, T v2) {
     v1.set(100);
     v1.set(101);
     v1.set(102);

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/basic/PrimitivesTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/basic/PrimitivesTest.java
@@ -316,6 +316,7 @@ public class PrimitivesTest extends WalaTestCase {
   /**
    * Test the MutableSharedBitVectorIntSet implementation
    */
+  @SuppressWarnings("static-method")
   @Test public void testMutableSharedBitVectorIntSet() {
     doMutableIntSet(new MutableSharedBitVectorIntSetFactory());
   }
@@ -323,6 +324,7 @@ public class PrimitivesTest extends WalaTestCase {
   /**
    * Test the MutableSparseIntSet implementation
    */
+  @SuppressWarnings("static-method")
   @Test public void testMutableSparseIntSet() {
     doMutableIntSet(new MutableSparseIntSetFactory());
   }
@@ -330,6 +332,7 @@ public class PrimitivesTest extends WalaTestCase {
   /**
    * Test the BimodalMutableSparseIntSet implementation
    */
+  @SuppressWarnings("static-method")
   @Test public void testBimodalMutableSparseIntSet() {
     doMutableIntSet(new BimodalMutableIntSetFactory());
   }
@@ -337,6 +340,7 @@ public class PrimitivesTest extends WalaTestCase {
   /**
    * Test the BitVectorIntSet implementation
    */
+  @SuppressWarnings("static-method")
   @Test public void testBitVectorIntSet() {
     doMutableIntSet(new BitVectorIntSetFactory());
   }
@@ -344,6 +348,7 @@ public class PrimitivesTest extends WalaTestCase {
   /**
    * Test the SemiSparseMutableIntSet implementation
    */
+  @SuppressWarnings("static-method")
   @Test public void testSemiSparseMutableIntSet() {
     doMutableIntSet(new SemiSparseMutableIntSetFactory());
   }
@@ -595,10 +600,12 @@ public class PrimitivesTest extends WalaTestCase {
   /**
    * Test the MutableSparseLongSet implementation
    */
+  @SuppressWarnings("static-method")
   @Test public void testMutableSparseLongSet() {
     doMutableLongSet(new MutableSparseLongSetFactory());
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testSmallMap() {
     SmallMap<Integer, Integer> M = new SmallMap<>();
     Integer I1 = new Integer(1);
@@ -621,6 +628,7 @@ public class PrimitivesTest extends WalaTestCase {
     Assert.assertTrue(I.equals(I3));
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testBimodalMap() {
     Map<Integer, Integer> M = new BimodalMap<>(3);
     Integer I1 = new Integer(1);
@@ -661,6 +669,7 @@ public class PrimitivesTest extends WalaTestCase {
     Assert.assertTrue(I.equals(I6));
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testBFSPathFinder() {
     NumberedGraph<Integer> G = makeBFSTestGraph();
 
@@ -675,6 +684,7 @@ public class PrimitivesTest extends WalaTestCase {
     }
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testBoundedBFS() {
     NumberedGraph<Integer> G = makeBFSTestGraph();
 
@@ -731,6 +741,7 @@ public class PrimitivesTest extends WalaTestCase {
     return G;
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testDominatorsA() {
     // test graph
     Graph<Object> G = SlowSparseNumberedGraph.make();
@@ -781,6 +792,7 @@ public class PrimitivesTest extends WalaTestCase {
     Assert.assertTrue(D.dominatorTree().getSuccNodeCount(nodes[10]) == 5);
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testBinaryIntegerRelation() {
     byte[] impl = new byte[] { BasicNaturalRelation.SIMPLE, BasicNaturalRelation.TWO_LEVEL, BasicNaturalRelation.SIMPLE };
     IBinaryNaturalRelation R = new BasicNaturalRelation(impl, BasicNaturalRelation.TWO_LEVEL);
@@ -827,6 +839,7 @@ public class PrimitivesTest extends WalaTestCase {
     Assert.assertTrue(R.getRelated(1).size() == 99);
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testUnionFind() {
     int SIZE = 10000;
     IntegerUnionFind uf = new IntegerUnionFind(SIZE);
@@ -867,26 +880,32 @@ public class PrimitivesTest extends WalaTestCase {
     return s.size();
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testBitVector() {
     testSingleBitVector(new BitVector());
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testOffsetBitVector0_10() {
     testSingleBitVector(new OffsetBitVector(0, 10));
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testOffsetBitVector10_10() {
     testSingleBitVector(new OffsetBitVector(10, 10));
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testOffsetBitVector50_10() {
     testSingleBitVector(new OffsetBitVector(50, 10));
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testOffsetBitVector50_50() {
     testSingleBitVector(new OffsetBitVector(50, 50));
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testOffsetBitVector100_10() {
     testSingleBitVector(new OffsetBitVector(100, 10));
   }
@@ -939,22 +958,27 @@ public class PrimitivesTest extends WalaTestCase {
     System.err.println(bv);
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testBitVectors() {
     testBitVectors(new BitVector(), new BitVector());
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testOffsetBitVectors150_10() {
     testBitVectors(new OffsetBitVector(150, 10), new OffsetBitVector(150, 10));
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testOffsetBitVectors100_200_10() {
     testBitVectors(new OffsetBitVector(100, 10), new OffsetBitVector(200, 10));
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testOffsetBitVectors100_25_10() {
     testBitVectors(new OffsetBitVector(100, 10), new OffsetBitVector(25, 10));
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testOffsetBitVectors35_25_20_10() {
     testBitVectors(new OffsetBitVector(35, 20), new OffsetBitVector(25, 10));
   }
@@ -1283,6 +1307,7 @@ public class PrimitivesTest extends WalaTestCase {
     return v1;
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testSpecificBugsInOffsetBitVectors() {
     OffsetBitVector v1 = makeBigTestOffsetVector();
     System.err.println(v1);
@@ -1310,6 +1335,7 @@ public class PrimitivesTest extends WalaTestCase {
     Assert.assertTrue(v2.isSubset(v1));
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testSpecificBugsInSemiSparseMutableIntSets() {
     SemiSparseMutableIntSet v1 = new SemiSparseMutableIntSet();
     v1.add(54);

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/AcyclicCallGraphTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/AcyclicCallGraphTest.java
@@ -30,6 +30,7 @@ import com.ibm.wala.util.intset.IntPair;
 
 public class AcyclicCallGraphTest extends WalaTestCase {
 
+  @SuppressWarnings("static-method")
   @Test public void testNList() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.WALA_TESTDATA,
         CallGraphTestUtil.REGRESSION_EXCLUSIONS);

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/CHACallGraphTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/CHACallGraphTest.java
@@ -28,6 +28,7 @@ import com.ibm.wala.util.functions.Function;
 
 public class CHACallGraphTest {
   
+  @SuppressWarnings("static-method")
   @Test public void testJava_cup() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     testCHA(TestConstants.JAVA_CUP, TestConstants.JAVA_CUP_MAIN, CallGraphTestUtil.REGRESSION_EXCLUSIONS);
   }

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/CPATest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/CPATest.java
@@ -50,7 +50,7 @@ public class CPATest extends WalaTestCase {
     doCPATest("Lcpa/CPATest2", "(Lcpa/CPATest2$N;I)Lcpa/CPATest2$N;");
   }
 
-  private void doCPATest(String testClass, String testIdSignature) throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+  private static void doCPATest(String testClass, String testIdSignature) throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
 
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.WALA_TESTDATA, CallGraphTestUtil.REGRESSION_EXCLUSIONS);
     ClassHierarchy cha = ClassHierarchyFactory.make(scope);

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/CallGraphTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/CallGraphTest.java
@@ -70,6 +70,7 @@ public class CallGraphTest extends WalaTestCase {
   }
 
 
+  @SuppressWarnings("static-method")
   @Test public void testJava_cup() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.JAVA_CUP, CallGraphTestUtil.REGRESSION_EXCLUSIONS);
     ClassHierarchy cha = ClassHierarchyFactory.make(scope);
@@ -80,6 +81,7 @@ public class CallGraphTest extends WalaTestCase {
     doCallGraphs(options, new AnalysisCacheImpl(), cha, scope, useShortProfile());
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testBcelVerifier() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.BCEL, CallGraphTestUtil.REGRESSION_EXCLUSIONS);
     ClassHierarchy cha = ClassHierarchyFactory.make(scope);
@@ -90,6 +92,7 @@ public class CallGraphTest extends WalaTestCase {
     doCallGraphs(options, new AnalysisCacheImpl(), cha, scope);
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testJLex() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.JLEX, CallGraphTestUtil.REGRESSION_EXCLUSIONS);
     ClassHierarchy cha = ClassHierarchyFactory.make(scope);
@@ -100,6 +103,7 @@ public class CallGraphTest extends WalaTestCase {
     doCallGraphs(options, new AnalysisCacheImpl(), cha, scope);
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testCornerCases() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.WALA_TESTDATA,
         CallGraphTestUtil.REGRESSION_EXCLUSIONS);
@@ -119,6 +123,7 @@ public class CallGraphTest extends WalaTestCase {
     Assert.assertTrue("reported a warning about Abstract2", ws.indexOf("cornerCases/Abstract2") == -1);
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testHello() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     if (analyzingJar()) return;
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.HELLO, CallGraphTestUtil.REGRESSION_EXCLUSIONS);
@@ -130,6 +135,7 @@ public class CallGraphTest extends WalaTestCase {
     doCallGraphs(options, new AnalysisCacheImpl(), cha, scope);
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testStaticInit() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.WALA_TESTDATA,
         CallGraphTestUtil.REGRESSION_EXCLUSIONS);
@@ -153,6 +159,7 @@ public class CallGraphTest extends WalaTestCase {
     }
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testJava8Smoke() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.WALA_TESTDATA,
         CallGraphTestUtil.REGRESSION_EXCLUSIONS);
@@ -170,6 +177,7 @@ public class CallGraphTest extends WalaTestCase {
     Assert.assertTrue("expected for sortForward", foundSortForward);
   }
   
+  @SuppressWarnings("static-method")
   @Test public void testSystemProperties() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.WALA_TESTDATA,
         CallGraphTestUtil.REGRESSION_EXCLUSIONS);
@@ -194,6 +202,7 @@ public class CallGraphTest extends WalaTestCase {
     }
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testRecursion() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.WALA_TESTDATA,
         CallGraphTestUtil.REGRESSION_EXCLUSIONS);
@@ -205,6 +214,7 @@ public class CallGraphTest extends WalaTestCase {
     doCallGraphs(options, new AnalysisCacheImpl(), cha, scope);
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testHelloAllEntrypoints() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     if (analyzingJar()) return;    
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.HELLO, CallGraphTestUtil.REGRESSION_EXCLUSIONS);
@@ -215,6 +225,7 @@ public class CallGraphTest extends WalaTestCase {
     doCallGraphs(options, new AnalysisCacheImpl(), cha, scope);
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testIO() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope("primordial.txt", CallGraphTestUtil.REGRESSION_EXCLUSIONS);
     ClassHierarchy cha = ClassHierarchyFactory.make(scope);
@@ -245,6 +256,7 @@ public class CallGraphTest extends WalaTestCase {
     };
   }
   
+  @SuppressWarnings("static-method")
   @Test public void testPrimordial() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     if (useShortProfile()) {
       return;
@@ -263,6 +275,7 @@ public class CallGraphTest extends WalaTestCase {
     CallGraphTestUtil.buildZeroCFA(options, new AnalysisCacheImpl(), cha, scope, false);
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testZeroOneContainerCopyOf() throws IOException, ClassHierarchyException, IllegalArgumentException, CancelException {
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.WALA_TESTDATA,

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/ClassConstantTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/ClassConstantTest.java
@@ -38,6 +38,7 @@ import com.ibm.wala.util.CancelException;
  */
 public class ClassConstantTest extends WalaTestCase {
 
+  @SuppressWarnings("static-method")
   @Test public void testClassConstants() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
 
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.WALA_TESTDATA,

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/CloneTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/CloneTest.java
@@ -40,6 +40,7 @@ import com.ibm.wala.util.CancelException;
  */
 public class CloneTest extends WalaTestCase {
 
+  @SuppressWarnings("static-method")
   @Test public void testClone() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
 
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.WALA_TESTDATA, CallGraphTestUtil.REGRESSION_EXCLUSIONS);

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/DefaultMethodsTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/DefaultMethodsTest.java
@@ -36,6 +36,7 @@ import com.ibm.wala.util.CancelException;
  */
 public class DefaultMethodsTest extends WalaTestCase {
 
+  @SuppressWarnings("static-method")
   @Test public void testDefaultMethods() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
 
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.WALA_TESTDATA, CallGraphTestUtil.REGRESSION_EXCLUSIONS);

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/FinalizerTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/FinalizerTest.java
@@ -36,6 +36,7 @@ import com.ibm.wala.util.CancelException;
  */
 public class FinalizerTest extends WalaTestCase {
 
+  @SuppressWarnings("static-method")
   @Test public void testFinalize() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
 
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.WALA_TESTDATA, CallGraphTestUtil.REGRESSION_EXCLUSIONS);

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/LambdaTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/LambdaTest.java
@@ -41,6 +41,7 @@ import com.ibm.wala.util.strings.Atom;
  */
 public class LambdaTest extends WalaTestCase {
 
+  @SuppressWarnings("static-method")
   @Test public void testBug144() throws IOException, ClassHierarchyException, IllegalArgumentException, CancelException {
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.WALA_TESTDATA, CallGraphTestUtil.REGRESSION_EXCLUSIONS);
     ClassHierarchy cha = ClassHierarchyFactory.make(scope);
@@ -51,6 +52,7 @@ public class LambdaTest extends WalaTestCase {
     CallGraph cg = CallGraphTestUtil.buildZeroCFA(options, new AnalysisCacheImpl(), cha, scope, false);
   }
   
+  @SuppressWarnings("static-method")
   @Test public void testBug137() throws IOException, ClassHierarchyException, IllegalArgumentException, CancelException {
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.WALA_TESTDATA, CallGraphTestUtil.REGRESSION_EXCLUSIONS);
     ClassHierarchy cha = ClassHierarchyFactory.make(scope);

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/PiNodeCallGraphTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/PiNodeCallGraphTest.java
@@ -74,7 +74,7 @@ public class PiNodeCallGraphTest extends WalaTestCase {
   private static final MemberReference unary2Ref = MethodReference.findOrCreate(whateverRef,
       Atom.findOrCreateUnicodeAtom("unary2"), Descriptor.findOrCreateUTF8("()V"));
 
-  private CallGraph doGraph(boolean usePiNodes) throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+  private static CallGraph doGraph(boolean usePiNodes) throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.WALA_TESTDATA, CallGraphTestUtil.REGRESSION_EXCLUSIONS);
     ClassHierarchy cha = ClassHierarchyFactory.make(scope);
     Iterable<Entrypoint> entrypoints = com.ibm.wala.ipa.callgraph.impl.Util.makeMainEntrypoints(scope, cha,
@@ -86,7 +86,7 @@ public class PiNodeCallGraphTest extends WalaTestCase {
     return CallGraphTestUtil.buildZeroCFA(options, new AnalysisCacheImpl(new DefaultIRFactory(), options.getSSAOptions()), cha, scope, false);
   }
 
-  private void checkCallAssertions(CallGraph cg, int desiredNumberOfTargets, int desiredNumberOfCalls, int numLocalCastCallees) {
+  private static void checkCallAssertions(CallGraph cg, int desiredNumberOfTargets, int desiredNumberOfCalls, int numLocalCastCallees) {
   
     int numberOfCalls = 0;
     Set<CGNode> callerNodes = HashSetFactory.make();

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/PiNodeCallGraphTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/PiNodeCallGraphTest.java
@@ -112,10 +112,12 @@ public class PiNodeCallGraphTest extends WalaTestCase {
     Assert.assertEquals(numLocalCastCallees, actualLocalCastCallees);
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testNoPiNodes() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     checkCallAssertions(doGraph(false), 2, 2, 2);
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testPiNodes() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     checkCallAssertions(doGraph(true), 1, 2, 1);
   } 

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/ReflectionTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/ReflectionTest.java
@@ -322,7 +322,7 @@ public class ReflectionTest extends WalaTestCase {
     Assert.assertTrue(filePermToStringNode != null);
   }
 
-  private Collection<CGNode> getSuccNodes(CallGraph cg, Collection<CGNode> nodes) {
+  private static Collection<CGNode> getSuccNodes(CallGraph cg, Collection<CGNode> nodes) {
     Set<CGNode> succNodes = HashSetFactory.make();
     for (CGNode newInstanceNode : nodes) {
       Iterator<? extends CGNode> succNodesIter = cg.getSuccNodes(newInstanceNode);

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/ReflectionTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/ReflectionTest.java
@@ -84,6 +84,7 @@ public class ReflectionTest extends WalaTestCase {
    * test that when analyzing Reflect1.main(), there is no warning about
    * "Integer".
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testReflect1() throws WalaException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -110,6 +111,7 @@ public class ReflectionTest extends WalaTestCase {
    * java.lang.Integer.<clinit>. This should be forced by the call for
    * Class.forName("java.lang.Integer").
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testReflect2() throws WalaException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -129,6 +131,7 @@ public class ReflectionTest extends WalaTestCase {
    * Check that when analyzing Reflect3, the successors of newInstance do not
    * include reflection/Reflect3$Hash
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testReflect3() throws IOException, ClassHierarchyException, IllegalArgumentException, CancelException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -161,6 +164,7 @@ public class ReflectionTest extends WalaTestCase {
    * Check that when analyzing Reflect4, successors of newInstance() do not
    * include FilePermission ctor.
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testReflect4() throws IOException, ClassHierarchyException, IllegalArgumentException, CancelException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -191,6 +195,7 @@ public class ReflectionTest extends WalaTestCase {
    * Check that when analyzing Reflect5, successors of newInstance do not
    * include a Reflect5$A ctor
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testReflect5() throws IOException, ClassHierarchyException, IllegalArgumentException, CancelException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -221,6 +226,7 @@ public class ReflectionTest extends WalaTestCase {
    * Check that when analyzing Reflect6, successors of newInstance do not
    * include a Reflect6$A ctor
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testReflect6() throws IOException, ClassHierarchyException, IllegalArgumentException, CancelException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -247,7 +253,7 @@ public class ReflectionTest extends WalaTestCase {
     Assert.assertTrue(succNodes.isEmpty());
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({ "static-method", "unchecked" })
   @Test
   public void testReflect7() throws Exception {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -331,6 +337,7 @@ public class ReflectionTest extends WalaTestCase {
    * Test that when analyzing reflect8, the call graph includes a node for
    * java.lang.Integer.toString()
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testReflect8() throws WalaException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -349,6 +356,7 @@ public class ReflectionTest extends WalaTestCase {
    * Test that when analyzing reflect9, the call graph includes a node for
    * java.lang.Integer.toString()
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testReflect9() throws WalaException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -367,6 +375,7 @@ public class ReflectionTest extends WalaTestCase {
    * Test that when analyzing Reflect10, the call graph includes a node for
    * java.lang.Integer.toString()
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testReflect10() throws WalaException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -385,6 +394,7 @@ public class ReflectionTest extends WalaTestCase {
    * Test that when analyzing Reflect11, the call graph includes a node for
    * java.lang.Object.wait()
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testReflect11() throws WalaException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -403,6 +413,7 @@ public class ReflectionTest extends WalaTestCase {
    * Test that when analyzing Reflect12, the call graph does not include a node
    * for reflection.Helper.n but does include a node for reflection.Helper.m
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testReflect12() throws WalaException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -424,6 +435,7 @@ public class ReflectionTest extends WalaTestCase {
    * Test that when analyzing Reflect13, the call graph includes both a node for
    * reflection.Helper.n and a node for reflection.Helper.m
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testReflect13() throws WalaException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -445,6 +457,7 @@ public class ReflectionTest extends WalaTestCase {
    * Test that when analyzing Reflect14, the call graph does not include a node
    * for reflection.Helper.n but does include a node for reflection.Helper.s
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testReflect14() throws WalaException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -467,6 +480,7 @@ public class ReflectionTest extends WalaTestCase {
    * constructor of Helper that takes 2 parameters and for Helper.n, but no node
    * for the constructors of Helper that takes 0 or 1 parameters.
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testReflect15() throws WalaException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -494,6 +508,7 @@ public class ReflectionTest extends WalaTestCase {
    * Test that when analyzing Reflect16, the call graph includes a node for
    * java.lang.Integer.toString()
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testReflect16() throws WalaException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -512,6 +527,7 @@ public class ReflectionTest extends WalaTestCase {
    * Test that when analyzing Reflect17, the call graph does not include any
    * edges from reflection.Helper.t()
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testReflect17() throws WalaException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -530,6 +546,7 @@ public class ReflectionTest extends WalaTestCase {
    * Test that when analyzing Reflect18, the call graph includes a node for
    * java.lang.Integer.toString()
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testReflect18() throws WalaException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -551,6 +568,7 @@ public class ReflectionTest extends WalaTestCase {
    * Test that when analyzing Reflect19, the call graph includes a node for
    * java.lang.Integer.toString()
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testReflect19() throws WalaException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -569,6 +587,7 @@ public class ReflectionTest extends WalaTestCase {
    * Test that when analyzing Reflect20, the call graph includes a node for
    * Helper.o.
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testReflect20() throws WalaException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -588,6 +607,7 @@ public class ReflectionTest extends WalaTestCase {
    * constructor of {@code Helper} that takes two {@link Object} parameters.
    * This is to test the support for Class.getDeclaredConstructor.
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testReflect21() throws WalaException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -607,6 +627,7 @@ public class ReflectionTest extends WalaTestCase {
    * constructor of {@code Helper} that takes one {@link Integer} parameters.
    * This is to test the support for Class.getDeclaredConstructors.
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testReflect22() throws WalaException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -626,6 +647,7 @@ public class ReflectionTest extends WalaTestCase {
    * constructor of {@code Helper} that takes one {@link Integer} parameters.
    * This is to test the support for Class.getDeclaredConstructors.
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testReflect23() throws WalaException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -657,6 +679,7 @@ public class ReflectionTest extends WalaTestCase {
    *  <li>GetMethodContext$C#foo()</li>
    * </ul>
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testGetMethodContext() throws WalaException, IllegalArgumentException, CancelException, IOException {
     TypeReference ta = TypeReference.findOrCreate(ClassLoaderReference.Application, "Lreflection/GetMethodContext$A");

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/SyntheticTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/SyntheticTest.java
@@ -40,6 +40,7 @@ import com.ibm.wala.util.CancelException;
  */
 public class SyntheticTest extends WalaTestCase {
 
+  @SuppressWarnings("static-method")
   @Test public void testMultiSubtypes() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.WALA_TESTDATA,
         CallGraphTestUtil.REGRESSION_EXCLUSIONS);

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cfg/exc/inter/NullPointerExceptionInterTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cfg/exc/inter/NullPointerExceptionInterTest.java
@@ -96,6 +96,7 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
     justThisTest(NullPointerExceptionInterTest.class);
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testIfException() throws UnsoundGraphException, CancelException, WalaException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callIfException()Lcfg/exc/intra/B");
@@ -113,6 +114,7 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
     Assert.assertTrue(intraExplodedCFG.hasExceptions());
   }
   
+  @SuppressWarnings("static-method")
   @Test
   public void testDynamicIfException() throws UnsoundGraphException, CancelException, WalaException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callDynamicIfException()Lcfg/exc/intra/B");
@@ -133,6 +135,7 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
   }
 
   
+  @SuppressWarnings("static-method")
   @Test
   public void testIfNoException() throws UnsoundGraphException, CancelException, WalaException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callIfNoException()Lcfg/exc/intra/B");
@@ -149,6 +152,7 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
     Assert.assertFalse(intraExplodedCFG.hasExceptions());
   }
   
+  @SuppressWarnings("static-method")
   @Test
   public void testDynamicIfNoException() throws UnsoundGraphException, CancelException, WalaException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callDynamicIfNoException()Lcfg/exc/intra/B");
@@ -165,6 +169,7 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
     Assert.assertFalse(intraExplodedCFG.hasExceptions());
   }
   
+  @SuppressWarnings("static-method")
   @Test
   public void testIf2Exception() throws UnsoundGraphException, CancelException, WalaException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callIf2Exception()Lcfg/exc/intra/B");
@@ -182,6 +187,7 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
     Assert.assertTrue(intraExplodedCFG.hasExceptions());
   }
   
+  @SuppressWarnings("static-method")
   @Test
   public void testDynamicIf2Exception() throws UnsoundGraphException, CancelException, WalaException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callDynamicIf2Exception()Lcfg/exc/intra/B");
@@ -202,6 +208,7 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
   }
 
   
+  @SuppressWarnings("static-method")
   @Test
   public void testIf2NoException() throws UnsoundGraphException, CancelException, WalaException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callIf2NoException()Lcfg/exc/intra/B");
@@ -218,6 +225,7 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
     Assert.assertFalse(intraExplodedCFG.hasExceptions());
   }
   
+  @SuppressWarnings("static-method")
   @Test
   public void testDynamicIf2NoException() throws UnsoundGraphException, CancelException, WalaException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callDynamicIf2NoException()Lcfg/exc/intra/B");
@@ -235,6 +243,7 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
   }
   
 
+  @SuppressWarnings("static-method")
   @Test
   public void testGetException() throws UnsoundGraphException, CancelException, WalaException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callGetException()Lcfg/exc/intra/B");
@@ -252,6 +261,7 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
     Assert.assertTrue(intraExplodedCFG.hasExceptions());
   }
   
+  @SuppressWarnings("static-method")
   @Test
   public void testDynamicGetException() throws UnsoundGraphException, CancelException, WalaException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callDynamicGetException()Lcfg/exc/intra/B");

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cfg/exc/intra/NullPointerExceptionIntraTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cfg/exc/intra/NullPointerExceptionIntraTest.java
@@ -82,6 +82,7 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
     justThisTest(NullPointerExceptionIntraTest.class);
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testParam() throws UnsoundGraphException, CancelException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccess.testParam(ZLcfg/exc/intra/B;Lcfg/exc/intra/B;)Lcfg/exc/intra/B");
@@ -116,6 +117,7 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
     }    
   }
   
+  @SuppressWarnings("static-method")
   @Test
   public void testDynamicParam() throws UnsoundGraphException, CancelException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccessDynamic.testParam(ZLcfg/exc/intra/B;Lcfg/exc/intra/B;)Lcfg/exc/intra/B");
@@ -150,6 +152,7 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
     }    
   }
   
+  @SuppressWarnings("static-method")
   @Test
   public void testParam2() throws UnsoundGraphException, CancelException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccess.testParam2(ZLcfg/exc/intra/B;Lcfg/exc/intra/B;)Lcfg/exc/intra/B");
@@ -184,6 +187,7 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
     }    
   }
   
+  @SuppressWarnings("static-method")
   public void testDynamicParam2() throws UnsoundGraphException, CancelException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccess.testDynamicParam2(ZLcfg/exc/intra/B;Lcfg/exc/intra/B;)Lcfg/exc/intra/B");
 
@@ -218,6 +222,7 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
   }
   
   
+  @SuppressWarnings("static-method")
   @Test
   public void testIf() throws UnsoundGraphException, CancelException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccess.testIf(ZLcfg/exc/intra/B;Lcfg/exc/intra/B;)Lcfg/exc/intra/B");
@@ -252,6 +257,7 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
     }    
   }
   
+  @SuppressWarnings("static-method")
   @Test
   public void testDynamicIf() throws UnsoundGraphException, CancelException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccessDynamic.testIf(ZLcfg/exc/intra/B;Lcfg/exc/intra/B;)Lcfg/exc/intra/B");
@@ -286,6 +292,7 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
     }    
   }
   
+  @SuppressWarnings("static-method")
   @Test
   public void testIf2() throws UnsoundGraphException, CancelException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccess.testIf2(ZLcfg/exc/intra/B;Lcfg/exc/intra/B;)Lcfg/exc/intra/B");
@@ -322,6 +329,7 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
     }    
   }
   
+  @SuppressWarnings("static-method")
   @Test
   public void testDynamicIf2() throws UnsoundGraphException, CancelException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccessDynamic.testIf2(ZLcfg/exc/intra/B;Lcfg/exc/intra/B;)Lcfg/exc/intra/B");
@@ -359,6 +367,7 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
   }
 
   
+  @SuppressWarnings("static-method")
   @Test
   public void testIfContinued() throws UnsoundGraphException, CancelException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccess.testIfContinued(ZLcfg/exc/intra/B;Lcfg/exc/intra/B;Lcfg/exc/intra/B;)Lcfg/exc/intra/B");
@@ -395,6 +404,7 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
     }    
   }
   
+  @SuppressWarnings("static-method")
   @Test
   public void testDynamicIfContinued() throws UnsoundGraphException, CancelException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccessDynamic.testIfContinued(ZLcfg/exc/intra/B;Lcfg/exc/intra/B;Lcfg/exc/intra/B;)Lcfg/exc/intra/B");
@@ -431,6 +441,7 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
     }    
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testIf3() throws UnsoundGraphException, CancelException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccess.testIf3(ZLcfg/exc/intra/B;)Lcfg/exc/intra/B");
@@ -468,6 +479,7 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
   }
 
   
+  @SuppressWarnings("static-method")
   @Test
   public void testDynamicIf3() throws UnsoundGraphException, CancelException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccessDynamic.testIf3(ZLcfg/exc/intra/B;)Lcfg/exc/intra/B");
@@ -505,6 +517,7 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
   }
   
   
+  @SuppressWarnings("static-method")
   @Test
   public void testWhile() throws UnsoundGraphException, CancelException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccess.testWhile(ZLcfg/exc/intra/B;)Lcfg/exc/intra/B");
@@ -541,6 +554,7 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
     }    
   }
   
+  @SuppressWarnings("static-method")
   @Test
   public void testWhileDynamic() throws UnsoundGraphException, CancelException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccessDynamic.testWhile(ZLcfg/exc/intra/B;)Lcfg/exc/intra/B");
@@ -577,6 +591,7 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
     }    
   }
   
+  @SuppressWarnings("static-method")
   @Test
   public void testWhile2() throws UnsoundGraphException, CancelException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccess.testWhile2(ZLcfg/exc/intra/B;)Lcfg/exc/intra/B");
@@ -611,6 +626,7 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
     }    
   }
   
+  @SuppressWarnings("static-method")
   @Test
   public void testDynamicWhile2() throws UnsoundGraphException, CancelException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccessDynamic.testWhile2(ZLcfg/exc/intra/B;)Lcfg/exc/intra/B");
@@ -645,6 +661,7 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
     }    
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testGet() throws UnsoundGraphException, CancelException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccess.testGet(ZLcfg/exc/intra/B;)Lcfg/exc/intra/B");
@@ -681,6 +698,7 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
     }    
   }
   
+  @SuppressWarnings("static-method")
   @Test
   public void testDynamicGet() throws UnsoundGraphException, CancelException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.intra.FieldAccessDynamic.testGet(ZLcfg/exc/intra/B;)Lcfg/exc/intra/B");

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cha/CodeDeletedTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cha/CodeDeletedTest.java
@@ -39,6 +39,7 @@ public class CodeDeletedTest extends WalaTestCase {
    * @throws IOException
    * @throws ClassHierarchyException
    */
+  @SuppressWarnings("static-method")
   @Test(expected = WalaRuntimeException.class)
   public void testDeletedCode() throws IOException, ClassHierarchyException {
     AnalysisScope scope = null;

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cha/DupFieldsTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cha/DupFieldsTest.java
@@ -32,6 +32,7 @@ import com.ibm.wala.util.strings.Atom;
 
 public class DupFieldsTest extends WalaTestCase {
 
+  @SuppressWarnings("static-method")
   @Test public void testDupFieldNames() throws IOException, ClassHierarchyException {
     AnalysisScope scope = null;
     scope = AnalysisScopeReader.readJavaScope(TestConstants.WALA_TESTDATA, (new FileProvider()).getFile("J2SEClassHierarchyExclusions.txt"), DupFieldsTest.class.getClassLoader());

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cha/ExclusionsTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cha/ExclusionsTest.java
@@ -25,6 +25,7 @@ import com.ibm.wala.util.strings.StringStuff;
 
 public class ExclusionsTest {
 
+  @SuppressWarnings("static-method")
   @Test
   public void testExclusions() throws IOException {
     AnalysisScope scope = AnalysisScopeReader.readJavaScope(TestConstants.WALA_TESTDATA, (new FileProvider()).getFile("GUIExclusions.txt"),

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cha/GetTargetsTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cha/GetTargetsTest.java
@@ -75,6 +75,7 @@ public class GetTargetsTest extends WalaTestCase {
   /**
    * Test for bug 1714480, reported OOM on {@link ClassHierarchy} getPossibleTargets()
    */
+  @SuppressWarnings("static-method")
   @Test public void testCell() {
     TypeReference t = TypeReference.findOrCreate(ClassLoaderReference.Application, "Lcell/Cell");
     MethodReference m = MethodReference.findOrCreate(t, "<init>", "(Ljava/lang/Object;)V");
@@ -88,6 +89,7 @@ public class GetTargetsTest extends WalaTestCase {
   /**
    * test that calls to <init> methods are treated specially 
    */
+  @SuppressWarnings("static-method")
   @Test public void testObjInit() {
     MethodReference m = MethodReference.findOrCreate(TypeReference.JavaLangObject, MethodReference.initSelector);
     Collection<IMethod> c = cha.getPossibleTargets(m);

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cha/InnerClassesTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cha/InnerClassesTest.java
@@ -67,6 +67,7 @@ public class InnerClassesTest extends WalaTestCase {
     cha = null;
   }
 
+  @SuppressWarnings("static-method")
   @Test public void test1() throws InvalidClassFileException {
     TypeReference t = TypeReference.findOrCreate(ClassLoaderReference.Application, TypeName
         .string2TypeName("Linner/TestStaticInner"));
@@ -76,6 +77,7 @@ public class InnerClassesTest extends WalaTestCase {
     Assert.assertFalse(s.isInnerClass());
   }
   
+  @SuppressWarnings("static-method")
   @Test public void test2() throws InvalidClassFileException {
     TypeReference t = TypeReference.findOrCreate(ClassLoaderReference.Application, TypeName
         .string2TypeName("Linner/TestStaticInner$A"));
@@ -86,6 +88,7 @@ public class InnerClassesTest extends WalaTestCase {
     Assert.assertTrue(s.isStaticInnerClass());
   }
   
+  @SuppressWarnings("static-method")
   @Test public void test3() throws InvalidClassFileException {
     TypeReference t = TypeReference.findOrCreate(ClassLoaderReference.Application, TypeName
         .string2TypeName("Linner/TestInner$A"));

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cha/InterfaceTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cha/InterfaceTest.java
@@ -67,6 +67,7 @@ public class InterfaceTest extends WalaTestCase {
   /**
    * Test for subtype tests with interfaces; bug reported by Bruno Dufour
    */
+  @SuppressWarnings("static-method")
   @Test public void test1() {
     TypeReference prep_stmt_type = TypeReference.findOrCreate(ClassLoaderReference.Primordial, TypeName
         .string2TypeName("Ljava/sql/PreparedStatement"));
@@ -87,6 +88,7 @@ public class InterfaceTest extends WalaTestCase {
   /**
    * check that arrays implement Cloneable and Serializable
    */
+  @SuppressWarnings("static-method")
   @Test public void test2() {
     IClass objArrayClass = cha.lookupClass(TypeReference.JavaLangObject.getArrayTypeForElementType());
     IClass stringArrayClass = cha.lookupClass(TypeReference.JavaLangString.getArrayTypeForElementType());

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cha/LibraryVersionTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cha/LibraryVersionTest.java
@@ -32,6 +32,7 @@ public class LibraryVersionTest extends WalaTestCase {
   
   private static final ClassLoader MY_CLASSLOADER = DeterministicIRTest.class.getClassLoader();
 
+  @SuppressWarnings("static-method")
   @Test public void testLibraryVersion() throws IOException {
     AnalysisScope scope = AnalysisScopeReader.readJavaScope(TestConstants.WALA_TESTDATA, (new FileProvider()).getFile("J2SEClassHierarchyExclusions.txt"), MY_CLASSLOADER);
     System.err.println("java library version is " + scope.getJavaLibraryVersion());

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cha/SourceMapTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cha/SourceMapTest.java
@@ -35,6 +35,7 @@ public class SourceMapTest extends WalaTestCase {
 
   private final static String CLASS_IN_PRIMORDIAL_JAR = "Lcom/ibm/wala/model/SyntheticFactory";
 
+  @SuppressWarnings("static-method")
   @Test public void testHello() throws ClassHierarchyException, IOException {
     if (analyzingJar()) return;
     AnalysisScope scope = null;
@@ -50,6 +51,7 @@ public class SourceMapTest extends WalaTestCase {
     Assert.assertTrue(sourceFile != null);
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testFromJar() throws ClassHierarchyException, IOException {
     if (analyzingJar()) return;
     AnalysisScope scope = null;

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/collections/SemiSparseMutableIntSetTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/collections/SemiSparseMutableIntSetTest.java
@@ -36,6 +36,7 @@ public final class SemiSparseMutableIntSetTest extends WalaTestCase {
   
   // --- Test cases
   
+  @SuppressWarnings("static-method")
   @Test public void testCase1() {
     final SemiSparseMutableIntSet ssmIntSet = new SemiSparseMutableIntSet();
     ssmIntSet.add(1);

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/collections/TwoLevelVectorTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/collections/TwoLevelVectorTest.java
@@ -37,6 +37,7 @@ public final class TwoLevelVectorTest extends WalaTestCase {
   
   // --- Test cases
   
+  @SuppressWarnings("static-method")
   @Test public void testCase1() {
     final TwoLevelVector<Integer> tlVector = new TwoLevelVector<>();
     tlVector.iterator();

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/demandpa/AbstractPtrTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/demandpa/AbstractPtrTest.java
@@ -258,7 +258,7 @@ public abstract class AbstractPtrTest {
    * @return
    * @throws ClassHierarchyException
    */
-  private IClassHierarchy findOrCreateCHA(AnalysisScope scope) throws ClassHierarchyException {
+  private static IClassHierarchy findOrCreateCHA(AnalysisScope scope) throws ClassHierarchyException {
     if (cachedCHA == null) {
       cachedCHA = ClassHierarchyFactory.make(scope);
     }

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/demandpa/AbstractPtrTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/demandpa/AbstractPtrTest.java
@@ -283,6 +283,7 @@ public abstract class AbstractPtrTest {
     cachedCHA = null;
   }
 
+  @SuppressWarnings("static-method")
   protected StateMachineFactory<IFlowLabel> getStateMachineFactory() {
     return new DummyStateMachine.Factory<>();
   }

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/exceptionpruning/ExceptionAnalysis2EdgeFilterTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/exceptionpruning/ExceptionAnalysis2EdgeFilterTest.java
@@ -178,7 +178,7 @@ public class ExceptionAnalysis2EdgeFilterTest {
     }
   }
 
-  private void checkRemovingNormalOk(CGNode node, ControlFlowGraph<SSAInstruction, ISSABasicBlock> cfg, ISSABasicBlock block,
+  private static void checkRemovingNormalOk(CGNode node, ControlFlowGraph<SSAInstruction, ISSABasicBlock> cfg, ISSABasicBlock block,
       ISSABasicBlock normalSucc) {
     if (!block.getLastInstruction().isPEI() || !filter.getFilter(node).alwaysThrowsException(block.getLastInstruction())) {
       specialCaseThrowFiltered(cfg, normalSucc);
@@ -198,7 +198,7 @@ public class ExceptionAnalysis2EdgeFilterTest {
    * @param cfg
    * @param normalSucc
    */
-  private void specialCaseThrowFiltered(ControlFlowGraph<SSAInstruction, ISSABasicBlock> cfg, ISSABasicBlock normalSucc) {
+  private static void specialCaseThrowFiltered(ControlFlowGraph<SSAInstruction, ISSABasicBlock> cfg, ISSABasicBlock normalSucc) {
     ISSABasicBlock next = normalSucc;
     while (!(next.getLastInstruction() instanceof SSAThrowInstruction)) {
       assertTrue(cfg.getNormalSuccessors(next).iterator().hasNext());
@@ -206,7 +206,7 @@ public class ExceptionAnalysis2EdgeFilterTest {
     }
   }
 
-  private void checkNoNewEdges(ControlFlowGraph<SSAInstruction, ISSABasicBlock> original,
+  private static void checkNoNewEdges(ControlFlowGraph<SSAInstruction, ISSABasicBlock> original,
       ControlFlowGraph<SSAInstruction, ISSABasicBlock> filtered) {
     for (ISSABasicBlock block : filtered) {
       for (ISSABasicBlock normalSucc : filtered.getNormalSuccessors(block)) {

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/exceptionpruning/ExceptionAnalysis2EdgeFilterTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/exceptionpruning/ExceptionAnalysis2EdgeFilterTest.java
@@ -101,6 +101,7 @@ public class ExceptionAnalysis2EdgeFilterTest {
         TypeReference.JavaLangNegativeArraySizeException)));
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void test() {
     HashMap<String, Integer> deletedExceptional = new HashMap<>();

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ir/CFGSanitizerTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ir/CFGSanitizerTest.java
@@ -51,6 +51,7 @@ public class CFGSanitizerTest extends WalaTestCase {
    * @throws IllegalArgumentException
    * @throws WalaException
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testSyntheticEdgeToExit() throws IOException, IllegalArgumentException, WalaException {
     AnalysisScope scope = AnalysisScopeReader.makePrimordialScope((new FileProvider()).getFile(CallGraphTestUtil.REGRESSION_EXCLUSIONS));

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ir/CornerCasesTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ir/CornerCasesTest.java
@@ -52,6 +52,7 @@ public class CornerCasesTest extends WalaTestCase {
    * @throws ClassHierarchyException
    * @throws IOException 
    */
+  @SuppressWarnings("static-method")
   @Test public void testBug38484() throws ClassHierarchyException, IOException {
     AnalysisScope scope = null;
     scope = AnalysisScopeReader.readJavaScope(TestConstants.WALA_TESTDATA, (new FileProvider()).getFile("J2SEClassHierarchyExclusions.txt"), MY_CLASSLOADER);
@@ -70,6 +71,7 @@ public class CornerCasesTest extends WalaTestCase {
    * @throws ClassHierarchyException
    * @throws IOException 
    */
+  @SuppressWarnings("static-method")
   @Test public void testBug38540() throws ClassHierarchyException, IOException {
     AnalysisScope scope = null;
     scope = AnalysisScopeReader.readJavaScope(TestConstants.WALA_TESTDATA, (new FileProvider()).getFile("J2SEClassHierarchyExclusions.txt"), MY_CLASSLOADER);

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ir/DeterministicIRTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ir/DeterministicIRTest.java
@@ -98,7 +98,7 @@ public class DeterministicIRTest extends WalaTestCase {
   /**
    * @param iterator
    */
-  private void checkNoneNull(Iterator<?> iterator) {
+  private static void checkNoneNull(Iterator<?> iterator) {
     while (iterator.hasNext()) {
       Assert.assertTrue(iterator.next() != null);
     }

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ir/LocalNamesTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ir/LocalNamesTest.java
@@ -99,6 +99,7 @@ public class LocalNamesTest extends WalaTestCase {
   /**
    * Build an IR, then check getLocalNames
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testAliasNames() {
     try {
@@ -132,6 +133,7 @@ public class LocalNamesTest extends WalaTestCase {
     }
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testLocalNamesWithoutPiNodes() {
     SSAPiNodePolicy save = options.getSSAOptions().getPiNodePolicy();
@@ -161,6 +163,7 @@ public class LocalNamesTest extends WalaTestCase {
     Assert.assertTrue("incorrect local name resolution #1 for v1@5: " + names[1], names[1].equals("b"));
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testLocalNamesWithPiNodes() {
     SSAPiNodePolicy save = options.getSSAOptions().getPiNodePolicy();

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ir/MultiNewArrayTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ir/MultiNewArrayTest.java
@@ -41,6 +41,7 @@ public class MultiNewArrayTest extends WalaTestCase {
 
   private static final ClassLoader MY_CLASSLOADER = MultiNewArrayTest.class.getClassLoader();
   
+  @SuppressWarnings("static-method")
   @Test public void testMultiNewArray1() throws IOException, ClassHierarchyException {
     AnalysisScope scope = null;
     scope = AnalysisScopeReader.readJavaScope(TestConstants.WALA_TESTDATA, (new FileProvider()).getFile("J2SEClassHierarchyExclusions.txt"), MY_CLASSLOADER);

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ptrs/MultiDimArrayTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ptrs/MultiDimArrayTest.java
@@ -57,6 +57,7 @@ public class MultiDimArrayTest extends WalaTestCase {
     
   }
 
+  @SuppressWarnings("static-method")
   @Test public void testMultiDim() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.WALA_TESTDATA, CallGraphTestUtil.REGRESSION_EXCLUSIONS);
     ClassHierarchy cha = ClassHierarchyFactory.make(scope);

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ptrs/TypeBasedArrayAliasTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ptrs/TypeBasedArrayAliasTest.java
@@ -39,6 +39,7 @@ import com.ibm.wala.util.intset.OrdinalSet;
 
 public class TypeBasedArrayAliasTest extends WalaTestCase {
 
+  @SuppressWarnings("static-method")
   @Test public void testTypeBasedArrayAlias() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.WALA_TESTDATA, CallGraphTestUtil.REGRESSION_EXCLUSIONS);
     ClassHierarchy cha = ClassHierarchyFactory.make(scope);

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ptrs/ZeroLengthArrayTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ptrs/ZeroLengthArrayTest.java
@@ -41,6 +41,7 @@ import com.ibm.wala.util.intset.OrdinalSet;
 
 public class ZeroLengthArrayTest {
 
+  @SuppressWarnings("static-method")
   @Test
   public void testZeroLengthArray() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.WALA_TESTDATA,

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/shrike/DynamicCallGraphTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/shrike/DynamicCallGraphTest.java
@@ -42,7 +42,7 @@ public class DynamicCallGraphTest extends DynamicCallGraphTestBase {
     this(getClasspathEntry("com.ibm.wala.core.testdata"));
   }
   
-  private CallGraph staticCG(String mainClass, String exclusionsFile) throws IOException, ClassHierarchyException, IllegalArgumentException, CancelException {
+  private static CallGraph staticCG(String mainClass, String exclusionsFile) throws IOException, ClassHierarchyException, IllegalArgumentException, CancelException {
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.WALA_TESTDATA, exclusionsFile != null? exclusionsFile: CallGraphTestUtil.REGRESSION_EXCLUSIONS);
     ClassHierarchy cha = ClassHierarchyFactory.make(scope);
     Iterable<Entrypoint> entrypoints = com.ibm.wala.ipa.callgraph.impl.Util.makeMainEntrypoints(scope, cha, mainClass);

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/shrike/DynamicCallGraphTestBase.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/shrike/DynamicCallGraphTestBase.java
@@ -143,7 +143,7 @@ public abstract class DynamicCallGraphTestBase extends WalaTestCase {
     void edgesTest(CallGraph staticCG, CGNode caller, MethodReference callee);
   }
  
-  private MethodReference callee(String calleeClass, String calleeMethod) {
+  private static MethodReference callee(String calleeClass, String calleeMethod) {
       return MethodReference.findOrCreate(TypeReference.findOrCreate(ClassLoaderReference.Application, "L" + calleeClass), Selector.make(calleeMethod));
   }
 

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/slicer/SlicerTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/slicer/SlicerTest.java
@@ -119,6 +119,7 @@ public class SlicerTest {
     cachedScope = null;
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testSlice1() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -150,6 +151,7 @@ public class SlicerTest {
     Assert.assertEquals(16, i);
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testSlice2() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -175,6 +177,7 @@ public class SlicerTest {
     Assert.assertEquals(slice.toString(), 9, countNormals(slice));
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testSlice3() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -198,6 +201,7 @@ public class SlicerTest {
     Assert.assertEquals(slice.toString(), 1, countAllocations(slice));
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testSlice4() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -222,6 +226,7 @@ public class SlicerTest {
     Assert.assertEquals(slice.toString(), 4, slice.size());
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testSlice5() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -253,6 +258,7 @@ public class SlicerTest {
    * @throws IllegalArgumentException
    * @throws IOException
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testSlice7() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -282,6 +288,7 @@ public class SlicerTest {
    * @throws IllegalArgumentException
    * @throws IOException
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testSlice8() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -309,6 +316,7 @@ public class SlicerTest {
     Assert.assertEquals(slice.toString(), 4, slice.size());
   }
   
+  @SuppressWarnings("static-method")
   @Test
   public void testSlice9() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -332,6 +340,7 @@ public class SlicerTest {
     Assert.assertEquals(/*slice.toString(), */5, countApplicationNormals(slice));
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testTestCD1() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -356,6 +365,7 @@ public class SlicerTest {
     Assert.assertEquals(slice.toString(), 2, countConditionals(slice));
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testTestCD2() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -380,6 +390,7 @@ public class SlicerTest {
     Assert.assertEquals(slice.toString(), 1, countConditionals(slice));
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testTestCD3() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -404,6 +415,7 @@ public class SlicerTest {
     Assert.assertEquals(slice.toString(), 0, countConditionals(slice));
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testTestCD4() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -435,6 +447,7 @@ public class SlicerTest {
     Assert.assertEquals(slice.toString(), 1, countConditionals(slice));
   }
   
+  @SuppressWarnings("static-method")
   @Test
   public void testTestCD5() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -460,6 +473,7 @@ public class SlicerTest {
     Assert.assertTrue(slice.toString(), slice.size() > 1);
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testTestCD6() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -485,6 +499,7 @@ public class SlicerTest {
     Assert.assertEquals(slice.toString(), 2, countInvokes(slice));
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testTestId() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -509,6 +524,7 @@ public class SlicerTest {
     Assert.assertEquals(slice.toString(), 1, countAllocations(slice));
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testTestArrays() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -534,6 +550,7 @@ public class SlicerTest {
     Assert.assertEquals(slice.toString(), 1, countAloads(slice));
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testTestFields() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -559,6 +576,7 @@ public class SlicerTest {
     Assert.assertEquals(slice.toString(), 1, countPutfields(slice));
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testThin1() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -594,6 +612,7 @@ public class SlicerTest {
     Assert.assertEquals(slice.toString(), 1, countPutfields(slice));
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testTestGlobal() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -620,6 +639,7 @@ public class SlicerTest {
     Assert.assertEquals(slice.toString(), 2, countGetstatics(slice));
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testTestMultiTarget() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -644,6 +664,7 @@ public class SlicerTest {
     Assert.assertEquals(slice.toString(), 2, countAllocations(slice));
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testTestRecursion() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -670,6 +691,7 @@ public class SlicerTest {
     Assert.assertEquals(slice.toString(), 2, countPutfields(slice));
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testPrimGetterSetter() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -703,6 +725,7 @@ public class SlicerTest {
    * to a getter method. Also tests disabling SMUSH_PRIMITIVE_HOLDERS to ensure
    * we get distinct abstract objects for two different primitive holders.
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testPrimGetterSetter2() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -739,6 +762,7 @@ public class SlicerTest {
     Assert.assertEquals(slice.toString(), 1, countAllocations(slice));
     Assert.assertEquals(slice.toString(), 1, countPutfields(slice));
   }
+  @SuppressWarnings("static-method")
   @Test
   public void testTestThrowCatch() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -765,6 +789,7 @@ public class SlicerTest {
     Assert.assertEquals(slice.toString(), 1, countGetfields(slice));
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testTestMessageFormat() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -791,6 +816,7 @@ public class SlicerTest {
   /**
    * test for bug reported on mailing list by Joshua Garcia, 5/16/2010
    */
+  @SuppressWarnings("static-method")
   @Test
   public void testTestInetAddr() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException, UnsoundGraphException {
     AnalysisScope scope = findOrCreateAnalysisScope();
@@ -806,6 +832,7 @@ public class SlicerTest {
     GraphIntegrity.check(sdg);
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testJustThrow() throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException, UnsoundGraphException {
     AnalysisScope scope = findOrCreateAnalysisScope();

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/typeInference/TypeInferenceTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/typeInference/TypeInferenceTest.java
@@ -88,6 +88,7 @@ public class TypeInferenceTest extends WalaTestCase {
     cache = null;
   }
 
+  @SuppressWarnings("static-method")
   @Test public void test1() {
     MethodReference method = scope.findMethod(AnalysisScope.APPLICATION, "LtypeInference/TI", Atom.findOrCreateUnicodeAtom("foo"),
         new ImmutableByteArray(UTF8Convert.toUTF8("()V")));
@@ -103,6 +104,7 @@ public class TypeInferenceTest extends WalaTestCase {
     }
   }
 
+  @SuppressWarnings("static-method")
   @Test public void test2() {
     MethodReference method = scope.findMethod(AnalysisScope.APPLICATION, "LtypeInference/TI", Atom.findOrCreateUnicodeAtom("bar"),
         new ImmutableByteArray(UTF8Convert.toUTF8("(I)V")));
@@ -116,6 +118,7 @@ public class TypeInferenceTest extends WalaTestCase {
     Assert.assertNotNull("null type abstraction for parameter", ti.getType(2));
   }
 
+  @SuppressWarnings("static-method")
   @Test public void test3() {
     MethodReference method = scope.findMethod(AnalysisScope.APPLICATION, "LtypeInference/TI", Atom.findOrCreateUnicodeAtom("inferInt"),
         new ImmutableByteArray(UTF8Convert.toUTF8("()V")));
@@ -131,6 +134,7 @@ public class TypeInferenceTest extends WalaTestCase {
     Assert.assertTrue("inferred wrong type", type.toString().equals("int"));
   }
 
+  @SuppressWarnings("static-method")
   @Test public void test4() {
     MethodReference method = scope.findMethod(AnalysisScope.APPLICATION, "LtypeInference/TI", Atom.findOrCreateUnicodeAtom("useCast"),
         new ImmutableByteArray(UTF8Convert.toUTF8("(Ljava/lang/Object;)V")));

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/examples/analysis/dataflow/DataflowTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/examples/analysis/dataflow/DataflowTest.java
@@ -105,6 +105,7 @@ public class DataflowTest extends WalaTestCase {
     cha = null;
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testIntraproc1() {
     IAnalysisCacheView cache = new AnalysisCacheImpl();
@@ -124,6 +125,7 @@ public class DataflowTest extends WalaTestCase {
     }
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testIntraproc2() {
     IAnalysisCacheView cache = new AnalysisCacheImpl();
@@ -144,6 +146,7 @@ public class DataflowTest extends WalaTestCase {
     }
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testContextInsensitive() throws IllegalArgumentException, CallGraphBuilderCancelException {
     Iterable<Entrypoint> entrypoints = com.ibm.wala.ipa.callgraph.impl.Util.makeMainEntrypoints(scope, cha,
@@ -176,6 +179,7 @@ public class DataflowTest extends WalaTestCase {
     }
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testContextSensitive() throws IllegalArgumentException, CancelException {
     Iterable<Entrypoint> entrypoints = com.ibm.wala.ipa.callgraph.impl.Util.makeMainEntrypoints(scope, cha,

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/util/io/FileProviderTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/util/io/FileProviderTest.java
@@ -21,6 +21,7 @@ import com.ibm.wala.util.PlatformUtil;
 
 public class FileProviderTest {
 
+  @SuppressWarnings("static-method")
   @Test
   public void testValidFile() throws MalformedURLException {
     // setup:
@@ -33,6 +34,7 @@ public class FileProviderTest {
   }
   
   
+  @SuppressWarnings("static-method")
   @Test
   public void testURLWithInvalidURIChars() throws MalformedURLException {
     // setup:
@@ -44,6 +46,7 @@ public class FileProviderTest {
     assertEquals(expected, actual);
   }
 
+  @SuppressWarnings("static-method")
   @Test
   public void testURLWithSpace() throws MalformedURLException {
     URL url = new URL("file:///With%20Space/File.jar");

--- a/com.ibm.wala.dalvik.test/source/com/ibm/wala/dalvik/test/callGraph/JVMLDalvikComparisonTest.java
+++ b/com.ibm.wala.dalvik.test/source/com/ibm/wala/dalvik/test/callGraph/JVMLDalvikComparisonTest.java
@@ -125,16 +125,19 @@ public class JVMLDalvikComparisonTest extends DalvikCallGraphTestBase {
 		Assert.assertTrue(!fail);		
 	}
 	
+	@SuppressWarnings("static-method")
 	@Test
 	public void testJLex() throws ClassHierarchyException, IllegalArgumentException, IOException, CancelException, InterruptedException {
 		test(TestConstants.JLEX_MAIN, TestConstants.JLEX);
 	}
 
+	@SuppressWarnings("static-method")
 	@Test
 	public void testJavaCup() throws ClassHierarchyException, IllegalArgumentException, IOException, CancelException, InterruptedException {
 		test(TestConstants.JAVA_CUP_MAIN, TestConstants.JAVA_CUP);
 	}
 
+	@SuppressWarnings("static-method")
 	@Test
 	public void testBCEL() throws ClassHierarchyException, IllegalArgumentException, IOException, CancelException, InterruptedException {
 		test(TestConstants.BCEL_VERIFIER_MAIN, TestConstants.BCEL);

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/analysis/typeInference/DalvikTypeInference.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/analysis/typeInference/DalvikTypeInference.java
@@ -93,7 +93,7 @@ public class DalvikTypeInference extends TypeInference {
 			}
 		}
 
-		private boolean containsNonPrimitiveAndZero(DalvikTypeVariable[] types) {
+		private static boolean containsNonPrimitiveAndZero(DalvikTypeVariable[] types) {
 			boolean containsNonPrimitive = false;
 			boolean containsZero = false;
 			for (int i = 0; i < types.length; i++) {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/DexIMethod.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/DexIMethod.java
@@ -3136,7 +3136,7 @@ public class DexIMethod implements IBytecodeMethod {
 		//      //comment out stop
 	}
 
-	private TypeReference findOutArrayElementType(
+	private static TypeReference findOutArrayElementType(
 			org.jf.dexlib.Code.Instruction[] instrucs, Instruction[] walaInstructions, int instCounter) {
 		if (instCounter < 0 || instrucs[instCounter].opcode != Opcode.FILL_ARRAY_DATA) {
 			throw new IllegalArgumentException();

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/WDexClassLoaderImpl.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/WDexClassLoaderImpl.java
@@ -119,7 +119,7 @@ public class WDexClassLoaderImpl extends ClassLoaderImpl {
     /**
      * Remove from s any class file module entries which already are in t
      */
-    private void removeClassFiles(Set<ModuleEntry> s, Set<ModuleEntry> t) {
+    private static void removeClassFiles(Set<ModuleEntry> s, Set<ModuleEntry> t) {
     	Set<String> old = HashSetFactory.make();
     	for (Iterator<ModuleEntry> it = t.iterator(); it.hasNext();) {
     		ModuleEntry m = it.next();
@@ -135,7 +135,7 @@ public class WDexClassLoaderImpl extends ClassLoaderImpl {
     	s.removeAll(toRemove);
     }
     
-    private Set<ModuleEntry> getDexFiles(Module M) {
+    private static Set<ModuleEntry> getDexFiles(Module M) {
     	HashSet<ModuleEntry> result = HashSetFactory.make();
     	for (Iterator<? extends ModuleEntry> it = M.getEntries(); it.hasNext();) {
     		ModuleEntry entry = it.next();

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/dex/instructions/Instruction.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/dex/instructions/Instruction.java
@@ -171,6 +171,7 @@ public abstract class Instruction {
         return opcode;
     }
 
+    @SuppressWarnings("static-method")
     public int[] getBranchTargets() {
         return noInstructions;
     }

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModel.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModel.java
@@ -327,6 +327,7 @@ public class AndroidModel /* makes SummarizedMethod */
      *  @param  ep  The EntryPoint in question
      *  @return if the given EntryPoint shall be part of the model
      */
+    @SuppressWarnings("static-method")
     protected boolean selectEntryPoint(AndroidEntryPoint ep) {
         return  true;
     }

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/FlatInstantiator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/FlatInstantiator.java
@@ -343,7 +343,7 @@ public class FlatInstantiator implements IInstantiator {
         return instance; 
     }
 
-    private void createPrimitive(SSAValue instance) {
+    private static void createPrimitive(SSAValue instance) {
         // XXX; something else?
         instance.setAssigned();
     }

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/Instantiator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/Instantiator.java
@@ -344,7 +344,7 @@ public class Instantiator implements IInstantiator {
         return instance; 
     }
 
-    private void createPrimitive(SSAValue instance) {
+    private static void createPrimitive(SSAValue instance) {
         // XXX; something else?
         instance.setAssigned();
     }

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/ReuseParameters.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/ReuseParameters.java
@@ -147,7 +147,7 @@ public class ReuseParameters {
      *
      *  @see    com.ibm.wala.util.ssa.ParameterAccessor
      */
-    private int ssaFor(IMethod inCallTo, int paramNo) {
+    private static int ssaFor(IMethod inCallTo, int paramNo) {
         assert (paramNo >= 0);
         assert (paramNo < inCallTo.getNumberOfParameters());
 
@@ -163,7 +163,7 @@ public class ReuseParameters {
      *
      *  @see    com.ibm.wala.util.ssa.ParameterAccessor
      */
-    private int firstOf(TypeName type, IMethod inCallTo) {
+    private static int firstOf(TypeName type, IMethod inCallTo) {
         for (int i = 0; i < inCallTo.getNumberOfParameters(); ++i) {
             if (inCallTo.getParameterType(i).getName().equals(type)) {
                 return i;

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/AbstractAndroidModel.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/AbstractAndroidModel.java
@@ -204,6 +204,7 @@ public abstract class AbstractAndroidModel  {
      *      you'll simply pass body.getNextProgramCounter()
      *  @return             Program Counter after insertion of the code
      */
+    @SuppressWarnings("static-method")
     protected int enterAT_FIRST(int PC) { return PC; }
 
      /**
@@ -218,6 +219,7 @@ public abstract class AbstractAndroidModel  {
      *      you'll simply pass body.getNextProgramCounter()
      *  @return             Program Counter after insertion of the code
      */
+    @SuppressWarnings("static-method")
     protected int enterBEFORE_LOOP (int PC) { return PC; }
 
     /**
@@ -232,6 +234,7 @@ public abstract class AbstractAndroidModel  {
      *      you'll simply pass body.getNextProgramCounter()
      *  @return             Program Counter after insertion of the code
      */
+    @SuppressWarnings("static-method")
     protected int enterSTART_OF_LOOP (int PC) { return PC; }
 
     /**
@@ -246,6 +249,7 @@ public abstract class AbstractAndroidModel  {
      *      you'll simply pass body.getNextProgramCounter()
      *  @return             Program Counter after insertion of the code
      */
+    @SuppressWarnings("static-method")
     protected int enterMIDDLE_OF_LOOP (int PC) { return PC; }
     
     /**
@@ -260,6 +264,7 @@ public abstract class AbstractAndroidModel  {
      *      you'll simply pass body.getNextProgramCounter()
      *  @return             Program Counter after insertion of the code
      */
+    @SuppressWarnings("static-method")
     protected int enterMULTIPLE_TIMES_IN_LOOP (int PC) { return PC; }
 
     /**
@@ -274,6 +279,7 @@ public abstract class AbstractAndroidModel  {
      *      you'll simply pass body.getNextProgramCounter()
      *  @return             Program Counter after insertion of the code
      */
+    @SuppressWarnings("static-method")
     protected int enterEND_OF_LOOP (int PC) { return PC; }
 
     /**
@@ -288,6 +294,7 @@ public abstract class AbstractAndroidModel  {
      *      you'll simply pass body.getNextProgramCounter()
      *  @return             Program Counter after insertion of the code
      */
+    @SuppressWarnings("static-method")
     protected int enterAFTER_LOOP (int PC) { return PC; }
 
     /**
@@ -302,6 +309,7 @@ public abstract class AbstractAndroidModel  {
      *      you'll simply pass body.getNextProgramCounter()
      *  @return             Program Counter after insertion of the code
      */
+    @SuppressWarnings("static-method")
     protected int enterAT_LAST (int PC) { return PC; }
 
     /**
@@ -316,6 +324,7 @@ public abstract class AbstractAndroidModel  {
      *      you'll simply pass body.getNextProgramCounter()
      *  @return             Program Counter after insertion of the code
      */
+    @SuppressWarnings("static-method")
     protected int leaveAT_LAST (int PC) { return PC; }
 
     /**

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentContextInterpreter.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentContextInterpreter.java
@@ -132,7 +132,7 @@ public class IntentContextInterpreter implements SSAContextInterpreter {
         }
     } 
 
-    private TypeReference getCaller(final Context ctx, final CGNode node) {
+    private static TypeReference getCaller(final Context ctx, final CGNode node) {
         if (ctx.get(ContextKey.CALLER) != null) {
             System.out.println("CALLER CONTEXT" + ctx.get(ContextKey.CALLER));
             return node.getMethod().getReference().getDeclaringClass();

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/AbstractIntRegisterMachine.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/AbstractIntRegisterMachine.java
@@ -352,7 +352,7 @@ public abstract class AbstractIntRegisterMachine implements FixedPointConstants 
      * @param bb the basic block at whose entry the meet occurs
      * @return true if the lhs value changes. false otherwise.
      */
-    private boolean meet(IVariable lhs, IVariable[] rhs, BasicBlock bb, Meeter meeter) {
+    private static boolean meet(IVariable lhs, IVariable[] rhs, BasicBlock bb, Meeter meeter) {
 
 //      boolean changed = meetStacks(lhs, rhs, bb, meeter);
 
@@ -368,7 +368,7 @@ public abstract class AbstractIntRegisterMachine implements FixedPointConstants 
      * @param bb the basic block at whose entry the meet occurs
      * @return true if the lhs value changes. false otherwise.
      */
-    private boolean meetForCatchBlock(IVariable lhs, IVariable[] rhs, BasicBlock bb, Meeter meeter) {
+    private static boolean meetForCatchBlock(IVariable lhs, IVariable[] rhs, BasicBlock bb, Meeter meeter) {
 
         boolean changed = meetLocals(lhs, rhs, bb, meeter);
 
@@ -473,7 +473,7 @@ public abstract class AbstractIntRegisterMachine implements FixedPointConstants 
      * @param bb the basic block at whose entry the meet occurs
      * @return true if the lhs value changes. false otherwise.
      */
-    private boolean meetLocals(IVariable lhs, IVariable[] rhs, BasicBlock bb, Meeter meeter) {
+    private static boolean meetLocals(IVariable lhs, IVariable[] rhs, BasicBlock bb, Meeter meeter) {
 
         boolean changed = false;
         MachineState L = (MachineState) lhs;

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/DexSSABuilder.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/DexSSABuilder.java
@@ -1514,7 +1514,7 @@ public class DexSSABuilder extends AbstractIntRegisterMachine {
         /**
          * @return the indices i s.t. x[i] == y, or null if none found.
          */
-        private int[] extractIndices(int[] x, int y) {
+        private static int[] extractIndices(int[] x, int y) {
             int count = 0;
             for (int i = 0; i < x.length; i++) {
                 if (x[i] == y) {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidEntryPointLocator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidEntryPointLocator.java
@@ -274,7 +274,7 @@ nextMethod:
 //        return test.getName().toString().contains("$"); // PRETTY!
 //    }
 
-    private AndroidEntryPoint makeEntryPointForHeuristic(final IMethod method, final IClassHierarchy cha) {
+    private static AndroidEntryPoint makeEntryPointForHeuristic(final IMethod method, final IClassHierarchy cha) {
         AndroidComponent compo;
         { // Guess component
             compo = AndroidComponent.from(method, cha);
@@ -404,11 +404,11 @@ nextMethod:
         }
     }
 
-    private boolean isAPIComponent(final IMethod method) {
+    private static boolean isAPIComponent(final IMethod method) {
         return isAPIComponent(method.getDeclaringClass());
     }
 
-    private boolean isAPIComponent(final IClass cls) {
+    private static boolean isAPIComponent(final IClass cls) {
         ClassLoaderReference clr = cls.getClassLoader().getReference();
 		if (! (clr.equals(ClassLoaderReference.Primordial) || clr.equals(ClassLoaderReference.Extension))) {
             if (cls.getName().toString().startsWith("Landroid/")) {
@@ -420,7 +420,7 @@ nextMethod:
         }
     }
 
-    private boolean isExcluded(final IClass cls) {
+    private static boolean isExcluded(final IClass cls) {
     	final SetOfClasses set = cls.getClassHierarchy().getScope().getExclusions();
     	if (set == null) {
     		return false; // exclusions null ==> no exclusions ==> no class is excluded
@@ -435,7 +435,7 @@ nextMethod:
      *
      *  Currently all methods are placed at ExecutionOrder.MULTIPLE_TIMES_IN_LOOP.
      */
-    private ExecutionOrder selectPositionForHeuristic(IMethod method) {
+    private static ExecutionOrder selectPositionForHeuristic(IMethod method) {
         return ExecutionOrder.MULTIPLE_TIMES_IN_LOOP;
     }
 

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidEntryPointManager.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidEntryPointManager.java
@@ -94,7 +94,7 @@ public final /* singleton */ class AndroidEntryPointManager implements Serializa
     /**
      *  Determines if any EntryPoint extends the specified component.
      */
-    public boolean EPContainAny(AndroidComponent compo) {
+    public static boolean EPContainAny(AndroidComponent compo) {
         for (AndroidEntryPoint ep: ENTRIES) {
             if (ep.belongsTo(compo)) {
                 return true;
@@ -110,7 +110,7 @@ public final /* singleton */ class AndroidEntryPointManager implements Serializa
         MANAGER = new AndroidEntryPointManager();
     }
 
-    public Set<TypeReference> getComponents() {
+    public static Set<TypeReference> getComponents() {
         if (ENTRIES.isEmpty()) {
             throw new IllegalStateException("No entrypoints loaded yet.");
         }

--- a/com.ibm.wala.ide.jdt.test/source/com/ibm/wala/cast/java/test/TypeInferenceAssertion.java
+++ b/com.ibm.wala.ide.jdt.test/source/com/ibm/wala/cast/java/test/TypeInferenceAssertion.java
@@ -51,7 +51,7 @@ final class TypeInferenceAssertion implements IRAssertion {
 
   }
 
-  private IR getIR(CallGraph cg, String fullyQualifiedTypeName, String methodName, String methodParameter, String methodReturnType) {
+  private static IR getIR(CallGraph cg, String fullyQualifiedTypeName, String methodName, String methodParameter, String methodReturnType) {
     IClassHierarchy classHierarchy = cg.getClassHierarchy();
     MethodReference methodRef = IRTests
         .descriptorToMethodRef(

--- a/com.ibm.wala.ide.jdt/source/com/ibm/wala/cast/java/translator/jdt/JDTSourceModuleTranslator.java
+++ b/com.ibm.wala.ide.jdt/source/com/ibm/wala/cast/java/translator/jdt/JDTSourceModuleTranslator.java
@@ -123,7 +123,7 @@ public class JDTSourceModuleTranslator implements SourceModuleTranslator {
     this.dump = dump;
   }
 
-  private void computeClassPath(AnalysisScope scope) {
+  private static void computeClassPath(AnalysisScope scope) {
     StringBuffer buf = new StringBuffer();
 
     ClassLoaderReference cl = scope.getApplicationLoader();

--- a/com.ibm.wala.ide.jsdt/source/com/ibm/wala/cast/js/client/EclipseJavaScriptAnalysisEngine.java
+++ b/com.ibm.wala.ide.jsdt/source/com/ibm/wala/cast/js/client/EclipseJavaScriptAnalysisEngine.java
@@ -129,7 +129,7 @@ public class EclipseJavaScriptAnalysisEngine<I extends InstanceKey> extends Ecli
     return getFieldBasedCallGraph(eps);
   }
   
-  private String getScriptName(AstMethod m) {
+  private static String getScriptName(AstMethod m) {
     
     // we want the original including file, since that will be the "script"
     Position p = m.getSourcePosition();

--- a/com.ibm.wala.ide/src/com/ibm/wala/ide/util/EclipseFileProvider.java
+++ b/com.ibm.wala.ide/src/com/ibm/wala/ide/util/EclipseFileProvider.java
@@ -121,7 +121,7 @@ public class EclipseFileProvider extends FileProvider {
    * @return the URL, or <code>null</code> if the file is not found
    * @throws IOException
    */
-  private  URL getFileURLFromPlugin(Plugin p, String fileName) throws IOException {
+  private static URL getFileURLFromPlugin(Plugin p, String fileName) throws IOException {
     try {
       URL url = FileLocator.find(p.getBundle(), new Path(fileName), null);
       if (url == null) {
@@ -159,7 +159,7 @@ public class EclipseFileProvider extends FileProvider {
    * @param url
    * @return an escaped version of the URL
    */
-  private URL fixupFileURLSpaces(URL url) {
+  private static URL fixupFileURLSpaces(URL url) {
     String urlString = url.toExternalForm();
     StringBuffer fixedUpUrl = new StringBuffer();
     int lastIndex = 0;

--- a/com.ibm.wala.ide/src/com/ibm/wala/ide/util/EclipseProjectPath.java
+++ b/com.ibm.wala.ide/src/com/ibm/wala/ide/util/EclipseProjectPath.java
@@ -266,7 +266,7 @@ public abstract class EclipseProjectPath<E, P> {
   /**
    * Is javaProject a plugin project?
    */
-  private boolean isPluginProject(IProject project) {
+  private static boolean isPluginProject(IProject project) {
     IPluginModelBase model = findModel(project);
     if (model == null) {
       return false;
@@ -349,13 +349,13 @@ public abstract class EclipseProjectPath<E, P> {
     }
   }
 
-  private IPluginModelBase findModel(IProject p) {
+  private static IPluginModelBase findModel(IProject p) {
     // PluginRegistry is specific to Eclipse 3.3+. Use PDECore for compatibility with 3.2
     // return PluginRegistry.findModel(p);
     return PDECore.getDefault().getModelManager().findModel(p);
   }
 
-  private IPluginModelBase findModel(BundleDescription bd) {
+  private static IPluginModelBase findModel(BundleDescription bd) {
     // PluginRegistry is specific to Eclipse 3.3+. Use PDECore for compatibility with 3.2
     // return PluginRegistry.findModel(bd);
     return PDECore.getDefault().getModelManager().findModel(bd);

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/OutflowAnalysis.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/OutflowAnalysis.java
@@ -122,7 +122,7 @@ public class OutflowAnalysis {
 		this.specs = specs;
 	}
 
-	private void addEdge(
+	private static void addEdge(
 			Map<FlowType<IExplodedBasicBlock>, Set<FlowType<IExplodedBasicBlock>>> graph,
 			FlowType<IExplodedBasicBlock> source,
 			FlowType<IExplodedBasicBlock> dest) {

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/functions/TaintTransferFunctions.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/functions/TaintTransferFunctions.java
@@ -466,7 +466,7 @@ public class TaintTransferFunctions<E extends ISSABasicBlock> implements
 		return elts;
 	}
 
-	private Set<CodeElement> getStaticFieldAccessCodeElts(CGNode node,
+	private static Set<CodeElement> getStaticFieldAccessCodeElts(CGNode node,
 			SSAFieldAccessInstruction inst) {
 		Set<CodeElement> elts = HashSetFactory.make();
 		final FieldReference fieldRef = inst.getDeclaredField();
@@ -496,7 +496,7 @@ public class TaintTransferFunctions<E extends ISSABasicBlock> implements
 		return elts;
 	}
 
-	private IUnaryFlowFunction union(final IUnaryFlowFunction g,
+	private static IUnaryFlowFunction union(final IUnaryFlowFunction g,
 			final IUnaryFlowFunction h) {
 		return new IUnaryFlowFunction() {
 			@Override
@@ -513,7 +513,7 @@ public class TaintTransferFunctions<E extends ISSABasicBlock> implements
 	 * @param g
 	 * @return { (x, z) | (x, y) \in g, (y, z) \in f }
 	 */
-	private IUnaryFlowFunction compose(final IUnaryFlowFunction f,
+	private static IUnaryFlowFunction compose(final IUnaryFlowFunction f,
 			final IUnaryFlowFunction g) {
 		return new IUnaryFlowFunction() {
 

--- a/com.ibm.wala.scandroid/source/org/scandroid/spec/CallRetSourceSpec.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/spec/CallRetSourceSpec.java
@@ -95,7 +95,7 @@ public class CallRetSourceSpec extends SourceSpec {
 		}
 	}
 
-	private<E extends ISSABasicBlock> Collection<FlowType<E>> getFlowType(
+	private static <E extends ISSABasicBlock> Collection<FlowType<E>> getFlowType(
 	        BasicBlockInContext<E> block,
 	        SSAInvokeInstruction invInst,
 			CGNode node, IMethod im, PointerAnalysis<InstanceKey> pa) {

--- a/com.ibm.wala.scandroid/source/org/scandroid/synthmethod/SSAtoXMLVisitor.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/synthmethod/SSAtoXMLVisitor.java
@@ -486,7 +486,7 @@ public class SSAtoXMLVisitor implements SSAInstruction.IVisitor {
     }
 
     @SuppressWarnings("unused")
-	private String typeRefToStr(TypeReference fieldType)
+	private static String typeRefToStr(TypeReference fieldType)
             throws UTFDataFormatException {
         Atom className = fieldType.getName().getClassName();
         Atom pkgName = fieldType.getName().getPackage();

--- a/com.ibm.wala.scandroid/source/org/scandroid/synthmethod/XMLSummaryWriter.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/synthmethod/XMLSummaryWriter.java
@@ -269,7 +269,7 @@ public class XMLSummaryWriter {
      * @param summary
      * @return
      */
-    private String getMethodDescriptor(MethodSummary summary) {
+    private static String getMethodDescriptor(MethodSummary summary) {
         StringBuilder typeSigs = new StringBuilder("(");
         
         int i=0;

--- a/com.ibm.wala.scandroid/source/org/scandroid/util/CLISCanDroidOptions.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/util/CLISCanDroidOptions.java
@@ -176,7 +176,7 @@ public class CLISCanDroidOptions implements ISCanDroidOptions {
 		}
 	}
 
-	private URI processURIArg(String arg) {
+	private static URI processURIArg(String arg) {
 		if (arg == null) {
 			return null;
 		} else {

--- a/com.ibm.wala.scandroid/source/org/scandroid/util/EntryPoints.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/util/EntryPoints.java
@@ -357,7 +357,7 @@ public class EntryPoints {
     }
 
     @SuppressWarnings("unused")
-	private String IntentToMethod(String intent) {
+	private static String IntentToMethod(String intent) {
         if (intent.contentEquals("android.intent.action.MAIN") ||
                 intent.contentEquals("android.media.action.IMAGE_CAPTURE") ||
                 intent.contentEquals("android.media.action.VIDEO_CAPTURE") ||

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrike/bench/Bench.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrike/bench/Bench.java
@@ -32,7 +32,7 @@ import com.ibm.wala.shrikeBT.analysis.Verifier;
 import com.ibm.wala.shrikeBT.shrikeCT.CTDecoder;
 import com.ibm.wala.shrikeBT.shrikeCT.ClassInstrumenter;
 import com.ibm.wala.shrikeBT.shrikeCT.OfflineInstrumenter;
-import com.ibm.wala.shrikeCT.ClassReader;
+import com.ibm.wala.shrikeCT.ClassConstants;
 import com.ibm.wala.shrikeCT.ClassWriter;
 
 /**
@@ -190,7 +190,7 @@ public class Bench {
 
     if (ci.isChanged()) {
       ClassWriter cw = ci.emitClass();
-      cw.addField(ClassReader.ACC_PUBLIC | ClassReader.ACC_STATIC, fieldName, Constants.TYPE_boolean, new ClassWriter.Element[0]);
+      cw.addField(ClassConstants.ACC_PUBLIC | ClassConstants.ACC_STATIC, fieldName, Constants.TYPE_boolean, new ClassWriter.Element[0]);
       instrumenter.outputModifiedClass(ci, cw);
     }
   }

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrike/copywriter/CopyWriter.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrike/copywriter/CopyWriter.java
@@ -23,6 +23,7 @@ import com.ibm.wala.shrikeBT.shrikeCT.CTCompiler;
 import com.ibm.wala.shrikeBT.shrikeCT.CTDecoder;
 import com.ibm.wala.shrikeBT.shrikeCT.ClassInstrumenter;
 import com.ibm.wala.shrikeBT.shrikeCT.OfflineInstrumenter;
+import com.ibm.wala.shrikeCT.ClassConstants;
 import com.ibm.wala.shrikeCT.ClassReader;
 import com.ibm.wala.shrikeCT.ClassReader.AttrIterator;
 import com.ibm.wala.shrikeCT.ClassWriter;
@@ -239,27 +240,27 @@ public class CopyWriter {
   private static int copyEntry(ConstantPoolParser cp, ClassWriter w, int i) throws InvalidClassFileException {
     byte t = cp.getItemType(i);
     switch (t) {
-    case ClassReader.CONSTANT_String:
+    case ClassConstants.CONSTANT_String:
       return w.addCPString(cp.getCPString(i));
-    case ClassReader.CONSTANT_Class:
+    case ClassConstants.CONSTANT_Class:
       return w.addCPClass(cp.getCPClass(i));
-    case ClassReader.CONSTANT_FieldRef:
+    case ClassConstants.CONSTANT_FieldRef:
       return w.addCPFieldRef(cp.getCPRefClass(i), cp.getCPRefName(i), cp.getCPRefType(i));
-    case ClassReader.CONSTANT_InterfaceMethodRef:
+    case ClassConstants.CONSTANT_InterfaceMethodRef:
       return w.addCPInterfaceMethodRef(cp.getCPRefClass(i), cp.getCPRefName(i), cp.getCPRefType(i));
-    case ClassReader.CONSTANT_MethodRef:
+    case ClassConstants.CONSTANT_MethodRef:
       return w.addCPMethodRef(cp.getCPRefClass(i), cp.getCPRefName(i), cp.getCPRefType(i));
-    case ClassReader.CONSTANT_NameAndType:
+    case ClassConstants.CONSTANT_NameAndType:
       return w.addCPNAT(cp.getCPNATName(i), cp.getCPNATType(i));
-    case ClassReader.CONSTANT_Integer:
+    case ClassConstants.CONSTANT_Integer:
       return w.addCPInt(cp.getCPInt(i));
-    case ClassReader.CONSTANT_Float:
+    case ClassConstants.CONSTANT_Float:
       return w.addCPFloat(cp.getCPFloat(i));
-    case ClassReader.CONSTANT_Long:
+    case ClassConstants.CONSTANT_Long:
       return w.addCPLong(cp.getCPLong(i));
-    case ClassReader.CONSTANT_Double:
+    case ClassConstants.CONSTANT_Double:
       return w.addCPDouble(cp.getCPDouble(i));
-    case ClassReader.CONSTANT_Utf8:
+    case ClassConstants.CONSTANT_Utf8:
       return w.addCPUtf8(cp.getCPUtf8(i));
     }
     return -1;
@@ -292,8 +293,8 @@ public class CopyWriter {
 
     if (1 < CPCount) {
       switch (cp.getItemType(1)) {
-      case ClassReader.CONSTANT_Long:
-      case ClassReader.CONSTANT_Double:
+      case ClassConstants.CONSTANT_Long:
+      case ClassConstants.CONSTANT_Double:
         // item 1 is a double-word item, so the next real item is at 3
         // to make sure item 3 is allocated at index 3, we'll need to
         // insert a dummy entry at index 2

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrike/copywriter/CopyWriter.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrike/copywriter/CopyWriter.java
@@ -236,7 +236,7 @@ public class CopyWriter {
     return elems;
   }
 
-  private int copyEntry(ConstantPoolParser cp, ClassWriter w, int i) throws InvalidClassFileException {
+  private static int copyEntry(ConstantPoolParser cp, ClassWriter w, int i) throws InvalidClassFileException {
     byte t = cp.getItemType(i);
     switch (t) {
     case ClassReader.CONSTANT_String:

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/ArrayStoreInstruction.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/ArrayStoreInstruction.java
@@ -59,7 +59,7 @@ final public class ArrayStoreInstruction extends Instruction implements IArraySt
 
   @Override
   public String getType() {
-    return Decoder.indexedTypes[opcode - OP_iastore];
+    return Constants.indexedTypes[opcode - OP_iastore];
   }
 
   @Override

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Compiler.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Compiler.java
@@ -448,7 +448,7 @@ public abstract class Compiler implements Constants {
     }
   }
 
-  private boolean applyPatches(ArrayList<Patch> patches) {
+  private static boolean applyPatches(ArrayList<Patch> patches) {
     for (Iterator<Patch> i = patches.iterator(); i.hasNext();) {
       Patch p = i.next();
       if (!p.apply()) {

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/ConstantInstruction.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/ConstantInstruction.java
@@ -111,10 +111,12 @@ public abstract class ConstantInstruction extends Instruction {
     super(opcode);
   }
 
+  @SuppressWarnings("static-method")
   ConstantPoolReader getLazyConstantPool() {
     return null;
   }
 
+  @SuppressWarnings("static-method")
   int getCPIndex() {
     return 0;
   }

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Decoder.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Decoder.java
@@ -214,7 +214,7 @@ public abstract class Decoder implements Constants {
     }
   }
 
-  private String getPrimitiveType(int t) throws InvalidBytecodeException {
+  private static String getPrimitiveType(int t) throws InvalidBytecodeException {
     switch (t) {
     case T_BOOLEAN:
       return TYPE_boolean;
@@ -698,7 +698,7 @@ public abstract class Decoder implements Constants {
     return index;
   }
 
-  private int applyInstructionToStack(Instruction i, int stackLen, byte[] stackWords) throws InvalidBytecodeException {
+  private static int applyInstructionToStack(Instruction i, int stackLen, byte[] stackWords) throws InvalidBytecodeException {
     stackLen -= i.getPoppedCount();
 
     if (stackLen < 0) {

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/GetInstruction.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/GetInstruction.java
@@ -27,6 +27,7 @@ public class GetInstruction extends Instruction implements IGetInstruction {
     this.fieldName = fieldName;
   }
 
+  @SuppressWarnings("static-method")
   ConstantPoolReader getLazyConstantPool() {
     return null;
   }

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/InvokeDynamicInstruction.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/InvokeDynamicInstruction.java
@@ -33,6 +33,7 @@ public class InvokeDynamicInstruction extends Instruction implements IInvokeInst
     this.methodType = methodType;
   }
 
+  @SuppressWarnings("static-method")
   ConstantPoolReader getLazyConstantPool() {
     return null;
   }

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/InvokeInstruction.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/InvokeInstruction.java
@@ -60,6 +60,7 @@ public class InvokeInstruction extends Instruction implements IInvokeInstruction
     return new InvokeInstruction(opcode, type, className, methodName);
   }
 
+  @SuppressWarnings("static-method")
   ConstantPoolReader getLazyConstantPool() {
     return null;
   }

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/MethodEditor.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/MethodEditor.java
@@ -145,7 +145,7 @@ public final class MethodEditor {
     }
   }
 
-  private String getStateMessage(int state) {
+  private static String getStateMessage(int state) {
     switch (state) {
     case BEFORE_PASS:
       return "This operation can only be performed before or after an editing pass";

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/PutInstruction.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/PutInstruction.java
@@ -27,6 +27,7 @@ public class PutInstruction extends Instruction implements IPutInstruction {
     this.fieldName = fieldName;
   }
 
+  @SuppressWarnings("static-method")
   ConstantPoolReader getLazyConstantPool() {
     return null;
   }

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/analysis/Analyzer.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/analysis/Analyzer.java
@@ -197,7 +197,7 @@ public class Analyzer {
     return ClassHierarchy.isSubtypeOf(hierarchy, patchType(t1), patchType(t2)) != ClassHierarchy.NO;
   }
 
-  private boolean isPrimitive(String type) {
+  private static boolean isPrimitive(String type) {
     return type != null && (!type.startsWith("L") && !type.startsWith("["));
   }
   
@@ -515,7 +515,7 @@ public class Analyzer {
     }
   }
 
-  private String[] cutArray(String[] a, int len) {
+  private static String[] cutArray(String[] a, int len) {
     if (len == 0) {
       return noStrings;
     } else {
@@ -532,7 +532,7 @@ public class Analyzer {
     return a||b;
   }
   
-  private boolean longType(String type) {
+  private static boolean longType(String type) {
     return Constants.TYPE_long.equals(type) || Constants.TYPE_double.equals(type);
   }
   

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/CTDecoder.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/CTDecoder.java
@@ -79,7 +79,7 @@ final public class CTDecoder extends Decoder {
       return cp.getItemType(index);
     }
 
-    private Error convertToError(InvalidClassFileException e) {
+    private static Error convertToError(InvalidClassFileException e) {
       e.printStackTrace();
       return new Error("Invalid class file: " + e.getMessage());
     }

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/tools/AddSerialVersion.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/tools/AddSerialVersion.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 
 import com.ibm.wala.shrikeBT.Util;
+import com.ibm.wala.shrikeCT.ClassConstants;
 import com.ibm.wala.shrikeCT.ClassReader;
 import com.ibm.wala.shrikeCT.ClassWriter;
 import com.ibm.wala.shrikeCT.ConstantValueWriter;
@@ -52,7 +53,7 @@ public class AddSerialVersion {
     }
 
     long UID = computeSerialVersionUID(r);
-    w.addField(ClassReader.ACC_PUBLIC | ClassReader.ACC_STATIC | ClassReader.ACC_FINAL, "serialVersionUID", "J",
+    w.addField(ClassConstants.ACC_PUBLIC | ClassConstants.ACC_STATIC | ClassConstants.ACC_FINAL, "serialVersionUID", "J",
         new ClassWriter.Element[] { new ConstantValueWriter(w, UID) });
   }
 
@@ -112,7 +113,7 @@ public class AddSerialVersion {
         int fieldCount = 0;
         for (int f = 0; f < fields.length; f++) {
           int flags = r.getFieldAccessFlags(f);
-          if ((flags & ClassReader.ACC_PRIVATE) == 0 || (flags & (ClassReader.ACC_STATIC | ClassReader.ACC_TRANSIENT)) == 0) {
+          if ((flags & ClassConstants.ACC_PRIVATE) == 0 || (flags & (ClassConstants.ACC_STATIC | ClassConstants.ACC_TRANSIENT)) == 0) {
             fields[fieldCount] = new Integer(f);
             fieldNames[f] = r.getFieldName(f);
             fieldCount++;
@@ -141,7 +142,7 @@ public class AddSerialVersion {
         for (int m = 0; m < methodSigs.length; m++) {
           String name = r.getMethodName(m);
           int flags = r.getMethodAccessFlags(m);
-          if (name.equals("<clinit>") || (flags & ClassReader.ACC_PRIVATE) == 0) {
+          if (name.equals("<clinit>") || (flags & ClassConstants.ACC_PRIVATE) == 0) {
             methods[methodCount] = new Integer(m);
             methodSigs[m] = name + r.getMethodType(m);
             if (name.equals("<clinit>")) {

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/tools/ClassSearcher.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/tools/ClassSearcher.java
@@ -16,6 +16,7 @@ import java.io.Writer;
 
 import com.ibm.wala.shrikeBT.shrikeCT.ClassInstrumenter;
 import com.ibm.wala.shrikeBT.shrikeCT.OfflineInstrumenter;
+import com.ibm.wala.shrikeCT.ClassConstants;
 import com.ibm.wala.shrikeCT.ClassReader;
 import com.ibm.wala.shrikeCT.ConstantPoolParser;
 
@@ -60,7 +61,7 @@ public class ClassSearcher {
     ClassReader r = ci.getReader();
     ConstantPoolParser cp = r.getCP();
     for (int i = 1; i < cp.getItemCount(); i++) {
-      if (cp.getItemType(i) == ConstantPoolParser.CONSTANT_Class && (cp.getCPClass(i).equals(cl1) || cp.getCPClass(i).equals(cl2))) {
+      if (cp.getItemType(i) == ClassConstants.CONSTANT_Class && (cp.getCPClass(i).equals(cl1) || cp.getCPClass(i).equals(cl2))) {
         w.write(cp.getCPClass(i) + " " + resource + " " + r.getName() + "\n");
       }
     }

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/StackMapTableWriter.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/StackMapTableWriter.java
@@ -38,7 +38,7 @@ public class StackMapTableWriter extends Element {
     this.data = serialize(writer, frames);
   }
   
-  private byte[] serialize(ClassWriter writer, List<StackMapFrame> frames) throws IOException {
+  private static byte[] serialize(ClassWriter writer, List<StackMapFrame> frames) throws IOException {
     ByteArrayOutputStream data = new ByteArrayOutputStream();
     
     for(StackMapFrame frame : frames) {

--- a/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/MethodPositions.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/MethodPositions.java
@@ -98,7 +98,7 @@ public final class MethodPositions extends PositionsAttribute {
    * @throws IOException
    *           if the input stream cannot be read
    */
-  private Range readRange(DataInputStream in, String startVarName, String endVarName, boolean undefinedAllowed) throws IOException {
+  private static Range readRange(DataInputStream in, String startVarName, String endVarName, boolean undefinedAllowed) throws IOException {
     boolean valid = true;
     Range range = null;
     Position start = null;
@@ -150,7 +150,7 @@ public final class MethodPositions extends PositionsAttribute {
    * @throws InvalidPositionException
    *           if the read position is invalid
    */
-  private Position readPosition(DataInputStream in, String varName) throws IOException, InvalidPositionException {
+  private static Position readPosition(DataInputStream in, String varName) throws IOException, InvalidPositionException {
     Position pos = null;
     try {
       pos = new Position(in.readInt());

--- a/com.ibm.wala.util/src/com/ibm/wala/dataflow/graph/AbstractMeetOperator.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/dataflow/graph/AbstractMeetOperator.java
@@ -23,6 +23,7 @@ public abstract class AbstractMeetOperator<T extends IVariable> extends Abstract
    * subclasses can override if needed
    * @return true iff this meet is a noop when applied to one argument
    */
+  @SuppressWarnings("static-method")
   public boolean isUnaryNoOp() {
     return true;
   }

--- a/com.ibm.wala.util/src/com/ibm/wala/fixedpoint/impl/AbstractFixedPointSolver.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/fixedpoint/impl/AbstractFixedPointSolver.java
@@ -584,6 +584,7 @@ public abstract class AbstractFixedPointSolver<T extends IVariable<?>> implement
   /**
    * subclasses should override as desired.
    */
+  @SuppressWarnings("static-method")
   protected int getVerboseInterval() {
     return DEFAULT_VERBOSE_INTERVAL;
   }
@@ -591,6 +592,7 @@ public abstract class AbstractFixedPointSolver<T extends IVariable<?>> implement
   /**
    * subclasses should override as desired.
    */
+  @SuppressWarnings("static-method")
   protected int getPeriodicMaintainInterval() {
     return DEFAULT_PERIODIC_MAINTENANCE_INTERVAL;
   }

--- a/com.ibm.wala.util/src/com/ibm/wala/fixpoint/UnaryOperator.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/fixpoint/UnaryOperator.java
@@ -34,6 +34,7 @@ public abstract class UnaryOperator<T extends IVariable> extends AbstractOperato
     return new BasicUnaryStatement<>(lhs, this, rhs);
   }
 
+  @SuppressWarnings("static-method")
   public boolean isIdentity() {
     return false;
   }

--- a/com.ibm.wala.util/src/com/ibm/wala/util/collections/ImmutableStack.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/collections/ImmutableStack.java
@@ -114,7 +114,7 @@ public class ImmutableStack<T> implements Iterable<T> {
 		return makeStack(tmpEntries);
 	}
 
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({ "static-method", "unchecked" })
 	protected T[] makeInternalArray(int size) {
 		return (T[]) new Object[size];
 	}

--- a/com.ibm.wala.util/src/com/ibm/wala/util/collections/Pair.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/collections/Pair.java
@@ -26,7 +26,7 @@ public class Pair<T,U> implements Serializable {
     this.snd = snd;
   }
 
-  private boolean check(Object x, Object y) {
+  private static boolean check(Object x, Object y) {
     return (x == null) ? (y == null) : x.equals(y);
   }
 
@@ -36,7 +36,7 @@ public class Pair<T,U> implements Serializable {
     return (o instanceof Pair) && check(fst, ((Pair) o).fst) && check(snd, ((Pair) o).snd);
   }
 
-  private int hc(Object o) {
+  private static int hc(Object o) {
     return (o == null) ? 0 : o.hashCode();
   }
 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/collections/TwoLevelVector.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/collections/TwoLevelVector.java
@@ -54,11 +54,11 @@ public class TwoLevelVector<T> implements IVector<T>, Serializable {
     return v.get(localX);
   }
 
-  private int getFirstIndexOnPage(int page) {
+  private static int getFirstIndexOnPage(int page) {
     return page << LOG_PAGE_SIZE;
   }
 
-  private int getPageNumber(int x) {
+  private static int getPageNumber(int x) {
     return x >> LOG_PAGE_SIZE;
   }
 
@@ -78,7 +78,7 @@ public class TwoLevelVector<T> implements IVector<T>, Serializable {
     v.set(localX, value);
   }
 
-  private int toLocalIndex(int x, int page) {
+  private static int toLocalIndex(int x, int page) {
     return x - getFirstIndexOnPage(page);
   }
 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/BimodalMutableIntSet.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/BimodalMutableIntSet.java
@@ -47,7 +47,7 @@ public class BimodalMutableIntSet implements MutableIntSet {
   /**
    * @return true iff we would like to use the same representation for V as we do for W
    */
-  private boolean sameRepresentation(IntSet V, IntSet W) {
+  private static boolean sameRepresentation(IntSet V, IntSet W) {
     // for now we assume that we always want to use the same representation for
     // V as
     // for W.

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/BitVectorIntSet.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/BitVectorIntSet.java
@@ -310,7 +310,7 @@ public final class BitVectorIntSet implements MutableIntSet {
     }
   }
 
-  private void actOnWord(IntSetAction action, int startingIndex, int word) {
+  private static void actOnWord(IntSetAction action, int startingIndex, int word) {
     if (word != 0) {
       if ((word & 0x1) != 0) {
         action.act(startingIndex);

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/MutableSparseIntSet.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/MutableSparseIntSet.java
@@ -107,10 +107,12 @@ public class MutableSparseIntSet extends SparseIntSet implements MutableIntSet {
 
 	/**
    */
+	@SuppressWarnings("static-method")
 	public int getInitialNonEmptySize() {
 		return INITIAL_NONEMPTY_SIZE;
 	}
 
+	@SuppressWarnings("static-method")
 	public float getExpansionFactor() {
 		return EXPANSION_FACTOR;
 	}

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/OffsetBitVector.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/OffsetBitVector.java
@@ -16,7 +16,7 @@ public final class OffsetBitVector extends BitVectorBase<OffsetBitVector> {
 
   int offset;
 
-  private int wordDiff(int offset1, int offset2) {
+  private static int wordDiff(int offset1, int offset2) {
     return (offset1 > offset2) ? (offset1 - offset2) >> LOG_BITS_PER_UNIT : -((offset2 - offset1) >> LOG_BITS_PER_UNIT);
   }
 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/SimpleIntVector.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/SimpleIntVector.java
@@ -45,10 +45,12 @@ public class SimpleIntVector implements IntVector, Serializable {
     store[0] = defaultValue;
   }
 
+  @SuppressWarnings("static-method")
   int getInitialSize() {
     return INITIAL_SIZE;
   }
 
+  @SuppressWarnings("static-method")
   float getGrowthFactor() {
     return GROWTH_FACTOR;
   }

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/TwoLevelIntVector.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/TwoLevelIntVector.java
@@ -54,15 +54,15 @@ public class TwoLevelIntVector implements IntVector, Serializable {
     return v.get(localX);
   }
 
-  private int toLocalIndex(int x, int page) {
+  private static int toLocalIndex(int x, int page) {
     return x - getFirstIndexOnPage(page);
   }
 
-  private int getFirstIndexOnPage(int page) {
+  private static int getFirstIndexOnPage(int page) {
     return page << LOG_PAGE_SIZE;
   }
 
-  private int getPageNumber(int x) {
+  private static int getPageNumber(int x) {
     return x >> LOG_PAGE_SIZE;
   }
 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/processes/JavaLauncher.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/processes/JavaLauncher.java
@@ -225,7 +225,7 @@ public class JavaLauncher extends Launcher {
     return lastProcess;
   }
 
-  private String makeLibPath() {
+  private static String makeLibPath() {
     String libPath = System.getProperty("java.library.path");
     if (libPath == null) {
       return null;

--- a/com.ibm.wala.util/src/com/ibm/wala/util/processes/Launcher.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/processes/Launcher.java
@@ -126,7 +126,7 @@ public abstract class Launcher {
     return p;
   }
 
-  private String[] buildEnv(Map<String,String> ev) {
+  private static String[] buildEnv(Map<String,String> ev) {
     String[] result = new String[ev.size()];
     int i = 0;
     for (Iterator<Map.Entry<String,String>> it = ev.entrySet().iterator(); it.hasNext();) {
@@ -273,7 +273,7 @@ public abstract class Launcher {
   /**
    * Drain some data from the input stream, and print said data to p.  Do not block.
    */
-  private void drainAndPrint(BufferedInputStream s, PrintStream p) throws IOException {
+  private static void drainAndPrint(BufferedInputStream s, PrintStream p) throws IOException {
     try {
       while (s.available() > 0) {
         byte[] data = new byte[s.available()];
@@ -289,7 +289,7 @@ public abstract class Launcher {
   /**
    * Drain all data from the input stream, and print said data to p.  Block if necessary.
    */
-  private void blockingDrainAndPrint(BufferedInputStream s, PrintStream p) throws IOException {
+  private static void blockingDrainAndPrint(BufferedInputStream s, PrintStream p) throws IOException {
     ByteArrayOutputStream b = new ByteArrayOutputStream();
     try {
       // gather all the data from the stream.
@@ -310,7 +310,7 @@ public abstract class Launcher {
   /**
    * Drain some data from the input stream, and append said data to b.  Do not block.
    */
-  private void drainAndCatch(BufferedInputStream s, ByteArrayOutputStream b) throws IOException {
+  private static void drainAndCatch(BufferedInputStream s, ByteArrayOutputStream b) throws IOException {
     try {
       while (s.available() > 0) {
         byte[] data = new byte[s.available()];
@@ -326,7 +326,7 @@ public abstract class Launcher {
   /**
    * Drain all data from the input stream, and append said data to p.  Block if necessary.
    */
-  private void blockingDrainAndCatch(BufferedInputStream s, ByteArrayOutputStream b) throws IOException {
+  private static void blockingDrainAndCatch(BufferedInputStream s, ByteArrayOutputStream b) throws IOException {
     try {
       int next = s.read();
       while (next != -1) {


### PR DESCRIPTION
Broadly speaking, these changes are of three forms:

1. Declare methods `static` where this is both possible and safe. Here “safe” means that the method cannot possibly be overridden by third-party code outside of the WALA tree. `private` methods are safe in this manner, as are `final` methods and methods of `final` classes.

1. Suppress Eclipse suggestions about making methods `static` where Eclipse is simply wrong. Some methods that seem suitable for `static` in isolation need to be non-`static` because they have overrides elsewhere and rely on dynamic dispatch. Also, JUnit `@Test` methods cannot be `static`.

1. Access `static` fields directly through the class that declares them, not through a subclass or an instance.