### PR TITLE
Tell M2Eclipse to run a few Maven plugins with no special handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,6 +259,51 @@
             </executions>
         </plugin>
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <versionRange>[3.0.0-M1,)</versionRange>
+                    <goals>
+                      <goal>javadoc</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <execute>
+                      <runOnIncremental>false</runOnIncremental>
+                    </execute>
+                  </action>
+                </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.eclipse.tycho</groupId>
+                    <artifactId>tycho-source-plugin</artifactId>
+                    <versionRange>[0.23.1,)</versionRange>
+                    <goals>
+                      <goal>plugin-source</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <execute>
+                      <runOnIncremental>false</runOnIncremental>
+                    </execute>
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
   <pluginRepositories>
   <pluginRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -258,8 +258,8 @@
                 </execution>
             </executions>
         </plugin>
-</plugins>
-</build>
+    </plugins>
+  </build>
   <pluginRepositories>
   <pluginRepository>
     <id>sonatype-public-repository</id>


### PR DESCRIPTION
Specifically, this will run the `javadoc` goal of the `maven-javadoc-plugin` and the `plugin-source` goal of the `tycho-source-plugin` whenever Eclipse does a full build.  It will not run these on incremental builds, though.  Maven plugins in general are usually not designed with incremental execution in mind, so rerunning them on every incremental build turns out to be too sluggish in practice.

Previously, M2Eclipse would occasionally notice these two plugins, realize it didn’t know what to do with them, and produce Eclipse error diagnostics that were difficult to resolve.  With this change we are telling Eclipse’s Maven builder to just run the plugins in the natural way even though M2Eclipse has no special handling built-in for them.

Fixes #198, much to my relief.