### PR TITLE
Add missing void type.

### DIFF
--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/typeInference/JavaPrimitiveType.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/typeInference/JavaPrimitiveType.java
@@ -36,6 +36,8 @@ public class JavaPrimitiveType extends PrimitiveType {
 
   public static final PrimitiveType DOUBLE = makePrimitive(TypeReference.Double, 64);
 
+  public static final PrimitiveType VOID = makePrimitive(TypeReference.Void, 0);
+
   public static void init() {
     
   }


### PR DESCRIPTION
You can see from: https://github.com/wala/WALA/blob/68f30f949d60b290a75bbd4d52956a412f01f91c/com.ibm.wala.core/src/com/ibm/wala/analysis/typeInference/JavaPrimitiveType.java#L62 that it's missing. In other words, That line would never print since the corresponding constant is missing.