### PR TITLE
Fix all Eclipse warnings about unnecessary semicolons

### DIFF
--- a/com.ibm.wala.cast.js.html.nu_validator/src/com/ibm/wala/cast/js/html/nu_validator/NuValidatorHtmlParser.java
+++ b/com.ibm.wala.cast.js.html.nu_validator/src/com/ibm/wala/cast/js/html/nu_validator/NuValidatorHtmlParser.java
@@ -55,7 +55,7 @@ public class NuValidatorHtmlParser implements IHtmlParser {
     parser.setXmlPolicy(XmlViolationPolicy.ALLOW);
     parser.setContentHandler(new ContentHandler() {
       private Locator locator;
-      private Stack<ITag> tags = new Stack<>();;
+      private Stack<ITag> tags = new Stack<>();
       
       private int countLines(char[] ch, int start, int length) {
         LineNumberReader r = new LineNumberReader(new StringReader (new String(ch, start, length)));  

--- a/com.ibm.wala.cast.js.rhino/source/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
+++ b/com.ibm.wala.cast.js.rhino/source/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
@@ -2394,7 +2394,7 @@ private CAstNode[] walkChildren(final Node n, WalkContext context) {
       public void warning(String arg0, String arg1, int arg2, String arg3, int arg4) {
         // ignore warnings
       } 
-    };
+    }
     
     CAstErrorReporter reporter = new CAstErrorReporter();
     CompilerEnvirons compilerEnv = new CompilerEnvirons();

--- a/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/FieldBasedCGUtil.java
+++ b/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/FieldBasedCGUtil.java
@@ -54,7 +54,7 @@ import com.ibm.wala.util.functions.Function;
  *
  */
 public class FieldBasedCGUtil {
-	public static enum BuilderType { PESSIMISTIC, OPTIMISTIC, OPTIMISTIC_WORKLIST };
+	public static enum BuilderType { PESSIMISTIC, OPTIMISTIC, OPTIMISTIC_WORKLIST }
 
 	private final JavaScriptTranslatorFactory translatorFactory;
 

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/analysis/typeInference/JSTypeInference.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/analysis/typeInference/JSTypeInference.java
@@ -81,7 +81,6 @@ public class JSTypeInference extends AstTypeInference {
         result = new DeclaredTypeOperator(new ConeType(cha.getRootClass()));
       }
     }
-    ;
 
     class JSTypeVarFactory extends TypeVarFactory {
 
@@ -104,7 +103,6 @@ public class JSTypeInference extends AstTypeInference {
         }
       }
     }
-    ;
 
     init(ir, new JSTypeVarFactory(), new JSTypeOperatorFactory());
   }

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/PrototypeFieldVertex.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/PrototypeFieldVertex.java
@@ -4,7 +4,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
 
 public class PrototypeFieldVertex extends Vertex implements PointerKey {
 
-  public enum PrototypeField { __proto__, prototype };
+  public enum PrototypeField { __proto__, prototype }
 
   private final PrototypeField field;
   private final ObjectVertex type;

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/client/JavaScriptAnalysisEngine.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/client/JavaScriptAnalysisEngine.java
@@ -116,7 +116,7 @@ public abstract class JavaScriptAnalysisEngine<I extends InstanceKey> extends Ab
   }
 
   public static class FieldBasedJavaScriptAnalysisEngine extends JavaScriptAnalysisEngine<ObjectVertex> {
-    public enum BuilderType { PESSIMISTIC, OPTIMISTIC, REFLECTIVE };
+    public enum BuilderType { PESSIMISTIC, OPTIMISTIC, REFLECTIVE }
     
     private BuilderType builderType = BuilderType.OPTIMISTIC;
     

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/html/RangeFileMapping.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/html/RangeFileMapping.java
@@ -125,7 +125,7 @@ public class RangeFileMapping implements FileMapping {
         public String toString() {
           return "[include:"+includePosition+"]"+super.toString();
         }
-      };
+      }
       
       return new Pos();
     } else {

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JSCallGraphUtil.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JSCallGraphUtil.java
@@ -321,7 +321,7 @@ public class JSCallGraphUtil extends com.ibm.wala.cast.ipa.callgraph.CAstCallGra
     public URL getURL() {
       return url;
     }      
-  };
+  }
   
   public static Module getPrologueFile(final String name) {
     return new Bootstrap(name, JSCallGraphUtil.class.getClassLoader().getResourceAsStream(name), JSCallGraphUtil.class.getClassLoader().getResource(name));

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JSSSAPropagationCallGraphBuilder.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JSSSAPropagationCallGraphBuilder.java
@@ -390,13 +390,13 @@ public class JSSSAPropagationCallGraphBuilder extends AstSSAPropagationCallGraph
       public void visitPrototypeLookup(PrototypeLookup instruction) {
       }
 
-    };
+    }
 
     @Override
     protected ImplicitPointsToSetVisitor makeImplicitPointsToVisitor(LocalPointerKey lpk) {
       return new JSImplicitPointsToSetVisitor(this, lpk);
     }
-  };
+  }
 
   @Override
   protected PropagationSystem makeSystem(AnalysisOptions options) {
@@ -639,7 +639,7 @@ public class JSSSAPropagationCallGraphBuilder extends AstSSAPropagationCallGraph
               public String toString() {
                 return "sub-dispatch for " + instruction + ": " + receiverType + ", " + fieldKey;
               } 
-            };
+            }
           
             system.newSideEffect(new FieldValueDispatch(), fieldKey);
         }

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/PropertyNameContextSelector.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/PropertyNameContextSelector.java
@@ -153,7 +153,7 @@ public class PropertyNameContextSelector implements ContextSelector {
     this.base = base;
   }
   
-  private enum Frequency { NEVER, SOMETIMES, ALWAYS };
+  private enum Frequency { NEVER, SOMETIMES, ALWAYS }
   private final HashMap<MethodReference, Frequency> usesFirstArgAsPropertyName_cache = HashMapFactory.make();
   
   /** Determine whether the method never/sometimes/always uses its first argument as a property name. */

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/translator/PropertyReadExpander.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/translator/PropertyReadExpander.java
@@ -95,7 +95,7 @@ public class PropertyReadExpander extends CAstRewriter<PropertyReadExpander.Rewr
       this.elementTemp = elementTemp;
     }
 
-  };
+  }
 
   private final static RewriteContext READ = new RewriteContext() {
     @Override

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/analysis/typeInference/AstTypeInference.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/analysis/typeInference/AstTypeInference.java
@@ -73,7 +73,7 @@ public abstract class AstTypeInference extends TypeInference {
     public void visitEcho(AstEchoInstruction inst) {
 
     }
-  };
+  }
 
   public AstTypeInference(IR ir, IClassHierarchy cha, TypeAbstraction booleanType, boolean doPrimitives) {
     super(ir, doPrimitives);

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/callgraph/AstSSAPropagationCallGraphBuilder.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/callgraph/AstSSAPropagationCallGraphBuilder.java
@@ -240,7 +240,7 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
 
       }
     }
-  };
+  }
 
   // /////////////////////////////////////////////////////////////////////////
   //
@@ -1209,7 +1209,7 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
           system.newConstraint(fieldKey, assignOperator, rhs);
         }
       }
-    };
+    }
 
     public void newFieldWrite(CGNode opNode, int objVn, int fieldsVn, final PointerKey rhs) {
       newFieldOperation(opNode, objVn, fieldsVn, false, new NormalWriter(rhs));

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
@@ -1385,7 +1385,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
 
   public static enum ScopeType {
     LOCAL, GLOBAL, SCRIPT, FUNCTION, TYPE
-  };
+  }
 
   private static final boolean DEBUG = false;
 
@@ -1556,7 +1556,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
     public Scope getDefiningScope() {
       return definingScope;
     }
-  };
+  }
 
   public abstract class AbstractScope implements Scope {
     private final Scope parent;
@@ -1711,7 +1711,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
 
     @Override
     public abstract CAstEntity getEntity();
-  };
+  }
 
   protected AbstractScope makeScriptScope(final CAstEntity s, Scope parent) {
     return new AbstractScope(parent) {
@@ -2982,7 +2982,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
     
       return false;
     }
-  };
+  }
  
   /**
    * record that in entity e, the access is performed.
@@ -4784,7 +4784,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
       return globalScope;
     }
     
-  };
+  }
 
   /**
    * translate module, represented by {@link CAstEntity} N

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/TranslatorToCAst.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/TranslatorToCAst.java
@@ -215,6 +215,6 @@ public interface TranslatorToCAst {
             breakNode);
       }
     }
-    };
+    }
 
 }

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/loader/AstMethod.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/loader/AstMethod.java
@@ -199,7 +199,7 @@ public abstract class AstMethod implements IMethod {
       return (o instanceof LexicalParent) && getName().equals(((LexicalParent) o).getName())
           && getMethod().equals(((LexicalParent) o).getMethod());
     }
-  };
+  }
 
   public abstract LexicalParent[] getParents();
 

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/CAstReference.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/CAstReference.java
@@ -22,4 +22,4 @@ public interface CAstReference {
 
   CAstType type();
 
-};
+}

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/rewrite/CAstBasicRewriter.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/rewrite/CAstBasicRewriter.java
@@ -67,7 +67,7 @@ public abstract class CAstBasicRewriter
     public NoKey parent() {
       return null;
     }
-  };
+  }
 
   protected CAstBasicRewriter(CAst Ast, boolean recursive) {
     super(Ast, recursive, new NonCopyingContext());

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/rewrite/CAstRewriter.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/rewrite/CAstRewriter.java
@@ -71,7 +71,7 @@ public abstract class CAstRewriter<C extends CAstRewriter.RewriteContext<K>, K e
      */
     Self parent();
 
-  };
+  }
 
   /**
    * interface to be implemented by contexts used while traversing the AST
@@ -83,7 +83,7 @@ public abstract class CAstRewriter<C extends CAstRewriter.RewriteContext<K>, K e
      */
     K key();
 
-  };
+  }
 
   /**
    * represents a rewritten CAst

--- a/com.ibm.wala.core.testdata/src/reflection/GetMethodContext.java
+++ b/com.ibm.wala.core.testdata/src/reflection/GetMethodContext.java
@@ -28,7 +28,7 @@ public class GetMethodContext {
     }
     public void baz() {
     }
-  };
+  }
 
   public static class B extends A {
     @Override
@@ -40,7 +40,7 @@ public class GetMethodContext {
     @Override
     public void baz() {
     }
-  };
+  }
 
   public static class C extends B {
     @Override
@@ -49,7 +49,7 @@ public class GetMethodContext {
     @Override
     public void bar() {
     }
-  };
+  }
 
   public static void main(String[] args) throws IllegalAccessException, NoSuchMethodException, IllegalArgumentException, InvocationTargetException {
     Method m;

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/arraybounds/hypergraph/SoftFinalHyperNode.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/arraybounds/hypergraph/SoftFinalHyperNode.java
@@ -23,5 +23,5 @@ public class SoftFinalHyperNode<T> extends HyperNode<T> {
     if (weight.equals(Weight.NOT_SET) || this.getWeight().equals(Weight.NOT_SET)) {
       super.setWeight(weight);
     }
-  };
+  }
 }

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/NullPointerState.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/NullPointerState.java
@@ -31,7 +31,7 @@ public class NullPointerState extends AbstractVariable<NullPointerState> {
    * Inital state is UNKNOWN.
    * Lattice: BOTH < { NULL, NOT_NULL } < UNKNOWN
    */
-  public enum State { UNKNOWN, BOTH, NULL, NOT_NULL };
+  public enum State { UNKNOWN, BOTH, NULL, NOT_NULL }
   
   // maps ssa variable number -> State
   private final State[] vars;

--- a/com.ibm.wala.core/src/com/ibm/wala/demandpa/alg/DemandRefinementPointsTo.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/demandpa/alg/DemandRefinementPointsTo.java
@@ -229,7 +229,7 @@ public class DemandRefinementPointsTo extends AbstractDemandPointsTo {
      * The budget specified in the {@link RefinementPolicy} was exceeded on all refinement passes
      */
     BUDGETEXCEEDED
-  };
+  }
 
   /**
    * re-initialize state for a new query

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PointerAnalysisImpl.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PointerAnalysisImpl.java
@@ -209,7 +209,7 @@ public class PointerAnalysisImpl extends AbstractPointerAnalysis {
     public void visitArrayLoad(SSAArrayLoadInstruction instruction) {
       pointsToSet = analysis.computeImplicitPointsToSetAtALoad(node, instruction);
     }
-  };
+  }
 
   protected ImplicitPointsToSetVisitor makeImplicitPointsToVisitor(LocalPointerKey lpk) {
     return new ImplicitPointsToSetVisitor(this, lpk);

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PropagationCallGraphBuilder.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PropagationCallGraphBuilder.java
@@ -1490,6 +1490,6 @@ public abstract class PropagationCallGraphBuilder implements CallGraphBuilder<In
   @Override
   public IAnalysisCacheView getAnalysisCache() {
     return analysisCache;
-  };
+  }
 
 }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/TargetMethodContextSelector.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/TargetMethodContextSelector.java
@@ -72,7 +72,6 @@ public class TargetMethodContextSelector implements ContextSelector {
         return (o instanceof MethodDispatchContext) && ((MethodDispatchContext) o).getTargetMethod().equals(M);
       }
     }
-    ;
 
     return new MethodDispatchContext();
   }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/cfa/CallStringContextSelector.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/cfa/CallStringContextSelector.java
@@ -72,7 +72,7 @@ public abstract class CallStringContextSelector implements ContextSelector {
     public CallString getCallString() {
       return cs;
     }
-  };
+  }
 
   protected final ContextSelector base;
 

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/DelegatingExplicitCallGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/DelegatingExplicitCallGraph.java
@@ -264,6 +264,6 @@ public class DelegatingExplicitCallGraph extends ExplicitCallGraph {
   @Override
   protected ExplicitEdgeManager makeEdgeManger() {
     return new DelegatingEdgeManager();
-  };
+  }
 
 }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/cfg/ExceptionPrunedCFG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/cfg/ExceptionPrunedCFG.java
@@ -34,7 +34,7 @@ public class ExceptionPrunedCFG {
     public boolean hasExceptionalEdge(T src, T dst) {
       return false;
     }
-  };
+  }
 
   public static <I, T extends IBasicBlock<I>> PrunedCFG<I, T> make(ControlFlowGraph<I, T> cfg) {
     return PrunedCFG.make(cfg, new ExceptionEdgePruner<I, T>(cfg));

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/PDG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/PDG.java
@@ -77,7 +77,7 @@ import com.ibm.wala.util.intset.OrdinalSet;
 public class PDG<T extends InstanceKey> implements NumberedGraph<Statement> {
 
 /** BEGIN Custom change: control deps */                
-  public enum Dependency {CONTROL_DEP, DATA_AND_CONTROL_DEP};
+  public enum Dependency {CONTROL_DEP, DATA_AND_CONTROL_DEP}
   
   private final SlowSparseNumberedLabeledGraph<Statement, Dependency> delegate =
     new SlowSparseNumberedLabeledGraph<Statement, Dependency>(Dependency.DATA_AND_CONTROL_DEP);

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/IR.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/IR.java
@@ -747,5 +747,5 @@ public abstract class IR implements IRView {
    */
   public SSAOptions getOptions() {
     return options;
-  };
+  }
 }

--- a/com.ibm.wala.core/src/com/ibm/wala/util/ssa/SSAValueManager.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/ssa/SSAValueManager.java
@@ -416,7 +416,7 @@ public class SSAValueManager {
             throw new IllegalArgumentException("The argument key may not be null");
         }
 
-        final SSAValue cand;;
+        final SSAValue cand;
         currentScope--;
         assert(currentScope >= 0 );
         cand = getCurrent(key);

--- a/com.ibm.wala.ide.jsdt/source/com/ibm/wala/cast/js/client/EclipseJavaScriptAnalysisEngine.java
+++ b/com.ibm.wala.ide.jsdt/source/com/ibm/wala/cast/js/client/EclipseJavaScriptAnalysisEngine.java
@@ -61,7 +61,7 @@ import com.ibm.wala.util.functions.Function;
 
 public class EclipseJavaScriptAnalysisEngine<I extends InstanceKey> extends EclipseProjectSourceAnalysisEngine<IJavaScriptProject, I> {
 
-  public enum BuilderType { PESSIMISTIC, OPTIMISTIC, REFLECTIVE };
+  public enum BuilderType { PESSIMISTIC, OPTIMISTIC, REFLECTIVE }
   
   private final BuilderType builderType;
   

--- a/com.ibm.wala.ide.jsdt/source/com/ibm/wala/ide/util/JsdtUtil.java
+++ b/com.ibm.wala.ide.jsdt/source/com/ibm/wala/ide/util/JsdtUtil.java
@@ -73,7 +73,7 @@ public class JsdtUtil {
   public static class CGInfo {
     public final Graph<IMember> cg = SlowSparseNumberedGraph.make();
     public final Set<FunctionInvocation> calls = HashSetFactory.make();
-  };
+  }
 
   public static Set<ModuleEntry> getJavaScriptCodeFromProject(String project) throws IOException, CoreException {
     IJavaScriptProject p = JavaScriptHeadlessUtil.getJavaScriptProjectFromWorkspace(project);

--- a/com.ibm.wala.ide/src/com/ibm/wala/ide/util/EclipseProjectPath.java
+++ b/com.ibm.wala.ide/src/com/ibm/wala/ide/util/EclipseProjectPath.java
@@ -74,7 +74,7 @@ public abstract class EclipseProjectPath<E, P> {
 
   public interface ILoader {
     ClassLoaderReference ref();
-  };
+  }
   
   /**
    * Eclipse projects are modeled with 3 loaders, as described above.
@@ -93,7 +93,7 @@ public abstract class EclipseProjectPath<E, P> {
     public ClassLoaderReference ref() {
       return ref;
     }
-  };
+  }
 
   public enum AnalysisScopeType {
     NO_SOURCE, SOURCE_FOR_PROJ, SOURCE_FOR_PROJ_AND_LINKED_PROJS

--- a/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/Debug.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/Debug.java
@@ -45,7 +45,7 @@ public final class Debug {
     public boolean isHigherPriority(LogLevel l) {
       return priority > l.priority;
     }
-  };
+  }
 
   private static PrintStream OUT_STREAM = System.out;
 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/graph/traverse/Topological.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/graph/traverse/Topological.java
@@ -52,7 +52,7 @@ public class Topological {
         finishTime = null;
         Graph<T> G_T = GraphInverter.invert(graph);
         return DFS.iterateFinishTime(G_T, rev);
-      };
+      }
     };
   }
 }

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/SemiSparseMutableIntSet.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/SemiSparseMutableIntSet.java
@@ -339,7 +339,6 @@ public class SemiSparseMutableIntSet implements MutableIntSet {
         return next;
       }
     }
-    ;
 
     if (sparsePart.isEmpty()) {
       if (densePart == null || densePart.isZero()) {


### PR DESCRIPTION
I have *not* upgraded this problem to be treated as an error in the future.  Unfortunately Eclipse uses a single configuration setting for both unnecessary semicolons and also for empty control-flow statements like `while (p) ;`.  I'm not convinced that it's worth rewriting all instances of the latter into `while (p) { }`.  So this is just going to stay as a warning for now.