### PR TITLE
Add `@Override` annotations to all methods that do override

### DIFF
--- a/com.ibm.wala.core.tests/src/com/ibm/wala/examples/analysis/dataflow/StaticInitializer.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/examples/analysis/dataflow/StaticInitializer.java
@@ -165,6 +165,7 @@ public class StaticInitializer {
               return result;
             }
 
+            @Override
             public String toString() {
               return "Initializer Normal Flow";
             }
@@ -189,6 +190,7 @@ public class StaticInitializer {
               return result;
             }
 
+            @Override
             public String toString() {
               return "Initializer Normal Flow";
             }
@@ -212,6 +214,7 @@ public class StaticInitializer {
             return result;
           }
 
+          @Override
           public String toString() {
             return "Initializer Normal Flow";
           }
@@ -237,6 +240,7 @@ public class StaticInitializer {
               return result;
             }
 
+            @Override
             public String toString() {
               return "Initializer Normal Flow";
             }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/VolatileMethodSummary.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/VolatileMethodSummary.java
@@ -98,12 +98,17 @@ public class VolatileMethodSummary {
      */
     private static final class Reserved extends SSAInstruction {
         public Reserved () { super(SSAInstruction.NO_INDEX); }
+        @Override
         public SSAInstruction copyForSSA (SSAInstructionFactory insts, int[] defs, int[] uses) {
             throw new IllegalStateException();
         }
+        @Override
         public int hashCode () { return 12384; }
+        @Override
         public boolean isFallThrough() { return true; }
+        @Override
         public String toString (SymbolTable symbolTable) { return "Reserved Slot"; }
+        @Override
         public void visit (IVisitor v) { throw new IllegalStateException(); }
     }
     private static final Reserved RESERVED = new Reserved();
@@ -609,6 +614,7 @@ public class VolatileMethodSummary {
     /**
      *  Generates a String-Representation of an instance of the class.
      */
+    @Override
     public java.lang.String toString() {
         return "VolatileMethodSummary of " + this.summary.toString();
     }

--- a/com.ibm.wala.core/src/com/ibm/wala/util/ssa/ParameterAccessor.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/ssa/ParameterAccessor.java
@@ -1671,6 +1671,7 @@ public class ParameterAccessor {
         return ret;
     }
 
+    @Override
     public String toString() {
         return "<ParamAccessor forMethod=" + this.forMethod() + " />";
     }

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/analysis/typeInference/DalvikTypeInference.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/analysis/typeInference/DalvikTypeInference.java
@@ -21,6 +21,7 @@ public class DalvikTypeInference extends TypeInference {
 		super(ir, doPrimitives);
 	}
 
+	@Override
 	protected void initialize() {
 		init(ir, this.new DalvikTypeVarFactory(), this.new TypeOperatorFactory());
 	}

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/DexIClass.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/DexIClass.java
@@ -287,6 +287,7 @@ public class DexIClass extends BytecodeClass<IClassLoader> {
     	  return getAnnotations((Set<AnnotationVisibility>)null);
       }
 
+      @Override
       public Collection<Annotation> getAnnotations(boolean runtimeInvisible) {
   		return getAnnotations(getTypes(runtimeInvisible));
       }

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/InstructionArray.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/InstructionArray.java
@@ -106,10 +106,12 @@ public class InstructionArray implements Collection<Instruction> {
         return instructions.containsAll(c);
     }
 
+    @Override
     public boolean equals(Object o) {
         return instructions.equals(o);
     }
 
+    @Override
     public int hashCode() {
         return instructions.hashCode();
     }

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/IntentModel.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/IntentModel.java
@@ -64,6 +64,7 @@ public class IntentModel extends AndroidModel {
      *  
      *  {@inheritDoc}
      */
+    @Override
     protected boolean selectEntryPoint(AndroidEntryPoint ep) {
         return ep.isMemberOf(this.target) || ep.belongsTo(AndroidComponent.APPLICATION) ||
             ep.belongsTo(AndroidComponent.PROVIDER);

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/MicroModel.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/MicroModel.java
@@ -64,6 +64,7 @@ public class MicroModel extends AndroidModel {
      *  
      *  {@inheritDoc}
      */
+    @Override
     protected boolean selectEntryPoint(AndroidEntryPoint ep) {
         return ep.isMemberOf(this.target);
     }

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/MiniModel.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/MiniModel.java
@@ -78,6 +78,7 @@ public class MiniModel extends AndroidModel {
      *  
      *  {@inheritDoc}
      */
+    @Override
     protected boolean selectEntryPoint(AndroidEntryPoint ep) {
         if (ep.belongsTo(forCompo)) {
              
@@ -85,6 +86,7 @@ public class MiniModel extends AndroidModel {
         }
         return false;
     }
+    @Override
     public Descriptor getDescriptor() throws CancelException {
         final Descriptor descr = super.getDescriptor();
          

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/SpecializedInstantiator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/SpecializedInstantiator.java
@@ -98,6 +98,7 @@ public class SpecializedInstantiator extends FlatInstantiator {
      *
      *  @todo   Do we want to mix in REUSE-Parameters?
      */
+    @Override
     public SSAValue createInstance(final TypeReference T, final boolean asManaged, VariableKey key, Set<? extends SSAValue> seen) {
         return createInstance(T, asManaged, key, seen, 0);
     }
@@ -260,6 +261,7 @@ public class SpecializedInstantiator extends FlatInstantiator {
     /**
      *  Satisfy the interface.
      */
+    @Override
     @SuppressWarnings("unchecked")
     public int createInstance(TypeReference type, Object... instantiatorArgs) {
         // public SSAValue createInstance(final TypeReference T, final boolean asManaged, VariableKey key, Set<SSAValue> seen) {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/LoopAndroidModel.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/LoopAndroidModel.java
@@ -102,6 +102,7 @@ public class LoopAndroidModel extends SingleStartAndroidModel {
      *
      * {@inheritDoc}
      */
+    @Override
     protected int enterSTART_OF_LOOP (int PC) {
         logger.info("PC {} is the jump target of START_OF_LOOP", PC);
         
@@ -136,6 +137,7 @@ public class LoopAndroidModel extends SingleStartAndroidModel {
      *
      *  {@inheritDoc}
      */
+    @Override
     protected int enterAFTER_LOOP (int PC) {
         assert(outerLoopPC > 0) : "Somehow you managed to get the loop-target negative. This is wierd!";
 
@@ -192,6 +194,7 @@ public class LoopAndroidModel extends SingleStartAndroidModel {
      *
      *  {@inheritDoc}
      */
+    @Override
     protected int leaveAT_LAST (int PC) {
         logger.info("Leaving Model with PC = {}", PC);
         return PC;

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/LoopKillAndroidModel.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/LoopKillAndroidModel.java
@@ -98,6 +98,7 @@ public class LoopKillAndroidModel extends LoopAndroidModel {
      *
      * {@inheritDoc}
      */
+    @Override
     protected int enterAT_FIRST(int PC) {
         logger.info("PC {} is the jump target of START_OF_LOOP", PC);
         
@@ -132,6 +133,7 @@ public class LoopKillAndroidModel extends LoopAndroidModel {
      *
      *  {@inheritDoc}
      */
+    @Override
     protected int leaveAT_LAST (int PC) {
         assert(outerLoopPC > 0) : "Somehow you managed to get the loop-target negative. This is wierd!";
 

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/SequentialAndroidModel.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/SequentialAndroidModel.java
@@ -78,6 +78,7 @@ public final class SequentialAndroidModel extends AbstractAndroidModel {
       *
       * {@inheritDoc}
       */
+    @Override
     protected int enterAT_FIRST(int PC) { 
         return PC;
     }
@@ -87,6 +88,7 @@ public final class SequentialAndroidModel extends AbstractAndroidModel {
       *
       * {@inheritDoc}
       */
+    @Override
     protected int enterBEFORE_LOOP (int PC) {
         return PC;
     }
@@ -96,6 +98,7 @@ public final class SequentialAndroidModel extends AbstractAndroidModel {
      *
      * {@inheritDoc}
      */
+    @Override
     protected int enterSTART_OF_LOOP (int PC) {
         return PC;
     }
@@ -105,6 +108,7 @@ public final class SequentialAndroidModel extends AbstractAndroidModel {
      *
      * {@inheritDoc}
      */
+    @Override
     protected int enterMIDDLE_OF_LOOP (int PC) {
         return PC;
     }
@@ -114,6 +118,7 @@ public final class SequentialAndroidModel extends AbstractAndroidModel {
      *
      * {@inheritDoc}
      */
+    @Override
     protected int enterMULTIPLE_TIMES_IN_LOOP (int PC) {
         return PC;
     }
@@ -123,6 +128,7 @@ public final class SequentialAndroidModel extends AbstractAndroidModel {
      *
      * {@inheritDoc}
      */
+    @Override
     protected int enterEND_OF_LOOP (int PC) {
         return PC;
     }
@@ -132,6 +138,7 @@ public final class SequentialAndroidModel extends AbstractAndroidModel {
      *
      * {@inheritDoc}
      */
+    @Override
     protected int enterAFTER_LOOP (int PC) {
         return PC;
     }
@@ -141,6 +148,7 @@ public final class SequentialAndroidModel extends AbstractAndroidModel {
      *
      * {@inheritDoc}
      */
+    @Override
     protected int enterAT_LAST (int PC) {
         return PC;
     }
@@ -150,6 +158,7 @@ public final class SequentialAndroidModel extends AbstractAndroidModel {
      *
      * {@inheritDoc}
      */
+    @Override
     protected int leaveAT_LAST (int PC) {
         return PC;
     }

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/SingleStartAndroidModel.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/SingleStartAndroidModel.java
@@ -102,6 +102,7 @@ public class SingleStartAndroidModel extends AbstractAndroidModel {
      *
      * {@inheritDoc}
      */
+    @Override
     protected int enterMULTIPLE_TIMES_IN_LOOP (int PC) {
         logger.info("PC {} is the jump target of START_OF_LOOP", PC);
         this.outerLoopPC = PC;
@@ -135,6 +136,7 @@ public class SingleStartAndroidModel extends AbstractAndroidModel {
      *
      *  {@inheritDoc}
      */
+    @Override
     protected int enterEND_OF_LOOP (int PC) {
         assert(outerLoopPC > 0) : "Somehow you managed to get the loop-target negative. This is wierd!";
 

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/Intent.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/Intent.java
@@ -151,6 +151,7 @@ public class Intent implements ContextItem, Comparable<Intent> {
         this.immutable = true;
     }
 
+    @Override
     public Intent clone() {
         final Intent clone = new Intent();
         clone.action = this.action; // OK here?

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/DexSSABuilder.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/DexSSABuilder.java
@@ -1454,6 +1454,7 @@ public class DexSSABuilder extends AbstractIntRegisterMachine {
          * @param index - index into IR instruction array
          * @param vn - value number
          */
+        @Override
         public String[] getLocalNames(int index, int vn) {
             try {
                 if (!dexCFG.getMethod().hasLocalVariableTable()) {

--- a/com.ibm.wala.ide.jsdt.tests/src/com/ibm/wala/ide/jsdt/tests/Activator.java
+++ b/com.ibm.wala.ide.jsdt.tests/src/com/ibm/wala/ide/jsdt/tests/Activator.java
@@ -31,6 +31,7 @@ public class Activator extends Plugin {
    * 
    * @see org.eclipse.core.runtime.Plugins#start(org.osgi.framework.BundleContext)
    */
+  @Override
   public void start(BundleContext context) throws Exception {
     super.start(context);
     plugin = this;
@@ -41,6 +42,7 @@ public class Activator extends Plugin {
    * 
    * @see org.eclipse.core.runtime.Plugin#stop(org.osgi.framework.BundleContext)
    */
+  @Override
   public void stop(BundleContext context) throws Exception {
     plugin = null;
     super.stop(context);

--- a/com.ibm.wala.scandroid/source/org/scandroid/domain/DomainElement.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/domain/DomainElement.java
@@ -87,6 +87,7 @@ public class DomainElement {
 	
 	
 	
+	@Override
 	public String toString() {
 		return codeElement.toString() + ", " + taintSource;
 	}

--- a/com.ibm.wala.scandroid/source/org/scandroid/domain/InstanceKeyElement.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/domain/InstanceKeyElement.java
@@ -70,6 +70,7 @@ public class InstanceKeyElement extends CodeElement {
         return ik.hashCode();
     }
 
+    @Override
     public String toString()
     {
         return "InstanceKeyElement("+ik+")";

--- a/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/PrefixVariable.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/PrefixVariable.java
@@ -128,6 +128,7 @@ public class PrefixVariable extends AbstractVariable<PrefixVariable>{
         }
     }
 
+    @Override
     public String toString() {
         return knownPrefixes.toString();
     }

--- a/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/StringBuilderUseAnalysis.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/StringBuilderUseAnalysis.java
@@ -204,6 +204,7 @@ public class StringBuilderUseAnalysis {
 			return retVal;
 		}
 
+		@Override
 		public String toString() {
 			return ("StringBuilderToString(instanceID = " + instanceID + "; concatenatedInstanceKeys = " + concatenatedInstanceKeys + ")");
 		}

--- a/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/modeledAllocations/ConstantString.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/modeledAllocations/ConstantString.java
@@ -70,6 +70,7 @@ public class ConstantString extends InstanceKeySite {
         return retVal;
     }
 
+    @Override
     public String toString() {
         return ("ConstantString(instanceID = " + instanceID + "; value = " + constantValue + ")");
     }

--- a/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/modeledAllocations/UriAppendString.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/modeledAllocations/UriAppendString.java
@@ -78,6 +78,7 @@ public class UriAppendString extends InstanceKeySite {
         return retVal;
     }
 
+    @Override
     public String toString() {
         return ("UriAppendString(instanceID = " + instanceID + "; uriInstanceID = " + uriInstanceID + "; stringInstanceID = " + stringInstanceID + ")");
     }

--- a/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/modeledAllocations/UriParseString.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/modeledAllocations/UriParseString.java
@@ -73,6 +73,7 @@ public class UriParseString extends InstanceKeySite {
         return retVal;
     }
 
+    @Override
     public String toString() {
         return ("UriParseString(instanceID = " + instanceID + "; stringInstanceID = " + stringInstanceID + ")");
     }

--- a/com.ibm.wala.scandroid/source/org/scandroid/spec/EntryArgSinkSpec.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/spec/EntryArgSinkSpec.java
@@ -71,6 +71,7 @@ public class EntryArgSinkSpec extends SinkSpec {
 		argNums = args;
 	}
 
+	@Override
 	public <E extends ISSABasicBlock> Collection<FlowType<E>> getFlowType(
 			BasicBlockInContext<E> block) {
 


### PR DESCRIPTION
This fixes 49 Eclipse code style warnings.  I'm not sure why these were overlooked in [my previous sweep of missing-`@Override` warnings](https://github.com/wala/WALA/commit/4cef26162c2d2f73449cd3cf2e80d2cf15cc459c). Ah well; got ’em this time around.