### PR TITLE
Simplify management of virtual frame buffer X server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: android
 jdk: oraclejdk8
 before_install:
- - "export DISPLAY=:99.0"
- - "sh -e /etc/init.d/xvfb start"
  - "git clone --depth=1 https://github.com/secure-software-engineering/DroidBench.git /tmp/DroidBench"
 install:
  - mvn clean verify -DskipTests=true -B -q
 script:
- - mvn clean verify -B -q
+ - xvfb-run mvn clean verify -B -q
  - jdk_switcher use oraclejdk7
  - ./build-maven-jars.py "install -Dgpg.skip"
 sudo: false


### PR DESCRIPTION
Using the `xvfb-run` script gives us automatic lifetime management for the virtual X server: it will start before the `mvn` test script and will terminate when that test script exits.  The `xvfb-run` script also sets `$DISPLAY` properly in the `mvn` test script, so we no longer need to manage that setting ourselves.