### PR TITLE
Suppress deprecation warnings about requesting an old AST version

### DIFF
--- a/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/ecj/ECJSourceModuleTranslator.java
+++ b/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/ecj/ECJSourceModuleTranslator.java
@@ -184,6 +184,7 @@ public class ECJSourceModuleTranslator implements SourceModuleTranslator {
     }
     
     String[] sourceFiles = sources.toArray(new String[ sources.size() ]);
+    @SuppressWarnings("deprecation")
     final ASTParser parser = ASTParser.newParser(AST.JLS8);
     parser.setResolveBindings(true);
     parser.setEnvironment(libs, this.sources, null, false);

--- a/com.ibm.wala.ide.jdt/source/com/ibm/wala/cast/java/translator/jdt/JDTSourceModuleTranslator.java
+++ b/com.ibm.wala.ide.jdt/source/com/ibm/wala/cast/java/translator/jdt/JDTSourceModuleTranslator.java
@@ -172,6 +172,7 @@ public class JDTSourceModuleTranslator implements SourceModuleTranslator {
       projectsFiles.get(proj).put(JavaCore.createCompilationUnitFrom(entry.getIFile()), entry);
     }
 
+    @SuppressWarnings("deprecation")
     final ASTParser parser = ASTParser.newParser(AST.JLS8);
  
     for (final Map.Entry<IProject,Map<ICompilationUnit,EclipseSourceFileModule>> proj : projectsFiles.entrySet()) {


### PR DESCRIPTION
Near as I can tell, the requests for deprecated versions here are intentional.  The non-deprecated version (`AST.JLS9`) is the latest and greatest, but as far as I can tell we really do want the older version here.

This is similar to 6caecce3e74cec12f4f206bddb39c44875e46ddc, though in that case `JLS8` was the non-deprecated latest version and we were still asking for `JLS3`.