### PR TITLE
Remove code to scan call sites for max param count

### DIFF
--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/PDG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/PDG.java
@@ -934,16 +934,6 @@ public class PDG<T extends InstanceKey> implements NumberedGraph<Statement> {
       ArrayList<Statement> list = new ArrayList<Statement>();
       int paramCount = node.getMethod().getNumberOfParameters();
       
-      for (Iterator<CGNode> callers = cg.getPredNodes(node); callers.hasNext(); ) {
-        CGNode caller = callers.next();
-        IR callerIR = caller.getIR();
-        for (Iterator<CallSiteReference> sites = cg.getPossibleSites(caller, node); sites.hasNext(); ) {
-          for (SSAAbstractInvokeInstruction inst : callerIR.getCalls(sites.next())) {
-           paramCount = Math.max(paramCount, inst.getNumberOfParameters()-1);
-          }
-        }
-      }
-      
       for (int i = 1; i <= paramCount; i++) {
         ParamCallee s = new ParamCallee(node, i);
         delegate.addNode(s);


### PR DESCRIPTION
We cannot find any case where this code fixes a problem,
and it doesn't seem to be a good fix anyway.