### PR TITLE
disable Maven nature for NodeJS project

### DIFF
--- a/com.ibm.wala.cast.js.nodejs/.project
+++ b/com.ibm.wala.cast.js.nodejs/.project
@@ -20,14 +20,8 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
-		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 	</natures>


### PR DESCRIPTION
This was causing a bunch of errors in Eclipse, but we don't care about Eclipse Maven integration