### PR TITLE
Enable ErrorProne on wala.util project

### DIFF
--- a/com.ibm.wala.util/mvncentral.xml
+++ b/com.ibm.wala.util/mvncentral.xml
@@ -69,11 +69,43 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.2</version>
+        <version>3.5</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <compilerId>javac-with-errorprone</compilerId>
+          <forceJavacCompilerUse>true</forceJavacCompilerUse>
+          <source>1.8</source>
+          <target>1.8</target>
+          <showWarnings>true</showWarnings>
+          <!-- <annotationProcessorPaths> -->
+          <!--   <path> -->
+          <!--     <groupId>com.uber.nullaway</groupId> -->
+          <!--     <artifactId>nullaway</artifactId> -->
+          <!--     <version>0.1.3</version> -->
+          <!--   </path> -->
+          <!-- </annotationProcessorPaths> -->
+          <compilerArgs>
+            <!-- <arg>-Xep:NullAway:ERROR</arg> -->
+            <!-- <arg>-XepOpt:NullAway:AnnotatedPackages=com.ibm.wala</arg> -->
+            <arg>-Werror</arg>
+            <arg>-Xep:IterableAndIterator:OFF</arg>
+            <arg>-Xep:AmbiguousMethodReference:OFF</arg>
+            <arg>-Xep:ReferenceEquality:OFF</arg>
+          </compilerArgs>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-compiler-javac-errorprone</artifactId>
+            <version>2.8</version>
+          </dependency>
+          <!-- override plexus-compiler-javac-errorprone's dependency on
+               Error Prone with the latest version -->
+          <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_core</artifactId>
+            <version>2.1.1</version>
+          </dependency>
+        </dependencies>        
       </plugin>
 
       <plugin>

--- a/com.ibm.wala.util/src/com/ibm/wala/fixpoint/BooleanVariable.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/fixpoint/BooleanVariable.java
@@ -63,7 +63,7 @@ public class BooleanVariable extends AbstractVariable<BooleanVariable> {
     if (other == null) {
       throw new IllegalArgumentException("other is null");
     }
-    B = B | other.B;
+    B = B || other.B;
   }
 
   public void set(boolean b) {

--- a/com.ibm.wala.util/src/com/ibm/wala/util/collections/Iterator2Collection.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/collections/Iterator2Collection.java
@@ -148,8 +148,7 @@ public abstract class Iterator2Collection<T> implements Collection<T> {
   }
 
   @Override
-  @SuppressWarnings("hiding")
-  public <T> T[] toArray(T[] a) {
+  public <U> U[] toArray(U[] a) {
     return getDelegate().toArray(a);
   }
 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/collections/ParanoidHashSet.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/collections/ParanoidHashSet.java
@@ -78,11 +78,11 @@ public class ParanoidHashSet<T> extends LinkedHashSet<T> {
     if (result) {
       nAdded++;
       int hc = arg0.hashCode();
-      Set<T> s = hcFreq.get(new Integer(hc));
+      Set<T> s = hcFreq.get(hc);
       if (s == null) {
         HashSet<T> h = new LinkedHashSet<>(1);
         h.add(arg0);
-        hcFreq.put(new Integer(hc), h);
+        hcFreq.put(hc, h);
       } else {
         if (s.size() == BAD_HC) {
           for (Iterator<T> it = s.iterator(); it.hasNext();) {

--- a/com.ibm.wala.util/src/com/ibm/wala/util/collections/Util.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/collections/Util.java
@@ -37,9 +37,12 @@
  */
 package com.ibm.wala.util.collections;
 
+import java.io.BufferedWriter;
 import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
 import java.security.Permission;
 import java.util.ArrayList;
 import java.util.BitSet;
@@ -71,7 +74,7 @@ public class Util {
     }
     // create a memory buffer to which to dump the trace
     ByteArrayOutputStream traceDump = new ByteArrayOutputStream();
-    try (final PrintWriter w = new PrintWriter(traceDump)) {
+    try (final PrintWriter w = new PrintWriter(new BufferedWriter(new OutputStreamWriter(traceDump, StandardCharsets.UTF_8)))) {
       thrown.printStackTrace(w);
     }
     return traceDump.toString();

--- a/com.ibm.wala.util/src/com/ibm/wala/util/config/FileOfClasses.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/config/FileOfClasses.java
@@ -14,6 +14,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -37,7 +38,7 @@ public class FileOfClasses extends SetOfClasses {
     if (input == null) {
       throw new IllegalArgumentException("null input");
     }
-    try (final BufferedReader is = new BufferedReader(new InputStreamReader(input))) {
+    try (final BufferedReader is = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
   
       StringBuffer regex = null;
       String line;

--- a/com.ibm.wala.util/src/com/ibm/wala/util/graph/traverse/DFS.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/graph/traverse/DFS.java
@@ -110,7 +110,7 @@ public class DFS {
     int i = 0;
     while (dfs.hasNext()) {
       T nxt = dfs.next();
-      order.put(nxt, new Integer(i++));
+      order.put(nxt, Integer.valueOf(i++));
       result.add(nxt);
     }
     return result;

--- a/com.ibm.wala.util/src/com/ibm/wala/util/heapTrace/HeapTracer.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/heapTrace/HeapTracer.java
@@ -283,7 +283,7 @@ public class HeapTracer {
 	} else {
 	    Integer S = sizeMap.get(c);
 	    if (S == null) {
-		S = new Integer(computeSizeOf(o));
+		S = Integer.valueOf(computeSizeOf(o));
 		sizeMap.put(c, S);
 	    }
 	    return S.intValue();
@@ -660,13 +660,13 @@ public class HeapTracer {
 	public void registerObject(Object key, Object o) {
 	    Integer I = instanceCount.get(key);
 	    int newCount = (I == null) ? 1 : I.intValue() + 1;
-	    instanceCount.put(key, new Integer(newCount));
+	    instanceCount.put(key, Integer.valueOf(newCount));
 	    totalInstances++;
 
 	    I = sizeCount.get(key);
 	    int s = sizeOf(o);
 	    int newSizeCount = (I == null) ? s : I.intValue() + s;
-	    sizeCount.put(key, new Integer(newSizeCount));
+	    sizeCount.put(key, Integer.valueOf(newSizeCount));
 	    totalSize += s;
 	}
 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/BitVectorIntSetFactory.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/BitVectorIntSetFactory.java
@@ -32,7 +32,7 @@ public class BitVectorIntSetFactory implements MutableIntSetFactory<BitVectorInt
       // XXX not very efficient.
       TreeSet<Integer> T = new TreeSet<>();
       for (int i = 0; i < set.length; i++) {
-        T.add(new Integer(set[i]));
+        T.add(set[i]);
       }
       BitVectorIntSet result = new BitVectorIntSet();
       for (Iterator<Integer> it = T.iterator(); it.hasNext();) {

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/Bits.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/Bits.java
@@ -65,7 +65,7 @@ public class Bits {
    * Does an int literal val fit in bits bits?
    */
   public static boolean fits(int val, int bits) {
-    val = val >> bits - 1;
+    val = val >> (bits - 1);
     return (val == 0 || val == -1);
   }
 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/DebuggingMutableIntSet.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/DebuggingMutableIntSet.java
@@ -316,15 +316,15 @@ class DebuggingMutableIntSet implements MutableIntSet {
     primaryImpl.foreach(new IntSetAction() {
       @Override
       public void act(int x) {
-        assert !bits.contains(new Integer(x));
-        bits.add(new Integer(x));
+        assert !bits.contains(Integer.valueOf(x));
+        bits.add(Integer.valueOf(x));
       }
     });
     secondaryImpl.foreach(new IntSetAction() {
       @Override
       public void act(int x) {
-        assert bits.contains(new Integer(x));
-        bits.remove(new Integer(x));
+        assert bits.contains(Integer.valueOf(x));
+        bits.remove(Integer.valueOf(x));
       }
     });
     assert bits.isEmpty();
@@ -341,15 +341,15 @@ class DebuggingMutableIntSet implements MutableIntSet {
     primaryImpl.foreachExcluding(X, new IntSetAction() {
       @Override
       public void act(int x) {
-        assert !bits.contains(new Integer(x));
-        bits.add(new Integer(x));
+        assert !bits.contains(Integer.valueOf(x));
+        bits.add(Integer.valueOf(x));
       }
     });
     secondaryImpl.foreachExcluding(X, new IntSetAction() {
       @Override
       public void act(int x) {
-        assert bits.contains(new Integer(x));
-        bits.remove(new Integer(x));
+        assert bits.contains(Integer.valueOf(x));
+        bits.remove(Integer.valueOf(x));
       }
     });
     assert bits.isEmpty();

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/IntSetUtil.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/IntSetUtil.java
@@ -31,7 +31,7 @@ public class IntSetUtil {
       try {
         @SuppressWarnings("unchecked")
         Class<? extends MutableIntSetFactory<?>> intSetFactoryClass = (Class<? extends MutableIntSetFactory<?>>) Class.forName(System.getProperty(INT_SET_FACTORY_CONFIG_PROPERTY_NAME));
-        MutableIntSetFactory<?> intSetFactory = intSetFactoryClass.newInstance();
+        MutableIntSetFactory<?> intSetFactory = intSetFactoryClass.getDeclaredConstructor().newInstance();
         setDefaultIntSetFactory(intSetFactory);
       } catch (Exception e) {
         System.err.println(("Cannot use int set factory " + System.getProperty(INT_SET_FACTORY_CONFIG_PROPERTY_NAME)));

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/LongSetUtil.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/LongSetUtil.java
@@ -27,7 +27,7 @@ public class LongSetUtil {
     if (System.getProperty(INT_SET_FACTORY_CONFIG_PROPERTY_NAME) != null) {
       try {
         Class<?> intSetFactoryClass = Class.forName(System.getProperty(INT_SET_FACTORY_CONFIG_PROPERTY_NAME));
-        MutableLongSetFactory intSetFactory = (MutableLongSetFactory) intSetFactoryClass.newInstance();
+        MutableLongSetFactory intSetFactory = (MutableLongSetFactory) intSetFactoryClass.getDeclaredConstructor().newInstance();
         setDefaultLongSetFactory(intSetFactory);
       } catch (Exception e) {
         System.err.println(("Cannot use int set factory " + System.getProperty(INT_SET_FACTORY_CONFIG_PROPERTY_NAME)));

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/MutableMapping.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/MutableMapping.java
@@ -100,7 +100,7 @@ public class MutableMapping<T> implements OrdinalSetMapping<T>, Serializable {
     if (I != null) {
       return I.intValue();
     }
-    map.put(o, new Integer(nextIndex));
+    map.put(o, nextIndex);
     if (nextIndex >= array.length) {
       Object[] old = array;
       array = new Object[2 * array.length];
@@ -159,7 +159,7 @@ public class MutableMapping<T> implements OrdinalSetMapping<T>, Serializable {
       throw new IllegalArgumentException("first element does not exist in map");
     }
     map.remove(a);
-    map.put(b, new Integer(i));
+    map.put(b, i);
     array[i] = b;
   }
 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/MutableSparseIntSetFactory.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/MutableSparseIntSetFactory.java
@@ -32,7 +32,7 @@ public class MutableSparseIntSetFactory implements MutableIntSetFactory<MutableS
       // XXX not very efficient.
       TreeSet<Integer> T = new TreeSet<>();
       for (int i = 0; i < set.length; i++) {
-        T.add(new Integer(set[i]));
+        T.add(set[i]);
       }
       int[] copy = new int[T.size()];
       int i = 0;

--- a/com.ibm.wala.util/src/com/ibm/wala/util/io/FileUtil.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/io/FileUtil.java
@@ -14,7 +14,6 @@ import java.io.File;
 import java.io.FileFilter;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Writer;

--- a/com.ibm.wala.util/src/com/ibm/wala/util/io/FileUtil.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/io/FileUtil.java
@@ -17,8 +17,11 @@ import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Writer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -183,7 +186,7 @@ public class FileUtil {
    * @throws IOException
    */
   public static void writeFile(File f, String content) throws IOException {
-    try (final FileWriter fw = new FileWriter(f)) {
+    try (final Writer fw = Files.newBufferedWriter(f.toPath(), StandardCharsets.UTF_8)) {
       fw.append(content);
     }
   }

--- a/com.ibm.wala.util/src/com/ibm/wala/util/io/TemporaryFile.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/io/TemporaryFile.java
@@ -15,6 +15,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -56,7 +57,7 @@ public class TemporaryFile {
     try (final FileOutputStream output = new FileOutputStream(F)) {
 
       for(String input : inputs) {
-        output.write(input.getBytes());
+        output.write(input.getBytes(StandardCharsets.UTF_8));
       }
     }
 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/processes/Launcher.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/processes/Launcher.java
@@ -15,6 +15,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
@@ -278,7 +279,7 @@ public abstract class Launcher {
       while (s.available() > 0) {
         byte[] data = new byte[s.available()];
         s.read(data);
-        p.print(new String(data));
+        p.print(new String(data, StandardCharsets.UTF_8));
       }
     } catch (IOException e) {
       // assume the stream has been closed (e.g. the process died)

--- a/com.ibm.wala.util/src/com/ibm/wala/util/tables/StringTable.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/tables/StringTable.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
+import java.nio.charset.StandardCharsets;
 import java.util.StringTokenizer;
 
 import com.ibm.wala.util.collections.SimpleVector;
@@ -108,7 +109,7 @@ public class StringTable extends Table<String> implements Cloneable {
     }
     StringTable result = new StringTable();
 
-    LineNumberReader reader = new LineNumberReader(new InputStreamReader(s));
+    LineNumberReader reader = new LineNumberReader(new InputStreamReader(s, StandardCharsets.UTF_8));
 
     // LineNumberReader reader = new LineNumberReader(new
     // InputStreamReader(new FileInputStream(f)));

--- a/com.ibm.wala.util/src/com/ibm/wala/viz/DotUtil.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/viz/DotUtil.java
@@ -12,8 +12,10 @@ package com.ibm.wala.viz;
 
 import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
@@ -164,7 +166,7 @@ public class DotUtil {
     }
     try {
       File f = new File(dotfile);
-      try (FileWriter fw = new FileWriter(f)) {
+      try (Writer fw = Files.newBufferedWriter(f.toPath(), StandardCharsets.UTF_8)) {
         fw.write(dotStringBuffer.toString());
       }
       return f;


### PR DESCRIPTION
Since @liblit was running out of warnings to fix... 😄 This PR enables [Error Prone](http://errorprone.info/) for building the Maven jar of wala.util.  I fixed most of the warnings it emitted, but turned a couple checks off since the issues needed more careful study.

The downside of this change is that Error Prone doesn't run during the standard Eclipse build.  Locally, you can run it by running `./build-maven-jars.py`, but you need to remember to do that.  Since the `wala.util` code is quite stable I think it's reasonable to enable here and experiment.

As you can see by the commented lines in `mvncentral.xml`, another goal is to try [NullAway](https://github.com/uber/NullAway) out on WALA to build up more robustness against NPEs.  But one step at a time.