### PR TITLE
Fix all remaining Eclipse "Unnecessary Code" warnings

### DIFF
--- a/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
+++ b/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
@@ -180,7 +180,6 @@ import com.ibm.wala.util.debug.Assertions;
 // * boxing (YUCK). see resolveBoxing()
 // * enums (probably in simplename or something. but using resolveConstantExpressionValue() possible)
 
-@SuppressWarnings("unchecked")
 public abstract class JDTJava2CAstTranslator<T extends Position> {
   protected boolean dump = false;
   
@@ -2371,7 +2370,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
 
     // First compute the control flow edges for the various case labels
     for (int i = 0; i < cases.size(); i++) {
-      Statement se = (Statement) cases.get(i);
+      Statement se = cases.get(i);
       if (se instanceof SwitchCase) {
         SwitchCase c = (SwitchCase) se;
 

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/SDGSupergraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/SDGSupergraph.java
@@ -15,7 +15,6 @@ import java.util.Iterator;
 import com.ibm.wala.dataflow.IFDS.ISupergraph;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
-import com.ibm.wala.ipa.slicer.Slicer.ControlDependenceOptions;
 import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.util.Predicate;
 import com.ibm.wala.util.collections.EmptyIterator;


### PR DESCRIPTION
There were only three left, all fairly straightforward to fix.