### PR TITLE
Disable Eclipse warnings about unqualified accesses to instance fields

### DIFF
--- a/com.ibm.wala.cast.js.nodejs.test/.settings/org.eclipse.jdt.core.prefs
+++ b/com.ibm.wala.cast.js.nodejs.test/.settings/org.eclipse.jdt.core.prefs
@@ -100,7 +100,7 @@ org.eclipse.jdt.core.compiler.problem.unlikelyCollectionMethodArgumentTypeStrict
 org.eclipse.jdt.core.compiler.problem.unlikelyEqualsArgumentType=error
 org.eclipse.jdt.core.compiler.problem.unnecessaryElse=ignore
 org.eclipse.jdt.core.compiler.problem.unnecessaryTypeCheck=error
-org.eclipse.jdt.core.compiler.problem.unqualifiedFieldAccess=error
+org.eclipse.jdt.core.compiler.problem.unqualifiedFieldAccess=ignore
 org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownException=error
 org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownExceptionExemptExceptionAndThrowable=enabled
 org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownExceptionIncludeDocCommentReference=enabled

--- a/com.ibm.wala.ide.jdt.test/.settings/org.eclipse.jdt.core.prefs
+++ b/com.ibm.wala.ide.jdt.test/.settings/org.eclipse.jdt.core.prefs
@@ -102,7 +102,7 @@ org.eclipse.jdt.core.compiler.problem.unlikelyCollectionMethodArgumentTypeStrict
 org.eclipse.jdt.core.compiler.problem.unlikelyEqualsArgumentType=error
 org.eclipse.jdt.core.compiler.problem.unnecessaryElse=ignore
 org.eclipse.jdt.core.compiler.problem.unnecessaryTypeCheck=error
-org.eclipse.jdt.core.compiler.problem.unqualifiedFieldAccess=warning
+org.eclipse.jdt.core.compiler.problem.unqualifiedFieldAccess=ignore
 org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownException=error
 org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownExceptionExemptExceptionAndThrowable=enabled
 org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownExceptionIncludeDocCommentReference=enabled


### PR DESCRIPTION
I’m very picky about code style, but even I see no benefit in requiring `this.field` instead of simply `field`.

This resolves all remaining Eclipse warnings in the “Code Style” category.