### PR TITLE
Fix all Eclipse warnings about unused locals and parameters

### DIFF
--- a/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
+++ b/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
@@ -509,12 +509,12 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
         else if (met.getParameterTypes().length > 0)
           memberEntities.add(createDefaultConstructorWithParameters(met, n, context, inits));
         else
-          memberEntities.add(createDefaultConstructor(name, typeBinding, context, inits, n));
+          memberEntities.add(createDefaultConstructor(typeBinding, context, inits, n));
       }
     }
 
     if (typeBinding.isEnum() && !typeBinding.isAnonymous())
-      doEnumHiddenEntities(typeBinding, staticInits, memberEntities, context);
+      doEnumHiddenEntities(typeBinding, memberEntities, context);
 
     // collect static inits
     if (!staticInits.isEmpty()) {
@@ -629,8 +629,8 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
 
   }
 
-  private CAstEntity createDefaultConstructor(String className, ITypeBinding classBinding, WalkContext oldContext,
-      ArrayList<ASTNode> inits, ASTNode positioningNode) {
+  private CAstEntity createDefaultConstructor(ITypeBinding classBinding, WalkContext oldContext, ArrayList<ASTNode> inits,
+      ASTNode positioningNode) {
     MethodDeclaration fakeCtor = ast.newMethodDeclaration();
     fakeCtor.setConstructor(true);
     // fakeCtor.setName(ast.newSimpleName(className)); will crash on anonymous types...
@@ -1733,19 +1733,19 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
     return visitNode(n.getExpression(), context);
   }
 
-  private CAstNode visit(BooleanLiteral n, WalkContext context) {
+  private CAstNode visit(BooleanLiteral n) {
     return fFactory.makeConstant(n.booleanValue());
   }
 
-  private CAstNode visit(CharacterLiteral n, WalkContext context) {
+  private CAstNode visit(CharacterLiteral n) {
     return fFactory.makeConstant(n.charValue());
   }
 
-  private CAstNode visit(NullLiteral n, WalkContext context) {
+  private CAstNode visit() {
     return fFactory.makeConstant(null);
   }
 
-  private CAstNode visit(StringLiteral n, WalkContext context) {
+  private CAstNode visit(StringLiteral n) {
     return fFactory.makeConstant(n.getLiteralValue());
   }
 
@@ -1754,7 +1754,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
     return makeNode(context, fFactory, n, CAstNode.TYPE_LITERAL_EXPR, fFactory.makeConstant(typeName));
   }
 
-  private CAstNode visit(NumberLiteral n, WalkContext context) {
+  private CAstNode visit(NumberLiteral n) {
     return fFactory.makeConstant(n.resolveConstantExpressionValue());
   }
 
@@ -2842,7 +2842,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
     } else if (n instanceof Block) {
       return visit((Block) n, context);
     } else if (n instanceof BooleanLiteral) {
-      return visit((BooleanLiteral) n, context);
+      return visit((BooleanLiteral) n);
     } else if (n instanceof BreakStatement) {
       return visit((BreakStatement) n, context);
     } else if (n instanceof CastExpression) {
@@ -2850,7 +2850,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
     } else if (n instanceof CatchClause) {
       return visit((CatchClause) n, context);
     } else if (n instanceof CharacterLiteral) {
-      return visit((CharacterLiteral) n, context);
+      return visit((CharacterLiteral) n);
     } else if (n instanceof ClassInstanceCreation) {
       return visit((ClassInstanceCreation) n, context);
     } else if (n instanceof ConditionalExpression) {
@@ -2882,9 +2882,9 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
     } else if (n instanceof MethodInvocation) {
       return visit((MethodInvocation) n, context);
     } else if (n instanceof NumberLiteral) {
-      return visit((NumberLiteral) n, context);
+      return visit((NumberLiteral) n);
     } else if (n instanceof NullLiteral) {
-      return visit((NullLiteral) n, context);
+      return visit();
     } else if (n instanceof ParenthesizedExpression) {
       return visit((ParenthesizedExpression) n, context);
     } else if (n instanceof PostfixExpression) {
@@ -2898,7 +2898,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
     } else if (n instanceof SimpleName) {
       return visit((SimpleName) n, context);
     } else if (n instanceof StringLiteral) {
-      return visit((StringLiteral) n, context);
+      return visit((StringLiteral) n);
     } else if (n instanceof SuperConstructorInvocation) {
       return visit((SuperConstructorInvocation) n, context);
     } else if (n instanceof SuperFieldAccess) {
@@ -3450,8 +3450,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
         .getModifiers(), handleAnnotations(enumType));
   }
 
-  private void doEnumHiddenEntities(ITypeBinding typeBinding, ArrayList<ASTNode> staticInits, List<CAstEntity> memberEntities,
-      WalkContext context) {
+  private void doEnumHiddenEntities(ITypeBinding typeBinding, List<CAstEntity> memberEntities, WalkContext context) {
     // PART I: create a $VALUES field
     // collect constants
     // ArrayList<String> constants = new ArrayList<String>();

--- a/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/ecj/ECJSourceLoaderImpl.java
+++ b/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/ecj/ECJSourceLoaderImpl.java
@@ -41,7 +41,6 @@ import java.io.IOException;
 
 import com.ibm.wala.cast.java.loader.JavaSourceLoaderImpl;
 import com.ibm.wala.cast.java.translator.SourceModuleTranslator;
-import com.ibm.wala.classLoader.ArrayClassLoader;
 import com.ibm.wala.classLoader.IClassLoader;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.types.ClassLoaderReference;
@@ -49,11 +48,6 @@ import com.ibm.wala.util.config.SetOfClasses;
 
 public class ECJSourceLoaderImpl extends JavaSourceLoaderImpl {
   private final boolean dump;
-
-  public ECJSourceLoaderImpl(ClassLoaderReference loader, ArrayClassLoader arrayClassLoader, IClassLoader parent,
-      SetOfClasses exclusions, IClassHierarchy cha) throws IOException {
-    this(loader, parent, exclusions, cha);
-  }
 
   public ECJSourceLoaderImpl(ClassLoaderReference loaderRef, IClassLoader parent, SetOfClasses exclusions, IClassHierarchy cha) throws IOException {
     this(loaderRef, parent, exclusions, cha, false);

--- a/com.ibm.wala.cast.java.test.data/src/Array1.java
+++ b/com.ibm.wala.cast.java.test.data/src/Array1.java
@@ -20,6 +20,7 @@ public class Array1 {
 	    ary[i]= i;
 	}
 
+	@SuppressWarnings("unused")
 	int sum = 0;
 
 	for(int j= 0; j < ary.length; j++) {

--- a/com.ibm.wala.cast.java.test.data/src/ArrayLiteral1.java
+++ b/com.ibm.wala.cast.java.test.data/src/ArrayLiteral1.java
@@ -9,6 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *****************************************************************************/
 public class ArrayLiteral1 {
+    @SuppressWarnings("unused")
     public static void main(String[] args) {
       ArrayLiteral1 al1= new ArrayLiteral1();
       int[] a= new int[] { 0, 1, 2, 3, 5 };

--- a/com.ibm.wala.cast.java.test.data/src/ArrayLiteral2.java
+++ b/com.ibm.wala.cast.java.test.data/src/ArrayLiteral2.java
@@ -9,6 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *****************************************************************************/
 public class ArrayLiteral2 {
+    @SuppressWarnings("unused")
     public static void main(String[] args) {
 	ArrayLiteral2 al2= new ArrayLiteral2();
 	int[] x= {};

--- a/com.ibm.wala.cast.java.test.data/src/Casts.java
+++ b/com.ibm.wala.cast.java.test.data/src/Casts.java
@@ -14,6 +14,7 @@ public class Casts {
     (new Casts()).test(args);
   }
 
+  @SuppressWarnings("unused")
   private void test(String[] args) {
     long l1 = Long.parseLong(args[0]);
     int i1 = Integer.parseInt(args[1]);

--- a/com.ibm.wala.cast.java.test.data/src/DefaultConstructors.java
+++ b/com.ibm.wala.cast.java.test.data/src/DefaultConstructors.java
@@ -11,6 +11,7 @@
 
 public class DefaultConstructors {
 	public static void main(String args[]) {
+		@SuppressWarnings("unused")
 		E e = new E();
 //		System.out.println(e.x);
 //		System.out.println(e.y);

--- a/com.ibm.wala.cast.java.test.data/src/Exception1.java
+++ b/com.ibm.wala.cast.java.test.data/src/Exception1.java
@@ -11,6 +11,7 @@
 
 public class Exception1 {
     public static void main(String[] args) {
+	@SuppressWarnings("unused")
 	Exception1 e1= new Exception1();
 	try {
 	    FooEx1 f = new FooEx1();

--- a/com.ibm.wala.cast.java.test.data/src/Exception2.java
+++ b/com.ibm.wala.cast.java.test.data/src/Exception2.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 public final class Exception2 {
 
   public static void main(String[] args) {
+    @SuppressWarnings("unused")
     Exception2 e2= new Exception2();
     FileInputStream fis = null;
     FileOutputStream fos = null;

--- a/com.ibm.wala.cast.java.test.data/src/Finally1.java
+++ b/com.ibm.wala.cast.java.test.data/src/Finally1.java
@@ -10,6 +10,7 @@
  *****************************************************************************/
 public class Finally1 {
     public static void main(String[] args) throws BadLanguageExceptionF1 {
+	@SuppressWarnings("unused")
 	Finally1 f1= new Finally1();
 	try {
 	    FooF1 f = new FooF1();

--- a/com.ibm.wala.cast.java.test.data/src/Inheritance1.java
+++ b/com.ibm.wala.cast.java.test.data/src/Inheritance1.java
@@ -10,6 +10,7 @@
  *****************************************************************************/
 public class Inheritance1 {
     public static void main(String[] args) {
+	@SuppressWarnings("unused")
 	Inheritance1 ih1= new Inheritance1();
 	Base b1 = new Base();
 	Base b2 = new Derived();
@@ -22,6 +23,7 @@ public class Inheritance1 {
 }
 class Base {
     public void foo() {
+	@SuppressWarnings("unused")
 	int i= 0;
     }
     public String bar(int x) {

--- a/com.ibm.wala.cast.java.test.data/src/InheritedField.java
+++ b/com.ibm.wala.cast.java.test.data/src/InheritedField.java
@@ -10,6 +10,7 @@
  *****************************************************************************/
 public class InheritedField {
     public static void main(String[] args) {
+	@SuppressWarnings("unused")
 	InheritedField if1= new InheritedField();
 	B b = new B();
 

--- a/com.ibm.wala.cast.java.test.data/src/InnerClass.java
+++ b/com.ibm.wala.cast.java.test.data/src/InnerClass.java
@@ -22,6 +22,7 @@ public class InnerClass {
     }
 
     public void method() {
+	@SuppressWarnings("unused")
 	WhatsIt w= new WhatsIt();
     }
 

--- a/com.ibm.wala.cast.java.test.data/src/InnerClassA.java
+++ b/com.ibm.wala.cast.java.test.data/src/InnerClassA.java
@@ -52,6 +52,7 @@ public class InnerClassA {
 			AB ab = new AB();
 			AB.ABSubA absuba = ab.new ABSubA();
 			absuba.aba_x = 7;
+			@SuppressWarnings("unused")
 			AB.ABA.ABAA abaa2 = ab.new ABA().new ABAA(); // just used to add ABA instance key in ABAA.getABA_X()
 			
 			AB.ABA aba = ab.new ABA();

--- a/com.ibm.wala.cast.java.test.data/src/InnerClassLexicalReads.java
+++ b/com.ibm.wala.cast.java.test.data/src/InnerClassLexicalReads.java
@@ -47,6 +47,7 @@ public class InnerClassLexicalReads {
 	 * 4   invokevirtual < Source, Ljava/io/PrintStream, println(I)V > v7,v8 @4 exception:v10[18:2] -> [18:38]
 	 */
 	public static void main(String args[]) {
+		@SuppressWarnings("unused")
 		InnerClassLexicalReads ignored = new InnerClassLexicalReads(); // call this just to make <init> reachable (test checks for unreachable methods)
 		int foo = 5;
 		int haha = foo * foo;

--- a/com.ibm.wala.cast.java.test.data/src/InterfaceTest1.java
+++ b/com.ibm.wala.cast.java.test.data/src/InterfaceTest1.java
@@ -10,8 +10,10 @@
  *****************************************************************************/
 public class InterfaceTest1 {
     public static void main(String[] args) {
+	@SuppressWarnings("unused")
 	InterfaceTest1 it= new InterfaceTest1();
 	IFoo foo = new FooIT1('a');
+	@SuppressWarnings("unused")
 	char ch2 = foo.getValue();
     }
 }

--- a/com.ibm.wala.cast.java.test.data/src/NullArrayInit.java
+++ b/com.ibm.wala.cast.java.test.data/src/NullArrayInit.java
@@ -11,6 +11,7 @@
 public class NullArrayInit {
   String[] x = {null};
 
+  @SuppressWarnings("unused")
   public static void main(String[] args) {
     new NullArrayInit();
     Object a[] = new Object[] {null,null};

--- a/com.ibm.wala.cast.java.test.data/src/QualifiedStatic.java
+++ b/com.ibm.wala.cast.java.test.data/src/QualifiedStatic.java
@@ -9,6 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *****************************************************************************/
 public class QualifiedStatic {
+    @SuppressWarnings("unused")
     public static void main(String[] args) {
 	QualifiedStatic qs= new QualifiedStatic();
 	FooQ fq= new FooQ();

--- a/com.ibm.wala.cast.java.test.data/src/Scoping1.java
+++ b/com.ibm.wala.cast.java.test.data/src/Scoping1.java
@@ -10,6 +10,7 @@
  *****************************************************************************/
 public class Scoping1 {
     public static void main(String[] args) {
+	@SuppressWarnings("unused")
 	Scoping1 s1= new Scoping1();
 	{
 	    int x= 5;

--- a/com.ibm.wala.cast.java.test.data/src/Scoping2.java
+++ b/com.ibm.wala.cast.java.test.data/src/Scoping2.java
@@ -10,6 +10,7 @@
  *****************************************************************************/
 public class Scoping2 {
   public static void main(String[] args) {
+    @SuppressWarnings("unused")
     Scoping2 s2 = new Scoping2();
     {
       final int x = 5;

--- a/com.ibm.wala.cast.java.test.data/src/Simple1.java
+++ b/com.ibm.wala.cast.java.test.data/src/Simple1.java
@@ -19,6 +19,7 @@ public class Simple1 {
 	this(0);
     }
     public static void doStuff(int N) {
+	@SuppressWarnings("unused")
 	int prod = 1;
 	for(int j=0; j < N; j++)
 	    prod *= j;

--- a/com.ibm.wala.cast.java.test.data/src/StaticNesting.java
+++ b/com.ibm.wala.cast.java.test.data/src/StaticNesting.java
@@ -9,6 +9,7 @@
  *     IBM Corporation - initial API and implementation
  *****************************************************************************/
 public class StaticNesting {
+    @SuppressWarnings("unused")
     public static void main(String[] args) {
 	StaticNesting sn= new StaticNesting();
 	WhatsIt w= new WhatsIt();

--- a/com.ibm.wala.cast.java.test.data/src/TwoClasses.java
+++ b/com.ibm.wala.cast.java.test.data/src/TwoClasses.java
@@ -18,6 +18,7 @@ public class TwoClasses {
 	this(0);
     }
     public static void doStuff(int N) {
+	@SuppressWarnings("unused")
 	int prod= 1;
 	TwoClasses tc= new TwoClasses();
 	tc.instanceMethod1();
@@ -35,6 +36,7 @@ public class TwoClasses {
 	instanceMethod2();
     }
     public void instanceMethod2() {
+	@SuppressWarnings("unused")
 	Bar b= Bar.create('a');
     }
 }

--- a/com.ibm.wala.cast.java.test.data/src/WhileTest1.java
+++ b/com.ibm.wala.cast.java.test.data/src/WhileTest1.java
@@ -10,6 +10,7 @@
  *****************************************************************************/
 public class WhileTest1 {
     public static void main(String[] args) {
+	@SuppressWarnings("unused")
 	WhileTest1 wt1= new WhileTest1();
 	int x= 235834;
 	boolean stop= false;

--- a/com.ibm.wala.cast.java.test.data/src/alreadywalaunittests/InnerClassAA.java
+++ b/com.ibm.wala.cast.java.test.data/src/alreadywalaunittests/InnerClassAA.java
@@ -87,6 +87,7 @@ public class InnerClassAA {
 			AB ab = new AB();
 			AB.ABSubA absuba = ab.new ABSubA();
 			absuba.aba_x = 7;
+			@SuppressWarnings("unused")
 			AB.ABA.ABAA abaa2 = ab.new ABA().new ABAA(); // just used to add ABA instance key in ABAA.getABA_X()
 			
 			AB.ABA aba = ab.new ABA();

--- a/com.ibm.wala.cast.java.test.data/src/foo/bar/hello/world/ArraysAndSuch.java
+++ b/com.ibm.wala.cast.java.test.data/src/foo/bar/hello/world/ArraysAndSuch.java
@@ -42,6 +42,7 @@ public class ArraysAndSuch {
 	public static void main(String args[]) {
 		ArraysAndSuch.main();
 	}
+	@SuppressWarnings("unused")
 	public static void main() {
 		Object o1 = null;
 		Object[] os1 = new Object[] { null, o1, null };

--- a/com.ibm.wala.cast.java.test.data/src/foo/bar/hello/world/ConstructorsAndInitializers.java
+++ b/com.ibm.wala.cast.java.test.data/src/foo/bar/hello/world/ConstructorsAndInitializers.java
@@ -101,6 +101,7 @@ public class ConstructorsAndInitializers extends Super {
 		class T{
 			
 		}
+		@SuppressWarnings("unused")
 		T t = new T();
 	}
 }

--- a/com.ibm.wala.cast.java.test.data/src/foo/bar/hello/world/CopyOfLoopsAndLabels.java
+++ b/com.ibm.wala.cast.java.test.data/src/foo/bar/hello/world/CopyOfLoopsAndLabels.java
@@ -40,6 +40,7 @@ package foo.bar.hello.world;
 public class CopyOfLoopsAndLabels {
 	static int X=5;
 	public static void main(String args[]) {
+		@SuppressWarnings("unused")
 		int k=X;
 		for (; ; k++)
 			break;

--- a/com.ibm.wala.cast.java.test.data/src/foo/bar/hello/world/InnerClasses.java
+++ b/com.ibm.wala.cast.java.test.data/src/foo/bar/hello/world/InnerClasses.java
@@ -87,6 +87,7 @@ public class InnerClasses extends Temp {
 		se2.setSEVar();
 		System.out.println(sub2.hello()); //1001
 		
+		@SuppressWarnings("unused")
 		int foo = 12;
 		foo++;
 		--foo;

--- a/com.ibm.wala.cast.java.test.data/src/foo/bar/hello/world/MiniaturList2.java
+++ b/com.ibm.wala.cast.java.test.data/src/foo/bar/hello/world/MiniaturList2.java
@@ -40,6 +40,7 @@ package foo.bar.hello.world;
 public class MiniaturList2 {
 
         public static void main(String[] args) {
+        	@SuppressWarnings("unused")
         	int a;
             for ( ;; ) {
                             break;

--- a/com.ibm.wala.cast.java.test.data/src/javaonepointfive/CustomGenericsAndFields.java
+++ b/com.ibm.wala.cast.java.test.data/src/javaonepointfive/CustomGenericsAndFields.java
@@ -113,11 +113,13 @@ public class CustomGenericsAndFields {
 
 		/////////////////////////////
 
+		@SuppressWarnings("unused")
 		String thrownaway = cg2.bar("a","b");
 		cg2.setFoo("real one");
 		MyGeneric<String,ConcreteGeneric2<String>> mygeneric = new MyGeneric<String,ConcreteGeneric2<String>>("useless",cg2);
 		String x = mygeneric.doFoo();
 		System.out.println(x);
+		@SuppressWarnings("unused")
 		String y = cg2.x;
 		System.out.println(mygeneric.getB().y);
 		System.out.println(mygeneric.b.y); // TODO: fields are going to be a pain... watch out for Lvalues in context?

--- a/com.ibm.wala.cast.java.test.data/src/javaonepointfive/ExplicitBoxingTest.java
+++ b/com.ibm.wala.cast.java.test.data/src/javaonepointfive/ExplicitBoxingTest.java
@@ -47,6 +47,7 @@ public class ExplicitBoxingTest {
 		int a = 6;
 		a = a + a;
 		System.out.println(a);
+		@SuppressWarnings("unused")
 		Integer useless1 = new Integer(5+6);
 		Integer aa = new Integer(a+a);
 		int aaa = aa.intValue();
@@ -55,6 +56,7 @@ public class ExplicitBoxingTest {
 		int b = 6;
 		b = b + b;
 		System.out.println(b);
+		@SuppressWarnings("unused")
 		Integer useless2 = 5+6;
 		Integer bb = b+b;
 		int bbb = bb;

--- a/com.ibm.wala.cast.java.test.data/src/javaonepointfive/GenericArrays.java
+++ b/com.ibm.wala.cast.java.test.data/src/javaonepointfive/GenericArrays.java
@@ -52,6 +52,7 @@ public class GenericArrays {
 		List<Integer> li = new ArrayList<Integer>();
 		li.add(new Integer(3));
 		oa[1] = li; // correct
+		@SuppressWarnings("unused")
 		String s = (String) lsa[1].get(0); // run time error, but cast is explicit
 
 	}

--- a/com.ibm.wala.cast.java.test.data/src/javaonepointfive/TypeInferencePrimAndStringOp.java
+++ b/com.ibm.wala.cast.java.test.data/src/javaonepointfive/TypeInferencePrimAndStringOp.java
@@ -13,6 +13,7 @@ package javaonepointfive;
 public class TypeInferencePrimAndStringOp {
   public static void main(String[] args) {
     int a = 2;
+    @SuppressWarnings("unused")
     String result = "a" + a;
   }
 }

--- a/com.ibm.wala.cast.java.test.data/src/p/NonPrimaryTopLevel.java
+++ b/com.ibm.wala.cast.java.test.data/src/p/NonPrimaryTopLevel.java
@@ -11,6 +11,7 @@
 package p;
 
 public class NonPrimaryTopLevel {
+    @SuppressWarnings("unused")
     public static void main(String[] args) {
 	NonPrimaryTopLevel nptl= new NonPrimaryTopLevel();
 	Foo f = new Foo();

--- a/com.ibm.wala.cast.java.test/src/com/ibm/wala/cast/java/test/JavaIRTests.java
+++ b/com.ibm.wala.cast.java.test/src/com/ibm/wala/cast/java/test/JavaIRTests.java
@@ -67,11 +67,11 @@ public abstract class JavaIRTests extends IRTests {
   @Test public void testSimple1() throws IllegalArgumentException, CancelException, IOException {
 
     List<? extends IRAssertion> assertions = Arrays.asList(
-        new SourceMapAssertion("Source#Simple1#doStuff#(I)V", "prod", 24),
-        new SourceMapAssertion("Source#Simple1#doStuff#(I)V", "j", 23), 
-        new SourceMapAssertion("Source#Simple1#main#([Ljava/lang/String;)V", "s", 32), 
-        new SourceMapAssertion("Source#Simple1#main#([Ljava/lang/String;)V", "i", 28), 
-        new SourceMapAssertion("Source#Simple1#main#([Ljava/lang/String;)V", "sum", 29), 
+        new SourceMapAssertion("Source#Simple1#doStuff#(I)V", "prod", 25),
+        new SourceMapAssertion("Source#Simple1#doStuff#(I)V", "j", 24), 
+        new SourceMapAssertion("Source#Simple1#main#([Ljava/lang/String;)V", "s", 33), 
+        new SourceMapAssertion("Source#Simple1#main#([Ljava/lang/String;)V", "i", 29), 
+        new SourceMapAssertion("Source#Simple1#main#([Ljava/lang/String;)V", "sum", 30), 
         EdgeAssertions.make("Source#Simple1#main#([Ljava/lang/String;)V", "Source#Simple1#doStuff#(I)V"), 
         EdgeAssertions.make("Source#Simple1#instanceMethod1#()V", "Source#Simple1#instanceMethod2#()V"));
 

--- a/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/vis/JsViewerDriver.java
+++ b/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/vis/JsViewerDriver.java
@@ -60,7 +60,8 @@ public class JsViewerDriver extends JSCallGraphBuilderUtil {
 		CallGraph cg = builder.makeCallGraph(builder.getOptions());
 		PointerAnalysis<InstanceKey> pa = builder.getPointerAnalysis();
 
-		new JsViewer(cg, pa);
+		@SuppressWarnings("unused")
+		JsViewer jsViewer = new JsViewer(cg, pa);
 	}
 
 	private static SourceModule[] getSources(boolean domless, URL url)

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/analysis/typeInference/JSPrimitiveType.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/analysis/typeInference/JSPrimitiveType.java
@@ -16,6 +16,7 @@ import com.ibm.wala.types.TypeReference;
 
 public class JSPrimitiveType extends PrimitiveType {
 
+  @SuppressWarnings("unused")
   public static void init() {
     new JSPrimitiveType(JavaScriptTypes.Undefined, -1);
 

--- a/com.ibm.wala.core.testdata/src/cpa/CPATest1.java
+++ b/com.ibm.wala.core.testdata/src/cpa/CPATest1.java
@@ -44,6 +44,7 @@ public class CPATest1 {
       return x;
     }
     
+    @SuppressWarnings("unused")
     public static void main(String[] args) {
       F f = new F(3.4);
       I i = new I(7);

--- a/com.ibm.wala.core.testdata/src/cpa/CPATest2.java
+++ b/com.ibm.wala.core.testdata/src/cpa/CPATest2.java
@@ -44,6 +44,7 @@ public class CPATest2 {
       return x;
     }
     
+    @SuppressWarnings("unused")
     public static void main(String[] args) {
       F f = new F(3.4);
       I i = new I(7);

--- a/com.ibm.wala.core.testdata/src/staticInit/TestStaticInitOrder.java
+++ b/com.ibm.wala.core.testdata/src/staticInit/TestStaticInitOrder.java
@@ -14,6 +14,7 @@ public class TestStaticInitOrder {
 
   private static class A {
 
+    @SuppressWarnings("unused")
     static int f;
     
     static {
@@ -26,6 +27,7 @@ public class TestStaticInitOrder {
   }
 
   private static class B {
+    @SuppressWarnings("unused")
     static int b;
     
     static {
@@ -39,6 +41,7 @@ public class TestStaticInitOrder {
   
   private static class C extends B {
     
+    @SuppressWarnings("unused")
     static int c = 5;
     
     public static void dostuff() {

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/CallGraphTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/CallGraphTest.java
@@ -399,6 +399,7 @@ public class CallGraphTest extends WalaTestCase {
     }
 
     // perform a little icfg exercise
+    @SuppressWarnings("unused")
     int count = 0;
     for (Iterator<BasicBlockInContext<ISSABasicBlock>> it = icfg.iterator(); it.hasNext();) {
       BasicBlockInContext<ISSABasicBlock> bb = it.next();

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/LambdaTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/LambdaTest.java
@@ -48,6 +48,7 @@ public class LambdaTest extends WalaTestCase {
         "Lbug144/A");
     AnalysisOptions options = CallGraphTestUtil.makeAnalysisOptions(scope, entrypoints);
 
+    @SuppressWarnings("unused")
     CallGraph cg = CallGraphTestUtil.buildZeroCFA(options, new AnalysisCacheImpl(), cha, scope, false);
   }
   

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cfg/exc/inter/NullPointerExceptionInterTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cfg/exc/inter/NullPointerExceptionInterTest.java
@@ -22,7 +22,6 @@ import com.ibm.wala.cfg.exc.NullPointerAnalysis;
 import com.ibm.wala.cfg.exc.intra.IntraprocNullPointerAnalysis;
 import com.ibm.wala.classLoader.ClassLoaderFactory;
 import com.ibm.wala.classLoader.ClassLoaderFactoryImpl;
-import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.core.tests.callGraph.CallGraphTestUtil;
 import com.ibm.wala.core.tests.util.TestConstants;
 import com.ibm.wala.core.tests.util.WalaTestCase;
@@ -100,7 +99,6 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
   public void testIfException() throws UnsoundGraphException, CancelException, WalaException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callIfException()Lcfg/exc/intra/B");
 
-    IMethod m = cha.resolveMethod(mr);
     IR ir = cache.getIR(m);
     InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG = 
         NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
@@ -117,8 +115,6 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
   public void testDynamicIfException() throws UnsoundGraphException, CancelException, WalaException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callDynamicIfException()Lcfg/exc/intra/B");
 
-    IMethod m = cha.resolveMethod(mr);
-    
     Assert.assertEquals(1, cg.getNodes(mr).size());
     final CGNode callNode = cg.getNodes(mr).iterator().next();
 
@@ -137,7 +133,6 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
   public void testIfNoException() throws UnsoundGraphException, CancelException, WalaException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callIfNoException()Lcfg/exc/intra/B");
 
-    IMethod m = cha.resolveMethod(mr);
     IR ir = cache.getIR(m);
     InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG = 
         NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
@@ -153,7 +148,6 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
   public void testDynamicIfNoException() throws UnsoundGraphException, CancelException, WalaException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callDynamicIfNoException()Lcfg/exc/intra/B");
 
-    IMethod m = cha.resolveMethod(mr);
     IR ir = cache.getIR(m);
     InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG = 
         NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
@@ -169,7 +163,6 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
   public void testIf2Exception() throws UnsoundGraphException, CancelException, WalaException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callIf2Exception()Lcfg/exc/intra/B");
 
-    IMethod m = cha.resolveMethod(mr);
     IR ir = cache.getIR(m);
     InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG = 
         NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
@@ -186,8 +179,6 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
   public void testDynamicIf2Exception() throws UnsoundGraphException, CancelException, WalaException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callDynamicIf2Exception()Lcfg/exc/intra/B");
 
-    IMethod m = cha.resolveMethod(mr);
-    
     Assert.assertEquals(1, cg.getNodes(mr).size());
     final CGNode callNode = cg.getNodes(mr).iterator().next();
 
@@ -206,7 +197,6 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
   public void testIf2NoException() throws UnsoundGraphException, CancelException, WalaException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callIf2NoException()Lcfg/exc/intra/B");
 
-    IMethod m = cha.resolveMethod(mr);
     IR ir = cache.getIR(m);
     InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG = 
         NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
@@ -222,7 +212,6 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
   public void testDynamicIf2NoException() throws UnsoundGraphException, CancelException, WalaException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callDynamicIf2NoException()Lcfg/exc/intra/B");
 
-    IMethod m = cha.resolveMethod(mr);
     IR ir = cache.getIR(m);
     InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG = 
         NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
@@ -239,7 +228,6 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
   public void testGetException() throws UnsoundGraphException, CancelException, WalaException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callGetException()Lcfg/exc/intra/B");
 
-    IMethod m = cha.resolveMethod(mr);
     IR ir = cache.getIR(m);
     InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG = 
         NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
@@ -256,8 +244,6 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
   public void testDynamicGetException() throws UnsoundGraphException, CancelException, WalaException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callDynamicGetException()Lcfg/exc/intra/B");
 
-    IMethod m = cha.resolveMethod(mr);
-    
     Assert.assertEquals(1, cg.getNodes(mr).size());
     final CGNode callNode = cg.getNodes(mr).iterator().next();
 

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cfg/exc/inter/NullPointerExceptionInterTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cfg/exc/inter/NullPointerExceptionInterTest.java
@@ -37,7 +37,6 @@ import com.ibm.wala.ipa.callgraph.impl.Util;
 import com.ibm.wala.ipa.cha.ClassHierarchy;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.ipa.cha.ClassHierarchyFactory;
-import com.ibm.wala.ssa.IR;
 import com.ibm.wala.ssa.SSAInstruction;
 import com.ibm.wala.ssa.analysis.IExplodedBasicBlock;
 import com.ibm.wala.types.MethodReference;
@@ -99,7 +98,6 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
   public void testIfException() throws UnsoundGraphException, CancelException, WalaException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callIfException()Lcfg/exc/intra/B");
 
-    IR ir = cache.getIR(m);
     InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG = 
         NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
 
@@ -118,7 +116,6 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
     Assert.assertEquals(1, cg.getNodes(mr).size());
     final CGNode callNode = cg.getNodes(mr).iterator().next();
 
-    IR ir = cache.getIR(m);
     InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG = 
         NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
 
@@ -133,7 +130,6 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
   public void testIfNoException() throws UnsoundGraphException, CancelException, WalaException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callIfNoException()Lcfg/exc/intra/B");
 
-    IR ir = cache.getIR(m);
     InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG = 
         NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
 
@@ -148,7 +144,6 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
   public void testDynamicIfNoException() throws UnsoundGraphException, CancelException, WalaException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callDynamicIfNoException()Lcfg/exc/intra/B");
 
-    IR ir = cache.getIR(m);
     InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG = 
         NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
 
@@ -163,7 +158,6 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
   public void testIf2Exception() throws UnsoundGraphException, CancelException, WalaException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callIf2Exception()Lcfg/exc/intra/B");
 
-    IR ir = cache.getIR(m);
     InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG = 
         NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
 
@@ -182,7 +176,6 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
     Assert.assertEquals(1, cg.getNodes(mr).size());
     final CGNode callNode = cg.getNodes(mr).iterator().next();
 
-    IR ir = cache.getIR(m);
     InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG = 
         NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
 
@@ -197,7 +190,6 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
   public void testIf2NoException() throws UnsoundGraphException, CancelException, WalaException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callIf2NoException()Lcfg/exc/intra/B");
 
-    IR ir = cache.getIR(m);
     InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG = 
         NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
 
@@ -212,7 +204,6 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
   public void testDynamicIf2NoException() throws UnsoundGraphException, CancelException, WalaException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callDynamicIf2NoException()Lcfg/exc/intra/B");
 
-    IR ir = cache.getIR(m);
     InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG = 
         NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
 
@@ -228,7 +219,6 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
   public void testGetException() throws UnsoundGraphException, CancelException, WalaException {
     MethodReference mr = StringStuff.makeMethodReference("cfg.exc.inter.CallFieldAccess.callGetException()Lcfg/exc/intra/B");
 
-    IR ir = cache.getIR(m);
     InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG = 
         NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
 
@@ -247,7 +237,6 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
     Assert.assertEquals(1, cg.getNodes(mr).size());
     final CGNode callNode = cg.getNodes(mr).iterator().next();
 
-    IR ir = cache.getIR(m);
     InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG = 
         NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
 

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/examples/drivers/JavaViewerDriver.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/examples/drivers/JavaViewerDriver.java
@@ -68,7 +68,8 @@ public class JavaViewerDriver {
     CallGraph cg = builder.makeCallGraph(options, null);
 
     PointerAnalysis<InstanceKey> pa = builder.getPointerAnalysis();
-    new WalaViewer(cg, pa);
+    @SuppressWarnings("unused")
+    WalaViewer walaViewer = new WalaViewer(cg, pa);
     
   }
 }

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/FactoryBypassInterpreter.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/FactoryBypassInterpreter.java
@@ -339,7 +339,7 @@ public class FactoryBypassInterpreter extends AbstractReflectionInterpreter {
     if (node == null) {
       throw new IllegalArgumentException("node is null");
     }
-    SpecializedFactoryMethod m = findOrCreateSpecializedFactoryMethod(node);
+    // SpecializedFactoryMethod m = findOrCreateSpecializedFactoryMethod(node);
     return cache.getDefUse(getIR(node));
   }
 

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/java7/MethodHandles.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/java7/MethodHandles.java
@@ -276,7 +276,7 @@ public class MethodHandles {
             code.addStatement(insts.InvokeInstruction(code.getNextProgramCounter(), 2*nargs+3, params, 2*nargs+4, site, null));
             code.addStatement(insts.ReturnInstruction(code.getNextProgramCounter(), 2*nargs+3, false));
           } else {
-            int nargs = node.getMethod().getNumberOfParameters();
+            // int nargs = node.getMethod().getNumberOfParameters();
           }
         } else {
           assert isType(node);

--- a/com.ibm.wala.core/src/com/ibm/wala/util/ssa/ParameterAccessor.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/ssa/ParameterAccessor.java
@@ -539,7 +539,7 @@ public class ParameterAccessor {
             switch (this.base) {
                 case IMETHOD:
                     {
-                        final int firstInSelector = firstInSelector();
+                        // final int firstInSelector = firstInSelector();
                         for (int i = ((hasImplicitThis())?1:0); i < this.method.getNumberOfParameters(); ++i) {   
                             debug("all() adding: Parameter({}, {}, {}, {}, {})", (i + 1), this.method.getParameterType(i),
                                     this.base,  this.method, this.descriptorOffset);

--- a/com.ibm.wala.core/src/com/ibm/wala/util/ssa/TypeSafeInstructionFactory.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/ssa/TypeSafeInstructionFactory.java
@@ -148,7 +148,7 @@ public class TypeSafeInstructionFactory {
             }
         }
 
-        final MethodReference mRef = site.getDeclaredTarget();
+        // final MethodReference mRef = site.getDeclaredTarget();
 
         // ***********
         // Params cosher, start typechecks
@@ -270,7 +270,7 @@ public class TypeSafeInstructionFactory {
 
         final int[] aParams = new int[params.size()];
         if (acc.hasImplicitThis()) { // Implicit This
-            final SSAValue targetThis = acc.getThis();
+            // final SSAValue targetThis = acc.getThis();
             final SSAValue givenThis = params.get(0);
 
             aParams[0] = givenThis.getNumber();
@@ -489,7 +489,7 @@ public class TypeSafeInstructionFactory {
             throw new IllegalArgumentException("The field " + field + " is not assignable from " + newValue);
         }
     
-        final MethodReference newValueValidIn = newValue.getValidIn();
+        // final MethodReference newValueValidIn = newValue.getValidIn();
 
         return insts.PutInstruction(iindex, newValue.getNumber(), field);
     }

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/dex/instructions/Instruction.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/dex/instructions/Instruction.java
@@ -54,9 +54,10 @@ import com.ibm.wala.dalvik.classLoader.DexIMethod;
 
 public abstract class Instruction {
 
+    @SuppressWarnings("unused")
     public static class Visitor {
  
-        public void visitArrayLength(ArrayLength instruction) {
+		public void visitArrayLength(ArrayLength instruction) {
          }
 
         public void visitArrayGet(ArrayGet instruction) {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModel.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModel.java
@@ -382,8 +382,8 @@ public class AndroidModel /* makes SummarizedMethod */
 
             
             {
-                final AndroidBoot boot = new AndroidBoot(null); 
-                boot.addBootCode(tsif, null, paramManager, this.body);
+                final AndroidBoot boot = new AndroidBoot(); 
+                boot.addBootCode(tsif, paramManager, this.body);
                 //tool.attachActivities(allActivities, application, boot.getMainThread(), /* Should be application context TODO */
                 //        boot.getPackageContext(), nullBinder, nullIntent); 
             }
@@ -699,7 +699,7 @@ public class AndroidModel /* makes SummarizedMethod */
         final SSAValue intent = acc.firstExtends(AndroidTypes.Intent, cha);
 
         final AndroidStartComponentTool tool = new AndroidStartComponentTool(getClassHierarchy(), asMethod, flags, caller, instructionFactory,
-                acc, pm, redirect, self, info, callerNd);
+                acc, pm, redirect, self, info);
 
         final AndroidTypes.AndroidContextType contextType;
         final SSAValue androidContext;  // of AndroidTypes.Context: The callers android-context

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/LoadedInstantiationBehavior.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/LoadedInstantiationBehavior.java
@@ -258,8 +258,7 @@ public class LoadedInstantiationBehavior extends IInstantiationBehavior {
         }
     }
 
-    public void setBehavior(final TypeName type, final TypeName asParameterTo, final MethodReference inCall, 
-            final String withName, final InstanceBehavior beh, final Exactness exactness) {
+    public void setBehavior(final TypeName type, final InstanceBehavior beh, final Exactness exactness) {
 
 
         final BehaviorKey<TypeName> typeK= BehaviorKey.mk(type);
@@ -268,8 +267,7 @@ public class LoadedInstantiationBehavior extends IInstantiationBehavior {
         behaviours.put(typeK, val);
     }
 
-    public void setBehavior(final Atom pack, final TypeName asParameterTo, final MethodReference inCall, 
-            final String withName, final InstanceBehavior beh, final Exactness exactness) {
+    public void setBehavior(final Atom pack, final InstanceBehavior beh, final Exactness exactness) {
 
 
         final BehaviorKey<Atom> typeK= BehaviorKey.mk(pack);

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/SpecializedInstantiator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/SpecializedInstantiator.java
@@ -131,11 +131,11 @@ public class SpecializedInstantiator extends FlatInstantiator {
         assert(understands(T));
 
         if (T.equals(AndroidTypes.Context)) {
-            return createContext(T, asManaged, key, seen);
+            return createContext(T, key);
         }
 
         if (T.equals(AndroidTypes.ContextWrapper)) {
-            return createContextWrapper(T, asManaged, key, seen);
+            return createContextWrapper(T, key);
         }
 
         return null;
@@ -159,7 +159,7 @@ public class SpecializedInstantiator extends FlatInstantiator {
     /**
      *  Creates a new instance of android/content/Context.
      */
-    public SSAValue createContext(final TypeReference T, final boolean asManaged, VariableKey key, Set<? extends SSAValue> seen) {
+    public SSAValue createContext(final TypeReference T, VariableKey key) {
         final List<SSAValue> appComponents = new ArrayList<>();
         {
             // TODO: Can we create a tighter conterxt?
@@ -233,14 +233,14 @@ public class SpecializedInstantiator extends FlatInstantiator {
     }
 
 
-    public SSAValue createContextWrapper(final TypeReference T, final boolean asManaged, VariableKey key, Set<? extends SSAValue> seen) {
+    public SSAValue createContextWrapper(final TypeReference T, VariableKey key) {
         final VariableKey contextKey = new SSAValue.TypeKey(AndroidTypes.ContextName);
         final SSAValue context;
         {
             if (this.pm.isSeen(contextKey)) {
                 context = this.pm.getCurrent(contextKey);
             } else {
-                context = createContext(AndroidTypes.Context, true, contextKey, seen);
+                context = createContext(AndroidTypes.Context, contextKey);
             }
         }
 

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/AndroidBoot.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/AndroidBoot.java
@@ -42,7 +42,6 @@ package com.ibm.wala.dalvik.ipa.callgraph.androidModel.stubs;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import com.ibm.wala.classLoader.CallSiteReference;
 import com.ibm.wala.classLoader.NewSiteReference;
@@ -57,7 +56,6 @@ import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.Selector;
 import com.ibm.wala.types.TypeName;
 import com.ibm.wala.types.TypeReference;
-import com.ibm.wala.util.ssa.ParameterAccessor;
 import com.ibm.wala.util.ssa.SSAValue;
 import com.ibm.wala.util.ssa.SSAValueManager;
 import com.ibm.wala.util.ssa.TypeSafeInstructionFactory;
@@ -97,16 +95,16 @@ public class AndroidBoot {
     private VolatileMethodSummary body;
 
 
-    public AndroidBoot(Set<BootAction> whatToDo) {
+//    public AndroidBoot() {
 //        this.scope = null;  // Place something here?
-    }
+//    }
 
     private SSAValue mainThread = null;
     private SSAValue systemContext = null;
     private SSAValue packageContext = null;
 
-    public void addBootCode(final TypeSafeInstructionFactory instructionFactory, final ParameterAccessor acc,
-            final SSAValueManager pm, final VolatileMethodSummary body) {
+    public void addBootCode(final TypeSafeInstructionFactory instructionFactory, final SSAValueManager pm,
+            final VolatileMethodSummary body) {
         this.instructionFactory = instructionFactory;
 //        this.acc = acc;
         this.pm = pm;
@@ -114,7 +112,7 @@ public class AndroidBoot {
 
         mainThread = createMainThred();
         systemContext = createSystemContext(mainThread);
-        packageContext = createPackageContext(mainThread, systemContext);
+        packageContext = createPackageContext(mainThread);
     }
 
     public SSAValue getSystemContext() {
@@ -213,7 +211,7 @@ public class AndroidBoot {
      *  @see    android.app.ContextImpl.createPackageContextAsUser
      */
     @SuppressWarnings("javadoc")
-	private SSAValue createPackageContext(final SSAValue mainThread, final SSAValue systemContext) {
+	private SSAValue createPackageContext(final SSAValue mainThread) {
         final SSAValue packageContext = this.pm.getUnmanaged(AndroidTypes.ContextImpl, "packageContextImpl");
         { // New-Site
             final int pc = this.body.getNextProgramCounter();

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/AndroidStartComponentTool.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/AndroidStartComponentTool.java
@@ -53,7 +53,6 @@ import com.ibm.wala.dalvik.ipa.callgraph.androidModel.AndroidModelClass;
 import com.ibm.wala.dalvik.ipa.callgraph.propagation.cfa.IntentStarters.StartInfo;
 import com.ibm.wala.dalvik.ipa.callgraph.propagation.cfa.IntentStarters.StarterFlags;
 import com.ibm.wala.dalvik.util.AndroidTypes;
-import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.ipa.summaries.VolatileMethodSummary;
 import com.ibm.wala.shrikeBT.IInvokeInstruction;
@@ -100,7 +99,7 @@ public class AndroidStartComponentTool {
     public AndroidStartComponentTool(final IClassHierarchy cha, final MethodReference asMethod, final Set<StarterFlags> flags,
             final TypeReference caller, final TypeSafeInstructionFactory instructionFactory, final ParameterAccessor acc,
             final SSAValueManager pm, final VolatileMethodSummary redirect, final Parameter self,
-            final StartInfo info, final CGNode callerNd) {
+            final StartInfo info) {
         
         if (cha == null) {
             throw new IllegalArgumentException("cha may not be null");

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/Overrides.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/Overrides.java
@@ -54,7 +54,6 @@ import com.ibm.wala.dalvik.util.AndroidComponent;
 import com.ibm.wala.dalvik.util.AndroidEntryPointManager;
 import com.ibm.wala.ipa.callgraph.AnalysisOptions;
 import com.ibm.wala.ipa.callgraph.CGNode;
-import com.ibm.wala.ipa.callgraph.Context;
 import com.ibm.wala.ipa.callgraph.IAnalysisCacheView;
 import com.ibm.wala.ipa.callgraph.MethodTargetSelector;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
@@ -159,7 +158,7 @@ public class Overrides {
             final MethodReference mRef = site.getDeclaredTarget();
             if (syntheticMethods.containsKey(mRef)) {
                 if (caller != null) {   // XXX: Debug remove
-                    Context ctx = caller.getContext();
+                    // Context ctx = caller.getContext();
 
                     
                     

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/Intent.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/Intent.java
@@ -269,6 +269,7 @@ public class Intent implements ContextItem, Comparable<Intent> {
      *
      *  Recomputes if the Intent is internal.
      *  TODO: 
+     *  @param intent 
      *  @todo   Implement it ;)
      *  @todo   What to return if it does not, but Summary-Information is available?
      *  @todo   We should read in the Manifest.xml rather than relying on the packet name!

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/DexSSABuilder.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/DexSSABuilder.java
@@ -136,8 +136,8 @@ public class DexSSABuilder extends AbstractIntRegisterMachine {
             boolean buildLocalMap, SSAPiNodePolicy piNodePolicy) {
         super(scfg);
         localMap = buildLocalMap ? new SSA2LocalMap(scfg, instructions.length, cfg.getNumberOfNodes(), method.getMaxLocals()) : null;
-        init(new SymbolTableMeeter(cfg, instructions, scfg), new SymbolicPropagator(scfg, instructions,
-                localMap, cfg, piNodePolicy));
+        init(new SymbolTableMeeter(cfg, scfg), new SymbolicPropagator(scfg, instructions,
+                cfg, piNodePolicy));
         this.method = method;
         this.symbolTable = symbolTable;
         this.insts = method.getDeclaringClass().getClassLoader().getInstructionFactory();
@@ -152,7 +152,7 @@ public class DexSSABuilder extends AbstractIntRegisterMachine {
 
         final DexCFG dexCFG;
 
-        SymbolTableMeeter(SSACFG cfg, SSAInstruction[] instructions, DexCFG dexCFG) {
+        SymbolTableMeeter(SSACFG cfg, DexCFG dexCFG) {
             this.cfg = cfg;
 //            this.instructions = instructions;
             this.dexCFG = dexCFG;
@@ -346,8 +346,8 @@ public class DexSSABuilder extends AbstractIntRegisterMachine {
 
         final SSAPiNodePolicy piNodePolicy;
 
-        public SymbolicPropagator(DexCFG dexCFG, SSAInstruction[] instructions, SSA2LocalMap localMap,
-                SSACFG cfg, SSAPiNodePolicy piNodePolicy) {
+        public SymbolicPropagator(DexCFG dexCFG, SSAInstruction[] instructions, SSACFG cfg,
+                SSAPiNodePolicy piNodePolicy) {
             super(dexCFG);
             this.piNodePolicy = piNodePolicy;
             this.cfg = cfg;

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidEntryPointLocator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidEntryPointLocator.java
@@ -282,7 +282,7 @@ nextMethod:
 
             }
         }
-        final AndroidEntryPoint ep = new AndroidEntryPoint(selectPositionForHeuristic(method), method, cha, compo);
+        final AndroidEntryPoint ep = new AndroidEntryPoint(selectPositionForHeuristic(), method, cha, compo);
 
         return ep;
     }
@@ -364,7 +364,7 @@ nextMethod:
                         final IMethod method = appClass.getMethod(ifMethod.getSelector());
                         if (method != null && method.getDeclaringClass().getClassLoader().getReference().equals(ClassLoaderReference.Application)) {
                             // The function is overridden
-                            final AndroidEntryPoint ep = new AndroidEntryPoint(selectPositionForHeuristic(method), method, cha);
+                            final AndroidEntryPoint ep = new AndroidEntryPoint(selectPositionForHeuristic(), method, cha);
 
                             if (! eps.contains(ep)) {  // Just to be sure that a previous element stays as-is
                             if (eps.add(ep)) {
@@ -435,7 +435,7 @@ nextMethod:
      *
      *  Currently all methods are placed at ExecutionOrder.MULTIPLE_TIMES_IN_LOOP.
      */
-    private ExecutionOrder selectPositionForHeuristic(IMethod method) {
+    private ExecutionOrder selectPositionForHeuristic() {
         return ExecutionOrder.MULTIPLE_TIMES_IN_LOOP;
     }
 
@@ -454,13 +454,13 @@ nextMethod:
         private final String name;
         public final AndroidEntryPoint.ExecutionOrder order;
 
-        public AndroidPossibleEntryPoint(AndroidComponent c, String n, ExecutionOrder o) { 
+        public AndroidPossibleEntryPoint(String n, ExecutionOrder o) {
 //            cls = c; 
             name = n; 
             order = o; 
         }
  
-        public AndroidPossibleEntryPoint(AndroidComponent c, String n, AndroidPossibleEntryPoint o) { 
+        public AndroidPossibleEntryPoint(String n, AndroidPossibleEntryPoint o) {
 //            cls = c; 
             name = n; 
             order = o.order; 

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
@@ -562,6 +562,7 @@ public class AndroidManifestXMLReader {
                 }
             }
 
+            /*
             // Pushing intent...
             final String pack;
             if ((attributesHistory.get(Attr.PACKAGE) != null ) && (!(attributesHistory.get(Attr.PACKAGE).isEmpty()))) {
@@ -570,6 +571,7 @@ public class AndroidManifestXMLReader {
                 logger.warn("Empty Package {}", attributesHistory.get(Attr.PACKAGE).peek());
                 pack = null;
             }
+            */
 
             if (!names.isEmpty()) {
                 for (String name : names) {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidPreFlightChecks.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidPreFlightChecks.java
@@ -46,7 +46,6 @@ import java.util.Set;
 
 import com.ibm.wala.dalvik.ipa.callgraph.androidModel.parameters.IInstantiationBehavior;
 import com.ibm.wala.dalvik.ipa.callgraph.impl.AndroidEntryPoint;
-import com.ibm.wala.ipa.callgraph.AnalysisOptions;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.types.Selector;
 import com.ibm.wala.types.TypeName;
@@ -68,7 +67,7 @@ public class AndroidPreFlightChecks {
 //    private final AnalysisOptions options;
     private final IClassHierarchy cha;
 
-    public AndroidPreFlightChecks(AndroidEntryPointManager manager, AnalysisOptions options, IClassHierarchy cha) {
+    public AndroidPreFlightChecks(AndroidEntryPointManager manager, IClassHierarchy cha) {
         this.manager = manager;
 //        this.options = options;
         this.cha = cha;

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/ActivityEP.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/ActivityEP.java
@@ -44,7 +44,6 @@ import java.util.List;
 
 import com.ibm.wala.dalvik.ipa.callgraph.impl.AndroidEntryPoint;
 import com.ibm.wala.dalvik.ipa.callgraph.impl.AndroidEntryPoint.ExecutionOrder;
-import com.ibm.wala.dalvik.util.AndroidComponent;
 import com.ibm.wala.dalvik.util.AndroidEntryPointLocator.AndroidPossibleEntryPoint;
 
 /**
@@ -71,9 +70,8 @@ public final class ActivityEP {
      *  This does not have to be called before Service.onCreate but the user assumably starts most 
      *  apps with an activity we place it slightly before the Services
      */
-    public static final AndroidPossibleEntryPoint onCreate = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY, 
-            "onCreate",
-			ExecutionOrder.after(
+    public static final AndroidPossibleEntryPoint onCreate = new AndroidPossibleEntryPoint("onCreate", 
+            ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     ExecutionOrder.AT_FIRST,
                     // ApplicationEP.onCreate,      // Uncommenting would create a ring-dependency
@@ -90,9 +88,8 @@ public final class ActivityEP {
      *  Called after onCreate(Bundle) — or after onRestart() when the activity had been stopped, but is now again 
      *  being displayed to the user. It will be followed by onResume(). 
      */
-	public static final AndroidPossibleEntryPoint onStart = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY, 
-            "onStart",
-			ExecutionOrder.after(
+	public static final AndroidPossibleEntryPoint onStart = new AndroidPossibleEntryPoint("onStart", 
+            ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onCreate, 
                     ExecutionOrder.START_OF_LOOP
@@ -109,8 +106,7 @@ public final class ActivityEP {
      *
      *  This method is called between onStart() and onPostCreate(Bundle).
      */
-    public static final AndroidPossibleEntryPoint onRestoreInstanceState = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY, 
-            "onRestoreInstanceState",
+    public static final AndroidPossibleEntryPoint onRestoreInstanceState = new AndroidPossibleEntryPoint("onRestoreInstanceState", 
             ExecutionOrder.after(onStart));
 
     /**
@@ -118,8 +114,7 @@ public final class ActivityEP {
      *
      *  Called after onStart() and onRestoreInstanceState(Bundle)
      */
-    public static final AndroidPossibleEntryPoint onPostCreate = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY, 
-            "onPostCreate",
+    public static final AndroidPossibleEntryPoint onPostCreate = new AndroidPossibleEntryPoint("onPostCreate", 
             ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onRestoreInstanceState,
@@ -133,9 +128,8 @@ public final class ActivityEP {
      *  Called after onRestoreInstanceState(Bundle), onRestart(), or onPause()
      *  Use onWindowFocusChanged(boolean) to know for certain that your activity is visible to the user.
      */
-	public static final AndroidPossibleEntryPoint onResume = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY, 
-            "onResume",
-			ExecutionOrder.after(
+	public static final AndroidPossibleEntryPoint onResume = new AndroidPossibleEntryPoint("onResume", 
+            ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
 				    onPostCreate,
                     onRestoreInstanceState,
@@ -147,8 +141,7 @@ public final class ActivityEP {
     /**
      *  Called when activity resume is complete.
      */
-    public static final AndroidPossibleEntryPoint onPostResume = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY, 
-            "onPostResume",
+    public static final AndroidPossibleEntryPoint onPostResume = new AndroidPossibleEntryPoint("onPostResume", 
             ExecutionOrder.after(onResume));
 
     /**
@@ -157,8 +150,7 @@ public final class ActivityEP {
      *
      *  An activity will always be paused before receiving a new intent, so you can count on onResume() being called after this method. 
      */
-    public static final AndroidPossibleEntryPoint onNewIntent = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onNewIntent",
+    public static final AndroidPossibleEntryPoint onNewIntent = new AndroidPossibleEntryPoint("onNewIntent",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onPostCreate,
@@ -172,8 +164,7 @@ public final class ActivityEP {
      *
      *  Next call will be either onRestart(), onDestroy(), or nothing, depending on later user activity. 
      */
-	public static final AndroidPossibleEntryPoint onStop = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY, 
-            "onStop",
+	public static final AndroidPossibleEntryPoint onStop = new AndroidPossibleEntryPoint("onStop", 
             ExecutionOrder.after(
             ExecutionOrder.END_OF_LOOP
             ));
@@ -183,9 +174,8 @@ public final class ActivityEP {
      *
      *  Called after onStop(), followed by onStart() and then onResume(). 
      */
-	public static final AndroidPossibleEntryPoint onRestart = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY, 
-            "onRestart",
-			ExecutionOrder.after(onStop) );
+	public static final AndroidPossibleEntryPoint onRestart = new AndroidPossibleEntryPoint("onRestart", 
+            ExecutionOrder.after(onStop) );
 
 
     /**
@@ -196,9 +186,8 @@ public final class ActivityEP {
      *  If called, this method will occur before onStop(). There are no guarantees about whether it will 
      *  occur before or after onPause().
      */
-   public static final AndroidPossibleEntryPoint onSaveInstanceState = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY, 
-           "onSaveInstanceState",
-            ExecutionOrder.after(onPostResume));
+   public static final AndroidPossibleEntryPoint onSaveInstanceState = new AndroidPossibleEntryPoint("onSaveInstanceState", 
+           ExecutionOrder.after(onPostResume));
 
    /**
     *   Activity is going to the background.
@@ -212,9 +201,8 @@ public final class ActivityEP {
     *   After receiving this call you will usually receive a following call to onStop()
     *   however in some cases there will be a direct call back to onResume() without going through the stopped state.
     */
-	public static final AndroidPossibleEntryPoint onPause = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY, 
-            "onPause",
-			ExecutionOrder.after(new AndroidEntryPoint.IExecutionOrder[] {
+	public static final AndroidPossibleEntryPoint onPause = new AndroidPossibleEntryPoint("onPause", 
+            ExecutionOrder.after(new AndroidEntryPoint.IExecutionOrder[] {
 				onResume,
 				onSaveInstanceState,
 				ExecutionOrder.MIDDLE_OF_LOOP
@@ -225,8 +213,7 @@ public final class ActivityEP {
      *  Someone called finish() on the Activity, or the system is temporarily destroying this Activity to save space.
      *  There are situations where the system will simply kill the activity's hosting process without calling this method.
      */
-	public static final AndroidPossibleEntryPoint onDestroy = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY, 
-            "onDestroy",
+	public static final AndroidPossibleEntryPoint onDestroy = new AndroidPossibleEntryPoint("onDestroy", 
             ExecutionOrder.after(new AndroidEntryPoint.IExecutionOrder[] {
                 onStop,
     			ExecutionOrder.AT_LAST
@@ -235,9 +222,8 @@ public final class ActivityEP {
     /**
      *  Called when an Activity started by this one returns its result.
      */
-	public static final AndroidPossibleEntryPoint onActivityResult = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY, 
-            "onActivityResult",
-			ExecutionOrder.after(
+	public static final AndroidPossibleEntryPoint onActivityResult = new AndroidPossibleEntryPoint("onActivityResult", 
+            ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     ExecutionOrder.MULTIPLE_TIMES_IN_LOOP,
                     // If this Activity starts an notherone it most certainly goes into background so
@@ -254,8 +240,7 @@ public final class ActivityEP {
      *
      * TODO: Assert included everywhere
      */
-    public static final AndroidPossibleEntryPoint dispatchPopulateAccessibilityEvent = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "dispatchPopulateAccessibilityEvent",
+    public static final AndroidPossibleEntryPoint dispatchPopulateAccessibilityEvent = new AndroidPossibleEntryPoint("dispatchPopulateAccessibilityEvent",
             ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     ExecutionOrder.AT_FIRST,
@@ -290,8 +275,7 @@ public final class ActivityEP {
      *
      *  This method was deprecated in API level 13.
      */
-    public static final AndroidPossibleEntryPoint onCreateDialog = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onCreateDialog",
+    public static final AndroidPossibleEntryPoint onCreateDialog = new AndroidPossibleEntryPoint("onCreateDialog",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     getVisible,
@@ -305,8 +289,7 @@ public final class ActivityEP {
      *
      *  This method was deprecated in API level 13.
      */
-    public static final AndroidPossibleEntryPoint onPrepareDialog = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onPrepareDialog",
+    public static final AndroidPossibleEntryPoint onPrepareDialog = new AndroidPossibleEntryPoint("onPrepareDialog",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onCreateDialog,
@@ -321,8 +304,7 @@ public final class ActivityEP {
      * TODO: More info 
      *  This implementation handles tags to embed fragments inside of the activity.
      */
-    public static final AndroidPossibleEntryPoint onCreateView = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onCreateView",
+    public static final AndroidPossibleEntryPoint onCreateView = new AndroidPossibleEntryPoint("onCreateView",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     getVisible,
@@ -335,8 +317,7 @@ public final class ActivityEP {
      *  Called when a Fragment is being attached to this activity, immediately after the call to its 
      *  Fragment.onAttach() method and before Fragment.onCreate(). 
      */
-    public static final AndroidPossibleEntryPoint onAttachFragment = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onAttachFragment",
+    public static final AndroidPossibleEntryPoint onAttachFragment = new AndroidPossibleEntryPoint("onAttachFragment",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onCreateView,
@@ -352,8 +333,7 @@ public final class ActivityEP {
      *  Note that this function is guaranteed to be called before View.onDraw
      *  including before or after onMeasure(int, int).
      */
-    public static final AndroidPossibleEntryPoint onAttachedToWindow = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onAttachedToWindow",
+    public static final AndroidPossibleEntryPoint onAttachedToWindow = new AndroidPossibleEntryPoint("onAttachedToWindow",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onCreateView,
@@ -366,8 +346,7 @@ public final class ActivityEP {
      *  Called when the main window associated with the activity has been detached from the window manager. 
      *  See View.onDetachedFromWindow() for more information.   # TODO See
      */
-     public static final AndroidPossibleEntryPoint onDetachedFromWindow = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onDetachedFromWindow",
+     public static final AndroidPossibleEntryPoint onDetachedFromWindow = new AndroidPossibleEntryPoint("onDetachedFromWindow",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onAttachedToWindow,
@@ -386,8 +365,7 @@ public final class ActivityEP {
      *
      *  Due to a call to Window.setContentView or Window.addContentView
      */
-     public static final AndroidPossibleEntryPoint onContentChanged = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onContentChanged",
+     public static final AndroidPossibleEntryPoint onContentChanged = new AndroidPossibleEntryPoint("onContentChanged",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onCreateView,
@@ -406,8 +384,7 @@ public final class ActivityEP {
       *
       * TODO: Do we have to register an entrypoint for this?
       */
-     public static final AndroidPossibleEntryPoint onApplyThemeResource = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-             "onApplyThemeResource",
+     public static final AndroidPossibleEntryPoint onApplyThemeResource = new AndroidPossibleEntryPoint("onApplyThemeResource",
              ExecutionOrder.directlyAfter(onStart)   // Narf
              );
 
@@ -417,8 +394,7 @@ public final class ActivityEP {
      *
      *  This simply returns null so that all panel sub-windows will have the default menu behavior. 
      */
-    public static final AndroidPossibleEntryPoint onCreatePanelView = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onCreatePanelView",
+    public static final AndroidPossibleEntryPoint onCreatePanelView = new AndroidPossibleEntryPoint("onCreatePanelView",
             ExecutionOrder.between(
                 getVisible,
                 allInitialViewsSetUp
@@ -429,8 +405,7 @@ public final class ActivityEP {
      *
      *  This calls through to the new onCreateOptionsMenu(Menu) method for the FEATURE_OPTIONS_PANEL panel
      */
-    public static final AndroidPossibleEntryPoint onCreatePanelMenu = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onCreatePanelMenu",
+    public static final AndroidPossibleEntryPoint onCreatePanelMenu = new AndroidPossibleEntryPoint("onCreatePanelMenu",
             ExecutionOrder.between(
                 getVisible,
                 allInitialViewsSetUp
@@ -441,8 +416,7 @@ public final class ActivityEP {
      *
      *  This calls through to the new onPrepareOptionsMenu(Menu) method for the FEATURE_OPTIONS_PANEL 
      */
-    public static final AndroidPossibleEntryPoint onPreparePanel = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onPreparePanel",
+    public static final AndroidPossibleEntryPoint onPreparePanel = new AndroidPossibleEntryPoint("onPreparePanel",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     getVisible,
@@ -459,8 +433,7 @@ public final class ActivityEP {
      *  This calls through to onOptionsMenuClosed(Menu) method for the FEATURE_OPTIONS_PANEL.
      *  For context menus (FEATURE_CONTEXT_MENU), the onContextMenuClosed(Menu) will be called. 
      */
-    public static final AndroidPossibleEntryPoint onPanelClosed = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onPanelClosed",
+    public static final AndroidPossibleEntryPoint onPanelClosed = new AndroidPossibleEntryPoint("onPanelClosed",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onCreatePanelMenu,                  
@@ -480,8 +453,7 @@ public final class ActivityEP {
      *
      * Use onContextItemSelected(android.view.MenuItem) to know when an item has been selected. 
      */
-    public static final AndroidPossibleEntryPoint onCreateContextMenu = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onCreateContextMenu",
+    public static final AndroidPossibleEntryPoint onCreateContextMenu = new AndroidPossibleEntryPoint("onCreateContextMenu",
             ExecutionOrder.between(
                 getVisible,
                 allInitialViewsSetUp
@@ -492,8 +464,7 @@ public final class ActivityEP {
      * 
      *  You can use this method for any items for which you would like to do processing without those other facilities. 
      */
-    public static final AndroidPossibleEntryPoint onContextItemSelected = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onContextItemSelected",
+    public static final AndroidPossibleEntryPoint onContextItemSelected = new AndroidPossibleEntryPoint("onContextItemSelected",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onCreateContextMenu,
@@ -508,8 +479,7 @@ public final class ActivityEP {
      *
      * either by the user canceling the menu with the back/menu button, or when an item is selected.
      */
-    public static final AndroidPossibleEntryPoint onContextMenuClosed = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onContextMenuClosed",
+    public static final AndroidPossibleEntryPoint onContextMenuClosed = new AndroidPossibleEntryPoint("onContextMenuClosed",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onCreateContextMenu,
@@ -519,17 +489,14 @@ public final class ActivityEP {
                 ExecutionOrder.AFTER_LOOP   // To much? XXX
             ));
  
-    public static final AndroidPossibleEntryPoint onCreateOptionsMenu = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onCreateOptionsMenu",
+    public static final AndroidPossibleEntryPoint onCreateOptionsMenu = new AndroidPossibleEntryPoint("onCreateOptionsMenu",
             ExecutionOrder.directlyAfter(onCreateContextMenu)   // TODO: Well it behaves different! See onPrepareOptionsMenu, 
             );
-    public static final AndroidPossibleEntryPoint onOptionsItemSelected = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onOptionsItemSelected",
+    public static final AndroidPossibleEntryPoint onOptionsItemSelected = new AndroidPossibleEntryPoint("onOptionsItemSelected",
             ExecutionOrder.directlyAfter(onContextItemSelected)
             );
     
-    public static final AndroidPossibleEntryPoint onPrepareOptionsMenu = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onPrepareOptionsMenu",
+    public static final AndroidPossibleEntryPoint onPrepareOptionsMenu = new AndroidPossibleEntryPoint("onPrepareOptionsMenu",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onCreateOptionsMenu,
@@ -541,15 +508,13 @@ public final class ActivityEP {
                 }
             ));
 
-    public static final AndroidPossibleEntryPoint onOptionsMenuClosed = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onOptionsMenuClosed",
+    public static final AndroidPossibleEntryPoint onOptionsMenuClosed = new AndroidPossibleEntryPoint("onOptionsMenuClosed",
             ExecutionOrder.directlyAfter(onContextMenuClosed)
             );
 
     
     /** TODO: More Info */
-    public static final AndroidPossibleEntryPoint onMenuOpened = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onMenuOpened",
+    public static final AndroidPossibleEntryPoint onMenuOpened = new AndroidPossibleEntryPoint("onMenuOpened",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onCreateOptionsMenu,
@@ -569,8 +534,7 @@ public final class ActivityEP {
      *
      * This calls through to the new onOptionsItemSelected(MenuItem) 
      */
-     public static final AndroidPossibleEntryPoint onMenuItemSelected = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onMenuItemSelected",
+     public static final AndroidPossibleEntryPoint onMenuItemSelected = new AndroidPossibleEntryPoint("onMenuItemSelected",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onCreateContextMenu,
@@ -586,13 +550,11 @@ public final class ActivityEP {
             ));
 
 
-    public static final AndroidPossibleEntryPoint onTitleChanged = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onTitleChanged",
-           ExecutionOrder.directlyAfter(getVisible)  // TODO: What placement to choose?
+    public static final AndroidPossibleEntryPoint onTitleChanged = new AndroidPossibleEntryPoint("onTitleChanged",
+            ExecutionOrder.directlyAfter(getVisible)  // TODO: What placement to choose?
     );
-    public static final AndroidPossibleEntryPoint onChildTitleChanged = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onChildTitleChanged",
-           ExecutionOrder.directlyAfter(onTitleChanged)
+    public static final AndroidPossibleEntryPoint onChildTitleChanged = new AndroidPossibleEntryPoint("onChildTitleChanged",
+            ExecutionOrder.directlyAfter(onTitleChanged)
     );
    
    
@@ -612,8 +574,7 @@ public final class ActivityEP {
      *  Note that this callback will be invoked for the touch down action that begins a touch gesture, but may not be invoked for 
      *  the touch-moved and touch-up actions that follow.
      */
-    public static final AndroidPossibleEntryPoint onUserInteraction = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onUserInteraction",
+    public static final AndroidPossibleEntryPoint onUserInteraction = new AndroidPossibleEntryPoint("onUserInteraction",
             ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     getVisible,
@@ -623,8 +584,7 @@ public final class ActivityEP {
                 }
             ));
 
-    public static final AndroidPossibleEntryPoint dispatchTouchEvent = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "dispatchTouchEvent",
+    public static final AndroidPossibleEntryPoint dispatchTouchEvent = new AndroidPossibleEntryPoint("dispatchTouchEvent",
             ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     // TODO: Relation to onGenericMotionEvent
@@ -641,8 +601,7 @@ public final class ActivityEP {
      *
      *  This is most useful to process touch events that happen outside of your window bounds, where there is no view to receive it.
      */
-    public static final AndroidPossibleEntryPoint onTouchEvent = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onTouchEvent",
+    public static final AndroidPossibleEntryPoint onTouchEvent = new AndroidPossibleEntryPoint("onTouchEvent",
             ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     // TODO: Relation to onGenericMotionEvent
@@ -657,8 +616,7 @@ public final class ActivityEP {
      *
      *  TODO: Verify before on... stuff
      */
-    public static final AndroidPossibleEntryPoint dispatchGenericMotionEvent = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "dispatchGenericMotionEvent",
+    public static final AndroidPossibleEntryPoint dispatchGenericMotionEvent = new AndroidPossibleEntryPoint("dispatchGenericMotionEvent",
             ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onUserInteraction,  // TODO: Verify
@@ -676,15 +634,13 @@ public final class ActivityEP {
      *
      *  TODO: After onUserInteraction?
      */
-    public static final AndroidPossibleEntryPoint onGenericMotionEvent = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onGenericMotionEvent",
+    public static final AndroidPossibleEntryPoint onGenericMotionEvent = new AndroidPossibleEntryPoint("onGenericMotionEvent",
             ExecutionOrder.after(
                 dispatchGenericMotionEvent
             ));
 
     
-    public static final AndroidPossibleEntryPoint dispatchTrackballEvent = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "dispatchTrackballEvent",
+    public static final AndroidPossibleEntryPoint dispatchTrackballEvent = new AndroidPossibleEntryPoint("dispatchTrackballEvent",
             ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     dispatchPopulateAccessibilityEvent,
@@ -702,8 +658,7 @@ public final class ActivityEP {
      *  The call here happens before trackball movements are converted to DPAD key events, which then get sent 
      *  back to the view hierarchy, and will be processed at the point for things like focus navigation.
      */
-    public static final AndroidPossibleEntryPoint onTrackballEvent = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onTrackballEvent",
+    public static final AndroidPossibleEntryPoint onTrackballEvent = new AndroidPossibleEntryPoint("onTrackballEvent",
             ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     dispatchTrackballEvent,
@@ -716,8 +671,7 @@ public final class ActivityEP {
      *  You can override this to intercept all key events before they are dispatched to the window.
      *  TODO: Verify before on... stuff
      */
-    public static final AndroidPossibleEntryPoint dispatchKeyEvent = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "dispatchKeyEvent",
+    public static final AndroidPossibleEntryPoint dispatchKeyEvent = new AndroidPossibleEntryPoint("dispatchKeyEvent",
             ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onUserInteraction,  // TODO: Verify
@@ -729,8 +683,7 @@ public final class ActivityEP {
                 }
             ));
 
-    public static final AndroidPossibleEntryPoint dispatchKeyShortcutEvent = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "dispatchKeyShortcutEvent",
+    public static final AndroidPossibleEntryPoint dispatchKeyShortcutEvent = new AndroidPossibleEntryPoint("dispatchKeyShortcutEvent",
             ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     dispatchKeyEvent,
@@ -751,8 +704,7 @@ public final class ActivityEP {
      *
      * TODO: After onUserInteraction?
      */
-    public static final AndroidPossibleEntryPoint onKeyDown = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onKeyDown",
+    public static final AndroidPossibleEntryPoint onKeyDown = new AndroidPossibleEntryPoint("onKeyDown",
             ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onUserInteraction,
@@ -761,8 +713,7 @@ public final class ActivityEP {
                 }
             ));
 
-    public static final AndroidPossibleEntryPoint onKeyLongPress = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onKeyLongPress",
+    public static final AndroidPossibleEntryPoint onKeyLongPress = new AndroidPossibleEntryPoint("onKeyLongPress",
             ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     dispatchKeyEvent,
@@ -770,8 +721,7 @@ public final class ActivityEP {
                 }
             ));
 
-    public static final AndroidPossibleEntryPoint onKeyMultiple = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onKeyMultiple",
+    public static final AndroidPossibleEntryPoint onKeyMultiple = new AndroidPossibleEntryPoint("onKeyMultiple",
             ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     dispatchKeyEvent,
@@ -779,8 +729,7 @@ public final class ActivityEP {
                 }
             ));
  
-    public static final AndroidPossibleEntryPoint onKeyShortcut = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onKeyShortcut",
+    public static final AndroidPossibleEntryPoint onKeyShortcut = new AndroidPossibleEntryPoint("onKeyShortcut",
             ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     dispatchKeyEvent,
@@ -792,8 +741,7 @@ public final class ActivityEP {
     /**
      * The default implementation handles KEYCODE_BACK to stop the activity and go back.
      */
-    public static final AndroidPossibleEntryPoint onKeyUp = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onKeyUp",
+    public static final AndroidPossibleEntryPoint onKeyUp = new AndroidPossibleEntryPoint("onKeyUp",
             ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     dispatchKeyEvent,
@@ -804,8 +752,7 @@ public final class ActivityEP {
                 }
             ));
 
-    public static final AndroidPossibleEntryPoint onBackPressed = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onBackPressed",
+    public static final AndroidPossibleEntryPoint onBackPressed = new AndroidPossibleEntryPoint("onBackPressed",
             ExecutionOrder.after(   // TODO Why is this so late?
                  new AndroidEntryPoint.IExecutionOrder[] {
                     dispatchKeyEvent,
@@ -818,8 +765,7 @@ public final class ActivityEP {
     /**
      *   This method will be invoked by the default implementation of onNavigateUp() 
      */
-    public static final AndroidPossibleEntryPoint onCreateNavigateUpTaskStack = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onCreateNavigateUpTaskStack",
+    public static final AndroidPossibleEntryPoint onCreateNavigateUpTaskStack = new AndroidPossibleEntryPoint("onCreateNavigateUpTaskStack",
             ExecutionOrder.between(
                  new AndroidEntryPoint.IExecutionOrder[] {
                    ExecutionOrder.START_OF_LOOP 
@@ -835,8 +781,7 @@ public final class ActivityEP {
     /**
      * Prepare the synthetic task stack that will be generated during Up navigation from a different task. 
      */
-    public static final AndroidPossibleEntryPoint onPrepareNavigateUpTaskStack = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onPrepareNavigateUpTaskStack",
+    public static final AndroidPossibleEntryPoint onPrepareNavigateUpTaskStack = new AndroidPossibleEntryPoint("onPrepareNavigateUpTaskStack",
             ExecutionOrder.between(
                  new AndroidEntryPoint.IExecutionOrder[] {
                     onCreateNavigateUpTaskStack,
@@ -853,9 +798,8 @@ public final class ActivityEP {
      *  This is called when a child activity of this one attempts to navigate up. 
      *  The default implementation simply calls onNavigateUp() on this activity (the parent).
      */
-    public static final AndroidPossibleEntryPoint onNavigateUpFromChild = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onNavigateUpFromChild",
-             ExecutionOrder.between(
+    public static final AndroidPossibleEntryPoint onNavigateUpFromChild = new AndroidPossibleEntryPoint("onNavigateUpFromChild",
+            ExecutionOrder.between(
                  new AndroidEntryPoint.IExecutionOrder[] {
                     onCreateNavigateUpTaskStack, //No
                      //onBackPressed,     // TODO: Verify
@@ -871,9 +815,8 @@ public final class ActivityEP {
     /**
      *  This method is called whenever the user chooses to navigate Up within your application's activity hierarchy from the action bar. 
      */
-    public static final AndroidPossibleEntryPoint onNavigateUp = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onNavigateUp",
-             ExecutionOrder.between(
+    public static final AndroidPossibleEntryPoint onNavigateUp = new AndroidPossibleEntryPoint("onNavigateUp",
+            ExecutionOrder.between(
                  new AndroidEntryPoint.IExecutionOrder[] {
                     //onBackPressed,     // TODO: Verify
                     onNavigateUpFromChild
@@ -891,8 +834,7 @@ public final class ActivityEP {
      *
      *  ..in response to a menu item, search button, or other widgets within your activity.
      */
-    public static final AndroidPossibleEntryPoint  onSearchRequested = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onSearchRequested",
+    public static final AndroidPossibleEntryPoint  onSearchRequested = new AndroidPossibleEntryPoint("onSearchRequested",
             ExecutionOrder.after(
                  new AndroidEntryPoint.IExecutionOrder[] {
                     ExecutionOrder.MULTIPLE_TIMES_IN_LOOP,
@@ -912,20 +854,17 @@ public final class ActivityEP {
     /**
      *  Menus may depend on it..
      */
-    public static final AndroidPossibleEntryPoint onActionModeStarted = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onActionModeStarted",
+    public static final AndroidPossibleEntryPoint onActionModeStarted = new AndroidPossibleEntryPoint("onActionModeStarted",
             ExecutionOrder.MULTIPLE_TIMES_IN_LOOP // TODO where to put??
         );
 
-    public static final AndroidPossibleEntryPoint onActionModeFinished = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onActionModeFinished",
+    public static final AndroidPossibleEntryPoint onActionModeFinished = new AndroidPossibleEntryPoint("onActionModeFinished",
             ExecutionOrder.after(onActionModeStarted)
             );
     /**
      * Give the Activity a chance to control the UI for an action mode requested by the system. 
      */
-    public static final AndroidPossibleEntryPoint onWindowStartingActionMode = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onWindowStartingActionMode",
+    public static final AndroidPossibleEntryPoint onWindowStartingActionMode = new AndroidPossibleEntryPoint("onWindowStartingActionMode",
             ExecutionOrder.between(
                 ExecutionOrder.MULTIPLE_TIMES_IN_LOOP, // TODO where to put??
                 onActionModeStarted
@@ -935,8 +874,7 @@ public final class ActivityEP {
      *  If any configuration change occurs that is not selected to be reported by that attribute, then instead of reporting it the system 
      *  will stop and restart the activity 
      */
-    public static final AndroidPossibleEntryPoint onConfigurationChanged = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onConfigurationChanged",
+    public static final AndroidPossibleEntryPoint onConfigurationChanged = new AndroidPossibleEntryPoint("onConfigurationChanged",
             ExecutionOrder.between( // TODO: Find a nice position
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onStop
@@ -946,8 +884,7 @@ public final class ActivityEP {
                 }
             ));
 
-    public static final AndroidPossibleEntryPoint onSharedPreferenceChanged = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onSharedPreferenceChanged",
+    public static final AndroidPossibleEntryPoint onSharedPreferenceChanged = new AndroidPossibleEntryPoint("onSharedPreferenceChanged",
             ExecutionOrder.between( // TODO: Find a nice position
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onStop
@@ -960,17 +897,15 @@ public final class ActivityEP {
     /**
      * This method is called before pausing 
      */
-    public static final AndroidPossibleEntryPoint onCreateDescription = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onCreateDescription",
-             ExecutionOrder.between(
+    public static final AndroidPossibleEntryPoint onCreateDescription = new AndroidPossibleEntryPoint("onCreateDescription",
+            ExecutionOrder.between(
                  onSaveInstanceState,
                  onPause
              ));
     /**
      * This method is called before pausing 
      */
-    public static final AndroidPossibleEntryPoint onCreateThumbnail = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onCreateThumbnail",
+    public static final AndroidPossibleEntryPoint onCreateThumbnail = new AndroidPossibleEntryPoint("onCreateThumbnail",
             ExecutionOrder.directlyBefore(onCreateDescription)
             );
     /**
@@ -979,8 +914,7 @@ public final class ActivityEP {
      *  Assit is requested by the user.
      *  TODO: WTF is this?
      */
-    public static final AndroidPossibleEntryPoint onProvideAssistData = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onProvideAssistData",
+    public static final AndroidPossibleEntryPoint onProvideAssistData = new AndroidPossibleEntryPoint("onProvideAssistData",
             ExecutionOrder.between(
                 allInitialViewsSetUp,
                 ExecutionOrder.MIDDLE_OF_LOOP
@@ -993,9 +927,8 @@ public final class ActivityEP {
      *  The function will be called between onStop() and onDestroy().
      *  A new instance of the activity will always be immediately created after this one's onDestroy() is called.
      */
-    public static final AndroidPossibleEntryPoint onRetainNonConfigurationInstance = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onRetainNonConfigurationInstance",
-             ExecutionOrder.between(
+    public static final AndroidPossibleEntryPoint onRetainNonConfigurationInstance = new AndroidPossibleEntryPoint("onRetainNonConfigurationInstance",
+            ExecutionOrder.between(
                     onStop,
                     onDestroy
              ));
@@ -1004,8 +937,7 @@ public final class ActivityEP {
      * While the exact point at which this will be called is not defined, generally it will happen when all background process have been killed. 
      * That is, before reaching the point of killing processes hosting service and foreground UI that we would like to avoid killing. 
      */
-    public static final AndroidPossibleEntryPoint onLowMemory = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onLowMemory",
+    public static final AndroidPossibleEntryPoint onLowMemory = new AndroidPossibleEntryPoint("onLowMemory",
             ExecutionOrder.between( // TODO: find a nice position
                 ExecutionOrder.END_OF_LOOP,
                 new AndroidEntryPoint.IExecutionOrder[] {
@@ -1018,8 +950,7 @@ public final class ActivityEP {
      *  This will happen for example when it goes in the background and there is not enough memory to keep as many 
      *  background processes running as desired. 
      */
-    public static final AndroidPossibleEntryPoint onTrimMemory = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onTrimMemory", // TODO: find a nice position
+    public static final AndroidPossibleEntryPoint onTrimMemory = new AndroidPossibleEntryPoint("onTrimMemory",
             ExecutionOrder.directlyBefore(onLowMemory)     // may potentially come before onLowMemory but they are near enough...
             );
     
@@ -1028,15 +959,13 @@ public final class ActivityEP {
      *
      * this method is called right before the activity's onPause() callback. 
      */
-    public static final AndroidPossibleEntryPoint onUserLeaveHint = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onUserLeaveHint",
+    public static final AndroidPossibleEntryPoint onUserLeaveHint = new AndroidPossibleEntryPoint("onUserLeaveHint",
             ExecutionOrder.directlyBefore(onPause)
             );
     /**
      * This is called whenever the current window attributes change. 
      */
-    public static final AndroidPossibleEntryPoint onWindowAttributesChanged = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onWindowAttributesChanged",
+    public static final AndroidPossibleEntryPoint onWindowAttributesChanged = new AndroidPossibleEntryPoint("onWindowAttributesChanged",
             ExecutionOrder.between( 
                 new AndroidEntryPoint.IExecutionOrder[] {   
                     ExecutionOrder.MULTIPLE_TIMES_IN_LOOP
@@ -1053,8 +982,7 @@ public final class ActivityEP {
      *  As such, while focus changes will generally have some relation to lifecycle changes, you should not rely on any particular 
      *  order between the callbacks here and those in the other lifecycle methods such as onResume(). 
      */
-    public static final AndroidPossibleEntryPoint onWindowFocusChanged = new AndroidPossibleEntryPoint(AndroidComponent.ACTIVITY,
-            "onWindowFocusChanged",
+    public static final AndroidPossibleEntryPoint onWindowFocusChanged = new AndroidPossibleEntryPoint("onWindowFocusChanged",
             ExecutionOrder.directlyAfter(onResume)    // TODO see above...
             );
 

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/ApplicationEP.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/ApplicationEP.java
@@ -44,7 +44,6 @@ import java.util.List;
 
 import com.ibm.wala.dalvik.ipa.callgraph.impl.AndroidEntryPoint;
 import com.ibm.wala.dalvik.ipa.callgraph.impl.AndroidEntryPoint.ExecutionOrder;
-import com.ibm.wala.dalvik.util.AndroidComponent;
 import com.ibm.wala.dalvik.util.AndroidEntryPointLocator.AndroidPossibleEntryPoint;
 
 /**
@@ -61,9 +60,8 @@ public final class ApplicationEP {
     /**
      * Called when the application is starting, before any activity, service, or receiver objects (excluding content providers) have been created.
      */
-	public static final AndroidPossibleEntryPoint onCreate = new AndroidPossibleEntryPoint(AndroidComponent.APPLICATION, 
-            "onCreate",
-			ExecutionOrder.between(
+	public static final AndroidPossibleEntryPoint onCreate = new AndroidPossibleEntryPoint("onCreate", 
+            ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     ExecutionOrder.AT_FIRST,
                     ProviderEP.onCreate     /* Yes, ContentProviders come before App! */
@@ -80,9 +78,8 @@ public final class ApplicationEP {
      *  Note that, unlike activities, other components are never restarted when a configuration changes: they must always deal with the 
      *  results of the change, such as by re-retrieving resources. 
      */
-	public static final AndroidPossibleEntryPoint onConfigurationChanged = new AndroidPossibleEntryPoint(AndroidComponent.APPLICATION, 
-            "onConfigurationChanged",   // TODO: Position
-			ExecutionOrder.between(
+	public static final AndroidPossibleEntryPoint onConfigurationChanged = new AndroidPossibleEntryPoint("onConfigurationChanged", 
+            ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     ActivityEP.onConfigurationChanged,
                     ExecutionOrder.END_OF_LOOP
@@ -97,9 +94,8 @@ public final class ApplicationEP {
      *  While the exact point at which this will be called is not defined, generally it will happen when all background process have been killed.
      *  That is, before reaching the point of killing processes hosting service and foreground UI that we would like to avoid killing. 
      */
-	public static final AndroidPossibleEntryPoint onLowMemory = new AndroidPossibleEntryPoint(AndroidComponent.APPLICATION, 
-            "onLowMemory",  // TODO: Position
-			ExecutionOrder.between(
+	public static final AndroidPossibleEntryPoint onLowMemory = new AndroidPossibleEntryPoint("onLowMemory", 
+            ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     ExecutionOrder.END_OF_LOOP,
                     ActivityEP.onLowMemory
@@ -123,8 +119,7 @@ public final class ApplicationEP {
     /**
      *  Called when the operating system has determined that it is a good time for a process to trim unneeded memory from its process.
      */
-	public static final AndroidPossibleEntryPoint onTrimMemory = new AndroidPossibleEntryPoint(AndroidComponent.APPLICATION, 
-            "onTrimMemory",
+	public static final AndroidPossibleEntryPoint onTrimMemory = new AndroidPossibleEntryPoint("onTrimMemory", 
             ExecutionOrder.directlyBefore(onLowMemory)     // may potentially come before onLowMemory 
             );
 

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/FragmentEP.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/FragmentEP.java
@@ -44,7 +44,6 @@ import java.util.List;
 
 import com.ibm.wala.dalvik.ipa.callgraph.impl.AndroidEntryPoint;
 import com.ibm.wala.dalvik.ipa.callgraph.impl.AndroidEntryPoint.ExecutionOrder;
-import com.ibm.wala.dalvik.util.AndroidComponent;
 import com.ibm.wala.dalvik.util.AndroidEntryPointLocator.AndroidPossibleEntryPoint;
 
 /**
@@ -68,8 +67,7 @@ public final class FragmentEP {
      *
      *  Called before onCreate
      */
-    public static final AndroidPossibleEntryPoint onAttach = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onAttach",
+    public static final AndroidPossibleEntryPoint onAttach = new AndroidPossibleEntryPoint("onAttach",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     ExecutionOrder.AT_FIRST,
@@ -90,8 +88,7 @@ public final class FragmentEP {
      *  Note that this can be called while the fragment's activity is still in the process of being created. 
      *  once the activity itself is created: onActivityCreated(Bundle).
      */
-    public static final AndroidPossibleEntryPoint onCreate = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onCreate",
+    public static final AndroidPossibleEntryPoint onCreate = new AndroidPossibleEntryPoint("onCreate",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     ExecutionOrder.AT_FIRST,
@@ -109,8 +106,7 @@ public final class FragmentEP {
      *  This will be called between onCreate(Bundle) and onActivityCreated(Bundle).     XXX: CONTRADICTING DOCUMENTATION!
      *  his is optional, and non-graphical fragments can return null.
      */
-    public static final AndroidPossibleEntryPoint onCreateView = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onCreateView",
+    public static final AndroidPossibleEntryPoint onCreateView = new AndroidPossibleEntryPoint("onCreateView",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     ExecutionOrder.AT_FIRST,
@@ -129,8 +125,7 @@ public final class FragmentEP {
      *  This is called after onCreateView                                               XXX: CONTRADICTING DOCUMENTATION!
      *  and before onViewStateRestored(Bundle).
      */
-    public static final AndroidPossibleEntryPoint onActivityCreated = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onActivityCreated",
+    public static final AndroidPossibleEntryPoint onActivityCreated = new AndroidPossibleEntryPoint("onActivityCreated",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     ExecutionOrder.AT_FIRST,
@@ -149,8 +144,7 @@ public final class FragmentEP {
      *  Called when all saved state has been restored into the view hierarchy of the fragment.
      *  This is called after onActivityCreated(Bundle) and before onStart().
      */
-    public static final AndroidPossibleEntryPoint onViewStateRestored = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onViewStateRestored",
+    public static final AndroidPossibleEntryPoint onViewStateRestored = new AndroidPossibleEntryPoint("onViewStateRestored",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     ExecutionOrder.AT_FIRST,    // TODO: Already Part of loop?
@@ -169,8 +163,7 @@ public final class FragmentEP {
      *  Called when the Fragment is visible to the user. 
      *  This is generally tied to Activity.onStart of the containing Activity's lifecycle. 
      */
-    public static final AndroidPossibleEntryPoint onStart = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onStart",
+    public static final AndroidPossibleEntryPoint onStart = new AndroidPossibleEntryPoint("onStart",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     ExecutionOrder.START_OF_LOOP,
@@ -188,8 +181,7 @@ public final class FragmentEP {
      *   Called when the fragment is visible to the user and actively running. 
      *   This is generally tied to Activity.onResume of the containing Activity's lifecycle. 
      */
-    public static final AndroidPossibleEntryPoint onResume = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onResume",
+    public static final AndroidPossibleEntryPoint onResume = new AndroidPossibleEntryPoint("onResume",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     ExecutionOrder.START_OF_LOOP,
@@ -215,8 +207,7 @@ public final class FragmentEP {
      *  Called when the Fragment is no longer resumed. 
      *  This is generally tied to Activity.onPause of the containing Activity's lifecycle. 
      */
-    public static final AndroidPossibleEntryPoint onPause = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onPause",
+    public static final AndroidPossibleEntryPoint onPause = new AndroidPossibleEntryPoint("onPause",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     ExecutionOrder.END_OF_LOOP,
@@ -234,9 +225,8 @@ public final class FragmentEP {
      * Called when the Fragment is no longer started. 
      * This is generally tied to Activity.onStop of the containing Activity's lifecycle. 
      */
-    public static final AndroidPossibleEntryPoint onStop = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onStop",
-             ExecutionOrder.after(
+    public static final AndroidPossibleEntryPoint onStop = new AndroidPossibleEntryPoint("onStop",
+            ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onPause,
                     ActivityEP.onStop      // TODO: Rather after or before?
@@ -251,8 +241,7 @@ public final class FragmentEP {
      *
      *  Internally it is called after the view's state has been saved but before it has been removed from its parent. 
      */
-    public static final AndroidPossibleEntryPoint onDestroyView = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onDestroyView",
+    public static final AndroidPossibleEntryPoint onDestroyView = new AndroidPossibleEntryPoint("onDestroyView",
             ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onStop,
@@ -265,8 +254,7 @@ public final class FragmentEP {
      *
      *  Called when the fragment is no longer in use. This is called after onStop() and before onDetach(). 
      */
-    public static final AndroidPossibleEntryPoint onDestroy = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onDestroy",
+    public static final AndroidPossibleEntryPoint onDestroy = new AndroidPossibleEntryPoint("onDestroy",
             ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onDestroyView,
@@ -279,8 +267,7 @@ public final class FragmentEP {
      *
      *  Called when the fragment is no longer attached to its activity. This is called after onDestroy(). 
      */
-    public static final AndroidPossibleEntryPoint onDetach = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onDetach",
+    public static final AndroidPossibleEntryPoint onDetach = new AndroidPossibleEntryPoint("onDetach",
             ExecutionOrder.between( 
                 new AndroidEntryPoint.IExecutionOrder[] {
                     ExecutionOrder.AT_LAST, 
@@ -299,8 +286,7 @@ public final class FragmentEP {
     /**
      *  @see ActivityEP#onActivityResult
      */
-    public static final AndroidPossibleEntryPoint onActivityResult = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onActivityResult",
+    public static final AndroidPossibleEntryPoint onActivityResult = new AndroidPossibleEntryPoint("onActivityResult",
             ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     ExecutionOrder.MULTIPLE_TIMES_IN_LOOP,
@@ -315,24 +301,21 @@ public final class FragmentEP {
     /**
      *  Unlike activities, other components are never restarted.
      */
-    public static final AndroidPossibleEntryPoint onConfigurationChanged = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onConfigurationChanged",
+    public static final AndroidPossibleEntryPoint onConfigurationChanged = new AndroidPossibleEntryPoint("onConfigurationChanged",
             ExecutionOrder.directlyAfter(ActivityEP.onConfigurationChanged)    // TODO: Verify
             );
 
     /**
      *  This hook is called whenever an item in a context menu is selected. 
      */
-    public static final AndroidPossibleEntryPoint onContextItemSelected = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onContextItemSelected",
+    public static final AndroidPossibleEntryPoint onContextItemSelected = new AndroidPossibleEntryPoint("onContextItemSelected",
             ExecutionOrder.directlyAfter(ActivityEP.onContextItemSelected) // TODO: Verify
             );
 
     /**
      *  Called when a fragment loads an animation. 
      */
-    public static final AndroidPossibleEntryPoint onCreateAnimator = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onCreateAnimator",
+    public static final AndroidPossibleEntryPoint onCreateAnimator = new AndroidPossibleEntryPoint("onCreateAnimator",
             ExecutionOrder.directlyAfter(onResume) // TODO: Here?
             );
 
@@ -341,16 +324,14 @@ public final class FragmentEP {
      *
      *  Unlike onCreateOptionsMenu, this will be called every time the context menu is about to be shown
      */
-    public static final AndroidPossibleEntryPoint onCreateContextMenu = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onCreateContextMenu",
+    public static final AndroidPossibleEntryPoint onCreateContextMenu = new AndroidPossibleEntryPoint("onCreateContextMenu",
             ExecutionOrder.directlyAfter(ActivityEP.onCreateContextMenu)
             );
 
     /**
      *  Initialize the contents of the Activity's standard options menu. 
      */
-    public static final AndroidPossibleEntryPoint onCreateOptionsMenu = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onCreateOptionsMenu",
+    public static final AndroidPossibleEntryPoint onCreateOptionsMenu = new AndroidPossibleEntryPoint("onCreateOptionsMenu",
             ExecutionOrder.directlyAfter(ActivityEP.onCreateOptionsMenu)
             );
 
@@ -359,8 +340,7 @@ public final class FragmentEP {
      *  Receiving this call means that the menu needed to be rebuilt, but this fragment's items were not included in the newly 
      *  built menu (its onCreateOptionsMenu was not called). 
      */
-    public static final AndroidPossibleEntryPoint onDestroyOptionsMenu = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onDestroyOptionsMenu",
+    public static final AndroidPossibleEntryPoint onDestroyOptionsMenu = new AndroidPossibleEntryPoint("onDestroyOptionsMenu",
             ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     ExecutionOrder.END_OF_LOOP, // TODO: Here?
@@ -372,9 +352,8 @@ public final class FragmentEP {
      *
      *  Fragments start out not hidden.
      */
-    public static final AndroidPossibleEntryPoint onHiddenChanged = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onHiddenChanged",
-             ExecutionOrder.after(
+    public static final AndroidPossibleEntryPoint onHiddenChanged = new AndroidPossibleEntryPoint("onHiddenChanged",
+            ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     ExecutionOrder.MIDDLE_OF_LOOP, // TODO: Here?
                 }
@@ -387,9 +366,8 @@ public final class FragmentEP {
      *  This may be called immediately after the fragment is created from a tag in a layout file. 
      *  Note this is before the fragment's onAttach(Activity) has been called...
      */
-    public static final AndroidPossibleEntryPoint onInflate = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onInflate",
-             ExecutionOrder.between( 
+    public static final AndroidPossibleEntryPoint onInflate = new AndroidPossibleEntryPoint("onInflate",
+            ExecutionOrder.between( 
                 new AndroidEntryPoint.IExecutionOrder[] {
                     ExecutionOrder.AT_FIRST, 
                     ApplicationEP.onCreate,     // TODO: Here?
@@ -404,23 +382,20 @@ public final class FragmentEP {
      *  @see    ActivityEP#onLowMemory
      *  @see    ApplicationEP#onLowMemory
      */
-    public static final AndroidPossibleEntryPoint onLowMemory = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onLowMemory",
+    public static final AndroidPossibleEntryPoint onLowMemory = new AndroidPossibleEntryPoint("onLowMemory",
             ExecutionOrder.directlyBefore(ActivityEP.onLowMemory)
             );
     /**
      *  @see    ActivityEP#onOptionsItemSelected
      */
-    public static final AndroidPossibleEntryPoint onOptionsItemSelected = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onOptionsItemSelected",
+    public static final AndroidPossibleEntryPoint onOptionsItemSelected = new AndroidPossibleEntryPoint("onOptionsItemSelected",
             ExecutionOrder.directlyAfter(ActivityEP.onOptionsItemSelected)  // TODO: After? Before?
             );
 
     /**
      *  @see    ActivityEP#onOptionsMenuClosed
      */
-    public static final AndroidPossibleEntryPoint onOptionsMenuClosed = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onOptionsMenuClosed",
+    public static final AndroidPossibleEntryPoint onOptionsMenuClosed = new AndroidPossibleEntryPoint("onOptionsMenuClosed",
             ExecutionOrder.directlyAfter(ActivityEP.onOptionsMenuClosed)  // TODO: After? Before?
             );
     
@@ -429,8 +404,7 @@ public final class FragmentEP {
      *
      *  @see    ActivityEP#onPrepareOptionsMenu
      */
-    public static final AndroidPossibleEntryPoint onPrepareOptionsMenu = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onPrepareOptionsMenu",
+    public static final AndroidPossibleEntryPoint onPrepareOptionsMenu = new AndroidPossibleEntryPoint("onPrepareOptionsMenu",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     ExecutionOrder.START_OF_LOOP,
@@ -453,8 +427,7 @@ public final class FragmentEP {
      *  This method may be called at any time before onDestroy(). There are many situations where a fragment may be mostly torn down, 
      *  but its state will not be saved until its owning activity actually needs to save its state.
      */
-    public static final AndroidPossibleEntryPoint onSaveInstanceState = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onSaveInstanceState",
+    public static final AndroidPossibleEntryPoint onSaveInstanceState = new AndroidPossibleEntryPoint("onSaveInstanceState",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onStop,
@@ -469,16 +442,14 @@ public final class FragmentEP {
     /**
      *  @see ActivityEP#onTrimMemory
      */
-    public static final AndroidPossibleEntryPoint onTrimMemory = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onTrimMemory",
+    public static final AndroidPossibleEntryPoint onTrimMemory = new AndroidPossibleEntryPoint("onTrimMemory",
             ExecutionOrder.directlyBefore(ActivityEP.onTrimMemory)
             );
 
     /**
      *  Called immediately after onCreateView has returned, but before any saved state has been restored in to the view. 
      */
-    public static final AndroidPossibleEntryPoint onViewCreated = new AndroidPossibleEntryPoint(AndroidComponent.FRAGMENT,
-            "onViewCreated",
+    public static final AndroidPossibleEntryPoint onViewCreated = new AndroidPossibleEntryPoint("onViewCreated",
             ExecutionOrder.between(
                 onCreateView,
                 new AndroidEntryPoint.IExecutionOrder[] {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/LoaderCB.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/LoaderCB.java
@@ -43,7 +43,6 @@ package com.ibm.wala.dalvik.util.androidEntryPoints;
 import java.util.List;
 
 import com.ibm.wala.dalvik.ipa.callgraph.impl.AndroidEntryPoint.ExecutionOrder;
-import com.ibm.wala.dalvik.util.AndroidComponent;
 import com.ibm.wala.dalvik.util.AndroidEntryPointLocator.AndroidPossibleEntryPoint;
 
 /**
@@ -60,20 +59,17 @@ public final class LoaderCB {
     /**
      * Instantiate and return a new Loader for the given ID.
      */
-    public static final AndroidPossibleEntryPoint onCreateLoader = new AndroidPossibleEntryPoint(AndroidComponent.LOADER_CB, "onCreateLoader",
-        ExecutionOrder.AT_FIRST); // TODO: Baaad position
+    public static final AndroidPossibleEntryPoint onCreateLoader = new AndroidPossibleEntryPoint("onCreateLoader", ExecutionOrder.AT_FIRST); // TODO: Baaad position
 
     /**
      *  Called when a previously created loader has finished its load.
      */
-    public static final AndroidPossibleEntryPoint onLoadFinished = new AndroidPossibleEntryPoint(AndroidComponent.LOADER_CB, "onLoadFinished",
-            ExecutionOrder.after(onCreateLoader)); // TODO: Baaad position
+    public static final AndroidPossibleEntryPoint onLoadFinished = new AndroidPossibleEntryPoint("onLoadFinished", ExecutionOrder.after(onCreateLoader)); // TODO: Baaad position
 
     /**
      *  Called when a previously created loader is being reset, and thus making its data unavailable.
      */
-    public static final AndroidPossibleEntryPoint onLoaderReset = new AndroidPossibleEntryPoint(AndroidComponent.LOADER_CB, "onLoaderReset",
-            ExecutionOrder.after(onCreateLoader)); // TODO: Baaad position
+    public static final AndroidPossibleEntryPoint onLoaderReset = new AndroidPossibleEntryPoint("onLoaderReset", ExecutionOrder.after(onCreateLoader)); // TODO: Baaad position
 
     /**
      *  Add the EntryPoint specifications defined in this file to the given list.

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/LocationEP.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/LocationEP.java
@@ -43,7 +43,6 @@ package com.ibm.wala.dalvik.util.androidEntryPoints;
 import java.util.List;
 
 import com.ibm.wala.dalvik.ipa.callgraph.impl.AndroidEntryPoint.ExecutionOrder;
-import com.ibm.wala.dalvik.util.AndroidComponent;
 import com.ibm.wala.dalvik.util.AndroidEntryPointLocator.AndroidPossibleEntryPoint;
 
 /**
@@ -56,23 +55,17 @@ import com.ibm.wala.dalvik.util.AndroidEntryPointLocator.AndroidPossibleEntryPoi
  *  @author Tobias Blaschke <code@tobiasblaschke.de>
  */
 public final class LocationEP {
-	public static final AndroidPossibleEntryPoint onLocationChanged = new AndroidPossibleEntryPoint(AndroidComponent.LOCATION_LISTENER, "onLocationChanged",
-			ExecutionOrder.MIDDLE_OF_LOOP);
+	public static final AndroidPossibleEntryPoint onLocationChanged = new AndroidPossibleEntryPoint("onLocationChanged", ExecutionOrder.MIDDLE_OF_LOOP);
 
-	public static final AndroidPossibleEntryPoint onProviderDisabled = new AndroidPossibleEntryPoint(AndroidComponent.LOCATION_LISTENER, "onProviderDisabled",
-			ExecutionOrder.MIDDLE_OF_LOOP);
+	public static final AndroidPossibleEntryPoint onProviderDisabled = new AndroidPossibleEntryPoint("onProviderDisabled", ExecutionOrder.MIDDLE_OF_LOOP);
 
-	public static final AndroidPossibleEntryPoint onProviderEnabled =  new AndroidPossibleEntryPoint(AndroidComponent.LOCATION_LISTENER, "onProviderEnabled",
-			ExecutionOrder.MIDDLE_OF_LOOP);
+	public static final AndroidPossibleEntryPoint onProviderEnabled =  new AndroidPossibleEntryPoint("onProviderEnabled", ExecutionOrder.MIDDLE_OF_LOOP);
 
-	public static final AndroidPossibleEntryPoint onStatusChanged =    new AndroidPossibleEntryPoint(AndroidComponent.LOCATION_LISTENER, "onStatusChanged",
-			ExecutionOrder.MIDDLE_OF_LOOP);
+	public static final AndroidPossibleEntryPoint onStatusChanged =    new AndroidPossibleEntryPoint("onStatusChanged", ExecutionOrder.MIDDLE_OF_LOOP);
 
-	public static final AndroidPossibleEntryPoint onGpsStatusChanged = new AndroidPossibleEntryPoint(AndroidComponent.GPS_LISTENER, "onGpsStatusChanged",
-			ExecutionOrder.MIDDLE_OF_LOOP);
+	public static final AndroidPossibleEntryPoint onGpsStatusChanged = new AndroidPossibleEntryPoint("onGpsStatusChanged", ExecutionOrder.MIDDLE_OF_LOOP);
 
-	public static final AndroidPossibleEntryPoint onNmeaReceived =    new AndroidPossibleEntryPoint(AndroidComponent.GPS_NMEA_LISTENER, "onNmeaReceived",
-			ExecutionOrder.MIDDLE_OF_LOOP);
+	public static final AndroidPossibleEntryPoint onNmeaReceived =    new AndroidPossibleEntryPoint("onNmeaReceived", ExecutionOrder.MIDDLE_OF_LOOP);
 
     /**
      *  Add the EntryPoint specifications defined in this file to the given list.

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/ProviderEP.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/ProviderEP.java
@@ -44,7 +44,6 @@ import java.util.List;
 
 import com.ibm.wala.dalvik.ipa.callgraph.impl.AndroidEntryPoint;
 import com.ibm.wala.dalvik.ipa.callgraph.impl.AndroidEntryPoint.ExecutionOrder;
-import com.ibm.wala.dalvik.util.AndroidComponent;
 import com.ibm.wala.dalvik.util.AndroidEntryPointLocator.AndroidPossibleEntryPoint;
 
 /**
@@ -56,50 +55,43 @@ import com.ibm.wala.dalvik.util.AndroidEntryPointLocator.AndroidPossibleEntryPoi
  *  @author Tobias Blaschke <code@tobiasblaschke.de>
  */
 public final class ProviderEP {
-	public static final AndroidPossibleEntryPoint onCreate = new AndroidPossibleEntryPoint(AndroidComponent.PROVIDER, "onCreate",
-			ExecutionOrder.AT_FIRST);
+	public static final AndroidPossibleEntryPoint onCreate = new AndroidPossibleEntryPoint("onCreate", ExecutionOrder.AT_FIRST);
 
-	public static final AndroidPossibleEntryPoint query = new AndroidPossibleEntryPoint(AndroidComponent.PROVIDER, "query",
-			ExecutionOrder.after(new AndroidEntryPoint.IExecutionOrder[] {
-				onCreate,
-				//ActivityEP.onResume,
-				ExecutionOrder.START_OF_LOOP
-				} ));
+	public static final AndroidPossibleEntryPoint query = new AndroidPossibleEntryPoint("query", ExecutionOrder.after(new AndroidEntryPoint.IExecutionOrder[] {
+		onCreate,
+		//ActivityEP.onResume,
+		ExecutionOrder.START_OF_LOOP
+		} ));
 
-	public static final AndroidPossibleEntryPoint insert = new AndroidPossibleEntryPoint(AndroidComponent.PROVIDER, "insert",
-			ExecutionOrder.after(new AndroidEntryPoint.IExecutionOrder[] {
-				onCreate,
-				//ActivityEP.onResume,
-				ExecutionOrder.START_OF_LOOP
-				} ));
+	public static final AndroidPossibleEntryPoint insert = new AndroidPossibleEntryPoint("insert", ExecutionOrder.after(new AndroidEntryPoint.IExecutionOrder[] {
+		onCreate,
+		//ActivityEP.onResume,
+		ExecutionOrder.START_OF_LOOP
+		} ));
 
-    public static final AndroidPossibleEntryPoint onConfigurationChanged = new AndroidPossibleEntryPoint(AndroidComponent.PROVIDER, "onConfigurationChanged",
-			ExecutionOrder.after(new AndroidEntryPoint.IExecutionOrder[] {
-				onCreate,
-				//ActivityEP.onResume,
-				ExecutionOrder.START_OF_LOOP
-				} ));
+    public static final AndroidPossibleEntryPoint onConfigurationChanged = new AndroidPossibleEntryPoint("onConfigurationChanged", ExecutionOrder.after(new AndroidEntryPoint.IExecutionOrder[] {
+		onCreate,
+		//ActivityEP.onResume,
+		ExecutionOrder.START_OF_LOOP
+		} ));
 
-    public static final AndroidPossibleEntryPoint onLowMemory = new AndroidPossibleEntryPoint(AndroidComponent.PROVIDER, "onLowMemory",
-			ExecutionOrder.after(new AndroidEntryPoint.IExecutionOrder[] {
-				onCreate,
-				//ActivityEP.onResume,
-				ExecutionOrder.START_OF_LOOP
-				} ));
+    public static final AndroidPossibleEntryPoint onLowMemory = new AndroidPossibleEntryPoint("onLowMemory", ExecutionOrder.after(new AndroidEntryPoint.IExecutionOrder[] {
+		onCreate,
+		//ActivityEP.onResume,
+		ExecutionOrder.START_OF_LOOP
+		} ));
 
-	public static final AndroidPossibleEntryPoint onTrimMemory = new AndroidPossibleEntryPoint(AndroidComponent.PROVIDER, "onTrimMemory",
-			ExecutionOrder.after(new AndroidEntryPoint.IExecutionOrder[] {
-				onCreate,
-				//ActivityEP.onResume,
-				ExecutionOrder.START_OF_LOOP
-				} ));
+	public static final AndroidPossibleEntryPoint onTrimMemory = new AndroidPossibleEntryPoint("onTrimMemory", ExecutionOrder.after(new AndroidEntryPoint.IExecutionOrder[] {
+		onCreate,
+		//ActivityEP.onResume,
+		ExecutionOrder.START_OF_LOOP
+		} ));
 
-	public static final AndroidPossibleEntryPoint update = new AndroidPossibleEntryPoint(AndroidComponent.PROVIDER, "update",
-			ExecutionOrder.after(new AndroidEntryPoint.IExecutionOrder[] {
-				onCreate,
-				//ActivityEP.onResume,
-				ExecutionOrder.START_OF_LOOP
-				} ));
+	public static final AndroidPossibleEntryPoint update = new AndroidPossibleEntryPoint("update", ExecutionOrder.after(new AndroidEntryPoint.IExecutionOrder[] {
+		onCreate,
+		//ActivityEP.onResume,
+		ExecutionOrder.START_OF_LOOP
+		} ));
     /**
      *  Add the EntryPoint specifications defined in this file to the given list.
      *

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/ServiceEP.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/ServiceEP.java
@@ -44,7 +44,6 @@ import java.util.List;
 
 import com.ibm.wala.dalvik.ipa.callgraph.impl.AndroidEntryPoint;
 import com.ibm.wala.dalvik.ipa.callgraph.impl.AndroidEntryPoint.ExecutionOrder;
-import com.ibm.wala.dalvik.util.AndroidComponent;
 import com.ibm.wala.dalvik.util.AndroidEntryPointLocator.AndroidPossibleEntryPoint;
 
 /**
@@ -59,9 +58,8 @@ public final class ServiceEP {
     /**
      *  Called by the system when the service is first created. 
      */
-    public static final AndroidPossibleEntryPoint onCreate = new AndroidPossibleEntryPoint(AndroidComponent.SERVICE, 
-            "onCreate",
-			ExecutionOrder.after(
+    public static final AndroidPossibleEntryPoint onCreate = new AndroidPossibleEntryPoint("onCreate", 
+            ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     ExecutionOrder.AT_FIRST,
                     ProviderEP.onCreate,
@@ -75,9 +73,8 @@ public final class ServiceEP {
      *
      *  startService-Services are not informed when they are stopped.
      */
-	public static final AndroidPossibleEntryPoint onStartCommand = new AndroidPossibleEntryPoint(AndroidComponent.SERVICE, 
-            "onStartCommand",
-			ExecutionOrder.after(
+	public static final AndroidPossibleEntryPoint onStartCommand = new AndroidPossibleEntryPoint("onStartCommand", 
+            ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] { 
                     ExecutionOrder.AT_FIRST,
                     onCreate
@@ -88,9 +85,8 @@ public final class ServiceEP {
     /**
      *  Only for backwards compatibility.
      */
-    public static final AndroidPossibleEntryPoint onStart = new AndroidPossibleEntryPoint(AndroidComponent.SERVICE, 
-            "onStart",
-			ExecutionOrder.after(
+    public static final AndroidPossibleEntryPoint onStart = new AndroidPossibleEntryPoint("onStart", 
+            ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     ExecutionOrder.AT_FIRST,
                     onCreate,
@@ -104,9 +100,8 @@ public final class ServiceEP {
      *
      * Services started this way can be notified before they get stopped via onUnbind
      */
-	public static final AndroidPossibleEntryPoint onBind = new AndroidPossibleEntryPoint(AndroidComponent.SERVICE, 
-            "onBind",
-			ExecutionOrder.after(
+	public static final AndroidPossibleEntryPoint onBind = new AndroidPossibleEntryPoint("onBind", 
+            ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onCreate, 
                     ExecutionOrder.BEFORE_LOOP
@@ -117,9 +112,8 @@ public final class ServiceEP {
      * Called when all clients have disconnected from a particular interface published by the service. 
      * Return true if you would like to have the service's onRebind(Intent) method later called when new clients bind to it. 
      */
-    public static final AndroidPossibleEntryPoint onUnbind = new AndroidPossibleEntryPoint(AndroidComponent.SERVICE, 
-            "onUnbind",
-			ExecutionOrder.after(
+    public static final AndroidPossibleEntryPoint onUnbind = new AndroidPossibleEntryPoint("onUnbind", 
+            ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onBind, 
                     ExecutionOrder.END_OF_LOOP
@@ -130,9 +124,8 @@ public final class ServiceEP {
      *  Called when new clients have connected to the service, after it had previously been notified that all had disconnected in its 
      *  onUnbind(Intent). This will only be called if the implementation of onUnbind(Intent) was overridden to return true.
      */
-    public static final AndroidPossibleEntryPoint onRebind = new AndroidPossibleEntryPoint(AndroidComponent.SERVICE, 
-            "onRebind",
-			ExecutionOrder.after(
+    public static final AndroidPossibleEntryPoint onRebind = new AndroidPossibleEntryPoint("onRebind", 
+            ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onBind, 
                     onUnbind
@@ -144,9 +137,8 @@ public final class ServiceEP {
      *  Called by the system to notify a Service that it is no longer used and is being removed. 
      *  Upon return, there will be no more calls in to this Service object and it is effectively dead. 
      */
-    public static final AndroidPossibleEntryPoint onDestroy = new AndroidPossibleEntryPoint(AndroidComponent.SERVICE, 
-            "onDestroy",
-			ExecutionOrder.after(
+    public static final AndroidPossibleEntryPoint onDestroy = new AndroidPossibleEntryPoint("onDestroy", 
+            ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onUnbind, 
                     onStart,
@@ -160,8 +152,7 @@ public final class ServiceEP {
      *  This is called if the service is currently running and the user has removed a task that comes from the service's application. 
      *  If you have set ServiceInfo.FLAG_STOP_WITH_TASK then you will not receive this callback; instead, the service will simply be stopped.
      */
-    public static final AndroidPossibleEntryPoint onTaskRemoved = new AndroidPossibleEntryPoint(AndroidComponent.SERVICE,
-            "onTaskRemoved",
+    public static final AndroidPossibleEntryPoint onTaskRemoved = new AndroidPossibleEntryPoint("onTaskRemoved",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onUnbind, 
@@ -178,8 +169,7 @@ public final class ServiceEP {
     /**
      * Called by the system when the device configuration changes while your component is running. 
      */
-    public static final AndroidPossibleEntryPoint onConfigurationChanged = new AndroidPossibleEntryPoint(AndroidComponent.SERVICE,
-            "onConfigurationChanged",
+    public static final AndroidPossibleEntryPoint onConfigurationChanged = new AndroidPossibleEntryPoint("onConfigurationChanged",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {   // TODO: Position
                     onCreate
@@ -192,8 +182,7 @@ public final class ServiceEP {
     /**
      * This is called when the overall system is running low on memory, and actively running processes should trim their memory usage. 
      */
-    public static final AndroidPossibleEntryPoint onLowMemory = new AndroidPossibleEntryPoint(AndroidComponent.SERVICE,
-            "onLowMemory",
+    public static final AndroidPossibleEntryPoint onLowMemory = new AndroidPossibleEntryPoint("onLowMemory",
             ExecutionOrder.between( // TODO: find a nice position
                 new AndroidEntryPoint.IExecutionOrder[] {
                     ExecutionOrder.END_OF_LOOP,
@@ -207,8 +196,7 @@ public final class ServiceEP {
     /**
      * Called when the operating system has determined that it is a good time for a process to trim unneeded memory from its process.
      */
-    public static final AndroidPossibleEntryPoint onTrimMemory = new AndroidPossibleEntryPoint(AndroidComponent.SERVICE,
-            "onTrimMemory",
+    public static final AndroidPossibleEntryPoint onTrimMemory = new AndroidPossibleEntryPoint("onTrimMemory",
             ExecutionOrder.between( // TODO: find a nice position
                 new AndroidEntryPoint.IExecutionOrder[] {
                     ExecutionOrder.END_OF_LOOP
@@ -219,8 +207,7 @@ public final class ServiceEP {
                 }
             ));
 
-    public static final AndroidPossibleEntryPoint onHandleIntent = new AndroidPossibleEntryPoint(AndroidComponent.INTENT_SERVICE,
-            "onHandleIntent", 
+    public static final AndroidPossibleEntryPoint onHandleIntent = new AndroidPossibleEntryPoint("onHandleIntent",
             ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onCreate
@@ -231,64 +218,49 @@ public final class ServiceEP {
             ));
 
     public static final AndroidPossibleEntryPoint onCreateInputMethodInterface = new AndroidPossibleEntryPoint(
-            AndroidComponent.ABSTRACT_INPUT_METHOD_SERVICE, "onCreateInputMethodInterface",
-            ExecutionOrder.directlyAfter(onCreate));
+            "onCreateInputMethodInterface", ExecutionOrder.directlyAfter(onCreate));
 
     public static final AndroidPossibleEntryPoint onCreateInputMethodSessionInterface = new AndroidPossibleEntryPoint(
-            AndroidComponent.ABSTRACT_INPUT_METHOD_SERVICE, "onCreateInputMethodSessionInterface",
-            ExecutionOrder.after(onCreateInputMethodInterface)); // TODO: Place
+            "onCreateInputMethodSessionInterface", ExecutionOrder.after(onCreateInputMethodInterface)); // TODO: Place
 
     public static final AndroidPossibleEntryPoint onGenericMotionEvent = new AndroidPossibleEntryPoint(
-            AndroidComponent.ABSTRACT_INPUT_METHOD_SERVICE, "onGenericMotionEvent",
-            ExecutionOrder.directlyAfter(ActivityEP.onGenericMotionEvent));
+            "onGenericMotionEvent", ExecutionOrder.directlyAfter(ActivityEP.onGenericMotionEvent));
 
     public static final AndroidPossibleEntryPoint onTrackballEvent = new AndroidPossibleEntryPoint(
-            AndroidComponent.ABSTRACT_INPUT_METHOD_SERVICE, "onTrackballEvent",
-            ActivityEP.onTrackballEvent);
+            "onTrackballEvent", ActivityEP.onTrackballEvent);
 
     public static final AndroidPossibleEntryPoint onAccessibilityEvent = new AndroidPossibleEntryPoint(
-            AndroidComponent.ACCESSIBILITY_SERVICE, "onAccessibilityEvent",
-            ExecutionOrder.after(onTrackballEvent)); // TODO: Place
+            "onAccessibilityEvent", ExecutionOrder.after(onTrackballEvent)); // TODO: Place
 
     public static final AndroidPossibleEntryPoint onInterrupt = new AndroidPossibleEntryPoint(
-            AndroidComponent.ACCESSIBILITY_SERVICE, "onInterrupt",
-            ExecutionOrder.after(onAccessibilityEvent));
+            "onInterrupt", ExecutionOrder.after(onAccessibilityEvent));
    
     public static final AndroidPossibleEntryPoint onActionModeFinished = new AndroidPossibleEntryPoint(
-            AndroidComponent.DREAM_SERVICE, "onActionModeFinished",
-            ActivityEP.onActionModeFinished);
+            "onActionModeFinished", ActivityEP.onActionModeFinished);
 
     public static final AndroidPossibleEntryPoint onActionModeStarted = new AndroidPossibleEntryPoint(
-            AndroidComponent.DREAM_SERVICE, "onActionModeStarted",
-            ActivityEP.onActionModeStarted);
+            "onActionModeStarted", ActivityEP.onActionModeStarted);
 
     public static final AndroidPossibleEntryPoint onAttachedToWindow = new AndroidPossibleEntryPoint(
-            AndroidComponent.DREAM_SERVICE, "onAttachedToWindow",
-            ActivityEP.onAttachedToWindow);
+            "onAttachedToWindow", ActivityEP.onAttachedToWindow);
    
     public static final AndroidPossibleEntryPoint onContentChanged = new AndroidPossibleEntryPoint(
-            AndroidComponent.DREAM_SERVICE, "onContentChanged",
-            ActivityEP.onContentChanged);
+            "onContentChanged", ActivityEP.onContentChanged);
 
     public static final AndroidPossibleEntryPoint onCreatePanelMenu = new AndroidPossibleEntryPoint(
-            AndroidComponent.DREAM_SERVICE, "onCreatePanelMenu",
-            ActivityEP.onCreatePanelMenu);
+            "onCreatePanelMenu", ActivityEP.onCreatePanelMenu);
 
     public static final AndroidPossibleEntryPoint onCreatePanelView = new AndroidPossibleEntryPoint(
-            AndroidComponent.DREAM_SERVICE, "onCreatePanelView",
-            ActivityEP.onCreatePanelView);
+            "onCreatePanelView", ActivityEP.onCreatePanelView);
 
     public static final AndroidPossibleEntryPoint onDetachedFromWindow = new AndroidPossibleEntryPoint(
-            AndroidComponent.DREAM_SERVICE, "onDetachedFromWindow",
-            ActivityEP.onDetachedFromWindow);
+            "onDetachedFromWindow", ActivityEP.onDetachedFromWindow);
    
     public static final AndroidPossibleEntryPoint onDreamingStarted = new AndroidPossibleEntryPoint(
-            AndroidComponent.DREAM_SERVICE, "onDreamingStarted",
-            ExecutionOrder.after(onStart)); // TODO: Place
+            "onDreamingStarted", ExecutionOrder.after(onStart)); // TODO: Place
 
     public static final AndroidPossibleEntryPoint onDreamingStopped = new AndroidPossibleEntryPoint(
-            AndroidComponent.DREAM_SERVICE, "onDreamingStopped",
-            ExecutionOrder.between(
+            "onDreamingStopped", ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {   // TODO: Place
                     onDreamingStarted,
                     onBind,
@@ -300,116 +272,88 @@ public final class ServiceEP {
                 }));
 
     public static final AndroidPossibleEntryPoint onMenuItemSelected = new AndroidPossibleEntryPoint(
-            AndroidComponent.DREAM_SERVICE, "onMenuItemSelected",
-            ActivityEP.onMenuItemSelected);
+            "onMenuItemSelected", ActivityEP.onMenuItemSelected);
     
     public static final AndroidPossibleEntryPoint onMenuOpened = new AndroidPossibleEntryPoint(
-            AndroidComponent.DREAM_SERVICE, "onMenuOpened",
-            ActivityEP.onMenuOpened);
+            "onMenuOpened", ActivityEP.onMenuOpened);
 
     public static final AndroidPossibleEntryPoint onPanelClosed = new AndroidPossibleEntryPoint(
-            AndroidComponent.DREAM_SERVICE, "onPanelClosed",
-            ActivityEP.onPanelClosed);
+            "onPanelClosed", ActivityEP.onPanelClosed);
 
     public static final AndroidPossibleEntryPoint onPreparePanel = new AndroidPossibleEntryPoint(
-            AndroidComponent.DREAM_SERVICE, "onPreparePanel",
-            ActivityEP.onPreparePanel);
+            "onPreparePanel", ActivityEP.onPreparePanel);
 
     public static final AndroidPossibleEntryPoint onSearchRequested = new AndroidPossibleEntryPoint(
-            AndroidComponent.DREAM_SERVICE, "onSearchRequested",
-            ActivityEP.onSearchRequested);
+            "onSearchRequested", ActivityEP.onSearchRequested);
 
     public static final AndroidPossibleEntryPoint onWindowAttributesChanged = new AndroidPossibleEntryPoint(
-            AndroidComponent.DREAM_SERVICE, "onWindowAttributesChanged",
-            ActivityEP.onWindowAttributesChanged);
+            "onWindowAttributesChanged", ActivityEP.onWindowAttributesChanged);
     
     public static final AndroidPossibleEntryPoint onWindowFocusChanged = new AndroidPossibleEntryPoint(
-            AndroidComponent.DREAM_SERVICE, "onWindowFocusChanged",
-            ActivityEP.onWindowFocusChanged);
+            "onWindowFocusChanged", ActivityEP.onWindowFocusChanged);
 
     public static final AndroidPossibleEntryPoint onWindowStartingActionMode = new AndroidPossibleEntryPoint(
-            AndroidComponent.DREAM_SERVICE, "onWindowStartingActionMode",
-            ActivityEP.onWindowStartingActionMode);
+            "onWindowStartingActionMode", ActivityEP.onWindowStartingActionMode);
 
     public static final AndroidPossibleEntryPoint onDeactivated = new AndroidPossibleEntryPoint(
-            AndroidComponent.HOST_APDU_SERVICE, "onDeactivated",
-            ExecutionOrder.directlyBefore(ActivityEP.onPause));
+            "onDeactivated", ExecutionOrder.directlyBefore(ActivityEP.onPause));
 
     public static final AndroidPossibleEntryPoint onCreateMediaRouteProvider = new AndroidPossibleEntryPoint(
-            AndroidComponent.MEDIA_ROUTE_PROVIDER_SERVICE, "onCreateMediaRouteProvider",
-            onCreate);
+            "onCreateMediaRouteProvider", onCreate);
 
     public static final AndroidPossibleEntryPoint onNotificationPosted = new AndroidPossibleEntryPoint(
-            AndroidComponent.NOTIFICATION_LISTENER_SERVICE, "onNotificationPosted",
-            ExecutionOrder.MULTIPLE_TIMES_IN_LOOP);
+            "onNotificationPosted", ExecutionOrder.MULTIPLE_TIMES_IN_LOOP);
 
     public static final AndroidPossibleEntryPoint onNotificationRemoved = new AndroidPossibleEntryPoint(
-            AndroidComponent.NOTIFICATION_LISTENER_SERVICE, "onNotificationRemoved",
-            ExecutionOrder.after(onNotificationPosted));
+            "onNotificationRemoved", ExecutionOrder.after(onNotificationPosted));
 
     public static final AndroidPossibleEntryPoint onConnected = new AndroidPossibleEntryPoint(
-            AndroidComponent.PRINT_SERVICE, "onConnected",
-            ExecutionOrder.after(onStart));
+            "onConnected", ExecutionOrder.after(onStart));
     
     public static final AndroidPossibleEntryPoint onCreatePrinterDiscoverySession = new AndroidPossibleEntryPoint(
-            AndroidComponent.PRINT_SERVICE, "onCreatePrinterDiscoverySession",
-            ExecutionOrder.between(onStart, onConnected));
+            "onCreatePrinterDiscoverySession", ExecutionOrder.between(onStart, onConnected));
     
     public static final AndroidPossibleEntryPoint onDisconnected = new AndroidPossibleEntryPoint(
-            AndroidComponent.PRINT_SERVICE, "onDisconnected",
-            ExecutionOrder.between(onConnected, onDestroy));    // XXX: Section hop
+            "onDisconnected", ExecutionOrder.between(onConnected, onDestroy));    // XXX: Section hop
 
     public static final AndroidPossibleEntryPoint onPrintJobQueued = new AndroidPossibleEntryPoint(
-            AndroidComponent.PRINT_SERVICE, "onPrintJobQueued",
-            ExecutionOrder.between(onConnected, onDisconnected)); // XXX: Section hop
+            "onPrintJobQueued", ExecutionOrder.between(onConnected, onDisconnected)); // XXX: Section hop
 
     public static final AndroidPossibleEntryPoint onRequestCancelPrintJob = new AndroidPossibleEntryPoint(
-            AndroidComponent.PRINT_SERVICE, "onRequestCancelPrintJob",
-            ExecutionOrder.between(onPrintJobQueued, onDisconnected)); // XXX: Section hop
+            "onRequestCancelPrintJob", ExecutionOrder.between(onPrintJobQueued, onDisconnected)); // XXX: Section hop
     
     public static final AndroidPossibleEntryPoint onCancel = new AndroidPossibleEntryPoint(
-            AndroidComponent.RECOGNITION_SERVICE, "onCancel",
-            ExecutionOrder.between(ExecutionOrder.MULTIPLE_TIMES_IN_LOOP, ExecutionOrder.END_OF_LOOP));
+            "onCancel", ExecutionOrder.between(ExecutionOrder.MULTIPLE_TIMES_IN_LOOP, ExecutionOrder.END_OF_LOOP));
    
     public static final AndroidPossibleEntryPoint onStartListening = new AndroidPossibleEntryPoint(
-            AndroidComponent.RECOGNITION_SERVICE, "onStartListening",
-            ExecutionOrder.between(ExecutionOrder.MULTIPLE_TIMES_IN_LOOP, onCancel));
+            "onStartListening", ExecutionOrder.between(ExecutionOrder.MULTIPLE_TIMES_IN_LOOP, onCancel));
 
     public static final AndroidPossibleEntryPoint onStopListening = new AndroidPossibleEntryPoint(
-            AndroidComponent.RECOGNITION_SERVICE, "onStopListening",
-            ExecutionOrder.between(onCancel, ExecutionOrder.END_OF_LOOP));
+            "onStopListening", ExecutionOrder.between(onCancel, ExecutionOrder.END_OF_LOOP));
     
     public static final AndroidPossibleEntryPoint onGetViewFactory = new AndroidPossibleEntryPoint(
-            AndroidComponent.REMOTE_VIEWS_SERVICE, "onGetViewFactory",
-            ExecutionOrder.after(onStart)); // TODO: Position
+            "onGetViewFactory", ExecutionOrder.after(onStart)); // TODO: Position
 
     public static final AndroidPossibleEntryPoint onGetEnabled = new AndroidPossibleEntryPoint(
-            AndroidComponent.SETTING_INJECTOR_SERVICE, "onGetEnabled",
-            ExecutionOrder.after(onStart)); // TODO: Position
+            "onGetEnabled", ExecutionOrder.after(onStart)); // TODO: Position
     
     public static final AndroidPossibleEntryPoint onGetSummary = new AndroidPossibleEntryPoint(
-            AndroidComponent.SETTING_INJECTOR_SERVICE, "onGetSummary",
-            ExecutionOrder.after(onStart)); // TODO: Position
+            "onGetSummary", ExecutionOrder.after(onStart)); // TODO: Position
 
     public static final AndroidPossibleEntryPoint onGetFeaturesForLanguage = new AndroidPossibleEntryPoint(
-            AndroidComponent.TEXT_TO_SPEECH_SERVICE, "onGetFeaturesForLanguage",
-            ExecutionOrder.after(onStart)); // TODO: Position
+            "onGetFeaturesForLanguage", ExecutionOrder.after(onStart)); // TODO: Position
 
     public static final AndroidPossibleEntryPoint onGetLanguage = new AndroidPossibleEntryPoint(
-            AndroidComponent.TEXT_TO_SPEECH_SERVICE, "onGetLanguage",
-            ExecutionOrder.directlyBefore(onGetFeaturesForLanguage));
+            "onGetLanguage", ExecutionOrder.directlyBefore(onGetFeaturesForLanguage));
 
     public static final AndroidPossibleEntryPoint onLoadLanguage = new AndroidPossibleEntryPoint(
-            AndroidComponent.TEXT_TO_SPEECH_SERVICE, "onLoadLanguage",
-            ExecutionOrder.directlyBefore(onGetLanguage));
+            "onLoadLanguage", ExecutionOrder.directlyBefore(onGetLanguage));
 
     public static final AndroidPossibleEntryPoint onIsLanguageAvailable = new AndroidPossibleEntryPoint(
-            AndroidComponent.TEXT_TO_SPEECH_SERVICE, "onIsLanguageAvailable",
-            ExecutionOrder.directlyBefore(onLoadLanguage));
+            "onIsLanguageAvailable", ExecutionOrder.directlyBefore(onLoadLanguage));
 
     public static final AndroidPossibleEntryPoint onSynthesizeText = new AndroidPossibleEntryPoint(
-            AndroidComponent.TEXT_TO_SPEECH_SERVICE, "onSynthesizeText",
-            ExecutionOrder.after(
+            "onSynthesizeText", ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onGetLanguage,
                     onLoadLanguage,
@@ -417,64 +361,53 @@ public final class ServiceEP {
                 }));
 
     public static final AndroidPossibleEntryPoint onStop = new AndroidPossibleEntryPoint(
-            AndroidComponent.TEXT_TO_SPEECH_SERVICE, "onStop",
-            ExecutionOrder.directlyBefore(ActivityEP.onStop));
+            "onStop", ExecutionOrder.directlyBefore(ActivityEP.onStop));
 
 
     public static final AndroidPossibleEntryPoint onRevoke = new AndroidPossibleEntryPoint(
-            AndroidComponent.VPN_SERVICE, "onRevoke",
-            ExecutionOrder.between(ExecutionOrder.END_OF_LOOP, onDestroy));
+            "onRevoke", ExecutionOrder.between(ExecutionOrder.END_OF_LOOP, onDestroy));
     
     public static final AndroidPossibleEntryPoint onCreateEngine = new AndroidPossibleEntryPoint(
-            AndroidComponent.WALLPAPER_SERVICE, "onCreateEngine",
-            ExecutionOrder.between(onCreate, onStart)); // TODO: Position
+            "onCreateEngine", ExecutionOrder.between(onCreate, onStart)); // TODO: Position
     
     public static final AndroidPossibleEntryPoint onAppPrivateCommand = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onAppPrivateCommand",
-            ExecutionOrder.MULTIPLE_TIMES_IN_LOOP);     // TODO: Position
+            "onAppPrivateCommand", ExecutionOrder.MULTIPLE_TIMES_IN_LOOP);     // TODO: Position
     
     /**
      *  to find out about switching to a new client.
      */
     public static final AndroidPossibleEntryPoint onBindInput = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onBindInput",
-            ExecutionOrder.after(ActivityEP.onResume));
+            "onBindInput", ExecutionOrder.after(ActivityEP.onResume));
 
     /**
      *  Compute the interesting insets into your UI.
      */
     public static final AndroidPossibleEntryPoint onComputeInsets = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onComputeInsets",
-            ExecutionOrder.after(onStart));
+            "onComputeInsets", ExecutionOrder.after(onStart));
 
     public static final AndroidPossibleEntryPoint onConfigureWindow = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onConfigureWindow",
-            ExecutionOrder.after(onComputeInsets));
+            "onConfigureWindow", ExecutionOrder.after(onComputeInsets));
 
     public static final AndroidPossibleEntryPoint onCreateCandidatesView = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onCreateCandidatesView",
-            ExecutionOrder.between(onStart, onComputeInsets));
+            "onCreateCandidatesView", ExecutionOrder.between(onStart, onComputeInsets));
     
     /**
      *  non-demand generation of the UI.
      */
     public static final AndroidPossibleEntryPoint onCreateExtractTextView = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onCreateExtractTextView",
-            ExecutionOrder.after(onCreateCandidatesView));
+            "onCreateExtractTextView", ExecutionOrder.after(onCreateCandidatesView));
 
     /**
      *  non-demand generation of the UI.
      */
     public static final AndroidPossibleEntryPoint onCreateInputView = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onCreateInputView",
-            onCreateExtractTextView);
+            "onCreateInputView", onCreateExtractTextView);
 
     /**
      *  non-demand generation of the UI.
      */
     public static final AndroidPossibleEntryPoint onStartCandidatesView = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onStartCandidatesView",
-            onCreateExtractTextView);
+            "onStartCandidatesView", onCreateExtractTextView);
 
     //public static final AndroidPossibleEntryPoint onCreateInputMethodInterface = new AndroidPossibleEntryPoint(
     //        AndroidComponent.INPUT_METHOD_SERVICE, "onCreateInputMethodInterface",
@@ -485,36 +418,28 @@ public final class ServiceEP {
     //        ExecutionOrder.directlyAfter(onCreateInputMethodInterface)); 
 
     public static final AndroidPossibleEntryPoint onDisplayCompletions = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onDisplayCompletions",
-            ExecutionOrder.MULTIPLE_TIMES_IN_LOOP);
+            "onDisplayCompletions", ExecutionOrder.MULTIPLE_TIMES_IN_LOOP);
     
     public static final AndroidPossibleEntryPoint onEvaluateFullscreenMode = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onEvaluateFullscreenMode",
-            ExecutionOrder.MULTIPLE_TIMES_IN_LOOP);
+            "onEvaluateFullscreenMode", ExecutionOrder.MULTIPLE_TIMES_IN_LOOP);
 
     public static final AndroidPossibleEntryPoint onEvaluateInputViewShown = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onEvaluateInputViewShown",
-            ExecutionOrder.MULTIPLE_TIMES_IN_LOOP);
+            "onEvaluateInputViewShown", ExecutionOrder.MULTIPLE_TIMES_IN_LOOP);
     
     public static final AndroidPossibleEntryPoint onExtractTextContextMenuItem = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onExtractTextContextMenuItem",
-            ExecutionOrder.MULTIPLE_TIMES_IN_LOOP);
+            "onExtractTextContextMenuItem", ExecutionOrder.MULTIPLE_TIMES_IN_LOOP);
 
     public static final AndroidPossibleEntryPoint onExtractedCursorMovement = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onExtractedCursorMovement",
-            ExecutionOrder.MULTIPLE_TIMES_IN_LOOP);
+            "onExtractedCursorMovement", ExecutionOrder.MULTIPLE_TIMES_IN_LOOP);
 
     public static final AndroidPossibleEntryPoint onExtractedSelectionChanged = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onExtractedSelectionChanged",
-            ExecutionOrder.directlyAfter(onExtractedCursorMovement));
+            "onExtractedSelectionChanged", ExecutionOrder.directlyAfter(onExtractedCursorMovement));
 
     public static final AndroidPossibleEntryPoint onExtractedTextClicked = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onExtractedTextClicked",
-            ExecutionOrder.directlyAfter(onExtractedCursorMovement));
+            "onExtractedTextClicked", ExecutionOrder.directlyAfter(onExtractedCursorMovement));
     
     public static final AndroidPossibleEntryPoint onExtractingInputChanged = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onExtractingInputChanged",
-            ExecutionOrder.after(
+            "onExtractingInputChanged", ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onExtractedTextClicked,
                     onExtractedSelectionChanged,
@@ -522,19 +447,16 @@ public final class ServiceEP {
                 }));
 
     public static final AndroidPossibleEntryPoint onFinishInput = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onFinishInput",
-            ExecutionOrder.after(
+            "onFinishInput", ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onExtractingInputChanged,
                 }));
 
     public static final AndroidPossibleEntryPoint onFinishInputView = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onFinishInputView",
-            ExecutionOrder.after(onFinishInput));
+            "onFinishInputView", ExecutionOrder.after(onFinishInput));
 
     public static final AndroidPossibleEntryPoint onFinishCandidatesView = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onFinishCandidatesView",
-            ExecutionOrder.after(
+            "onFinishCandidatesView", ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onExtractingInputChanged,
                     onFinishInput,
@@ -549,35 +471,28 @@ public final class ServiceEP {
      *  for user-interface initialization, in particular to deal with configuration changes while the service is running.
      */
     public static final AndroidPossibleEntryPoint onInitializeInterface = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onInitializeInterface",
-            ExecutionOrder.MULTIPLE_TIMES_IN_LOOP); // TODO: Position
+            "onInitializeInterface", ExecutionOrder.MULTIPLE_TIMES_IN_LOOP); // TODO: Position
 
     public static final AndroidPossibleEntryPoint onKeyDown = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onKeyDown",
-            ExecutionOrder.directlyBefore(ActivityEP.onKeyDown));
+            "onKeyDown", ExecutionOrder.directlyBefore(ActivityEP.onKeyDown));
 
     public static final AndroidPossibleEntryPoint onKeyLongPress = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onKeyLongPress",
-            ExecutionOrder.directlyBefore(ActivityEP.onKeyLongPress));
+            "onKeyLongPress", ExecutionOrder.directlyBefore(ActivityEP.onKeyLongPress));
 
     public static final AndroidPossibleEntryPoint onKeyMultiple = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onKeyMultiple",
-            ExecutionOrder.directlyBefore(ActivityEP.onKeyMultiple));
+            "onKeyMultiple", ExecutionOrder.directlyBefore(ActivityEP.onKeyMultiple));
 
     public static final AndroidPossibleEntryPoint onKeyUp = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onKeyUp",
-            ExecutionOrder.directlyBefore(ActivityEP.onKeyUp));
+            "onKeyUp", ExecutionOrder.directlyBefore(ActivityEP.onKeyUp));
     
     public static final AndroidPossibleEntryPoint onShowInputRequested = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onShowInputRequested",
-            ExecutionOrder.MULTIPLE_TIMES_IN_LOOP);
+            "onShowInputRequested", ExecutionOrder.MULTIPLE_TIMES_IN_LOOP);
 
     /**
      * deal with an input session starting with the client. 
      */
     public static final AndroidPossibleEntryPoint onStartInput = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onStartInput",
-            ExecutionOrder.after(
+            "onStartInput", ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onCreateInputMethodSessionInterface,
                     ActivityEP.onResume
@@ -587,40 +502,32 @@ public final class ServiceEP {
      * deal with input starting within the input area of the IME. 
      */
     public static final AndroidPossibleEntryPoint onStartInputView = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onStartInputView",
-            onStartInput);
+            "onStartInputView", onStartInput);
     
     // InputMethodService.onTrackballEvent
     public static final AndroidPossibleEntryPoint onUnbindInput = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onUnbindInput",
-            onUnbind);  // TODO: Position
+            "onUnbindInput", onUnbind);  // TODO: Position
     
     public static final AndroidPossibleEntryPoint onUpdateCursor = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onUpdateCursor",
-            ExecutionOrder.directlyBefore(onGenericMotionEvent));
+            "onUpdateCursor", ExecutionOrder.directlyBefore(onGenericMotionEvent));
     
     /**
      * Called when the application has reported new extracted text to be shown due to changes in its current text state. 
      */
     public static final AndroidPossibleEntryPoint onUpdateExtractedText = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onUpdateExtractedText",
-            ExecutionOrder.directlyAfter(onExtractedTextClicked));
+            "onUpdateExtractedText", ExecutionOrder.directlyAfter(onExtractedTextClicked));
     
     public static final AndroidPossibleEntryPoint onUpdateExtractingViews = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onUpdateExtractingViews",
-            ExecutionOrder.after(onExtractingInputChanged));
+            "onUpdateExtractingViews", ExecutionOrder.after(onExtractingInputChanged));
     
     public static final AndroidPossibleEntryPoint onUpdateExtractingVisibility = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onUpdateExtractingVisibility",
-            ExecutionOrder.after(onUpdateExtractingViews));
+            "onUpdateExtractingVisibility", ExecutionOrder.after(onUpdateExtractingViews));
     
     public static final AndroidPossibleEntryPoint onUpdateSelection = new AndroidPossibleEntryPoint(
-             AndroidComponent.INPUT_METHOD_SERVICE, "onUpdateSelection",
-             ExecutionOrder.after(onExtractedSelectionChanged));
+             "onUpdateSelection", ExecutionOrder.after(onExtractedSelectionChanged));
     
     public static final AndroidPossibleEntryPoint onViewClicked = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onViewClicked",
-            ExecutionOrder.after(
+            "onViewClicked", ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onGenericMotionEvent,
                     onTrackballEvent,
@@ -628,16 +535,14 @@ public final class ServiceEP {
                 }));
     
     public static final AndroidPossibleEntryPoint onWindowShown = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onWindowShown",
-            ExecutionOrder.after(
+            "onWindowShown", ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onConfigureWindow,
                     onCreateCandidatesView
                 }));
     
     public static final AndroidPossibleEntryPoint onWindowHidden = new AndroidPossibleEntryPoint(
-            AndroidComponent.INPUT_METHOD_SERVICE, "onWindowHidden",
-            ExecutionOrder.between(
+            "onWindowHidden", ExecutionOrder.between(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     onWindowShown,
                 },
@@ -651,8 +556,7 @@ public final class ServiceEP {
      *
      *  As a BroadcastReceiver is oftain used in conjunction with a service it's defined here...
      */
-    public static final AndroidPossibleEntryPoint onReceive = new AndroidPossibleEntryPoint(AndroidComponent.BROADCAST_RECEIVER,
-            "onReceive", 
+    public static final AndroidPossibleEntryPoint onReceive = new AndroidPossibleEntryPoint("onReceive",
             ExecutionOrder.after(
                 new AndroidEntryPoint.IExecutionOrder[] {
                     ExecutionOrder.AT_FIRST, 

--- a/com.ibm.wala.scandroid/source/org/scandroid/domain/CodeElement.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/domain/CodeElement.java
@@ -50,15 +50,11 @@ package org.scandroid.domain;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.ibm.wala.ipa.callgraph.CGNode;
-import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
-import com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis;
-
 public abstract class CodeElement {
     /* For a given value number, and enclosing call graph node, yield
      * the set of all CodeElements that that it may refer to (i.e., the
      * associated local variable and any instances it may refer to). */
-    public static Set<CodeElement> valueElements(PointerAnalysis<InstanceKey> pa, CGNode node, int valueNumber) {
+    public static Set<CodeElement> valueElements(int valueNumber) {
     	//System.out.println("ValueNumber: " + valueNumber + ", Node: " + node.getMethod().getSignature());
         Set<CodeElement> elements = new HashSet<>();
         elements.add(new LocalElement(valueNumber));

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/FlowAnalysis.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/FlowAnalysis.java
@@ -80,7 +80,6 @@ import com.ibm.wala.ipa.cfg.BasicBlockInContext;
 import com.ibm.wala.ssa.ISSABasicBlock;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.CancelRuntimeException;
-import com.ibm.wala.util.MonitorUtil.IProgressMonitor;
 
 
 public class FlowAnalysis {
@@ -90,10 +89,9 @@ public class FlowAnalysis {
     analyze(final CGAnalysisContext<E> analysisContext,
           Map<BasicBlockInContext<E>,
           Map<FlowType<E>,Set<CodeElement>>> initialTaints,
-          IFDSTaintDomain<E> d,
-          IProgressMonitor progressMonitor
+          IFDSTaintDomain<E> d
           ) throws CancelRuntimeException {
-        return analyze(analysisContext.graph, analysisContext.cg, analysisContext.pa, initialTaints, d, progressMonitor);
+        return analyze(analysisContext.graph, analysisContext.cg, analysisContext.pa, initialTaints, d);
     }
     
     public static <E extends ISSABasicBlock>
@@ -102,10 +100,9 @@ public class FlowAnalysis {
           Map<BasicBlockInContext<E>,
           Map<FlowType<E>,Set<CodeElement>>> initialTaints,
           IFDSTaintDomain<E> d,
-          IProgressMonitor progressMonitor,
           IFlowFunctionMap<BasicBlockInContext<E>> flowFunctionMap
           ) throws CancelRuntimeException {
-        return analyze(analysisContext.graph, analysisContext.cg, analysisContext.pa, initialTaints, d, progressMonitor, flowFunctionMap);
+        return analyze(analysisContext.graph, analysisContext.cg, initialTaints, d, flowFunctionMap);
     }
     
     public static <E extends ISSABasicBlock>
@@ -115,11 +112,9 @@ public class FlowAnalysis {
 	          CallGraph cg,
 	          PointerAnalysis<InstanceKey> pa,
 	          Map<BasicBlockInContext<E>, Map<FlowType<E>,Set<CodeElement>>> initialTaints,
-	          IFDSTaintDomain<E> d,
-	          IProgressMonitor progressMonitor
+	          IFDSTaintDomain<E> d
 	        ) {
-				return analyze(graph, cg, pa, initialTaints, d,
-						progressMonitor, new TaintTransferFunctions<>(d, graph, pa));
+				return analyze(graph, cg, initialTaints, d, new TaintTransferFunctions<>(d, pa));
 
 //    			return analyze(graph, cg, pa, initialTaints, d,
 //    					progressMonitor, new IDTransferFunctions<E>(d, graph, pa));
@@ -134,10 +129,8 @@ public class FlowAnalysis {
       analyze(final ISupergraph<BasicBlockInContext<E>, 
     		  CGNode> graph,
               CallGraph cg,
-              PointerAnalysis<InstanceKey> pa,
               Map<BasicBlockInContext<E>, Map<FlowType<E>,Set<CodeElement>>> initialTaints,
               IFDSTaintDomain<E> d,
-              IProgressMonitor progressMonitor, 
               final IFlowFunctionMap<BasicBlockInContext<E>> flowFunctionMap
             ) {
 

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/InflowAnalysis.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/InflowAnalysis.java
@@ -154,7 +154,6 @@ public class InflowAnalysis {
                             StaticFieldSourceSpec ss, 
                             CallGraph cg, 
                             ISupergraph<BasicBlockInContext<E>, CGNode> graph,
-                            ClassHierarchy cha,
                             PointerAnalysis<InstanceKey> pa) {
     	// get the first block:
     	BasicBlockInContext<E> bb = null;
@@ -216,9 +215,9 @@ public class InflowAnalysis {
 
     public static <E extends ISSABasicBlock>
       Map<BasicBlockInContext<E>,Map<FlowType<E>,Set<CodeElement>>> analyze(
-            CGAnalysisContext<E> analysisContext, Map<InstanceKey, String> prefixes,
+            CGAnalysisContext<E> analysisContext,
             ISpecs s) {
-        return analyze(analysisContext, analysisContext.cg, analysisContext.getClassHierarchy(), analysisContext.graph, analysisContext.pa, prefixes, s);
+        return analyze(analysisContext, analysisContext.cg, analysisContext.getClassHierarchy(), analysisContext.graph, analysisContext.pa, s);
     }
 
     public static <E extends ISSABasicBlock>
@@ -228,7 +227,6 @@ public class InflowAnalysis {
           ClassHierarchy cha, 
           ISupergraph<BasicBlockInContext<E>, CGNode> graph,
           PointerAnalysis<InstanceKey> pa, 
-          Map<InstanceKey, String> prefixes,
           ISpecs s) {
 
         Map<BasicBlockInContext<E>, Map<FlowType<E>,Set<CodeElement>>> taintMap = HashMapFactory.make();
@@ -242,7 +240,7 @@ public class InflowAnalysis {
         	else if (ss[i] instanceof CallRetSourceSpec || ss[i] instanceof CallArgSourceSpec)
         		ssAL.add(ss[i]);
         	else if (ss[i] instanceof StaticFieldSourceSpec) {
-        		processStaticFieldSource(ctx, taintMap, (StaticFieldSourceSpec)ss[i], cg, graph, cha, pa);
+        		processStaticFieldSource(ctx, taintMap, (StaticFieldSourceSpec)ss[i], cg, graph, pa);
         	} else 
         		throw new UnsupportedOperationException("Unrecognized SourceSpec");
         } 

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/OutflowAnalysis.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/OutflowAnalysis.java
@@ -76,7 +76,6 @@ import org.scandroid.util.CGAnalysisContext;
 
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.dataflow.IFDS.ICFGSupergraph;
-import com.ibm.wala.dataflow.IFDS.ISupergraph;
 import com.ibm.wala.dataflow.IFDS.TabulationResult;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.CallGraph;

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/OutflowAnalysis.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/OutflowAnalysis.java
@@ -409,17 +409,13 @@ public class OutflowAnalysis {
 	public Map<FlowType<IExplodedBasicBlock>, Set<FlowType<IExplodedBasicBlock>>> analyze(
 			TabulationResult<BasicBlockInContext<IExplodedBasicBlock>, CGNode, DomainElement> flowResult,
 			IFDSTaintDomain<IExplodedBasicBlock> domain) {
-		return analyze(ctx.cg, ctx.getClassHierarchy(), ctx.graph, ctx.pa,
-				flowResult, domain, specs);
+		return analyze(flowResult, domain, specs);
 	}
 
 	public Map<FlowType<IExplodedBasicBlock>, Set<FlowType<IExplodedBasicBlock>>> analyze(
-			CallGraph cg,
-			ClassHierarchy cha,
-			ISupergraph<BasicBlockInContext<IExplodedBasicBlock>, CGNode> graph,
-			PointerAnalysis<InstanceKey> pa,
 			TabulationResult<BasicBlockInContext<IExplodedBasicBlock>, CGNode, DomainElement> flowResult,
-			IFDSTaintDomain<IExplodedBasicBlock> domain, ISpecs s) {
+			IFDSTaintDomain<IExplodedBasicBlock> domain,
+			ISpecs s) {
 
 		
 		

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/functions/IDTransferFunctions.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/functions/IDTransferFunctions.java
@@ -47,17 +47,11 @@
 package org.scandroid.flow.functions;
 
 
-import org.scandroid.domain.IFDSTaintDomain;
-
 import com.ibm.wala.dataflow.IFDS.IFlowFunction;
 import com.ibm.wala.dataflow.IFDS.IFlowFunctionMap;
 import com.ibm.wala.dataflow.IFDS.IReversibleFlowFunction;
-import com.ibm.wala.dataflow.IFDS.ISupergraph;
 import com.ibm.wala.dataflow.IFDS.IUnaryFlowFunction;
 import com.ibm.wala.dataflow.IFDS.IdentityFlowFunction;
-import com.ibm.wala.ipa.callgraph.CGNode;
-import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
-import com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis;
 import com.ibm.wala.ipa.cfg.BasicBlockInContext;
 import com.ibm.wala.ssa.ISSABasicBlock;
 import com.ibm.wala.util.intset.IntSet;
@@ -71,11 +65,6 @@ public class IDTransferFunctions <E extends ISSABasicBlock> implements
 
     private static final IReversibleFlowFunction IDENTITY_FN = new IdentityFlowFunction();
     
-    public IDTransferFunctions(IFDSTaintDomain<E> domain,
-            ISupergraph<BasicBlockInContext<E>, CGNode> graph, 
-            PointerAnalysis<InstanceKey> pa) {
-    }
-
 	@Override
 	public IUnaryFlowFunction getNormalFlowFunction(BasicBlockInContext<E> src,
 			BasicBlockInContext<E> dest) {

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/functions/IFDSTaintFlowFunctionProvider.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/functions/IFDSTaintFlowFunctionProvider.java
@@ -186,10 +186,10 @@ implements IFlowFunctionMap<BasicBlockInContext<E>> {
 			else
 			{
 				for (int i = 0; i < instruction.getNumberOfUses(); i++) {
-					p.uses.addAll(CodeElement.valueElements(pa, bb.getNode(), instruction.getUse(i)));
+					p.uses.addAll(CodeElement.valueElements(instruction.getUse(i)));
 				}
 				for (int j = 0; j < instruction.getNumberOfDefs(); j++) {
-					p.defs.addAll(CodeElement.valueElements(pa, bb.getNode(), instruction.getDef(j)));
+					p.defs.addAll(CodeElement.valueElements(instruction.getDef(j)));
 				}
 			}
 			
@@ -206,7 +206,7 @@ implements IFlowFunctionMap<BasicBlockInContext<E>> {
 				{
 					//p.uses.add(new LocalElement(instruction.getUse(i)));
 					p.uses.addAll(
-						CodeElement.valueElements(pa, bb.getNode(), instruction.getUse(i)));
+						CodeElement.valueElements(instruction.getUse(i)));
 					
 				}
 				p.defs.add(new ReturnElement());
@@ -222,12 +222,12 @@ implements IFlowFunctionMap<BasicBlockInContext<E>> {
 				//System.out.println("adding receiver flow in "+this+" for "+invInst);
 				//System.out.println("\tadding local element "+invInst.getReceiver());
 				//getReceiver() == getUse(0) == param[0] == this
-				p.uses.addAll(CodeElement.valueElements(pa, bb.getNode(), invInst.getReceiver()));
+				p.uses.addAll(CodeElement.valueElements(invInst.getReceiver()));
 				for(int i = 0; i < invInst.getNumberOfDefs(); i++)
 				{
 					//System.out.println("\tadding def local element "+invInst.getDef(i));
 					//return valuenumber of invoke instruction
-					p.defs.addAll(CodeElement.valueElements(pa, bb.getNode(), invInst.getDef(i)));
+					p.defs.addAll(CodeElement.valueElements(invInst.getDef(i)));
 				}
 			}
 			thisToResult = true;
@@ -268,12 +268,12 @@ implements IFlowFunctionMap<BasicBlockInContext<E>> {
 					// These loops cause all parameters flow into the 
 					// 'this' param (due to instruction.getUse(0))
 					for (int i = 1; i < instruction.getNumberOfUses(); i++) {
-						p.uses.addAll(CodeElement.valueElements(pa, bb.getNode(), instruction.getUse(i)));
+						p.uses.addAll(CodeElement.valueElements(instruction.getUse(i)));
 					}
 				
 
 					if (instruction.getNumberOfUses() > 0) {
-						p.defs.addAll(CodeElement.valueElements(pa, bb.getNode(), instruction.getUse(0)));
+						p.defs.addAll(CodeElement.valueElements(instruction.getUse(0)));
 					}
 				}
 			}
@@ -281,8 +281,8 @@ implements IFlowFunctionMap<BasicBlockInContext<E>> {
 
 		private void handleOutflowArrayStoreInstruction(
 				SSAInstruction instruction, UseDefSetPair p) {
-			p.uses.addAll(CodeElement.valueElements(pa, bb.getNode(), instruction.getUse(2)));
-			p.defs.addAll(CodeElement.valueElements(pa, bb.getNode(), instruction.getUse(0)));
+			p.uses.addAll(CodeElement.valueElements(instruction.getUse(2)));
+			p.defs.addAll(CodeElement.valueElements(instruction.getUse(0)));
 		}
 
 		private void handleOutflowPutInstruction(SSAInstruction instruction,
@@ -291,7 +291,7 @@ implements IFlowFunctionMap<BasicBlockInContext<E>> {
 			PointerKey pk;
 			Set<CodeElement> elements = HashSetFactory.make();
 			if (pi.isStatic()) {
-			    p.uses.addAll(CodeElement.valueElements(pa, bb.getNode(), instruction.getUse(0)));
+			    p.uses.addAll(CodeElement.valueElements(instruction.getUse(0)));
 			    FieldReference declaredField = pi.getDeclaredField();
 			    IField staticField = getStaticIField(ch, declaredField);
 			    if (staticField == null) {
@@ -301,7 +301,7 @@ implements IFlowFunctionMap<BasicBlockInContext<E>> {
 			    }
 			} else {
 			    p.uses.addAll(
-			    		CodeElement.valueElements(pa, bb.getNode(), instruction.getUse(1)));
+			    		CodeElement.valueElements(instruction.getUse(1)));
 
 			    // this value number seems to be the object referenced in this instruction (?)
 				int valueNumber = instruction.getUse(0);
@@ -311,7 +311,7 @@ implements IFlowFunctionMap<BasicBlockInContext<E>> {
 				
 				// add the object that holds the field that was modified
 				// to the list of things tainted by this flow:
-				p.defs.addAll(CodeElement.valueElements(pa, bb.getNode(), valueNumber));
+				p.defs.addAll(CodeElement.valueElements(valueNumber));
 			}	
 			// now add the field keys to the defs list so that they
 			// are also tainted:
@@ -329,8 +329,8 @@ implements IFlowFunctionMap<BasicBlockInContext<E>> {
 
 		private void handleInflowArrayLoadInstruction(
 				SSAInstruction instruction, UseDefSetPair p) {
-			p.uses.addAll(CodeElement.valueElements(pa, bb.getNode(), instruction.getUse(0)));
-			p.defs.addAll(CodeElement.valueElements(pa, bb.getNode(),instruction.getDef()));
+			p.uses.addAll(CodeElement.valueElements(instruction.getUse(0)));
+			p.defs.addAll(CodeElement.valueElements(instruction.getDef()));
 		}
 
 		private void handleInflowGetInstruction(SSAInstruction instruction,
@@ -456,7 +456,7 @@ implements IFlowFunctionMap<BasicBlockInContext<E>> {
 
 		final Map<CodeElement,CodeElement> parameterMap = HashMapFactory.make();
 		for (int i = 0; i < instruction.getNumberOfParameters(); i++) {
-			Set<CodeElement> elements = CodeElement.valueElements(pa, src.getNode(), instruction.getUse(i));
+			Set<CodeElement> elements = CodeElement.valueElements(instruction.getUse(i));
 			for(CodeElement e: elements) {
 				parameterMap.put(e, new LocalElement(i+1));
 			}
@@ -541,7 +541,7 @@ implements IFlowFunctionMap<BasicBlockInContext<E>> {
 
 						if ( !invInst.isStatic() ) {
 							//used to be invInst.getReceiver(), but I believe that was incorrect.
-							receivers.addAll(CodeElement.valueElements(pa, call.getNode(), invInst.getReceiver()));
+							receivers.addAll(CodeElement.valueElements(invInst.getReceiver()));
 							//receivers.addAll(CodeElement.valueElements(pa, call.getNode(), invInst.getReturnValue(0)));
 						}
 					}

--- a/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/UriPrefixTransferGraph.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/UriPrefixTransferGraph.java
@@ -103,11 +103,11 @@ public class UriPrefixTransferGraph implements Graph<InstanceKeySite> {
         final Collection<InstanceKey> instanceKeys = pa.getInstanceKeys();
         
         for (final InstanceKey k : instanceKeys) {
-        	handleStringBuilder(k, pa, mapping, unresolvedDependencies);
+        	handleStringBuilder(k, pa);
         }
         
         for (final InstanceKey k : instanceKeys) {
-        	handleString(k, pa, mapping, unresolvedDependencies);
+        	handleString(k, mapping, unresolvedDependencies);
         }
 
         for (final PointerKey pk : pa.getPointerKeys()) {
@@ -135,8 +135,7 @@ public class UriPrefixTransferGraph implements Graph<InstanceKeySite> {
         }
     }
     
-    private void handleString(final InstanceKey ik, final PointerAnalysis<InstanceKey> pa,
-    		final OrdinalSetMapping<InstanceKey> mapping,
+    private void handleString(final InstanceKey ik, final OrdinalSetMapping<InstanceKey> mapping,
     		final Map<InstanceKeySite, Set<InstanceKey>> unresolvedDependencies) {
         if (isOfType(ik, "Ljava/lang/String")) {
             if (ik instanceof ConstantKey) {
@@ -146,14 +145,12 @@ public class UriPrefixTransferGraph implements Graph<InstanceKeySite> {
                 nodeMap.put(ik, node);
             } else if (ik instanceof NormalAllocationInNode) {
             	final NormalAllocationInNode nain = (NormalAllocationInNode) ik;
-            	handleStringBuilderToString(nain, pa, mapping, unresolvedDependencies);
+            	handleStringBuilderToString(nain, mapping, unresolvedDependencies);
             }
         }
     }
     
-    private void handleStringBuilder(final InstanceKey ik, final PointerAnalysis<InstanceKey> pa,
-    		final OrdinalSetMapping<InstanceKey> mapping,
-    		final Map<InstanceKeySite, Set<InstanceKey>> unresolvedDependencies) {
+    private void handleStringBuilder(final InstanceKey ik, final PointerAnalysis<InstanceKey> pa) {
     	
         if (isOfType(ik, "Ljava/lang/StringBuilder")) {
             if (ik instanceof AllocationSiteInNode) {
@@ -173,8 +170,7 @@ public class UriPrefixTransferGraph implements Graph<InstanceKeySite> {
         }
     }
     
-    private void handleStringBuilderToString(final NormalAllocationInNode nain, final PointerAnalysis<InstanceKey> pa,
-    		final OrdinalSetMapping<InstanceKey> mapping,
+    private void handleStringBuilderToString(final NormalAllocationInNode nain, final OrdinalSetMapping<InstanceKey> mapping,
     		final Map<InstanceKeySite, Set<InstanceKey>> unresolvedDependencies) {
         if (hasSignature(nain, "java.lang.StringBuilder.toString()Ljava/lang/String;")) {
             final Context context = nain.getNode().getContext();

--- a/com.ibm.wala.scandroid/source/org/scandroid/spec/CallArgSourceSpec.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/spec/CallArgSourceSpec.java
@@ -104,8 +104,7 @@ public class CallArgSourceSpec extends SourceSpec {
 				// that this SSA value might point to
 				final int ssaVal = invInst.getUse(newArgNums[j]);
 				final CGNode node = block.getNode();
-				Set<CodeElement> valueElements = CodeElement.valueElements(pa,
-						node, ssaVal);
+				Set<CodeElement> valueElements = CodeElement.valueElements(ssaVal);
 				PointerKey pk = pa.getHeapModel().getPointerKeyForLocal(node, ssaVal);
 				for (InstanceKey ik : pa.getPointsToSet(pk)) {
 					valueElements.add(new InstanceKeyElement(ik));

--- a/com.ibm.wala.scandroid/source/org/scandroid/spec/CallRetSourceSpec.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/spec/CallRetSourceSpec.java
@@ -89,16 +89,14 @@ public class CallRetSourceSpec extends SourceSpec {
 			BasicBlockInContext<E> block, SSAInvokeInstruction invInst, int[] newArgNums,
 			ISupergraph<BasicBlockInContext<E>, CGNode> graph, PointerAnalysis<InstanceKey> pa, CallGraph cg) {
 
-		for (FlowType<E> ft:getFlowType(block, invInst,block.getNode(), im, pa)) {
+		for (FlowType<E> ft:getFlowType(block)) {
 			InflowAnalysis.addDomainElements(taintMap, block, ft, 
-			        CodeElement.valueElements(pa, block.getNode(), invInst.getDef(0)));
+			        CodeElement.valueElements(invInst.getDef(0)));
 		}
 	}
 
 	private<E extends ISSABasicBlock> Collection<FlowType<E>> getFlowType(
-	        BasicBlockInContext<E> block,
-	        SSAInvokeInstruction invInst,
-			CGNode node, IMethod im, PointerAnalysis<InstanceKey> pa) {
+	        BasicBlockInContext<E> block) {
 
 		HashSet<FlowType<E>> flowSet = new HashSet<>();
 		flowSet.clear();

--- a/com.ibm.wala.scandroid/source/org/scandroid/spec/EntryArgSourceSpec.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/spec/EntryArgSourceSpec.java
@@ -98,7 +98,7 @@ public class EntryArgSourceSpec extends SourceSpec {
 		    for(int i: newArgNums) {
 		        FlowType<E> flow = new ParameterFlow<>(block, i, true);
 		        final int ssaVal = node.getIR().getParameter(i);
-				final Set<CodeElement> valueElements = CodeElement.valueElements(pa, node, ssaVal);
+				final Set<CodeElement> valueElements = CodeElement.valueElements(ssaVal);
 				
 				PointerKey pk = pa.getHeapModel().getPointerKeyForLocal(node, ssaVal);
 				final OrdinalSet<InstanceKey> pointsToSet = pa.getPointsToSet(pk);

--- a/com.ibm.wala.scandroid/source/org/scandroid/util/AndroidAnalysisContext.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/util/AndroidAnalysisContext.java
@@ -54,7 +54,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Deque;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -87,7 +86,6 @@ import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.io.FileProvider;
 import com.ibm.wala.util.strings.Atom;
-import com.ibm.wala.util.warnings.Warning;
 import com.ibm.wala.util.warnings.Warnings;
 
 public class AndroidAnalysisContext {
@@ -122,6 +120,7 @@ public class AndroidAnalysisContext {
 		
 		cha = ClassHierarchyFactory.make(scope);
 
+		/*
 		if (options.classHierarchyWarnings()) {
 			// log ClassHierarchy warnings
 			for (Iterator<Warning> wi = Warnings.iterator(); wi.hasNext();) {
@@ -129,6 +128,7 @@ public class AndroidAnalysisContext {
 				
 			}
 		}
+		*/
 		Warnings.clear();
 	}
 	

--- a/com.ibm.wala.scandroid/source/org/scandroid/util/AndroidAnalysisContext.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/util/AndroidAnalysisContext.java
@@ -55,7 +55,6 @@ import java.io.InputStream;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -68,7 +67,6 @@ import com.ibm.wala.ipa.callgraph.AnalysisOptions;
 import com.ibm.wala.ipa.callgraph.AnalysisScope;
 import com.ibm.wala.ipa.callgraph.ClassTargetSelector;
 import com.ibm.wala.ipa.callgraph.ContextSelector;
-import com.ibm.wala.ipa.callgraph.Entrypoint;
 import com.ibm.wala.ipa.callgraph.MethodTargetSelector;
 import com.ibm.wala.ipa.callgraph.impl.Util;
 import com.ibm.wala.ipa.callgraph.propagation.SSAContextInterpreter;
@@ -135,15 +133,6 @@ public class AndroidAnalysisContext {
 	}
 	
 	
-
-	// ContextSelector, entry points, reflection options, IR Factory, call graph
-	// type, include library
-	public void buildGraphs(List<Entrypoint> localEntries,
-			InputStream summariesStream) {
-
-		
-
-	}
 
 	public static SSAPropagationCallGraphBuilder makeVanillaZeroOneCFABuilder(
 			AnalysisOptions options, AnalysisCache cache, IClassHierarchy cha,

--- a/com.ibm.wala.scandroid/source/org/scandroid/util/CGAnalysisContext.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/util/CGAnalysisContext.java
@@ -88,9 +88,6 @@ import com.ibm.wala.ipa.callgraph.propagation.SSAPropagationCallGraphBuilder;
 import com.ibm.wala.ipa.cfg.BasicBlockInContext;
 import com.ibm.wala.ipa.cha.ClassHierarchy;
 import com.ibm.wala.ssa.ISSABasicBlock;
-import com.ibm.wala.ssa.SSACFG;
-import com.ibm.wala.ssa.SSACFG.BasicBlock;
-import com.ibm.wala.ssa.SSAInstruction;
 import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.Predicate;
@@ -98,7 +95,6 @@ import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.graph.Graph;
 import com.ibm.wala.util.graph.GraphSlicer;
 import com.ibm.wala.util.intset.OrdinalSet;
-import com.ibm.wala.util.warnings.Warning;
 import com.ibm.wala.util.warnings.Warnings;
 
 /**
@@ -139,9 +135,11 @@ public class CGAnalysisContext<E extends ISSABasicBlock> {
 
 		entrypoints = specifier.specify(analysisContext);
 		AnalysisOptions analysisOptions = new AnalysisOptions(scope, entrypoints);
+		/*
 		for (Entrypoint e : entrypoints) {
 			
 		}
+		*/
 		analysisOptions.setReflectionOptions(options.getReflectionOptions());
 
 		AnalysisCache cache = new AnalysisCacheImpl(new DexIRFactory());
@@ -157,6 +155,7 @@ public class CGAnalysisContext<E extends ISSABasicBlock> {
 		cgb = AndroidAnalysisContext.makeZeroCFABuilder(analysisOptions, cache,	cha, scope,
 				new DefaultContextSelector(analysisOptions, cha), null, extraSummaries, null);
 
+		/*
 		if (analysisContext.getOptions().cgBuilderWarnings()) {
 			// CallGraphBuilder construction warnings
 			for (Iterator<Warning> wi = Warnings.iterator(); wi.hasNext();) {
@@ -164,6 +163,7 @@ public class CGAnalysisContext<E extends ISSABasicBlock> {
 				
 			}
 		}
+		*/
 		Warnings.clear();
 
 		
@@ -188,11 +188,13 @@ public class CGAnalysisContext<E extends ISSABasicBlock> {
 			System.exit(status);
 		}
 
+		/*
 		// makeCallGraph warnings
 		for (Iterator<Warning> wi = Warnings.iterator(); wi.hasNext();) {
 			Warning w = wi.next();
 			
 		}
+		*/
 		Warnings.clear();
 
 		pa = cgb.getPointerAnalysis();
@@ -276,6 +278,7 @@ public class CGAnalysisContext<E extends ISSABasicBlock> {
 			}
 		});
 
+		/*
 		if (options.stdoutCG()) {
 			for (Iterator<CGNode> nodeI = cg.iterator(); nodeI.hasNext();) {
 				CGNode node = nodeI.next();
@@ -298,6 +301,7 @@ public class CGAnalysisContext<E extends ISSABasicBlock> {
 				}
 			}
 		}
+		*/
 	}
 
 	/**

--- a/com.ibm.wala.scandroid/source/org/scandroid/util/DexDotUtil.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/util/DexDotUtil.java
@@ -110,12 +110,12 @@ public class DexDotUtil extends DotUtil {
             }
             if (output.available() > 0) {
               byte[] data = new byte[output.available()];
-              int nRead = output.read(data);
+              output.read(data);
               
             }
             if (error.available() > 0) {
               byte[] data = new byte[error.available()];
-              int nRead = error.read(data);
+              error.read(data);
               
             }
             try {

--- a/com.ibm.wala.scandroid/source/org/scandroid/util/EntryPoints.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/util/EntryPoints.java
@@ -89,7 +89,7 @@ public class EntryPoints {
 
     private LinkedList<Entrypoint> entries;
 
-    public void listenerEntryPoints(ClassHierarchy cha, AndroidAnalysisContext loader) {
+    public void listenerEntryPoints(ClassHierarchy cha) {
         ArrayList<MethodReference> entryPointMRs = new ArrayList<>();
 
         // onLocation
@@ -124,7 +124,7 @@ public class EntryPoints {
     	return entries;
     }
     
-    public void activityModelEntry(ClassHierarchy cha, AndroidAnalysisContext loader) {
+    public void activityModelEntry(ClassHierarchy cha) {
         String[] methodReferences = {
             "android.app.Activity.ActivityModel()V",
             // find all onActivityResult functions and add them as entry points
@@ -184,7 +184,7 @@ public class EntryPoints {
     }
     
     
-    public void addTestEntry(ClassHierarchy cha, AndroidAnalysisContext loader) {
+    public void addTestEntry(ClassHierarchy cha) {
     	String[] methodReferences = {
 //    			"Test.Apps.Outer$PrivateInnerClass.printNum()V",
     			//"Test.Apps.Outer$PublicInnerClass.printNum()V"

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/LineNumberTableReader.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/LineNumberTableReader.java
@@ -68,7 +68,8 @@ public final class LineNumberTableReader extends AttributeReader {
         }
 
         // check length
-        new LineNumberTableReader(iter);
+        @SuppressWarnings("unused")
+        LineNumberTableReader lineNumberTableReader = new LineNumberTableReader(iter);
         int attr = iter.getRawOffset();
         int count = cr.getUShort(attr + 6);
         int offset = attr + 8;

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/LocalVariableTableReader.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/LocalVariableTableReader.java
@@ -76,7 +76,8 @@ public final class LocalVariableTableReader extends AttributeReader {
         }
 
         // check length
-        new LocalVariableTableReader(iter);
+        @SuppressWarnings("unused")
+        LocalVariableTableReader localVariableTableReader = new LocalVariableTableReader(iter);
         int attr = iter.getRawOffset();
         int count = cr.getUShort(attr + 6);
         int offset = attr + 8;


### PR DESCRIPTION
Taken together, these commits fix or suppress 201 Eclipse warnings relating to unused local variables and method parameters. A few of these commits warrant closer attention:

- d9d471df6b7d17e36cc69f0d0b6a79e1e3fd3b4b comments out several large chunks of code that were only manipulating local variables that were otherwise unused. A typical example would be code that loops over a list of warnings, but does not actually print or log the warnings. I decided to be cautious here and comment out the code rather than removing it entirely. Perhaps someone will decide to do something more significant with this code in the future, such as actually logging those warnings. It is also possible that I accidentally commented out something with important side effects, though I made a conscious effort to watch for and avoid that.

- b4eaa8dc36f2e510904f2731068cc3b3954cd221 and a9e4c2e3f7bd0fc8d9eb9afaa1ac799caf1139ab respectively remove many calls to `AnalysisCache.getIR()` and `ClassHierarchy.resolveMethod()` whose result is never subsequently used. My impression is that neither of these calls has side effects we need here. If I am mistaken, then it should be easy enough to back all of these changes out _en masse_.

- d43cecff3ca0f3a14d8947f5ca601c79ebe6fabb removes unused method arguments; some of these changes could affect public API visible to third-party WALA code.