### PR TITLE
Remove a default encoding setting that Eclipse considers unnecessary

### DIFF
--- a/com.ibm.wala.cast.js.nodejs/build.properties
+++ b/com.ibm.wala.cast.js.nodejs/build.properties
@@ -11,4 +11,3 @@ javacProjectSettings = true
 bin.excludes = dat/core-modules/.eslintrc,\
                dat/core-modules/.gitignore,\
                dat/core-modules/.gitkeep
-javacDefaultEncoding.. = UTF-8


### PR DESCRIPTION
@juliandolby added this in a recent commit, but has told me that he does not think it is necessary, and that I am free to remove it if it is causing trouble.  Removing this does indeed fix one Eclipse error diagnostic: "Default encoding (UTF-8) for library '.' should be removed as the workspace does not specify an explicit encoding."