### PR TITLE
Remove a default encoding setting that Eclipse considers unnecessary

### DIFF
--- a/com.ibm.wala.cast.js.nodejs/build.properties
+++ b/com.ibm.wala.cast.js.nodejs/build.properties
@@ -11,4 +11,3 @@ javacProjectSettings = true
 bin.excludes = dat/core-modules/.eslintrc,\
                dat/core-modules/.gitignore,\
                dat/core-modules/.gitkeep
-javacDefaultEncoding.. = UTF-8


### PR DESCRIPTION
Fixes one Eclipse error diagnostic: "Default encoding (UTF-8) for library '.' should be removed as the workspace does not specify an explicit encoding."

This reapplies the fox from ecd1ff72fecb9fd618d37a3f03b9ea9dba88f972, which was reverted (apparently unintentionally) as part of a larger group of changes in 8d65788aefc7726e4c0714c4b6e64d9a60a96eba.