### PR TITLE
Update Maven Central configurations to also use Java 8

### DIFF
--- a/com.ibm.wala.cast.java.ecj/mvncentral.xml
+++ b/com.ibm.wala.cast.java.ecj/mvncentral.xml
@@ -106,8 +106,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.2</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
 

--- a/com.ibm.wala.cast.java/mvncentral.xml
+++ b/com.ibm.wala.cast.java/mvncentral.xml
@@ -91,8 +91,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.2</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
 

--- a/com.ibm.wala.cast.js.rhino/mvncentral.xml
+++ b/com.ibm.wala.cast.js.rhino/mvncentral.xml
@@ -96,8 +96,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.2</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
 

--- a/com.ibm.wala.cast.js/mvncentral.xml
+++ b/com.ibm.wala.cast.js/mvncentral.xml
@@ -106,8 +106,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.2</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
 

--- a/com.ibm.wala.cast/mvncentral.xml
+++ b/com.ibm.wala.cast/mvncentral.xml
@@ -91,8 +91,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.2</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
 

--- a/com.ibm.wala.dalvik/mvncentral.xml
+++ b/com.ibm.wala.dalvik/mvncentral.xml
@@ -135,8 +135,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.2</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
 

--- a/com.ibm.wala.scandroid/mvncentral.xml
+++ b/com.ibm.wala.scandroid/mvncentral.xml
@@ -105,8 +105,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.2</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
 

--- a/com.ibm.wala.shrike/mvncentral.xml
+++ b/com.ibm.wala.shrike/mvncentral.xml
@@ -76,8 +76,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.2</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
E-mail exchanged with @juliandolby suggests that this is the right thing to do, and that it should have been done back when we converted other parts of the build configuration to Java 8.