### PR TITLE
Fix or suppress all Eclipse code style warnings relating to static methods and fields

### DIFF
--- a/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
+++ b/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
@@ -396,7 +396,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
 
   }
 
-  private boolean isInterface(AbstractTypeDeclaration decl) {
+  private static boolean isInterface(AbstractTypeDeclaration decl) {
     return decl instanceof AnnotationTypeDeclaration ||
       (decl instanceof TypeDeclaration && ((TypeDeclaration)decl).isInterface());
   }
@@ -640,7 +640,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
     return visit(fakeCtor, classBinding, oldContext, inits);
   }
 
-  private IMethodBinding findDefaultCtor(ITypeBinding superClass) {
+  private static IMethodBinding findDefaultCtor(ITypeBinding superClass) {
     for (IMethodBinding met : superClass.getDeclaredMethods()) {
       if (met.isConstructor() && met.getParameterTypes().length == 0)
         return met;
@@ -1832,7 +1832,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
    * @param isPrivate
    * @return
    */
-  private ITypeBinding findClosestEnclosingClassSubclassOf(ITypeBinding typeOfThis, ITypeBinding owningType, boolean isPrivate) {
+  private static ITypeBinding findClosestEnclosingClassSubclassOf(ITypeBinding typeOfThis, ITypeBinding owningType, boolean isPrivate) {
     // GENERICS
 //    if (owningType.isParameterizedType())
 //      owningType = owningType.getTypeDeclaration();

--- a/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/ecj/ECJSourceModuleTranslator.java
+++ b/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/ecj/ECJSourceModuleTranslator.java
@@ -128,7 +128,7 @@ public class ECJSourceModuleTranslator implements SourceModuleTranslator {
     libs = paths.snd;
   }
 
-  private Pair<String[],String[]> computeClassPath(AnalysisScope scope) {
+  private static Pair<String[],String[]> computeClassPath(AnalysisScope scope) {
     List<String> sources = new LinkedList<>();
     List<String> libs = new LinkedList<>();
     for (ClassLoaderReference cl : scope.getLoaders()) {

--- a/com.ibm.wala.cast.java.test.data/src/foo/bar/hello/world/MethodMadness.java
+++ b/com.ibm.wala.cast.java.test.data/src/foo/bar/hello/world/MethodMadness.java
@@ -99,6 +99,7 @@ public class MethodMadness {
 			return 233 + x;
 		}
 		
+		@SuppressWarnings("static-access")
 		public void hello() {
 			System.out.println(privateInteger()); // inner function, inner this, 200013
 			System.out.println(MethodMadness.this.privateInteger()); // outer function, outer this, 100007 

--- a/com.ibm.wala.cast.java.test.data/src/foo/bar/hello/world/MethodMadness.java
+++ b/com.ibm.wala.cast.java.test.data/src/foo/bar/hello/world/MethodMadness.java
@@ -51,6 +51,7 @@ public class MethodMadness {
 	public static void staticTest() {
 		System.out.println("staticTest");
 	}
+	@SuppressWarnings("static-access")
 	protected int protectedInteger() {
 		this.s = 5;
 		new MethodMadness("thrownaway").staticTest(); // MethodMadness object evaluated but thrown away

--- a/com.ibm.wala.cast.java.test/.settings/org.eclipse.jdt.core.prefs
+++ b/com.ibm.wala.cast.java.test/.settings/org.eclipse.jdt.core.prefs
@@ -53,6 +53,7 @@ org.eclipse.jdt.core.compiler.problem.parameterAssignment=ignore
 org.eclipse.jdt.core.compiler.problem.possibleAccidentalBooleanAssignment=warning
 org.eclipse.jdt.core.compiler.problem.rawTypeReference=ignore
 org.eclipse.jdt.core.compiler.problem.redundantNullCheck=ignore
+org.eclipse.jdt.core.compiler.problem.reportMethodCanBePotentiallyStatic=ignore
 org.eclipse.jdt.core.compiler.problem.specialParameterHidingField=disabled
 org.eclipse.jdt.core.compiler.problem.staticAccessReceiver=warning
 org.eclipse.jdt.core.compiler.problem.suppressWarnings=enabled

--- a/com.ibm.wala.cast.java.test/src/com/ibm/wala/cast/java/test/JavaIRTests.java
+++ b/com.ibm.wala.cast.java.test/src/com/ibm/wala/cast/java/test/JavaIRTests.java
@@ -596,7 +596,7 @@ public abstract class JavaIRTests extends IRTests {
     runTest(singleTestSrc(), rtJar, simpleTestEntryPoint(), emptyList, true);
   }
 
-  private MethodReference getSliceRootReference(String className, String methodName, String methodDescriptor) {
+  private static MethodReference getSliceRootReference(String className, String methodName, String methodDescriptor) {
     TypeName clsName = TypeName.string2TypeName("L" + className.replace('.', '/'));
     TypeReference clsRef = TypeReference.findOrCreate(JavaSourceAnalysisScope.SOURCE, clsName);
 

--- a/com.ibm.wala.cast.java/.settings/org.eclipse.jdt.core.prefs
+++ b/com.ibm.wala.cast.java/.settings/org.eclipse.jdt.core.prefs
@@ -54,6 +54,7 @@ org.eclipse.jdt.core.compiler.problem.possibleAccidentalBooleanAssignment=warnin
 org.eclipse.jdt.core.compiler.problem.potentialNullReference=ignore
 org.eclipse.jdt.core.compiler.problem.rawTypeReference=ignore
 org.eclipse.jdt.core.compiler.problem.redundantNullCheck=ignore
+org.eclipse.jdt.core.compiler.problem.reportMethodCanBePotentiallyStatic=ignore
 org.eclipse.jdt.core.compiler.problem.specialParameterHidingField=disabled
 org.eclipse.jdt.core.compiler.problem.staticAccessReceiver=warning
 org.eclipse.jdt.core.compiler.problem.suppressWarnings=enabled

--- a/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/examples/ast/SynchronizedBlockDuplicator.java
+++ b/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/examples/ast/SynchronizedBlockDuplicator.java
@@ -164,7 +164,7 @@ public class SynchronizedBlockDuplicator extends
     return oldTarget;
   }
 
-  private boolean contains(RewriteContext<UnwindKey> c, CAstNode n) {
+  private static boolean contains(RewriteContext<UnwindKey> c, CAstNode n) {
     if (c instanceof SyncContext) {
       return ((SyncContext) c).containsNode(n);
     } else {
@@ -176,7 +176,7 @@ public class SynchronizedBlockDuplicator extends
    * does root represent a synchronized block? if so, return the variable whose
    * lock is acquired. otherwise, return <code>null</code>
    */
-  private String isSynchronizedOnVar(CAstNode root) {
+  private static String isSynchronizedOnVar(CAstNode root) {
     if (root.getKind() == CAstNode.UNWIND) {
       CAstNode unwindBody = root.getChild(0);
       if (unwindBody.getKind() == CAstNode.BLOCK_STMT) {

--- a/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/loader/JavaSourceLoaderImpl.java
+++ b/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/loader/JavaSourceLoaderImpl.java
@@ -535,7 +535,7 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
     ((JavaClass) owner).addField(n);
   }
 
-  private TypeName toWALATypeName(CAstType type) {
+  private static TypeName toWALATypeName(CAstType type) {
     return TypeName.string2TypeName(type.getName());
   }
   

--- a/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/translator/JavaCAst2IRTranslator.java
+++ b/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/translator/JavaCAst2IRTranslator.java
@@ -167,7 +167,7 @@ public class JavaCAst2IRTranslator extends AstTranslator {
     processExceptions(newNode, context);
   }
 
-  private void processExceptions(CAstNode n, WalkContext context) {
+  private static void processExceptions(CAstNode n, WalkContext context) {
     context.cfg().addPreNode(n, context.getUnwindState());
     context.cfg().newBlock(true);
 
@@ -412,7 +412,7 @@ public class JavaCAst2IRTranslator extends AstTranslator {
     }
   }
 
-  private CAstType getType(final String name) {
+  private static CAstType getType(final String name) {
     return new CAstType.Class() {
       
       @Override

--- a/com.ibm.wala.cast.js.nodejs/src/com/ibm/wala/cast/js/nodejs/NodejsRequireTargetSelector.java
+++ b/com.ibm.wala.cast.js.nodejs/src/com/ibm/wala/cast/js/nodejs/NodejsRequireTargetSelector.java
@@ -24,8 +24,8 @@ import org.json.JSONObject;
 import com.ibm.wala.cast.js.ipa.callgraph.JSCallGraphUtil;
 import com.ibm.wala.cast.js.loader.JavaScriptLoader;
 import com.ibm.wala.cast.js.ssa.JavaScriptInvoke;
-import com.ibm.wala.cast.js.types.JavaScriptMethods;
 import com.ibm.wala.cast.js.types.JavaScriptTypes;
+import com.ibm.wala.cast.types.AstMethodReference;
 import com.ibm.wala.classLoader.CallSiteReference;
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IMethod;
@@ -118,7 +118,7 @@ public class NodejsRequireTargetSelector implements MethodTargetSelector {
 					
 					System.err.println(builder.getClassHierarchy());
 					
-					IMethod method = script.getMethod(JavaScriptMethods.fnSelector);
+					IMethod method = script.getMethod(AstMethodReference.fnSelector);
 					previouslyRequired.put(sourceModule.getClassName(), method);
 					
 					return method;

--- a/com.ibm.wala.cast.js.rhino.test/.settings/org.eclipse.jdt.core.prefs
+++ b/com.ibm.wala.cast.js.rhino.test/.settings/org.eclipse.jdt.core.prefs
@@ -53,6 +53,7 @@ org.eclipse.jdt.core.compiler.problem.parameterAssignment=ignore
 org.eclipse.jdt.core.compiler.problem.possibleAccidentalBooleanAssignment=warning
 org.eclipse.jdt.core.compiler.problem.rawTypeReference=ignore
 org.eclipse.jdt.core.compiler.problem.redundantNullCheck=ignore
+org.eclipse.jdt.core.compiler.problem.reportMethodCanBePotentiallyStatic=ignore
 org.eclipse.jdt.core.compiler.problem.specialParameterHidingField=disabled
 org.eclipse.jdt.core.compiler.problem.staticAccessReceiver=warning
 org.eclipse.jdt.core.compiler.problem.suppressWarnings=enabled

--- a/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/examples/hybrid/Driver.java
+++ b/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/examples/hybrid/Driver.java
@@ -12,7 +12,6 @@ import com.ibm.wala.cast.js.ipa.callgraph.JSCallGraphUtil;
 import com.ibm.wala.cast.js.ipa.callgraph.JavaScriptConstructTargetSelector;
 import com.ibm.wala.cast.js.ipa.callgraph.JavaScriptEntryPoints;
 import com.ibm.wala.cast.js.loader.JavaScriptLoader;
-import com.ibm.wala.cast.js.test.JSCallGraphBuilderUtil;
 import com.ibm.wala.cast.js.translator.CAstRhinoTranslatorFactory;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.classLoader.Language;
@@ -57,7 +56,7 @@ public class Driver {
 
     scope.addToScope(
         scope.getJavaScriptLoader(),
-        JSCallGraphBuilderUtil.getPrologueFile("prologue.js"));
+        JSCallGraphUtil.getPrologueFile("prologue.js"));
     for(int i = 1; i < args.length; i++) {
       URL script = Driver.class.getClassLoader().getResource(args[i]);
       scope.addToScope(

--- a/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/test/TestRhinoSourceMap.java
+++ b/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/test/TestRhinoSourceMap.java
@@ -153,7 +153,7 @@ public class TestRhinoSourceMap {
 		  checkFunctionBodies("jquery_spec_test.js", jquery_spec_testSource);
 	  }
 
-	  private void checkFunctionBodies(String fileName, String[][] assertions) throws IOException, ClassHierarchyException {
+	  private static void checkFunctionBodies(String fileName, String[][] assertions) throws IOException, ClassHierarchyException {
 		  Map<String, String> sources = HashMapFactory.make();
 		  for(String[] assertion : assertions) {
 			  sources.put(assertion[0], assertion[1]);

--- a/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/vis/JsViewerDriver.java
+++ b/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/vis/JsViewerDriver.java
@@ -25,6 +25,7 @@ import com.ibm.wala.cast.js.html.WebPageLoaderFactory;
 import com.ibm.wala.cast.js.html.WebUtil;
 import com.ibm.wala.cast.js.html.jericho.JerichoHtmlParser;
 import com.ibm.wala.cast.js.ipa.callgraph.JSCFABuilder;
+import com.ibm.wala.cast.js.ipa.callgraph.JSCallGraphUtil;
 import com.ibm.wala.cast.js.loader.JavaScriptLoader;
 import com.ibm.wala.cast.js.test.JSCallGraphBuilderUtil;
 import com.ibm.wala.cast.js.translator.CAstRhinoTranslatorFactory;
@@ -49,7 +50,7 @@ public class JsViewerDriver extends JSCallGraphBuilderUtil {
 		URL url = new URL(args[0]); 
 		
 		// computing CG + PA
-		JSCallGraphBuilderUtil.setTranslatorFactory(new CAstRhinoTranslatorFactory());
+		JSCallGraphUtil.setTranslatorFactory(new CAstRhinoTranslatorFactory());
 		JavaScriptLoader.addBootstrapFile(WebUtil.preamble);
 
 		SourceModule[] sources = getSources(domless, url);

--- a/com.ibm.wala.cast.js.rhino/source/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
+++ b/com.ibm.wala.cast.js.rhino/source/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
@@ -213,7 +213,7 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
 
   }
 
-  private String operationReceiverName(int operationIndex) {
+  private static String operationReceiverName(int operationIndex) {
     return "$$destructure$rcvr" + operationIndex;
   }
 
@@ -221,7 +221,7 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
     return Ast.makeNode(CAstNode.VAR, Ast.makeConstant(operationReceiverName(operationIndex)));
   }
   
-  private String operationElementName(int operationIndex) {
+  private static String operationElementName(int operationIndex) {
     return "$$destructure$elt" + operationIndex;
   }
 
@@ -229,7 +229,7 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
     return Ast.makeNode(CAstNode.VAR, Ast.makeConstant(operationElementName(operationIndex)));
   }
 
-  private CAstNode translateOpcode(int nodeType) {
+  private static CAstNode translateOpcode(int nodeType) {
     switch (nodeType) {
     case Token.POS:
     case Token.ADD:
@@ -311,26 +311,26 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
     return makeCtorCall(value, arguments, context);
   }
 
-  private boolean isPrologueScript(WalkContext context) {
+  private static boolean isPrologueScript(WalkContext context) {
     return JavaScriptLoader.bootstrapFileNames.contains(context.script());
   }
 
-  private Node getCallTarget(FunctionCall n) {
+  private static Node getCallTarget(FunctionCall n) {
 	  return n.getTarget();
   }
   /**
    * is n a call to "primitive" within our synthetic modeling code?
    */
-  private boolean isPrimitiveCall(WalkContext context, FunctionCall n) {
+  private static boolean isPrimitiveCall(WalkContext context, FunctionCall n) {
     return isPrologueScript(context) && n.getType() == Token.CALL && getCallTarget(n).getType() == Token.NAME
         && getCallTarget(n).getString().equals("primitive");
   }
 
-  private Node getNewTarget(NewExpression n) {
+  private static Node getNewTarget(NewExpression n) {
 	  return n.getTarget();
   }
   
-  private boolean isPrimitiveCreation(WalkContext context, NewExpression n) {
+  private static boolean isPrimitiveCreation(WalkContext context, NewExpression n) {
 	  Node target = getNewTarget(n);
     return isPrologueScript(context) && n.getType() == Token.NEW && target.getType() == Token.NAME
         && target.getString().equals("Primitives");
@@ -585,14 +585,14 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
     return cn;
   }
   
-  private List<Label> getLabels(AstNode node) {
+  private static List<Label> getLabels(AstNode node) {
 	  if (node instanceof LabeledStatement || ((node = node.getParent()) instanceof LabeledStatement)) {
 		  return ((LabeledStatement)node).getLabels();
 	  } else {
 		  return null;
 	  }
   }
-  private AstNode makeEmptyLabelStmt(String label) {
+  private static AstNode makeEmptyLabelStmt(String label) {
 	  Label l = new Label();
 	  l.setName(label);
 	  LabeledStatement st = new LabeledStatement();
@@ -603,7 +603,7 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
 	  return st;
   }
   
-  private WalkContext makeLoopContext(AstNode node, WalkContext arg,
+  private static WalkContext makeLoopContext(AstNode node, WalkContext arg,
 			AstNode breakStmt, AstNode contStmt) {
 	  WalkContext loopContext = arg;
 	  List<Label> labels = getLabels(node);
@@ -617,7 +617,7 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
 	  return loopContext;
   }
 
-  private WalkContext makeBreakContext(AstNode node, WalkContext arg,
+  private static WalkContext makeBreakContext(AstNode node, WalkContext arg,
       AstNode breakStmt) {
     WalkContext loopContext = arg;
     List<Label> labels = getLabels(node);

--- a/com.ibm.wala.cast.js.test/.settings/org.eclipse.jdt.core.prefs
+++ b/com.ibm.wala.cast.js.test/.settings/org.eclipse.jdt.core.prefs
@@ -53,6 +53,7 @@ org.eclipse.jdt.core.compiler.problem.possibleAccidentalBooleanAssignment=warnin
 org.eclipse.jdt.core.compiler.problem.potentialNullReference=ignore
 org.eclipse.jdt.core.compiler.problem.rawTypeReference=ignore
 org.eclipse.jdt.core.compiler.problem.redundantNullCheck=ignore
+org.eclipse.jdt.core.compiler.problem.reportMethodCanBePotentiallyStatic=ignore
 org.eclipse.jdt.core.compiler.problem.specialParameterHidingField=disabled
 org.eclipse.jdt.core.compiler.problem.staticAccessReceiver=warning
 org.eclipse.jdt.core.compiler.problem.suppressWarnings=enabled

--- a/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/FieldBasedCGUtil.java
+++ b/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/FieldBasedCGUtil.java
@@ -78,7 +78,7 @@ public class FieldBasedCGUtil {
     JavaScriptLoaderFactory loaders = new JavaScriptLoaderFactory(translatorFactory);
     Module[] scripts = new Module[]{
         new SourceURLModule(url),
-        JSCallGraphBuilderUtil.getPrologueFile("prologue.js")
+        JSCallGraphUtil.getPrologueFile("prologue.js")
     };
     return buildCG(loaders, scripts, builderType, monitor, supportFullPointerAnalysis);
 	}

--- a/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/TestForInLoopHack.java
+++ b/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/TestForInLoopHack.java
@@ -172,7 +172,7 @@ public abstract class TestForInLoopHack extends TestJSCallGraphShape {
   }
   */
   
-  private void addHackedForInLoopSensitivity(JSCFABuilder builder) {
+  private static void addHackedForInLoopSensitivity(JSCFABuilder builder) {
     final ContextSelector orig = builder.getContextSelector();
     builder.setContextSelector(new PropertyNameContextSelector(builder.getAnalysisCache(), orig));
   }

--- a/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/TestPointerAnalyses.java
+++ b/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/TestPointerAnalyses.java
@@ -93,7 +93,7 @@ public abstract class TestPointerAnalyses {
     JSCallGraphUtil.setTranslatorFactory(factory);
   }
 
-  private Pair<CGNode, NewSiteReference> map(CallGraph CG, Pair<CGNode, NewSiteReference> ptr) {
+  private static Pair<CGNode, NewSiteReference> map(CallGraph CG, Pair<CGNode, NewSiteReference> ptr) {
     CGNode n = ptr.fst;
     
     if (! (n.getMethod() instanceof JavaScriptConstructor)) {
@@ -116,7 +116,7 @@ public abstract class TestPointerAnalyses {
     return Pair.make(caller, new NewSiteReference(site.getProgramCounter(), ptr.snd.getDeclaredType()));
   }
   
-  private Set<Pair<CGNode, NewSiteReference>> map(CallGraph CG, Set<Pair<CGNode, NewSiteReference>> ptrs) {
+  private static Set<Pair<CGNode, NewSiteReference>> map(CallGraph CG, Set<Pair<CGNode, NewSiteReference>> ptrs) {
     Set<Pair<CGNode, NewSiteReference>> result = HashSetFactory.make();
     for(Pair<CGNode, NewSiteReference> ptr : ptrs) {
       result.add(map(CG, ptr));
@@ -124,7 +124,7 @@ public abstract class TestPointerAnalyses {
     return result;
   }
   
-  private Set<Pair<CGNode, NewSiteReference>> ptrs(Set<CGNode> functions, int local, CallGraph CG, PointerAnalysis<? extends InstanceKey> pa) {
+  private static Set<Pair<CGNode, NewSiteReference>> ptrs(Set<CGNode> functions, int local, CallGraph CG, PointerAnalysis<? extends InstanceKey> pa) {
     Set<Pair<CGNode, NewSiteReference>> result = HashSetFactory.make();
 
     for(CGNode n : functions) {
@@ -144,7 +144,7 @@ public abstract class TestPointerAnalyses {
     return result;
   }
   
-  private boolean isGlobal(Set<CGNode> functions, int local, PointerAnalysis<? extends InstanceKey> pa) {
+  private static boolean isGlobal(Set<CGNode> functions, int local, PointerAnalysis<? extends InstanceKey> pa) {
     for(CGNode n : functions) {
       PointerKey l = pa.getHeapModel().getPointerKeyForLocal(n, local);
       if (l != null) {

--- a/com.ibm.wala.cast.js/.settings/org.eclipse.jdt.core.prefs
+++ b/com.ibm.wala.cast.js/.settings/org.eclipse.jdt.core.prefs
@@ -54,6 +54,7 @@ org.eclipse.jdt.core.compiler.problem.possibleAccidentalBooleanAssignment=warnin
 org.eclipse.jdt.core.compiler.problem.potentialNullReference=ignore
 org.eclipse.jdt.core.compiler.problem.rawTypeReference=ignore
 org.eclipse.jdt.core.compiler.problem.redundantNullCheck=ignore
+org.eclipse.jdt.core.compiler.problem.reportMethodCanBePotentiallyStatic=ignore
 org.eclipse.jdt.core.compiler.problem.specialParameterHidingField=disabled
 org.eclipse.jdt.core.compiler.problem.staticAccessReceiver=warning
 org.eclipse.jdt.core.compiler.problem.suppressWarnings=enabled

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/callgraph/fieldbased/FieldBasedCallGraphBuilder.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/callgraph/fieldbased/FieldBasedCallGraphBuilder.java
@@ -87,7 +87,7 @@ public abstract class FieldBasedCallGraphBuilder {
 		this.supportFullPointerAnalysis = supportFullPointerAnalysis;
 	}
 
-  private MethodTargetSelector setupMethodTargetSelector(IClassHierarchy cha, JavaScriptConstructorFunctions constructors2, AnalysisOptions options) {
+  private static MethodTargetSelector setupMethodTargetSelector(IClassHierarchy cha, JavaScriptConstructorFunctions constructors2, AnalysisOptions options) {
     MethodTargetSelector result = new JavaScriptConstructTargetSelector(constructors2, options.getMethodTargetSelector());
     if (options instanceof JSAnalysisOptions && ((JSAnalysisOptions)options).handleCallApply()) {
       result = new JavaScriptFunctionApplyTargetSelector(new JavaScriptFunctionDotCallTargetSelector(result));
@@ -243,7 +243,7 @@ public abstract class FieldBasedCallGraphBuilder {
   
   Everywhere targetContext = Everywhere.EVERYWHERE;
   @SuppressWarnings("deprecation")
-  private boolean addCGEdgeWithContext(final JSCallGraph cg, CallSiteReference site, IMethod target, CGNode caller,
+  private static boolean addCGEdgeWithContext(final JSCallGraph cg, CallSiteReference site, IMethod target, CGNode caller,
       Context targetContext) throws CancelException {
     boolean ret = false;
     if(target != null) {
@@ -266,14 +266,14 @@ public abstract class FieldBasedCallGraphBuilder {
    * FuncVertex nodes for the reflectively-invoked methods
    * @throws CancelException 
    */
-	private OrdinalSet<FuncVertex> getReflectiveTargets(FlowGraph flowGraph, CallVertex callVertex, IProgressMonitor monitor) throws CancelException {
+	private static OrdinalSet<FuncVertex> getReflectiveTargets(FlowGraph flowGraph, CallVertex callVertex, IProgressMonitor monitor) throws CancelException {
 	  SSAAbstractInvokeInstruction invoke = callVertex.getInstruction();
 	  VarVertex functionParam = flowGraph.getVertexFactory().makeVarVertex(callVertex.getCaller(), invoke.getUse(1));
 	  return flowGraph.getReachingSet(functionParam, monitor);
   }
 
   @SuppressWarnings("unused")
-  private OrdinalSet<FuncVertex> getConstructorTargets(FlowGraph flowGraph, CallVertex callVertex, IProgressMonitor monitor) throws CancelException {
+  private static OrdinalSet<FuncVertex> getConstructorTargets(FlowGraph flowGraph, CallVertex callVertex, IProgressMonitor monitor) throws CancelException {
     SSAAbstractInvokeInstruction invoke = callVertex.getInstruction();
     assert invoke.getDeclaredTarget().getName().equals(JavaScriptMethods.ctorAtom);
     VarVertex objectParam = flowGraph.getVertexFactory().makeVarVertex(callVertex.getCaller(), invoke.getUse(0));

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/callgraph/fieldbased/OptimisticCallgraphBuilder.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/callgraph/fieldbased/OptimisticCallgraphBuilder.java
@@ -93,7 +93,7 @@ public class OptimisticCallgraphBuilder extends FieldBasedCallGraphBuilder {
 	}
 
 	// add flow corresponding to a new call edge
-	private void addEdge(FlowGraph flowgraph, CallVertex c, FuncVertex callee, IProgressMonitor monitor) throws CancelException {
+	private static void addEdge(FlowGraph flowgraph, CallVertex c, FuncVertex callee, IProgressMonitor monitor) throws CancelException {
 	  VertexFactory factory = flowgraph.getVertexFactory();
 	  JavaScriptInvoke invk = c.getInstruction();
 	  FuncVertex caller = c.getCaller();
@@ -116,7 +116,7 @@ public class OptimisticCallgraphBuilder extends FieldBasedCallGraphBuilder {
 	
 	// add data flow corresponding to a reflective invocation via Function.prototype.call
 	// NB: for f.call(...), f will _not_ appear as a call target, but the appropriate argument and return data flow will be set up
-	private void addReflectiveCallEdge(FlowGraph flowgraph, CallVertex c, IProgressMonitor monitor) throws CancelException {
+	private static void addReflectiveCallEdge(FlowGraph flowgraph, CallVertex c, IProgressMonitor monitor) throws CancelException {
 	  VertexFactory factory = flowgraph.getVertexFactory();
 	  FuncVertex caller = c.getCaller();
 	  JavaScriptInvoke invk = c.getInstruction();

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/FlowGraph.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/FlowGraph.java
@@ -104,7 +104,7 @@ public class FlowGraph implements Iterable<Vertex> {
 		optimistic_closure = computeClosure(graph, monitor, FuncVertex.class);
 	}
 	
-	private <T> GraphReachability<Vertex, T> computeClosure(NumberedGraph<Vertex> graph, IProgressMonitor monitor, final Class<?> type) throws CancelException {
+	private static <T> GraphReachability<Vertex, T> computeClosure(NumberedGraph<Vertex> graph, IProgressMonitor monitor, final Class<?> type) throws CancelException {
 		// prune flowgraph by taking out 'unknown' vertex
 		Graph<Vertex> pruned_flowgraph = GraphSlicer.prune(graph, new Predicate<Vertex>() {
 			@Override

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/html/DefaultSourceExtractor.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/html/DefaultSourceExtractor.java
@@ -100,7 +100,7 @@ public class DefaultSourceExtractor extends DomLessSourceExtractor{
       domRegion.println("");
     }
 
-    private String makeRef(String object, String property) {
+    private static String makeRef(String object, String property) {
       assert object != null && property != null;
       return object + "[\"" + property + "\"]";
     }

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/html/DomLessSourceExtractor.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/html/DomLessSourceExtractor.java
@@ -140,7 +140,7 @@ public class DomLessSourceExtractor extends JSSourceExtractor {
       handleDOM(tag);
     }
 
-    private boolean isUsableIdentifier(String x) {
+    private static boolean isUsableIdentifier(String x) {
       return x != null &&
           LEGAL_JS_IDENTIFIER_REGEXP.matcher(x).matches() &&
           !LEGAL_JS_KEYWORD_REGEXP.matcher(x).matches();
@@ -217,7 +217,7 @@ public class DomLessSourceExtractor extends JSSourceExtractor {
       return Pair.make(value, quote);
     }
     
-    private String extructJS(String attValue) {
+    private static String extructJS(String attValue) {
       if (attValue == null){
         return "";
       }
@@ -350,7 +350,7 @@ public class DomLessSourceExtractor extends JSSourceExtractor {
     return new HtmlCallback(entrypointUrl, urlResolver);
   }
 
-  private File createOutputFile(URL url, boolean delete, boolean useTempName) throws IOException {
+  private static File createOutputFile(URL url, boolean delete, boolean useTempName) throws IOException {
     File outputFile;
     String fileName = new File(url.getFile()).getName();
     if (fileName.length() < 5) {

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionApplyContextInterpreter.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionApplyContextInterpreter.java
@@ -61,7 +61,7 @@ public class JavaScriptFunctionApplyContextInterpreter extends AstContextInsensi
     }
   }
 
-  private IR makeIRForArgList(CGNode node) {
+  private static IR makeIRForArgList(CGNode node) {
     // we have: v1 is dummy apply method
     // v2 is function to be invoked
     // v3 is argument to be passed as 'this'
@@ -121,7 +121,7 @@ public class JavaScriptFunctionApplyContextInterpreter extends AstContextInsensi
   }
 
   @SuppressWarnings("unused")
-  private int passArbitraryPropertyValAsParams(JSInstructionFactory insts, int nargs, JavaScriptSummary S, int[] paramsToPassToInvoked) {
+  private static int passArbitraryPropertyValAsParams(JSInstructionFactory insts, int nargs, JavaScriptSummary S, int[] paramsToPassToInvoked) {
     // read an arbitrary property name via EachElementGet
     int curValNum = nargs + 2;
     int eachElementGetResult = curValNum++;
@@ -139,7 +139,7 @@ public class JavaScriptFunctionApplyContextInterpreter extends AstContextInsensi
     return curValNum;
   }
   
-  private int passActualPropertyValsAsParams(JSInstructionFactory insts, int nargs, JavaScriptSummary S, int[] paramsToPassToInvoked) {
+  private static int passActualPropertyValsAsParams(JSInstructionFactory insts, int nargs, JavaScriptSummary S, int[] paramsToPassToInvoked) {
     // read an arbitrary property name via EachElementGet
     int nullVn = nargs + 2;
     S.addConstant(nullVn, new ConstantValue(null));
@@ -165,7 +165,7 @@ public class JavaScriptFunctionApplyContextInterpreter extends AstContextInsensi
     return curValNum;
   }
 
-  private IR makeIRForNoArgList(CGNode node) {
+  private static IR makeIRForNoArgList(CGNode node) {
     // kind of a hack; re-use the summarized function infrastructure
     MethodReference ref = node.getMethod().getReference();
     IClass declaringClass = node.getMethod().getDeclaringClass();

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionApplyTargetSelector.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionApplyTargetSelector.java
@@ -42,7 +42,7 @@ public class JavaScriptFunctionApplyTargetSelector implements MethodTargetSelect
     this.base = base;
   }
 
-  private IMethod createApplyDummyMethod(IClass declaringClass) {
+  private static IMethod createApplyDummyMethod(IClass declaringClass) {
     final MethodReference ref = genSyntheticMethodRef(declaringClass);
     // number of args doesn't matter
     JavaScriptSummary S = new JavaScriptSummary(ref, 1);
@@ -51,7 +51,7 @@ public class JavaScriptFunctionApplyTargetSelector implements MethodTargetSelect
 
   public static final String SYNTHETIC_APPLY_METHOD_PREFIX = "$$ apply_dummy";
 
-  private MethodReference genSyntheticMethodRef(IClass receiver) {
+  private static MethodReference genSyntheticMethodRef(IClass receiver) {
     Atom atom = Atom.findOrCreateUnicodeAtom(SYNTHETIC_APPLY_METHOD_PREFIX);
     Descriptor desc = Descriptor.findOrCreateUTF8(JavaScriptLoader.JS, "()LRoot;");
     MethodReference ref = MethodReference.findOrCreate(receiver.getReference(), atom, desc);

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionDotCallTargetSelector.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionDotCallTargetSelector.java
@@ -174,14 +174,14 @@ public class JavaScriptFunctionDotCallTargetSelector implements MethodTargetSele
 
   public static final String SYNTHETIC_CALL_METHOD_PREFIX = "$$ call_";
 
-  private MethodReference genSyntheticMethodRef(IClass receiver, int nargs, String key) {
+  private static MethodReference genSyntheticMethodRef(IClass receiver, int nargs, String key) {
     Atom atom = Atom.findOrCreateUnicodeAtom(SYNTHETIC_CALL_METHOD_PREFIX + key);
     Descriptor desc = Descriptor.findOrCreateUTF8(JavaScriptLoader.JS, "()LRoot;");
     MethodReference ref = MethodReference.findOrCreate(receiver.getReference(), atom, desc);
     return ref;
   }
 
-  private String getKey(int nargs, CGNode caller, CallSiteReference site) {
+  private static String getKey(int nargs, CGNode caller, CallSiteReference site) {
     if (SEPARATE_SYNTHETIC_METHOD_PER_SITE) {
       return JSCallGraphUtil.getShortName(caller) + "_" + caller.getGraphNodeId() + "_" + site.getProgramCounter();
     } else {
@@ -189,7 +189,7 @@ public class JavaScriptFunctionDotCallTargetSelector implements MethodTargetSele
     }
   }
 
-  private int getNumberOfArgsPassed(CGNode caller, CallSiteReference site) {
+  private static int getNumberOfArgsPassed(CGNode caller, CallSiteReference site) {
     IR callerIR = caller.getIR();
     SSAAbstractInvokeInstruction callStmts[] = callerIR.getCalls(site);
     assert callStmts.length == 1;

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionDotCallTargetSelector.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionDotCallTargetSelector.java
@@ -12,6 +12,7 @@ package com.ibm.wala.cast.js.ipa.callgraph;
 
 import java.util.Map;
 
+import com.ibm.wala.cast.ipa.callgraph.CAstCallGraphUtil;
 import com.ibm.wala.cast.js.ipa.summaries.JavaScriptSummarizedFunction;
 import com.ibm.wala.cast.js.ipa.summaries.JavaScriptSummary;
 import com.ibm.wala.cast.js.loader.JSCallSiteReference;
@@ -183,7 +184,7 @@ public class JavaScriptFunctionDotCallTargetSelector implements MethodTargetSele
 
   private static String getKey(int nargs, CGNode caller, CallSiteReference site) {
     if (SEPARATE_SYNTHETIC_METHOD_PER_SITE) {
-      return JSCallGraphUtil.getShortName(caller) + "_" + caller.getGraphNodeId() + "_" + site.getProgramCounter();
+      return CAstCallGraphUtil.getShortName(caller) + "_" + caller.getGraphNodeId() + "_" + site.getProgramCounter();
     } else {
       return ""+nargs;
     }

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/LoadFileTargetSelector.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/LoadFileTargetSelector.java
@@ -18,7 +18,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import com.ibm.wala.cast.js.loader.JavaScriptLoader;
-import com.ibm.wala.cast.js.types.JavaScriptMethods;
 import com.ibm.wala.cast.js.types.JavaScriptTypes;
 import com.ibm.wala.cast.types.AstMethodReference;
 import com.ibm.wala.classLoader.CallSiteReference;
@@ -79,7 +78,7 @@ public class LoadFileTargetSelector implements MethodTargetSelector {
               JSCallGraphUtil.loadAdditionalFile(builder.getClassHierarchy() , cl, url);
               loadedFiles.add(url);
               IClass script = builder.getClassHierarchy().lookupClass(TypeReference.findOrCreate(cl.getReference(), "L" + url.getFile()));
-              return script.getMethod(JavaScriptMethods.fnSelector);
+              return script.getMethod(AstMethodReference.fnSelector);
             }
           } catch (MalformedURLException e1) {
             // do nothing, fall through and return 'target'

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/RecursionCheckContextSelector.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/RecursionCheckContextSelector.java
@@ -61,7 +61,7 @@ public class RecursionCheckContextSelector implements ContextSelector {
     return baseContext;
   }
 
-  private boolean recursiveContext(Context baseContext, IMethod callee) {
+  private static boolean recursiveContext(Context baseContext, IMethod callee) {
     if (!recursionPossible(callee)) {
       return false;
     }
@@ -100,7 +100,7 @@ public class RecursionCheckContextSelector implements ContextSelector {
     return false;
   }
 
-  private boolean updateForNode(Context baseContext, Collection<IMethod> curEncountered, LinkedList<Pair<Context, Collection<IMethod>>> worklist, CGNode callerNode) {
+  private static boolean updateForNode(Context baseContext, Collection<IMethod> curEncountered, LinkedList<Pair<Context, Collection<IMethod>>> worklist, CGNode callerNode) {
     final IMethod method = callerNode.getMethod();
     if (!recursionPossible(method)) {
       assert !curEncountered.contains(method);
@@ -132,7 +132,7 @@ public class RecursionCheckContextSelector implements ContextSelector {
    * @param m
    * @return
    */
-  private boolean recursionPossible(IMethod m) {
+  private static boolean recursionPossible(IMethod m) {
     // object or array constructors cannot be involved
     if (m.getReference().getName().equals(JavaScriptMethods.ctorAtom)) {
       TypeReference declaringClass = m.getReference().getDeclaringClass();

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/correlations/CorrelationFinder.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/correlations/CorrelationFinder.java
@@ -244,7 +244,7 @@ public class CorrelationFinder {
     printCorrelatedAccesses(findCorrelatedAccesses(url));
   }
 
-  private void printCorrelatedAccesses(Map<IMethod, CorrelationSummary> summaries) {
+  private static void printCorrelatedAccesses(Map<IMethod, CorrelationSummary> summaries) {
     List<Pair<Position, String>> correlations = new ArrayList<>();
     for(CorrelationSummary summary : summaries.values())
       correlations.addAll(summary.pp());

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/ClosureExtractor.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/ClosureExtractor.java
@@ -666,7 +666,7 @@ public class ClosureExtractor extends CAstRewriterExt {
     return stmts;
   }
   
-  private CAstNode addSpuriousExnFlow(CAstNode node, CAstControlFlowMap cfg) {
+  private static CAstNode addSpuriousExnFlow(CAstNode node, CAstControlFlowMap cfg) {
     CAstControlFlowRecorder flow = (CAstControlFlowRecorder)cfg;
     if(node.getKind() == ASSIGN) {
       if(node.getChild(0).getKind() == VAR) {

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/CorrelatedPairExtractionPolicy.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/CorrelatedPairExtractionPolicy.java
@@ -179,7 +179,7 @@ public class CorrelatedPairExtractionPolicy extends ExtractionPolicy {
     return true;
   }
   
-  private void filterNames(Set<ChildPos> nodes, String indexName) {
+  private static void filterNames(Set<ChildPos> nodes, String indexName) {
     for(Iterator<ChildPos> iter=nodes.iterator();iter.hasNext();) {
       CAstNode node = iter.next().getChild();
       if(node.getKind() == CAstNode.OBJECT_REF) {
@@ -191,7 +191,7 @@ public class CorrelatedPairExtractionPolicy extends ExtractionPolicy {
     }
   }
 
-  private Pair<CAstNode, ? extends ExtractionRegion> findClosestContainingBlock(CAstEntity entity, ChildPos startNode, ChildPos endNode, String parmName, List<String> locals) {
+  private static Pair<CAstNode, ? extends ExtractionRegion> findClosestContainingBlock(CAstEntity entity, ChildPos startNode, ChildPos endNode, String parmName, List<String> locals) {
     ChildPos pos = startNode;
     CAstNode block = null;
     int start = -1, end = 0;

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/summaries/JavaScriptConstructorFunctions.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/summaries/JavaScriptConstructorFunctions.java
@@ -88,7 +88,7 @@ public class JavaScriptConstructorFunctions {
     return m;
   }
 
-  private IMethod makeNullaryValueConstructor(IClass cls, Object value) {
+  private static IMethod makeNullaryValueConstructor(IClass cls, Object value) {
     JSInstructionFactory insts = (JSInstructionFactory)cls.getClassLoader().getInstructionFactory();
     MethodReference ref = JavaScriptMethods.makeCtorReference(cls.getReference());
     JavaScriptSummary S = new JavaScriptSummary(ref, 1);
@@ -118,7 +118,7 @@ public class JavaScriptConstructorFunctions {
     return new JavaScriptConstructor(ref, S, cls, cls);
   }
 
-  private IMethod makeUnaryValueConstructor(IClass cls) {
+  private static IMethod makeUnaryValueConstructor(IClass cls) {
     JSInstructionFactory insts = (JSInstructionFactory)cls.getClassLoader().getInstructionFactory();
    MethodReference ref = JavaScriptMethods.makeCtorReference(cls.getReference());
     JavaScriptSummary S = new JavaScriptSummary(ref, 2);

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/translator/JSAstTranslator.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/translator/JSAstTranslator.java
@@ -54,7 +54,7 @@ public class JSAstTranslator extends AstTranslator {
     super(loader);
   }
 
-  private boolean isPrologueScript(WalkContext context) {
+  private static boolean isPrologueScript(WalkContext context) {
     return JavaScriptLoader.bootstrapFileNames.contains( context.getModule().getName() );
   }
 

--- a/com.ibm.wala.cast.test/.settings/org.eclipse.jdt.core.prefs
+++ b/com.ibm.wala.cast.test/.settings/org.eclipse.jdt.core.prefs
@@ -52,6 +52,7 @@ org.eclipse.jdt.core.compiler.problem.parameterAssignment=ignore
 org.eclipse.jdt.core.compiler.problem.possibleAccidentalBooleanAssignment=warning
 org.eclipse.jdt.core.compiler.problem.rawTypeReference=ignore
 org.eclipse.jdt.core.compiler.problem.redundantNullCheck=ignore
+org.eclipse.jdt.core.compiler.problem.reportMethodCanBePotentiallyStatic=ignore
 org.eclipse.jdt.core.compiler.problem.specialParameterHidingField=disabled
 org.eclipse.jdt.core.compiler.problem.staticAccessReceiver=warning
 org.eclipse.jdt.core.compiler.problem.suppressWarnings=enabled

--- a/com.ibm.wala.cast.test/harness-src/com/ibm/wala/cast/test/TestCAstPattern.java
+++ b/com.ibm.wala.cast.test/harness-src/com/ibm/wala/cast/test/TestCAstPattern.java
@@ -60,7 +60,7 @@ public class TestCAstPattern extends WalaTestCase {
 
   }
 
-  private void test(CAstPattern p, CAstNode n, Map names) {
+  private static void test(CAstPattern p, CAstNode n, Map names) {
     System.err.println(("testing pattern " + p));
     System.err.println(("testing with input " + CAstPrinter.print(n)));
 

--- a/com.ibm.wala.cast/.settings/org.eclipse.jdt.core.prefs
+++ b/com.ibm.wala.cast/.settings/org.eclipse.jdt.core.prefs
@@ -54,6 +54,7 @@ org.eclipse.jdt.core.compiler.problem.possibleAccidentalBooleanAssignment=warnin
 org.eclipse.jdt.core.compiler.problem.potentialNullReference=ignore
 org.eclipse.jdt.core.compiler.problem.rawTypeReference=ignore
 org.eclipse.jdt.core.compiler.problem.redundantNullCheck=ignore
+org.eclipse.jdt.core.compiler.problem.reportMethodCanBePotentiallyStatic=ignore
 org.eclipse.jdt.core.compiler.problem.specialParameterHidingField=disabled
 org.eclipse.jdt.core.compiler.problem.staticAccessReceiver=warning
 org.eclipse.jdt.core.compiler.problem.suppressWarnings=enabled

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/callgraph/AstSSAPropagationCallGraphBuilder.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/callgraph/AstSSAPropagationCallGraphBuilder.java
@@ -357,7 +357,7 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
       return ((AstPointerKeyFactory) getBuilder().getPointerKeyFactory()).getPointerKeysForReflectedFieldWrite(I, F);
     }
 
-    private void visitLexical(AstLexicalAccess instruction, final LexicalOperator op) {
+    private static void visitLexical(AstLexicalAccess instruction, final LexicalOperator op) {
       op.doLexicalPointerKeys(false);
       // I have no idea what the code below does, but commenting it out doesn't
       // break any regression tests. --MS

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/AbstractSSAConversion.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/AbstractSSAConversion.java
@@ -306,15 +306,15 @@ public abstract class AbstractSSAConversion {
     }
   }
 
-   private <T> void push(ArrayList<T> stack, T elt) {
+   private static <T> void push(ArrayList<T> stack, T elt) {
     stack.add(elt);
   }
   
-  private <T> T peek(ArrayList<T> stack) {
+  private static <T> T peek(ArrayList<T> stack) {
     return stack.get(stack.size()-1); 
   }
   
-  private <T> T pop(ArrayList<T> stack) {
+  private static <T> T pop(ArrayList<T> stack) {
     T e = stack.get(stack.size()-1);
     stack.remove(stack.size()-1);
     return e;

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/SSAConversion.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/SSAConversion.java
@@ -332,11 +332,11 @@ public class SSAConversion extends AbstractSSAConversion {
     return null;
   }
 
-  private <T> void push(ArrayList<T> stack, T elt) {
+  private static <T> void push(ArrayList<T> stack, T elt) {
     stack.add(elt);
   }
   
-  private <T> T peek(ArrayList<T> stack) {
+  private static <T> T peek(ArrayList<T> stack) {
     return stack.get(stack.size()-1); 
   }
 

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
@@ -3153,7 +3153,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
     return map;
   }
 
-  protected final CAstType getTypeForNode(WalkContext context, CAstNode node) {
+  protected final static CAstType getTypeForNode(WalkContext context, CAstNode node) {
     if (context.top().getNodeTypeMap() != null) {
       return context.top().getNodeTypeMap().getNodeType(node);
     } else {

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
@@ -342,7 +342,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
    * call sites, as would be required for
    * {@link #doLexicallyScopedRead(CAstNode, WalkContext, String)}
    */
-  private int doLexReadHelper(WalkContext context, final String name, TypeReference type) {
+  private static int doLexReadHelper(WalkContext context, final String name, TypeReference type) {
     Symbol S = context.currentScope().lookup(name);
     Scope definingScope = S.getDefiningScope();
     CAstEntity E = definingScope.getEntity();
@@ -369,7 +369,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
    * @param entityName
    * @param isWrite
    */
-  private void markExposedInEnclosingEntities(WalkContext context, final String name, Scope definingScope, TypeReference type, CAstEntity E,
+  private static void markExposedInEnclosingEntities(WalkContext context, final String name, Scope definingScope, TypeReference type, CAstEntity E,
       final String entityName, boolean isWrite) {
     Scope curScope = context.currentScope();
     while (!curScope.equals(definingScope)) {
@@ -1158,7 +1158,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
       }
     }
     
-    private boolean checkBlockBoundaries(IncipientCFG icfg) {
+    private static boolean checkBlockBoundaries(IncipientCFG icfg) {
       MutableIntSet boundaries = IntSetUtil.make();
       for(PreBasicBlock b : icfg) {
         if (b.getFirstInstructionIndex() >= 0) {
@@ -2798,7 +2798,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
       readOnlyNames = original.readOnlyNames;
     }
 
-    private int[] buildLexicalUseArray(Pair<Pair<String, String>, Integer>[] exposedNames, String entityName) {
+    private static int[] buildLexicalUseArray(Pair<Pair<String, String>, Integer>[] exposedNames, String entityName) {
       if (exposedNames != null) {
         int[] lexicalUses = new int[exposedNames.length];
         for (int j = 0; j < exposedNames.length; j++) {
@@ -2815,7 +2815,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
       }
     }
 
-    private Pair<String, String>[] buildLexicalNamesArray(Pair<Pair<String, String>, Integer>[] exposedNames) {
+    private static Pair<String, String>[] buildLexicalNamesArray(Pair<Pair<String, String>, Integer>[] exposedNames) {
       if (exposedNames != null) {
         @SuppressWarnings("unchecked")
         Pair<String, String>[] lexicalNames = new Pair[exposedNames.length];
@@ -2993,7 +2993,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
    * used to update an instruction that performs all the accesses at the
    * beginning of the method and defines the locals.
    */
-  private void addAccess(WalkContext context, CAstEntity e, Access access) {
+  private static void addAccess(WalkContext context, CAstEntity e, Access access) {
     context.getAccesses(e).add(access);
   }
 
@@ -3016,7 +3016,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
    * @param valueNumber
    *          the name's value number in the scope of entity
    */
-  private void addExposedName(CAstEntity entity, CAstEntity declaration, String name, int valueNumber, boolean isWrite, WalkContext context) {
+  private static void addExposedName(CAstEntity entity, CAstEntity declaration, String name, int valueNumber, boolean isWrite, WalkContext context) {
     Pair<Pair<String, String>, Integer> newVal = Pair.make(Pair.make(name, context.getEntityName(declaration)), valueNumber);
     context.exposeNameSet(entity, isWrite).add(newVal);
   }
@@ -3624,7 +3624,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
     return false;
   }
 
-  private boolean handleBinaryOpThrow(CAstNode n, CAstNode op, WalkContext context) {
+  private static boolean handleBinaryOpThrow(CAstNode n, CAstNode op, WalkContext context) {
     // currently, only integer / and % throw exceptions
     boolean mayBeInteger = false;
     Collection labels = context.getControlFlow().getTargetLabels(n);
@@ -3997,7 +3997,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
     }
   }
 
-  private int[] gatherArrayDims(WalkContext c, CAstNode n) {
+  private static int[] gatherArrayDims(WalkContext c, CAstNode n) {
     int numDims = n.getChildCount() - 2;
     int[] dims = new int[numDims];
     for (int i = 0; i < numDims; i++)
@@ -4175,7 +4175,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
     }
   }
 
-  private boolean isSimpleSwitch(CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
+  private static boolean isSimpleSwitch(CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
     CAstControlFlowMap ctrl = context.getControlFlow();
     Collection caseLabels = ctrl.getTargetLabels(n);
     for (Iterator kases = caseLabels.iterator(); kases.hasNext();) {

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/util/CAstPrinter.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/util/CAstPrinter.java
@@ -192,7 +192,7 @@ public class CAstPrinter {
       instance.doXmlTo(top, pos, w);
   }
 
-  private void doXmlTo(CAstNode top, CAstSourcePositionMap pos, Writer w) {
+  private static void doXmlTo(CAstNode top, CAstSourcePositionMap pos, Writer w) {
     printTo(top, pos, w, 0, true);
   }
 

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/util/CAstPrinter.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/util/CAstPrinter.java
@@ -189,7 +189,7 @@ public class CAstPrinter {
   }
 
   public static void xmlTo(CAstNode top, CAstSourcePositionMap pos, Writer w) {
-      instance.doXmlTo(top, pos, w);
+      doXmlTo(top, pos, w);
   }
 
   private static void doXmlTo(CAstNode top, CAstSourcePositionMap pos, Writer w) {

--- a/com.ibm.wala.core.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/com.ibm.wala.core.tests/.settings/org.eclipse.jdt.core.prefs
@@ -54,6 +54,7 @@ org.eclipse.jdt.core.compiler.problem.possibleAccidentalBooleanAssignment=warnin
 org.eclipse.jdt.core.compiler.problem.potentialNullReference=ignore
 org.eclipse.jdt.core.compiler.problem.rawTypeReference=ignore
 org.eclipse.jdt.core.compiler.problem.redundantNullCheck=ignore
+org.eclipse.jdt.core.compiler.problem.reportMethodCanBePotentiallyStatic=ignore
 org.eclipse.jdt.core.compiler.problem.specialParameterHidingField=disabled
 org.eclipse.jdt.core.compiler.problem.staticAccessReceiver=warning
 org.eclipse.jdt.core.compiler.problem.suppressWarnings=enabled

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/basic/PrimitivesTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/basic/PrimitivesTest.java
@@ -64,7 +64,7 @@ public class PrimitivesTest extends WalaTestCase {
   /**
    * Test the MutableSparseIntSet implementation
    */
-  private void doMutableIntSet(MutableIntSetFactory factory) {
+  private static void doMutableIntSet(MutableIntSetFactory factory) {
     MutableIntSet v = factory.parse("{9,17}");
     MutableIntSet w = factory.make(new int[] {});
     MutableIntSet x = factory.make(new int[] { 7, 4, 2, 4, 2, 2 });
@@ -351,7 +351,7 @@ public class PrimitivesTest extends WalaTestCase {
   /**
    * Test the MutableSparseIntSet implementation
    */
-  private void doMutableLongSet(MutableLongSetFactory factory) {
+  private static void doMutableLongSet(MutableLongSetFactory factory) {
     MutableLongSet v = factory.parse("{9,17}");
     MutableLongSet w = factory.make(new long[] {});
     MutableLongSet x = factory.make(new long[] { 7, 4, 2, 4, 2, 2 });
@@ -707,7 +707,7 @@ public class PrimitivesTest extends WalaTestCase {
     Assert.assertTrue(c.size() == 10);
   }
 
-  private NumberedGraph<Integer> makeBFSTestGraph() {
+  private static NumberedGraph<Integer> makeBFSTestGraph() {
     // test graph
     NumberedGraph<Integer> G = SlowSparseNumberedGraph.make();
 
@@ -859,7 +859,7 @@ public class PrimitivesTest extends WalaTestCase {
     Assert.assertTrue("Got count " + count, count == 2);
   }
 
-  private int countEquivalenceClasses(IntegerUnionFind uf) {
+  private static int countEquivalenceClasses(IntegerUnionFind uf) {
     HashSet<Integer> s = HashSetFactory.make();
     for (int i = 0; i < uf.size(); i++) {
       s.add(new Integer(uf.find(i)));
@@ -891,7 +891,7 @@ public class PrimitivesTest extends WalaTestCase {
     testSingleBitVector(new OffsetBitVector(100, 10));
   }
 
-  private void testSingleBitVector(BitVectorBase bv) {
+  private static void testSingleBitVector(BitVectorBase bv) {
     // does the following not automatically scale the bitvector to
     // a reasonable size?
     bv.set(55);
@@ -960,7 +960,7 @@ public class PrimitivesTest extends WalaTestCase {
   }
 
   @SuppressWarnings("unchecked")
-  private <T extends BitVectorBase> void testBitVectors(T v1, T v2) {
+  private static <T extends BitVectorBase> void testBitVectors(T v1, T v2) {
     v1.set(100);
     v1.set(101);
     v1.set(102);

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/CPATest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/CPATest.java
@@ -50,7 +50,7 @@ public class CPATest extends WalaTestCase {
     doCPATest("Lcpa/CPATest2", "(Lcpa/CPATest2$N;I)Lcpa/CPATest2$N;");
   }
 
-  private void doCPATest(String testClass, String testIdSignature) throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+  private static void doCPATest(String testClass, String testIdSignature) throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
 
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.WALA_TESTDATA, CallGraphTestUtil.REGRESSION_EXCLUSIONS);
     ClassHierarchy cha = ClassHierarchyFactory.make(scope);

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/PiNodeCallGraphTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/PiNodeCallGraphTest.java
@@ -74,7 +74,7 @@ public class PiNodeCallGraphTest extends WalaTestCase {
   private static final MemberReference unary2Ref = MethodReference.findOrCreate(whateverRef,
       Atom.findOrCreateUnicodeAtom("unary2"), Descriptor.findOrCreateUTF8("()V"));
 
-  private CallGraph doGraph(boolean usePiNodes) throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+  private static CallGraph doGraph(boolean usePiNodes) throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.WALA_TESTDATA, CallGraphTestUtil.REGRESSION_EXCLUSIONS);
     ClassHierarchy cha = ClassHierarchyFactory.make(scope);
     Iterable<Entrypoint> entrypoints = com.ibm.wala.ipa.callgraph.impl.Util.makeMainEntrypoints(scope, cha,
@@ -86,7 +86,7 @@ public class PiNodeCallGraphTest extends WalaTestCase {
     return CallGraphTestUtil.buildZeroCFA(options, new AnalysisCacheImpl(new DefaultIRFactory(), options.getSSAOptions()), cha, scope, false);
   }
 
-  private void checkCallAssertions(CallGraph cg, int desiredNumberOfTargets, int desiredNumberOfCalls, int numLocalCastCallees) {
+  private static void checkCallAssertions(CallGraph cg, int desiredNumberOfTargets, int desiredNumberOfCalls, int numLocalCastCallees) {
   
     int numberOfCalls = 0;
     Set<CGNode> callerNodes = HashSetFactory.make();

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/ReflectionTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/ReflectionTest.java
@@ -316,7 +316,7 @@ public class ReflectionTest extends WalaTestCase {
     Assert.assertTrue(filePermToStringNode != null);
   }
 
-  private Collection<CGNode> getSuccNodes(CallGraph cg, Collection<CGNode> nodes) {
+  private static Collection<CGNode> getSuccNodes(CallGraph cg, Collection<CGNode> nodes) {
     Set<CGNode> succNodes = HashSetFactory.make();
     for (CGNode newInstanceNode : nodes) {
       Iterator<? extends CGNode> succNodesIter = cg.getSuccNodes(newInstanceNode);

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/collections/SemiSparseMutableIntSetTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/collections/SemiSparseMutableIntSetTest.java
@@ -36,6 +36,7 @@ public final class SemiSparseMutableIntSetTest extends WalaTestCase {
   
   // --- Test cases
   
+  @SuppressWarnings("static-method")
   @Test public void testCase1() {
     final SemiSparseMutableIntSet ssmIntSet = new SemiSparseMutableIntSet();
     ssmIntSet.add(1);

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/collections/TwoLevelVectorTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/collections/TwoLevelVectorTest.java
@@ -37,6 +37,7 @@ public final class TwoLevelVectorTest extends WalaTestCase {
   
   // --- Test cases
   
+  @SuppressWarnings("static-method")
   @Test public void testCase1() {
     final TwoLevelVector<Integer> tlVector = new TwoLevelVector<>();
     tlVector.iterator();

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/demandpa/AbstractPtrTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/demandpa/AbstractPtrTest.java
@@ -258,7 +258,7 @@ public abstract class AbstractPtrTest {
    * @return
    * @throws ClassHierarchyException
    */
-  private IClassHierarchy findOrCreateCHA(AnalysisScope scope) throws ClassHierarchyException {
+  private static IClassHierarchy findOrCreateCHA(AnalysisScope scope) throws ClassHierarchyException {
     if (cachedCHA == null) {
       cachedCHA = ClassHierarchyFactory.make(scope);
     }

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/exceptionpruning/ExceptionAnalysis2EdgeFilterTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/exceptionpruning/ExceptionAnalysis2EdgeFilterTest.java
@@ -177,7 +177,7 @@ public class ExceptionAnalysis2EdgeFilterTest {
     }
   }
 
-  private void checkRemovingNormalOk(CGNode node, ControlFlowGraph<SSAInstruction, ISSABasicBlock> cfg, ISSABasicBlock block,
+  private static void checkRemovingNormalOk(CGNode node, ControlFlowGraph<SSAInstruction, ISSABasicBlock> cfg, ISSABasicBlock block,
       ISSABasicBlock normalSucc) {
     if (!block.getLastInstruction().isPEI() || !filter.getFilter(node).alwaysThrowsException(block.getLastInstruction())) {
       specialCaseThrowFiltered(cfg, normalSucc);
@@ -197,7 +197,7 @@ public class ExceptionAnalysis2EdgeFilterTest {
    * @param cfg
    * @param normalSucc
    */
-  private void specialCaseThrowFiltered(ControlFlowGraph<SSAInstruction, ISSABasicBlock> cfg, ISSABasicBlock normalSucc) {
+  private static void specialCaseThrowFiltered(ControlFlowGraph<SSAInstruction, ISSABasicBlock> cfg, ISSABasicBlock normalSucc) {
     ISSABasicBlock next = normalSucc;
     while (!(next.getLastInstruction() instanceof SSAThrowInstruction)) {
       assertTrue(cfg.getNormalSuccessors(next).iterator().hasNext());
@@ -205,7 +205,7 @@ public class ExceptionAnalysis2EdgeFilterTest {
     }
   }
 
-  private void checkNoNewEdges(ControlFlowGraph<SSAInstruction, ISSABasicBlock> original,
+  private static void checkNoNewEdges(ControlFlowGraph<SSAInstruction, ISSABasicBlock> original,
       ControlFlowGraph<SSAInstruction, ISSABasicBlock> filtered) {
     for (ISSABasicBlock block : filtered) {
       for (ISSABasicBlock normalSucc : filtered.getNormalSuccessors(block)) {

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ir/DeterministicIRTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ir/DeterministicIRTest.java
@@ -98,7 +98,7 @@ public class DeterministicIRTest extends WalaTestCase {
   /**
    * @param iterator
    */
-  private void checkNoneNull(Iterator<?> iterator) {
+  private static void checkNoneNull(Iterator<?> iterator) {
     while (iterator.hasNext()) {
       Assert.assertTrue(iterator.next() != null);
     }

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/shrike/DynamicCallGraphTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/shrike/DynamicCallGraphTest.java
@@ -42,7 +42,7 @@ public class DynamicCallGraphTest extends DynamicCallGraphTestBase {
     this(getClasspathEntry("com.ibm.wala.core.testdata"));
   }
   
-  private CallGraph staticCG(String mainClass, String exclusionsFile) throws IOException, ClassHierarchyException, IllegalArgumentException, CancelException {
+  private static CallGraph staticCG(String mainClass, String exclusionsFile) throws IOException, ClassHierarchyException, IllegalArgumentException, CancelException {
     AnalysisScope scope = CallGraphTestUtil.makeJ2SEAnalysisScope(TestConstants.WALA_TESTDATA, exclusionsFile != null? exclusionsFile: CallGraphTestUtil.REGRESSION_EXCLUSIONS);
     ClassHierarchy cha = ClassHierarchyFactory.make(scope);
     Iterable<Entrypoint> entrypoints = com.ibm.wala.ipa.callgraph.impl.Util.makeMainEntrypoints(scope, cha, mainClass);

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/shrike/DynamicCallGraphTestBase.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/shrike/DynamicCallGraphTestBase.java
@@ -143,7 +143,7 @@ public abstract class DynamicCallGraphTestBase extends WalaTestCase {
     void edgesTest(CallGraph staticCG, CGNode caller, MethodReference callee);
   }
  
-  private MethodReference callee(String calleeClass, String calleeMethod) {
+  private static MethodReference callee(String calleeClass, String calleeMethod) {
       return MethodReference.findOrCreate(TypeReference.findOrCreate(ClassLoaderReference.Application, "L" + calleeClass), Selector.make(calleeMethod));
   }
 

--- a/com.ibm.wala.dalvik.test/.settings/org.eclipse.jdt.core.prefs
+++ b/com.ibm.wala.dalvik.test/.settings/org.eclipse.jdt.core.prefs
@@ -45,6 +45,7 @@ org.eclipse.jdt.core.compiler.problem.parameterAssignment=ignore
 org.eclipse.jdt.core.compiler.problem.possibleAccidentalBooleanAssignment=warning
 org.eclipse.jdt.core.compiler.problem.rawTypeReference=ignore
 org.eclipse.jdt.core.compiler.problem.redundantNullCheck=ignore
+org.eclipse.jdt.core.compiler.problem.reportMethodCanBePotentiallyStatic=ignore
 org.eclipse.jdt.core.compiler.problem.specialParameterHidingField=disabled
 org.eclipse.jdt.core.compiler.problem.staticAccessReceiver=warning
 org.eclipse.jdt.core.compiler.problem.suppressWarnings=enabled

--- a/com.ibm.wala.dalvik/.settings/org.eclipse.jdt.core.prefs
+++ b/com.ibm.wala.dalvik/.settings/org.eclipse.jdt.core.prefs
@@ -25,6 +25,7 @@ org.eclipse.jdt.core.compiler.problem.missingJavadocTagDescription=return_tag
 org.eclipse.jdt.core.compiler.problem.invalidJavadocTagsNotVisibleRef=disabled
 org.eclipse.jdt.core.compiler.problem.missingJavadocTags=ignore
 org.eclipse.jdt.core.compiler.problem.potentialNullReference=ignore
+org.eclipse.jdt.core.compiler.problem.reportMethodCanBePotentiallyStatic=ignore
 org.eclipse.jdt.core.compiler.problem.syntheticAccessEmulation=ignore
 org.eclipse.jdt.core.compiler.problem.undocumentedEmptyBlock=ignore
 org.eclipse.jdt.core.compiler.problem.unnecessaryElse=ignore

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/analysis/typeInference/DalvikTypeInference.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/analysis/typeInference/DalvikTypeInference.java
@@ -94,7 +94,7 @@ public class DalvikTypeInference extends TypeInference {
 			}
 		}
 
-		private boolean containsNonPrimitiveAndZero(DalvikTypeVariable[] types) {
+		private static boolean containsNonPrimitiveAndZero(DalvikTypeVariable[] types) {
 			boolean containsNonPrimitive = false;
 			boolean containsZero = false;
 			for (int i = 0; i < types.length; i++) {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/DexIMethod.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/DexIMethod.java
@@ -3136,7 +3136,7 @@ public class DexIMethod implements IBytecodeMethod {
 		//      //comment out stop
 	}
 
-	private TypeReference findOutArrayElementType(
+	private static TypeReference findOutArrayElementType(
 			org.jf.dexlib.Code.Instruction[] instrucs, Instruction[] walaInstructions, int instCounter) {
 		if (instCounter < 0 || instrucs[instCounter].opcode != Opcode.FILL_ARRAY_DATA) {
 			throw new IllegalArgumentException();

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/WDexClassLoaderImpl.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/WDexClassLoaderImpl.java
@@ -119,7 +119,7 @@ public class WDexClassLoaderImpl extends ClassLoaderImpl {
     /**
      * Remove from s any class file module entries which already are in t
      */
-    private void removeClassFiles(Set<ModuleEntry> s, Set<ModuleEntry> t) {
+    private static void removeClassFiles(Set<ModuleEntry> s, Set<ModuleEntry> t) {
     	Set<String> old = HashSetFactory.make();
     	for (Iterator<ModuleEntry> it = t.iterator(); it.hasNext();) {
     		ModuleEntry m = it.next();
@@ -135,7 +135,7 @@ public class WDexClassLoaderImpl extends ClassLoaderImpl {
     	s.removeAll(toRemove);
     }
     
-    private Set<ModuleEntry> getDexFiles(Module M) {
+    private static Set<ModuleEntry> getDexFiles(Module M) {
     	HashSet<ModuleEntry> result = HashSetFactory.make();
     	for (Iterator<? extends ModuleEntry> it = M.getEntries(); it.hasNext();) {
     		ModuleEntry entry = it.next();

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModelClass.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModelClass.java
@@ -127,7 +127,7 @@ public final /* singleton */ class AndroidModelClass extends SyntheticClass {
         clinit.setStatic(true);
         final TypeSafeInstructionFactory instructionFactory = new TypeSafeInstructionFactory(cha);
         
-        final Set<TypeReference> components = AndroidEntryPointManager.MANAGER.getComponents();
+        final Set<TypeReference> components = AndroidEntryPointManager.getComponents();
         int ssaNo = 1;
 
         if (AndroidEntryPointManager.MANAGER.doFlatComponents()) {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/FlatInstantiator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/FlatInstantiator.java
@@ -161,7 +161,7 @@ public class FlatInstantiator implements IInstantiator {
         { // Special type?
             final SpecializedInstantiator sInst = new SpecializedInstantiator(body, instructionFactory, pm,
                     cha, scope, analysisScope, this);
-            if (sInst.understands(T)) {
+            if (SpecializedInstantiator.understands(T)) {
                 return sInst.createInstance(T, asManaged, key, seen, currentDepth);
             }
         }

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/FlatInstantiator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/FlatInstantiator.java
@@ -343,7 +343,7 @@ public class FlatInstantiator implements IInstantiator {
         return instance; 
     }
 
-    private void createPrimitive(SSAValue instance) {
+    private static void createPrimitive(SSAValue instance) {
         // XXX; something else?
         instance.setAssigned();
     }

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/Instantiator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/Instantiator.java
@@ -344,7 +344,7 @@ public class Instantiator implements IInstantiator {
         return instance; 
     }
 
-    private void createPrimitive(SSAValue instance) {
+    private static void createPrimitive(SSAValue instance) {
         // XXX; something else?
         instance.setAssigned();
     }

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/ReuseParameters.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/ReuseParameters.java
@@ -147,7 +147,7 @@ public class ReuseParameters {
      *
      *  @see    com.ibm.wala.util.ssa.ParameterAccessor
      */
-    private int ssaFor(IMethod inCallTo, int paramNo) {
+    private static int ssaFor(IMethod inCallTo, int paramNo) {
         assert (paramNo >= 0);
         assert (paramNo < inCallTo.getNumberOfParameters());
 
@@ -163,7 +163,7 @@ public class ReuseParameters {
      *
      *  @see    com.ibm.wala.util.ssa.ParameterAccessor
      */
-    private int firstOf(TypeName type, IMethod inCallTo) {
+    private static int firstOf(TypeName type, IMethod inCallTo) {
         for (int i = 0; i < inCallTo.getNumberOfParameters(); ++i) {
             if (inCallTo.getParameterType(i).getName().equals(type)) {
                 return i;

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/SpecializedInstantiator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/SpecializedInstantiator.java
@@ -197,7 +197,7 @@ public class SpecializedInstantiator extends FlatInstantiator {
                     appComponents.add(instance);
                 }
             } else {
-                for (TypeReference component : AndroidEntryPointManager.MANAGER.getComponents()) {
+                for (TypeReference component : AndroidEntryPointManager.getComponents()) {
                     final VariableKey iKey = new SSAValue.TypeKey(component.getName());
 
                     if (this.pm.isSeen(iKey)) {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/Overrides.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/Overrides.java
@@ -204,7 +204,7 @@ public class Overrides {
 
         { // Make Mini-Models to override to
             for (final AndroidComponent target: AndroidComponent.values()) {
-                if (AndroidEntryPointManager.MANAGER.EPContainAny(target)) {
+                if (AndroidEntryPointManager.EPContainAny(target)) {
                     final AndroidModel targetModel = new UnknownTargetModel(this.cha, this.options, this.cache, target);
                     callTo.put(target, targetModel); 
                 } else {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentContextInterpreter.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentContextInterpreter.java
@@ -132,7 +132,7 @@ public class IntentContextInterpreter implements SSAContextInterpreter {
         }
     } 
 
-    private TypeReference getCaller(final Context ctx, final CGNode node) {
+    private static TypeReference getCaller(final Context ctx, final CGNode node) {
         if (ctx.get(ContextKey.CALLER) != null) {
             System.out.println("CALLER CONTEXT" + ctx.get(ContextKey.CALLER));
             return node.getMethod().getReference().getDeclaringClass();

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/AbstractIntRegisterMachine.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/AbstractIntRegisterMachine.java
@@ -352,7 +352,7 @@ public abstract class AbstractIntRegisterMachine implements FixedPointConstants 
      * @param bb the basic block at whose entry the meet occurs
      * @return true if the lhs value changes. false otherwise.
      */
-    private boolean meet(IVariable lhs, IVariable[] rhs, BasicBlock bb, Meeter meeter) {
+    private static boolean meet(IVariable lhs, IVariable[] rhs, BasicBlock bb, Meeter meeter) {
 
 //      boolean changed = meetStacks(lhs, rhs, bb, meeter);
 
@@ -368,7 +368,7 @@ public abstract class AbstractIntRegisterMachine implements FixedPointConstants 
      * @param bb the basic block at whose entry the meet occurs
      * @return true if the lhs value changes. false otherwise.
      */
-    private boolean meetForCatchBlock(IVariable lhs, IVariable[] rhs, BasicBlock bb, Meeter meeter) {
+    private static boolean meetForCatchBlock(IVariable lhs, IVariable[] rhs, BasicBlock bb, Meeter meeter) {
 
         boolean changed = meetLocals(lhs, rhs, bb, meeter);
 
@@ -473,7 +473,7 @@ public abstract class AbstractIntRegisterMachine implements FixedPointConstants 
      * @param bb the basic block at whose entry the meet occurs
      * @return true if the lhs value changes. false otherwise.
      */
-    private boolean meetLocals(IVariable lhs, IVariable[] rhs, BasicBlock bb, Meeter meeter) {
+    private static boolean meetLocals(IVariable lhs, IVariable[] rhs, BasicBlock bb, Meeter meeter) {
 
         boolean changed = false;
         MachineState L = (MachineState) lhs;

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/DexSSABuilder.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/DexSSABuilder.java
@@ -1515,7 +1515,7 @@ public class DexSSABuilder extends AbstractIntRegisterMachine {
         /**
          * @return the indices i s.t. x[i] == y, or null if none found.
          */
-        private int[] extractIndices(int[] x, int y) {
+        private static int[] extractIndices(int[] x, int y) {
             int count = 0;
             for (int i = 0; i < x.length; i++) {
                 if (x[i] == y) {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidEntryPointLocator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidEntryPointLocator.java
@@ -274,7 +274,7 @@ nextMethod:
 //        return test.getName().toString().contains("$"); // PRETTY!
 //    }
 
-    private AndroidEntryPoint makeEntryPointForHeuristic(final IMethod method, final IClassHierarchy cha) {
+    private static AndroidEntryPoint makeEntryPointForHeuristic(final IMethod method, final IClassHierarchy cha) {
         AndroidComponent compo;
         { // Guess component
             compo = AndroidComponent.from(method, cha);
@@ -404,11 +404,11 @@ nextMethod:
         }
     }
 
-    private boolean isAPIComponent(final IMethod method) {
+    private static boolean isAPIComponent(final IMethod method) {
         return isAPIComponent(method.getDeclaringClass());
     }
 
-    private boolean isAPIComponent(final IClass cls) {
+    private static boolean isAPIComponent(final IClass cls) {
         ClassLoaderReference clr = cls.getClassLoader().getReference();
 		if (! (clr.equals(ClassLoaderReference.Primordial) || clr.equals(ClassLoaderReference.Extension))) {
             if (cls.getName().toString().startsWith("Landroid/")) {
@@ -420,7 +420,7 @@ nextMethod:
         }
     }
 
-    private boolean isExcluded(final IClass cls) {
+    private static boolean isExcluded(final IClass cls) {
     	final SetOfClasses set = cls.getClassHierarchy().getScope().getExclusions();
     	if (set == null) {
     		return false; // exclusions null ==> no exclusions ==> no class is excluded
@@ -435,7 +435,7 @@ nextMethod:
      *
      *  Currently all methods are placed at ExecutionOrder.MULTIPLE_TIMES_IN_LOOP.
      */
-    private ExecutionOrder selectPositionForHeuristic() {
+    private static ExecutionOrder selectPositionForHeuristic() {
         return ExecutionOrder.MULTIPLE_TIMES_IN_LOOP;
     }
 

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidEntryPointManager.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidEntryPointManager.java
@@ -94,7 +94,7 @@ public final /* singleton */ class AndroidEntryPointManager implements Serializa
     /**
      *  Determines if any EntryPoint extends the specified component.
      */
-    public boolean EPContainAny(AndroidComponent compo) {
+    public static boolean EPContainAny(AndroidComponent compo) {
         for (AndroidEntryPoint ep: ENTRIES) {
             if (ep.belongsTo(compo)) {
                 return true;
@@ -110,7 +110,7 @@ public final /* singleton */ class AndroidEntryPointManager implements Serializa
         MANAGER = new AndroidEntryPointManager();
     }
 
-    public Set<TypeReference> getComponents() {
+    public static Set<TypeReference> getComponents() {
         if (ENTRIES.isEmpty()) {
             throw new IllegalStateException("No entrypoints loaded yet.");
         }

--- a/com.ibm.wala.ide.jdt.test/source/com/ibm/wala/cast/java/test/TypeInferenceAssertion.java
+++ b/com.ibm.wala.ide.jdt.test/source/com/ibm/wala/cast/java/test/TypeInferenceAssertion.java
@@ -51,7 +51,7 @@ final class TypeInferenceAssertion implements IRAssertion {
 
   }
 
-  private IR getIR(CallGraph cg, String fullyQualifiedTypeName, String methodName, String methodParameter, String methodReturnType) {
+  private static IR getIR(CallGraph cg, String fullyQualifiedTypeName, String methodName, String methodParameter, String methodReturnType) {
     IClassHierarchy classHierarchy = cg.getClassHierarchy();
     MethodReference methodRef = IRTests
         .descriptorToMethodRef(

--- a/com.ibm.wala.ide.jdt/source/com/ibm/wala/cast/java/translator/jdt/JDTSourceModuleTranslator.java
+++ b/com.ibm.wala.ide.jdt/source/com/ibm/wala/cast/java/translator/jdt/JDTSourceModuleTranslator.java
@@ -123,7 +123,7 @@ public class JDTSourceModuleTranslator implements SourceModuleTranslator {
     this.dump = dump;
   }
 
-  private void computeClassPath(AnalysisScope scope) {
+  private static void computeClassPath(AnalysisScope scope) {
     StringBuffer buf = new StringBuffer();
 
     ClassLoaderReference cl = scope.getApplicationLoader();

--- a/com.ibm.wala.ide.jsdt.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/com.ibm.wala.ide.jsdt.tests/.settings/org.eclipse.jdt.core.prefs
@@ -53,6 +53,7 @@ org.eclipse.jdt.core.compiler.problem.parameterAssignment=ignore
 org.eclipse.jdt.core.compiler.problem.possibleAccidentalBooleanAssignment=warning
 org.eclipse.jdt.core.compiler.problem.rawTypeReference=ignore
 org.eclipse.jdt.core.compiler.problem.redundantNullCheck=ignore
+org.eclipse.jdt.core.compiler.problem.reportMethodCanBePotentiallyStatic=ignore
 org.eclipse.jdt.core.compiler.problem.specialParameterHidingField=disabled
 org.eclipse.jdt.core.compiler.problem.staticAccessReceiver=warning
 org.eclipse.jdt.core.compiler.problem.suppressWarnings=enabled

--- a/com.ibm.wala.ide.jsdt/source/com/ibm/wala/cast/js/client/EclipseJavaScriptAnalysisEngine.java
+++ b/com.ibm.wala.ide.jsdt/source/com/ibm/wala/cast/js/client/EclipseJavaScriptAnalysisEngine.java
@@ -129,7 +129,7 @@ public class EclipseJavaScriptAnalysisEngine<I extends InstanceKey> extends Ecli
     return getFieldBasedCallGraph(eps);
   }
   
-  private String getScriptName(AstMethod m) {
+  private static String getScriptName(AstMethod m) {
     
     // we want the original including file, since that will be the "script"
     Position p = m.getSourcePosition();

--- a/com.ibm.wala.ide/.settings/org.eclipse.jdt.core.prefs
+++ b/com.ibm.wala.ide/.settings/org.eclipse.jdt.core.prefs
@@ -54,6 +54,7 @@ org.eclipse.jdt.core.compiler.problem.possibleAccidentalBooleanAssignment=warnin
 org.eclipse.jdt.core.compiler.problem.potentialNullReference=ignore
 org.eclipse.jdt.core.compiler.problem.rawTypeReference=ignore
 org.eclipse.jdt.core.compiler.problem.redundantNullCheck=ignore
+org.eclipse.jdt.core.compiler.problem.reportMethodCanBePotentiallyStatic=ignore
 org.eclipse.jdt.core.compiler.problem.specialParameterHidingField=disabled
 org.eclipse.jdt.core.compiler.problem.staticAccessReceiver=warning
 org.eclipse.jdt.core.compiler.problem.suppressWarnings=enabled

--- a/com.ibm.wala.ide/src/com/ibm/wala/ide/util/EclipseFileProvider.java
+++ b/com.ibm.wala.ide/src/com/ibm/wala/ide/util/EclipseFileProvider.java
@@ -121,7 +121,7 @@ public class EclipseFileProvider extends FileProvider {
    * @return the URL, or <code>null</code> if the file is not found
    * @throws IOException
    */
-  private  URL getFileURLFromPlugin(Plugin p, String fileName) throws IOException {
+  private static URL getFileURLFromPlugin(Plugin p, String fileName) throws IOException {
     try {
       URL url = FileLocator.find(p.getBundle(), new Path(fileName), null);
       if (url == null) {
@@ -159,7 +159,7 @@ public class EclipseFileProvider extends FileProvider {
    * @param url
    * @return an escaped version of the URL
    */
-  private URL fixupFileURLSpaces(URL url) {
+  private static URL fixupFileURLSpaces(URL url) {
     String urlString = url.toExternalForm();
     StringBuffer fixedUpUrl = new StringBuffer();
     int lastIndex = 0;

--- a/com.ibm.wala.ide/src/com/ibm/wala/ide/util/EclipseProjectPath.java
+++ b/com.ibm.wala.ide/src/com/ibm/wala/ide/util/EclipseProjectPath.java
@@ -266,7 +266,7 @@ public abstract class EclipseProjectPath<E, P> {
   /**
    * Is javaProject a plugin project?
    */
-  private boolean isPluginProject(IProject project) {
+  private static boolean isPluginProject(IProject project) {
     IPluginModelBase model = findModel(project);
     if (model == null) {
       return false;
@@ -349,13 +349,13 @@ public abstract class EclipseProjectPath<E, P> {
     }
   }
 
-  private IPluginModelBase findModel(IProject p) {
+  private static IPluginModelBase findModel(IProject p) {
     // PluginRegistry is specific to Eclipse 3.3+. Use PDECore for compatibility with 3.2
     // return PluginRegistry.findModel(p);
     return PDECore.getDefault().getModelManager().findModel(p);
   }
 
-  private IPluginModelBase findModel(BundleDescription bd) {
+  private static IPluginModelBase findModel(BundleDescription bd) {
     // PluginRegistry is specific to Eclipse 3.3+. Use PDECore for compatibility with 3.2
     // return PluginRegistry.findModel(bd);
     return PDECore.getDefault().getModelManager().findModel(bd);

--- a/com.ibm.wala.scandroid/.settings/org.eclipse.jdt.core.prefs
+++ b/com.ibm.wala.scandroid/.settings/org.eclipse.jdt.core.prefs
@@ -10,6 +10,7 @@ org.eclipse.jdt.core.compiler.problem.missingJavadocCommentsVisibility=public
 org.eclipse.jdt.core.compiler.problem.missingJavadocTagDescription=no_tag
 org.eclipse.jdt.core.compiler.problem.missingJavadocTags=ignore
 org.eclipse.jdt.core.compiler.problem.potentialNullReference=ignore
+org.eclipse.jdt.core.compiler.problem.reportMethodCanBePotentiallyStatic=ignore
 org.eclipse.jdt.core.compiler.problem.syntheticAccessEmulation=ignore
 org.eclipse.jdt.core.compiler.problem.undocumentedEmptyBlock=ignore
 org.eclipse.jdt.core.compiler.problem.unnecessaryElse=ignore

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/OutflowAnalysis.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/OutflowAnalysis.java
@@ -121,7 +121,7 @@ public class OutflowAnalysis {
 		this.specs = specs;
 	}
 
-	private void addEdge(
+	private static void addEdge(
 			Map<FlowType<IExplodedBasicBlock>, Set<FlowType<IExplodedBasicBlock>>> graph,
 			FlowType<IExplodedBasicBlock> source,
 			FlowType<IExplodedBasicBlock> dest) {

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/functions/TaintTransferFunctions.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/functions/TaintTransferFunctions.java
@@ -461,7 +461,7 @@ public class TaintTransferFunctions<E extends ISSABasicBlock> implements
 		return elts;
 	}
 
-	private Set<CodeElement> getStaticFieldAccessCodeElts(SSAFieldAccessInstruction inst) {
+	private static Set<CodeElement> getStaticFieldAccessCodeElts(SSAFieldAccessInstruction inst) {
 		Set<CodeElement> elts = HashSetFactory.make();
 		final FieldReference fieldRef = inst.getDeclaredField();
 		elts.add(new StaticFieldElement(fieldRef));
@@ -490,7 +490,7 @@ public class TaintTransferFunctions<E extends ISSABasicBlock> implements
 		return elts;
 	}
 
-	private IUnaryFlowFunction union(final IUnaryFlowFunction g,
+	private static IUnaryFlowFunction union(final IUnaryFlowFunction g,
 			final IUnaryFlowFunction h) {
 		return new IUnaryFlowFunction() {
 			@Override
@@ -507,7 +507,7 @@ public class TaintTransferFunctions<E extends ISSABasicBlock> implements
 	 * @param g
 	 * @return { (x, z) | (x, y) \in g, (y, z) \in f }
 	 */
-	private IUnaryFlowFunction compose(final IUnaryFlowFunction f,
+	private static IUnaryFlowFunction compose(final IUnaryFlowFunction f,
 			final IUnaryFlowFunction g) {
 		return new IUnaryFlowFunction() {
 

--- a/com.ibm.wala.scandroid/source/org/scandroid/spec/CallRetSourceSpec.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/spec/CallRetSourceSpec.java
@@ -95,8 +95,8 @@ public class CallRetSourceSpec extends SourceSpec {
 		}
 	}
 
-	private<E extends ISSABasicBlock> Collection<FlowType<E>> getFlowType(
-	        BasicBlockInContext<E> block) {
+	private static <E extends ISSABasicBlock> Collection<FlowType<E>> getFlowType(
+																				  BasicBlockInContext<E> block) {
 
 		HashSet<FlowType<E>> flowSet = new HashSet<>();
 		flowSet.clear();

--- a/com.ibm.wala.scandroid/source/org/scandroid/synthmethod/SSAtoXMLVisitor.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/synthmethod/SSAtoXMLVisitor.java
@@ -486,7 +486,7 @@ public class SSAtoXMLVisitor implements SSAInstruction.IVisitor {
     }
 
     @SuppressWarnings("unused")
-	private String typeRefToStr(TypeReference fieldType)
+	private static String typeRefToStr(TypeReference fieldType)
             throws UTFDataFormatException {
         Atom className = fieldType.getName().getClassName();
         Atom pkgName = fieldType.getName().getPackage();

--- a/com.ibm.wala.scandroid/source/org/scandroid/synthmethod/XMLSummaryWriter.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/synthmethod/XMLSummaryWriter.java
@@ -269,7 +269,7 @@ public class XMLSummaryWriter {
      * @param summary
      * @return
      */
-    private String getMethodDescriptor(MethodSummary summary) {
+    private static String getMethodDescriptor(MethodSummary summary) {
         StringBuilder typeSigs = new StringBuilder("(");
         
         int i=0;

--- a/com.ibm.wala.scandroid/source/org/scandroid/util/CLISCanDroidOptions.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/util/CLISCanDroidOptions.java
@@ -176,7 +176,7 @@ public class CLISCanDroidOptions implements ISCanDroidOptions {
 		}
 	}
 
-	private URI processURIArg(String arg) {
+	private static URI processURIArg(String arg) {
 		if (arg == null) {
 			return null;
 		} else {

--- a/com.ibm.wala.scandroid/source/org/scandroid/util/EntryPoints.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/util/EntryPoints.java
@@ -357,7 +357,7 @@ public class EntryPoints {
     }
 
     @SuppressWarnings("unused")
-	private String IntentToMethod(String intent) {
+	private static String IntentToMethod(String intent) {
         if (intent.contentEquals("android.intent.action.MAIN") ||
                 intent.contentEquals("android.media.action.IMAGE_CAPTURE") ||
                 intent.contentEquals("android.media.action.VIDEO_CAPTURE") ||

--- a/com.ibm.wala.shrike/.settings/org.eclipse.jdt.core.prefs
+++ b/com.ibm.wala.shrike/.settings/org.eclipse.jdt.core.prefs
@@ -64,6 +64,7 @@ org.eclipse.jdt.core.compiler.problem.possibleAccidentalBooleanAssignment=warnin
 org.eclipse.jdt.core.compiler.problem.potentialNullReference=ignore
 org.eclipse.jdt.core.compiler.problem.rawTypeReference=ignore
 org.eclipse.jdt.core.compiler.problem.redundantNullCheck=ignore
+org.eclipse.jdt.core.compiler.problem.reportMethodCanBePotentiallyStatic=ignore
 org.eclipse.jdt.core.compiler.problem.specialParameterHidingField=disabled
 org.eclipse.jdt.core.compiler.problem.staticAccessReceiver=warning
 org.eclipse.jdt.core.compiler.problem.suppressWarnings=enabled

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrike/bench/Bench.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrike/bench/Bench.java
@@ -32,7 +32,7 @@ import com.ibm.wala.shrikeBT.analysis.Verifier;
 import com.ibm.wala.shrikeBT.shrikeCT.CTDecoder;
 import com.ibm.wala.shrikeBT.shrikeCT.ClassInstrumenter;
 import com.ibm.wala.shrikeBT.shrikeCT.OfflineInstrumenter;
-import com.ibm.wala.shrikeCT.ClassReader;
+import com.ibm.wala.shrikeCT.ClassConstants;
 import com.ibm.wala.shrikeCT.ClassWriter;
 
 /**
@@ -190,7 +190,7 @@ public class Bench {
 
     if (ci.isChanged()) {
       ClassWriter cw = ci.emitClass();
-      cw.addField(ClassReader.ACC_PUBLIC | ClassReader.ACC_STATIC, fieldName, Constants.TYPE_boolean, new ClassWriter.Element[0]);
+      cw.addField(ClassConstants.ACC_PUBLIC | ClassConstants.ACC_STATIC, fieldName, Constants.TYPE_boolean, new ClassWriter.Element[0]);
       instrumenter.outputModifiedClass(ci, cw);
     }
   }

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrike/copywriter/CopyWriter.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrike/copywriter/CopyWriter.java
@@ -23,6 +23,7 @@ import com.ibm.wala.shrikeBT.shrikeCT.CTCompiler;
 import com.ibm.wala.shrikeBT.shrikeCT.CTDecoder;
 import com.ibm.wala.shrikeBT.shrikeCT.ClassInstrumenter;
 import com.ibm.wala.shrikeBT.shrikeCT.OfflineInstrumenter;
+import com.ibm.wala.shrikeCT.ClassConstants;
 import com.ibm.wala.shrikeCT.ClassReader;
 import com.ibm.wala.shrikeCT.ClassReader.AttrIterator;
 import com.ibm.wala.shrikeCT.ClassWriter;
@@ -239,27 +240,27 @@ public class CopyWriter {
   private static int copyEntry(ConstantPoolParser cp, ClassWriter w, int i) throws InvalidClassFileException {
     byte t = cp.getItemType(i);
     switch (t) {
-    case ClassReader.CONSTANT_String:
+    case ClassConstants.CONSTANT_String:
       return w.addCPString(cp.getCPString(i));
-    case ClassReader.CONSTANT_Class:
+    case ClassConstants.CONSTANT_Class:
       return w.addCPClass(cp.getCPClass(i));
-    case ClassReader.CONSTANT_FieldRef:
+    case ClassConstants.CONSTANT_FieldRef:
       return w.addCPFieldRef(cp.getCPRefClass(i), cp.getCPRefName(i), cp.getCPRefType(i));
-    case ClassReader.CONSTANT_InterfaceMethodRef:
+    case ClassConstants.CONSTANT_InterfaceMethodRef:
       return w.addCPInterfaceMethodRef(cp.getCPRefClass(i), cp.getCPRefName(i), cp.getCPRefType(i));
-    case ClassReader.CONSTANT_MethodRef:
+    case ClassConstants.CONSTANT_MethodRef:
       return w.addCPMethodRef(cp.getCPRefClass(i), cp.getCPRefName(i), cp.getCPRefType(i));
-    case ClassReader.CONSTANT_NameAndType:
+    case ClassConstants.CONSTANT_NameAndType:
       return w.addCPNAT(cp.getCPNATName(i), cp.getCPNATType(i));
-    case ClassReader.CONSTANT_Integer:
+    case ClassConstants.CONSTANT_Integer:
       return w.addCPInt(cp.getCPInt(i));
-    case ClassReader.CONSTANT_Float:
+    case ClassConstants.CONSTANT_Float:
       return w.addCPFloat(cp.getCPFloat(i));
-    case ClassReader.CONSTANT_Long:
+    case ClassConstants.CONSTANT_Long:
       return w.addCPLong(cp.getCPLong(i));
-    case ClassReader.CONSTANT_Double:
+    case ClassConstants.CONSTANT_Double:
       return w.addCPDouble(cp.getCPDouble(i));
-    case ClassReader.CONSTANT_Utf8:
+    case ClassConstants.CONSTANT_Utf8:
       return w.addCPUtf8(cp.getCPUtf8(i));
     }
     return -1;
@@ -292,8 +293,8 @@ public class CopyWriter {
 
     if (1 < CPCount) {
       switch (cp.getItemType(1)) {
-      case ClassReader.CONSTANT_Long:
-      case ClassReader.CONSTANT_Double:
+      case ClassConstants.CONSTANT_Long:
+      case ClassConstants.CONSTANT_Double:
         // item 1 is a double-word item, so the next real item is at 3
         // to make sure item 3 is allocated at index 3, we'll need to
         // insert a dummy entry at index 2

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrike/copywriter/CopyWriter.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrike/copywriter/CopyWriter.java
@@ -236,7 +236,7 @@ public class CopyWriter {
     return elems;
   }
 
-  private int copyEntry(ConstantPoolParser cp, ClassWriter w, int i) throws InvalidClassFileException {
+  private static int copyEntry(ConstantPoolParser cp, ClassWriter w, int i) throws InvalidClassFileException {
     byte t = cp.getItemType(i);
     switch (t) {
     case ClassReader.CONSTANT_String:

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/ArrayStoreInstruction.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/ArrayStoreInstruction.java
@@ -59,7 +59,7 @@ final public class ArrayStoreInstruction extends Instruction implements IArraySt
 
   @Override
   public String getType() {
-    return Decoder.indexedTypes[opcode - OP_iastore];
+    return Constants.indexedTypes[opcode - OP_iastore];
   }
 
   @Override

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Compiler.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Compiler.java
@@ -448,7 +448,7 @@ public abstract class Compiler implements Constants {
     }
   }
 
-  private boolean applyPatches(ArrayList<Patch> patches) {
+  private static boolean applyPatches(ArrayList<Patch> patches) {
     for (Iterator<Patch> i = patches.iterator(); i.hasNext();) {
       Patch p = i.next();
       if (!p.apply()) {

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Decoder.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Decoder.java
@@ -214,7 +214,7 @@ public abstract class Decoder implements Constants {
     }
   }
 
-  private String getPrimitiveType(int t) throws InvalidBytecodeException {
+  private static String getPrimitiveType(int t) throws InvalidBytecodeException {
     switch (t) {
     case T_BOOLEAN:
       return TYPE_boolean;
@@ -698,7 +698,7 @@ public abstract class Decoder implements Constants {
     return index;
   }
 
-  private int applyInstructionToStack(Instruction i, int stackLen, byte[] stackWords) throws InvalidBytecodeException {
+  private static int applyInstructionToStack(Instruction i, int stackLen, byte[] stackWords) throws InvalidBytecodeException {
     stackLen -= i.getPoppedCount();
 
     if (stackLen < 0) {

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/MethodEditor.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/MethodEditor.java
@@ -145,7 +145,7 @@ public final class MethodEditor {
     }
   }
 
-  private String getStateMessage(int state) {
+  private static String getStateMessage(int state) {
     switch (state) {
     case BEFORE_PASS:
       return "This operation can only be performed before or after an editing pass";

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/analysis/Analyzer.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/analysis/Analyzer.java
@@ -197,7 +197,7 @@ public class Analyzer {
     return ClassHierarchy.isSubtypeOf(hierarchy, patchType(t1), patchType(t2)) != ClassHierarchy.NO;
   }
 
-  private boolean isPrimitive(String type) {
+  private static boolean isPrimitive(String type) {
     return type != null && (!type.startsWith("L") && !type.startsWith("["));
   }
   
@@ -515,7 +515,7 @@ public class Analyzer {
     }
   }
 
-  private String[] cutArray(String[] a, int len) {
+  private static String[] cutArray(String[] a, int len) {
     if (len == 0) {
       return noStrings;
     } else {
@@ -532,7 +532,7 @@ public class Analyzer {
     return a||b;
   }
   
-  private boolean longType(String type) {
+  private static boolean longType(String type) {
     return Constants.TYPE_long.equals(type) || Constants.TYPE_double.equals(type);
   }
   

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/CTDecoder.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/CTDecoder.java
@@ -79,7 +79,7 @@ final public class CTDecoder extends Decoder {
       return cp.getItemType(index);
     }
 
-    private Error convertToError(InvalidClassFileException e) {
+    private static Error convertToError(InvalidClassFileException e) {
       e.printStackTrace();
       return new Error("Invalid class file: " + e.getMessage());
     }

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/tools/AddSerialVersion.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/tools/AddSerialVersion.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 
 import com.ibm.wala.shrikeBT.Util;
+import com.ibm.wala.shrikeCT.ClassConstants;
 import com.ibm.wala.shrikeCT.ClassReader;
 import com.ibm.wala.shrikeCT.ClassWriter;
 import com.ibm.wala.shrikeCT.ConstantValueWriter;
@@ -52,7 +53,7 @@ public class AddSerialVersion {
     }
 
     long UID = computeSerialVersionUID(r);
-    w.addField(ClassReader.ACC_PUBLIC | ClassReader.ACC_STATIC | ClassReader.ACC_FINAL, "serialVersionUID", "J",
+    w.addField(ClassConstants.ACC_PUBLIC | ClassConstants.ACC_STATIC | ClassConstants.ACC_FINAL, "serialVersionUID", "J",
         new ClassWriter.Element[] { new ConstantValueWriter(w, UID) });
   }
 
@@ -112,7 +113,7 @@ public class AddSerialVersion {
         int fieldCount = 0;
         for (int f = 0; f < fields.length; f++) {
           int flags = r.getFieldAccessFlags(f);
-          if ((flags & ClassReader.ACC_PRIVATE) == 0 || (flags & (ClassReader.ACC_STATIC | ClassReader.ACC_TRANSIENT)) == 0) {
+          if ((flags & ClassConstants.ACC_PRIVATE) == 0 || (flags & (ClassConstants.ACC_STATIC | ClassConstants.ACC_TRANSIENT)) == 0) {
             fields[fieldCount] = new Integer(f);
             fieldNames[f] = r.getFieldName(f);
             fieldCount++;
@@ -141,7 +142,7 @@ public class AddSerialVersion {
         for (int m = 0; m < methodSigs.length; m++) {
           String name = r.getMethodName(m);
           int flags = r.getMethodAccessFlags(m);
-          if (name.equals("<clinit>") || (flags & ClassReader.ACC_PRIVATE) == 0) {
+          if (name.equals("<clinit>") || (flags & ClassConstants.ACC_PRIVATE) == 0) {
             methods[methodCount] = new Integer(m);
             methodSigs[m] = name + r.getMethodType(m);
             if (name.equals("<clinit>")) {

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/tools/ClassSearcher.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/tools/ClassSearcher.java
@@ -16,6 +16,7 @@ import java.io.Writer;
 
 import com.ibm.wala.shrikeBT.shrikeCT.ClassInstrumenter;
 import com.ibm.wala.shrikeBT.shrikeCT.OfflineInstrumenter;
+import com.ibm.wala.shrikeCT.ClassConstants;
 import com.ibm.wala.shrikeCT.ClassReader;
 import com.ibm.wala.shrikeCT.ConstantPoolParser;
 
@@ -60,7 +61,7 @@ public class ClassSearcher {
     ClassReader r = ci.getReader();
     ConstantPoolParser cp = r.getCP();
     for (int i = 1; i < cp.getItemCount(); i++) {
-      if (cp.getItemType(i) == ConstantPoolParser.CONSTANT_Class && (cp.getCPClass(i).equals(cl1) || cp.getCPClass(i).equals(cl2))) {
+      if (cp.getItemType(i) == ClassConstants.CONSTANT_Class && (cp.getCPClass(i).equals(cl1) || cp.getCPClass(i).equals(cl2))) {
         w.write(cp.getCPClass(i) + " " + resource + " " + r.getName() + "\n");
       }
     }

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/StackMapTableWriter.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/StackMapTableWriter.java
@@ -38,7 +38,7 @@ public class StackMapTableWriter extends Element {
     this.data = serialize(writer, frames);
   }
   
-  private byte[] serialize(ClassWriter writer, List<StackMapFrame> frames) throws IOException {
+  private static byte[] serialize(ClassWriter writer, List<StackMapFrame> frames) throws IOException {
     ByteArrayOutputStream data = new ByteArrayOutputStream();
     
     for(StackMapFrame frame : frames) {

--- a/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/MethodPositions.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/MethodPositions.java
@@ -98,7 +98,7 @@ public final class MethodPositions extends PositionsAttribute {
    * @throws IOException
    *           if the input stream cannot be read
    */
-  private Range readRange(DataInputStream in, String startVarName, String endVarName, boolean undefinedAllowed) throws IOException {
+  private static Range readRange(DataInputStream in, String startVarName, String endVarName, boolean undefinedAllowed) throws IOException {
     boolean valid = true;
     Range range = null;
     Position start = null;
@@ -150,7 +150,7 @@ public final class MethodPositions extends PositionsAttribute {
    * @throws InvalidPositionException
    *           if the read position is invalid
    */
-  private Position readPosition(DataInputStream in, String varName) throws IOException, InvalidPositionException {
+  private static Position readPosition(DataInputStream in, String varName) throws IOException, InvalidPositionException {
     Position pos = null;
     try {
       pos = new Position(in.readInt());

--- a/com.ibm.wala.util/.settings/org.eclipse.jdt.core.prefs
+++ b/com.ibm.wala.util/.settings/org.eclipse.jdt.core.prefs
@@ -54,6 +54,7 @@ org.eclipse.jdt.core.compiler.problem.possibleAccidentalBooleanAssignment=warnin
 org.eclipse.jdt.core.compiler.problem.potentialNullReference=ignore
 org.eclipse.jdt.core.compiler.problem.rawTypeReference=ignore
 org.eclipse.jdt.core.compiler.problem.redundantNullCheck=ignore
+org.eclipse.jdt.core.compiler.problem.reportMethodCanBePotentiallyStatic=ignore
 org.eclipse.jdt.core.compiler.problem.specialParameterHidingField=disabled
 org.eclipse.jdt.core.compiler.problem.staticAccessReceiver=warning
 org.eclipse.jdt.core.compiler.problem.suppressWarnings=enabled

--- a/com.ibm.wala.util/src/com/ibm/wala/util/collections/Pair.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/collections/Pair.java
@@ -26,7 +26,7 @@ public class Pair<T,U> implements Serializable {
     this.snd = snd;
   }
 
-  private boolean check(Object x, Object y) {
+  private static boolean check(Object x, Object y) {
     return (x == null) ? (y == null) : x.equals(y);
   }
 
@@ -36,7 +36,7 @@ public class Pair<T,U> implements Serializable {
     return (o instanceof Pair) && check(fst, ((Pair) o).fst) && check(snd, ((Pair) o).snd);
   }
 
-  private int hc(Object o) {
+  private static int hc(Object o) {
     return (o == null) ? 0 : o.hashCode();
   }
 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/collections/TwoLevelVector.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/collections/TwoLevelVector.java
@@ -54,11 +54,11 @@ public class TwoLevelVector<T> implements IVector<T>, Serializable {
     return v.get(localX);
   }
 
-  private int getFirstIndexOnPage(int page) {
+  private static int getFirstIndexOnPage(int page) {
     return page << LOG_PAGE_SIZE;
   }
 
-  private int getPageNumber(int x) {
+  private static int getPageNumber(int x) {
     return x >> LOG_PAGE_SIZE;
   }
 
@@ -78,7 +78,7 @@ public class TwoLevelVector<T> implements IVector<T>, Serializable {
     v.set(localX, value);
   }
 
-  private int toLocalIndex(int x, int page) {
+  private static int toLocalIndex(int x, int page) {
     return x - getFirstIndexOnPage(page);
   }
 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/BimodalMutableIntSet.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/BimodalMutableIntSet.java
@@ -47,7 +47,7 @@ public class BimodalMutableIntSet implements MutableIntSet {
   /**
    * @return true iff we would like to use the same representation for V as we do for W
    */
-  private boolean sameRepresentation(IntSet V, IntSet W) {
+  private static boolean sameRepresentation(IntSet V, IntSet W) {
     // for now we assume that we always want to use the same representation for
     // V as
     // for W.

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/BitVectorIntSet.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/BitVectorIntSet.java
@@ -310,7 +310,7 @@ public final class BitVectorIntSet implements MutableIntSet {
     }
   }
 
-  private void actOnWord(IntSetAction action, int startingIndex, int word) {
+  private static void actOnWord(IntSetAction action, int startingIndex, int word) {
     if (word != 0) {
       if ((word & 0x1) != 0) {
         action.act(startingIndex);

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/OffsetBitVector.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/OffsetBitVector.java
@@ -16,7 +16,7 @@ public final class OffsetBitVector extends BitVectorBase<OffsetBitVector> {
 
   int offset;
 
-  private int wordDiff(int offset1, int offset2) {
+  private static int wordDiff(int offset1, int offset2) {
     return (offset1 > offset2) ? (offset1 - offset2) >> LOG_BITS_PER_UNIT : -((offset2 - offset1) >> LOG_BITS_PER_UNIT);
   }
 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/TwoLevelIntVector.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/TwoLevelIntVector.java
@@ -54,15 +54,15 @@ public class TwoLevelIntVector implements IntVector, Serializable {
     return v.get(localX);
   }
 
-  private int toLocalIndex(int x, int page) {
+  private static int toLocalIndex(int x, int page) {
     return x - getFirstIndexOnPage(page);
   }
 
-  private int getFirstIndexOnPage(int page) {
+  private static int getFirstIndexOnPage(int page) {
     return page << LOG_PAGE_SIZE;
   }
 
-  private int getPageNumber(int x) {
+  private static int getPageNumber(int x) {
     return x >> LOG_PAGE_SIZE;
   }
 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/processes/JavaLauncher.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/processes/JavaLauncher.java
@@ -225,7 +225,7 @@ public class JavaLauncher extends Launcher {
     return lastProcess;
   }
 
-  private String makeLibPath() {
+  private static String makeLibPath() {
     String libPath = System.getProperty("java.library.path");
     if (libPath == null) {
       return null;

--- a/com.ibm.wala.util/src/com/ibm/wala/util/processes/Launcher.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/processes/Launcher.java
@@ -126,7 +126,7 @@ public abstract class Launcher {
     return p;
   }
 
-  private String[] buildEnv(Map<String,String> ev) {
+  private static String[] buildEnv(Map<String,String> ev) {
     String[] result = new String[ev.size()];
     int i = 0;
     for (Iterator<Map.Entry<String,String>> it = ev.entrySet().iterator(); it.hasNext();) {
@@ -273,7 +273,7 @@ public abstract class Launcher {
   /**
    * Drain some data from the input stream, and print said data to p.  Do not block.
    */
-  private void drainAndPrint(BufferedInputStream s, PrintStream p) throws IOException {
+  private static void drainAndPrint(BufferedInputStream s, PrintStream p) throws IOException {
     try {
       while (s.available() > 0) {
         byte[] data = new byte[s.available()];
@@ -289,7 +289,7 @@ public abstract class Launcher {
   /**
    * Drain all data from the input stream, and print said data to p.  Block if necessary.
    */
-  private void blockingDrainAndPrint(BufferedInputStream s, PrintStream p) throws IOException {
+  private static void blockingDrainAndPrint(BufferedInputStream s, PrintStream p) throws IOException {
     ByteArrayOutputStream b = new ByteArrayOutputStream();
     try {
       // gather all the data from the stream.
@@ -310,7 +310,7 @@ public abstract class Launcher {
   /**
    * Drain some data from the input stream, and append said data to b.  Do not block.
    */
-  private void drainAndCatch(BufferedInputStream s, ByteArrayOutputStream b) throws IOException {
+  private static void drainAndCatch(BufferedInputStream s, ByteArrayOutputStream b) throws IOException {
     try {
       while (s.available() > 0) {
         byte[] data = new byte[s.available()];
@@ -326,7 +326,7 @@ public abstract class Launcher {
   /**
    * Drain all data from the input stream, and append said data to p.  Block if necessary.
    */
-  private void blockingDrainAndCatch(BufferedInputStream s, ByteArrayOutputStream b) throws IOException {
+  private static void blockingDrainAndCatch(BufferedInputStream s, ByteArrayOutputStream b) throws IOException {
     try {
       int next = s.read();
       while (next != -1) {


### PR DESCRIPTION
Taken together, these commits fix or suppress 238 Eclipse code style warnings relating to `static` methods and accesses to `static` fields.

Many of these fixes consist of declaring methods `static` wherever it is safe to do so. I’ve made that change only in cases where the affected method cannot possibly be overridden by third-party code: `private` methods (40359dfb2baadc68de999b0c3eb110ea2ee64e63), `final` methods (9e9a861d8cd32d0435f3c566119f27875c7479b6), and methods of `final` classes (79209e96fe81ac82773bc5564a78625d7f014a04). An additional group of fixes involve accessing static fields directly through the classes that declare them, rather than through some subclass or instance (91d85ab9ef418559bd850a69645042a41ac304a4).

In other cases, we suppress Eclipse’s recommendations because we know things Eclipse does not. For example, methods that third-party code can see and potentially override should not be changed, since the third-party code may rely on dynamic dispatch of calls to these methods (423d80835659430aebac9df02732d6bef66d5a71). Also, JUnit `@Test` methods must not be static, but Eclipse doesn’t know about that rule (b458dd568bbc91b37d471d278303b2e8034f08df). Sometimes test inputs intentionally do seemingly-goofy things that we would want to fix in regular code, but which we should silently allow in test code because that’s the point of the test (6bea42fab206a6838889b4daa774ef8f87e484f2).