### PR TITLE
Modernize loops and iterators

### DIFF
--- a/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/ecj/util/SourceDirCallGraph.java
+++ b/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/ecj/util/SourceDirCallGraph.java
@@ -52,8 +52,8 @@ public class SourceDirCallGraph {
     AnalysisScope scope = new JavaSourceAnalysisScope();
     // add standard libraries to scope
     String[] stdlibs = WalaProperties.getJ2SEJarFiles();
-    for (int i = 0; i < stdlibs.length; i++) {
-      scope.addToScope(ClassLoaderReference.Primordial, new JarFile(stdlibs[i]));
+    for (String stdlib : stdlibs) {
+      scope.addToScope(ClassLoaderReference.Primordial, new JarFile(stdlib));
     }
     // add the source directory
     scope.addToScope(JavaSourceAnalysisScope.SOURCE, new SourceDirectoryTreeModule(new File(sourceDir)));

--- a/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
+++ b/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
@@ -1411,8 +1411,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
     argNodes[idx++] = fFactory.makeConstant(callSiteRef);
 
     // rest of args
-    for (Iterator<?> iter = arguments.iterator(); iter.hasNext();) {
-      Object arg = iter.next();
+    for (Object arg : arguments) {
       argNodes[idx++] = (arg instanceof CAstNode) ? ((CAstNode) arg) : visitNode((Expression) arg, context);
     }
     callNode = makeNode(context, fFactory, nn, CAstNode.CALL, argNodes);

--- a/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/ecj/ECJSourceModuleTranslator.java
+++ b/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/ecj/ECJSourceModuleTranslator.java
@@ -42,7 +42,6 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Hashtable;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -136,9 +135,7 @@ public class ECJSourceModuleTranslator implements SourceModuleTranslator {
     while (cl != null) {
       List<Module> modules = scope.getModules(cl);
 
-      for (Iterator<Module> iter = modules.iterator(); iter.hasNext();) {
-        Module m = iter.next();
-
+      for (Module m : modules) {
         if (m instanceof JarFileModule) {
           JarFileModule jarFileModule = (JarFileModule) m;
 

--- a/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/analysis/typeInference/AstJavaTypeInference.java
+++ b/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/analysis/typeInference/AstJavaTypeInference.java
@@ -132,9 +132,8 @@ public class AstJavaTypeInference extends AstTypeInference {
     public byte evaluate(TypeVariable lhs, TypeVariable[] rhs) {
       TypeAbstraction meet = null;
 
-      for (int i = 0; i < rhs.length; i++) {
-        if (rhs[i] != null) {
-          TypeVariable r = rhs[i];
+      for (TypeVariable r : rhs) {
+        if (r != null) {
           TypeAbstraction ta = r.getType();
           if (ta instanceof PointType) {
             if (ta.getType().equals(getStringClass())) {

--- a/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/ipa/callgraph/AstJavaSSAPropagationCallGraphBuilder.java
+++ b/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/ipa/callgraph/AstJavaSSAPropagationCallGraphBuilder.java
@@ -173,8 +173,8 @@ public class AstJavaSSAPropagationCallGraphBuilder extends AstSSAPropagationCall
 
         InstanceKey[] objs = getInvariantContents(objVal);
 
-        for (int i = 0; i < objs.length; i++) {
-          PointerKey enclosing = new EnclosingObjectReferenceKey(objs[i], cls);
+        for (InstanceKey obj : objs) {
+          PointerKey enclosing = new EnclosingObjectReferenceKey(obj, cls);
           system.newConstraint(lvalKey, assignOperator, enclosing);
         }
 

--- a/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/ipa/callgraph/AstJavaZeroXCFABuilder.java
+++ b/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/ipa/callgraph/AstJavaZeroXCFABuilder.java
@@ -53,8 +53,8 @@ public class AstJavaZeroXCFABuilder extends AstJavaCFABuilder {
       AnalysisScope scope, String[] xmlFiles, byte instancePolicy) {
 
     com.ibm.wala.ipa.callgraph.impl.Util.addDefaultSelectors(options, cha);
-    for (int i = 0; i < xmlFiles.length; i++) {
-      com.ibm.wala.ipa.callgraph.impl.Util.addBypassLogic(options, scope, cl, xmlFiles[i], cha);
+    for (String xmlFile : xmlFiles) {
+      com.ibm.wala.ipa.callgraph.impl.Util.addBypassLogic(options, scope, cl, xmlFile, cha);
     }
 
     return new AstJavaZeroXCFABuilder(cha, options, cache, null, null, instancePolicy);

--- a/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/ipa/callgraph/JavaScopeMappingInstanceKeys.java
+++ b/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/ipa/callgraph/JavaScopeMappingInstanceKeys.java
@@ -44,8 +44,8 @@ public class JavaScopeMappingInstanceKeys extends ScopeMappingInstanceKeys {
         if ((m instanceof AstMethod) && !m.isStatic()) {
           AstMethod M = (AstMethod) m;
           LexicalParent[] parents = M.getParents();
-          for (int i = 0; i < parents.length; i++) {
-            result.add(parents[i]);
+          for (LexicalParent parent : parents) {
+            result.add(parent);
           }
         }
       }

--- a/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/ipa/slicer/AstJavaSlicer.java
+++ b/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/ipa/slicer/AstJavaSlicer.java
@@ -12,7 +12,6 @@ package com.ibm.wala.cast.java.ipa.slicer;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -59,8 +58,7 @@ public class AstJavaSlicer extends Slicer {
 
   public static Set<Statement> gatherStatements(CallGraph CG, Collection<CGNode> partialRoots, Predicate<SSAInstruction> filter) {
     Set<Statement> result = new HashSet<>();
-    for (Iterator<CGNode> ns = DFS.getReachableNodes(CG, partialRoots).iterator(); ns.hasNext();) {
-      CGNode n = ns.next();
+    for (CGNode n : DFS.getReachableNodes(CG, partialRoots)) {
       IR nir = n.getIR();
       if (nir != null) {
 	SSAInstruction insts[] = nir.getInstructions();

--- a/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/loader/JavaSourceLoaderImpl.java
+++ b/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/loader/JavaSourceLoaderImpl.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -123,8 +122,7 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
     @Override
     public IClass getSuperclass() {
       boolean excludedSupertype=false;
-      for (Iterator<TypeName> iter = superTypeNames.iterator(); iter.hasNext();) {
-        TypeName name = iter.next();
+      for (TypeName name : superTypeNames) {
         IClass domoType = lookupClass(name);
         if (domoType != null && !domoType.isInterface()) {
           return domoType;

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/callgraph/fieldbased/FieldBasedCallGraphBuilder.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/callgraph/fieldbased/FieldBasedCallGraphBuilder.java
@@ -158,8 +158,7 @@ public abstract class FieldBasedCallGraphBuilder {
 		// set up call edges from fake root to all script nodes
 		AbstractRootMethod fakeRootMethod = (AbstractRootMethod)cg.getFakeRootNode().getMethod();
 		CGNode fakeRootNode = cg.findOrCreateNode(fakeRootMethod, Everywhere.EVERYWHERE);
-		for(Iterator<? extends Entrypoint> iter = eps.iterator(); iter.hasNext();) {
-			Entrypoint ep = iter.next();
+		for (Entrypoint ep : eps) {
 			CGNode nd = cg.findOrCreateNode(ep.getMethod(), Everywhere.EVERYWHERE);
 			SSAAbstractInvokeInstruction invk = ep.addCall(fakeRootMethod);
 			fakeRootNode.addTarget(invk.getCallSite(), nd);

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/html/jericho/JerichoHtmlParser.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/html/jericho/JerichoHtmlParser.java
@@ -13,7 +13,6 @@ package com.ibm.wala.cast.js.html.jericho;
 import java.io.IOException;
 import java.io.Reader;
 import java.net.URL;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -110,8 +109,7 @@ public class JerichoHtmlParser implements IHtmlParser{
 			src = new Source(reader);
 			src.setLogger(Config.LoggerProvider.getLogger(fileName));
 			List<Element> childElements = src.getChildElements();
-			for (Iterator<Element> nodeIterator = childElements.iterator(); nodeIterator.hasNext();) {
-				Element e = nodeIterator.next();
+			for (Element e : childElements) {
 				parser.parse(e);
 			}
 			if (! warnings.isEmpty()) {
@@ -139,8 +137,7 @@ public class JerichoHtmlParser implements IHtmlParser{
 			handler.handleStartTag(tag);
 			handler.handleText(tag.getElementPosition(), tag.getBodyText().snd);
 			List<Element> childElements = root.getChildElements();
-			for (Iterator<Element> nodeIterator = childElements.iterator(); nodeIterator.hasNext();) {
-				Element child = nodeIterator.next();
+			for (Element child : childElements) {
 				parse(child);
 			}
 			handler.handleEndTag(tag);

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JSSSAPropagationCallGraphBuilder.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JSSSAPropagationCallGraphBuilder.java
@@ -528,8 +528,8 @@ public class JSSSAPropagationCallGraphBuilder extends AstSSAPropagationCallGraph
       if (contentsAreInvariant(symbolTable, du, rval)) {
         system.recordImplicitPointsToSet(rvalKey);
         InstanceKey[] ik = getInvariantContents(rval);
-        for (int i = 0; i < ik.length; i++) {
-          system.newConstraint(p, ik[i]);
+        for (InstanceKey element : ik) {
+          system.newConstraint(p, element);
         }
       } else {
         system.newConstraint(p, assignOperator, rvalKey);
@@ -668,8 +668,8 @@ public class JSSSAPropagationCallGraphBuilder extends AstSSAPropagationCallGraph
       if (contentsAreInvariant(symbolTable, du, receiverVn)) {
           system.recordImplicitPointsToSet(receiverKey);
           InstanceKey[] ik = getInvariantContents(receiverVn);
-          for (int i = 0; i < ik.length; i++) {
-            handleJavascriptDispatch(instruction, ik[i]);
+          for (InstanceKey element : ik) {
+            handleJavascriptDispatch(instruction, element);
           }
       } else {
         class ReceiverForDispatchOp extends UnaryOperator<PointsToSetVariable> {
@@ -810,17 +810,17 @@ public class JSSSAPropagationCallGraphBuilder extends AstSSAPropagationCallGraph
           InstanceKey[] iks2 = getInstancesArray(arg2);
 
           if ((instruction.getOperator() == BinaryOpInstruction.Operator.ADD) && (getOptions().getTraceStringConstants())) {
-            for (int i = 0; i < iks1.length; i++) {
-              if (isStringConstant(iks1[i])) {
-                for (int j = 0; j < iks2.length; j++) {
-                  if (isStringConstant(iks2[j])) {
+            for (InstanceKey element : iks1) {
+              if (isStringConstant(element)) {
+                for (InstanceKey element2 : iks2) {
+                  if (isStringConstant(element2)) {
                     try {
                       MonitorUtil.throwExceptionIfCanceled(builder.monitor);
                     } catch (CancelException e) {
                       throw new CancelRuntimeException(e);
                     }
-                    String v1 = (String) ((ConstantKey<?>) iks1[i]).getValue();
-                    String v2 = (String) ((ConstantKey<?>) iks2[j]).getValue();
+                    String v1 = (String) ((ConstantKey<?>) element).getValue();
+                    String v2 = (String) ((ConstantKey<?>) element2).getValue();
                     if (v1.indexOf(v2) == -1 && v2.indexOf(v1) == -1) {
                       InstanceKey lvalKey = getInstanceKeyForConstant(v1 + v2);
                       if (addKey(lvalKey)) {
@@ -842,14 +842,14 @@ public class JSSSAPropagationCallGraphBuilder extends AstSSAPropagationCallGraph
           }
 
           if (doDefault) {
-              for (int i = 0; i < iks1.length; i++) {
-                for (int j = 0; j < iks2.length; j++) {
+              for (InstanceKey element : iks1) {
+                for (InstanceKey element2 : iks2) {
                   try {
                     MonitorUtil.throwExceptionIfCanceled(builder.monitor);
                   } catch (CancelException e) {
                     throw new CancelRuntimeException(e);
                   }
-                  if (handleBinaryOperatorArgs(iks1[i], iks2[j])) {
+                  if (handleBinaryOperatorArgs(element, element2)) {
                     changed = CHANGED;
                   }
                 }
@@ -1097,8 +1097,8 @@ public class JSSSAPropagationCallGraphBuilder extends AstSSAPropagationCallGraph
       InstanceKey[] nullkeys = builder.getInvariantContents(sourceST, sourceDU, caller, nullvn, builder);
       for (int i = argCount; i < paramCount; i++) {
         PointerKey F = builder.getPointerKeyForLocal(target, targetST.getParameter(i));
-        for (int k = 0; k < nullkeys.length; k++) {
-          builder.getSystem().newConstraint(F, nullkeys[k]);
+        for (InstanceKey nullkey : nullkeys) {
+          builder.getSystem().newConstraint(F, nullkey);
         }
       }
     }

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JSZeroOrOneXCFABuilder.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JSZeroOrOneXCFABuilder.java
@@ -110,8 +110,8 @@ public class JSZeroOrOneXCFABuilder extends JSCFABuilder {
   public static JSCFABuilder make(JSAnalysisOptions options, IAnalysisCacheView cache, IClassHierarchy cha, ClassLoader cl,
       AnalysisScope scope, String[] xmlFiles, byte instancePolicy, boolean doOneCFA) {
     com.ibm.wala.ipa.callgraph.impl.Util.addDefaultSelectors(options, cha);
-    for (int i = 0; i < xmlFiles.length; i++) {
-      com.ibm.wala.ipa.callgraph.impl.Util.addBypassLogic(options, scope, cl, xmlFiles[i], cha);
+    for (String xmlFile : xmlFiles) {
+      com.ibm.wala.ipa.callgraph.impl.Util.addBypassLogic(options, scope, cl, xmlFile, cha);
     }
 
     return new JSZeroOrOneXCFABuilder(cha, options, cache, null, null, instancePolicy, doOneCFA);

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/ClosureExtractor.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/ClosureExtractor.java
@@ -464,8 +464,8 @@ public class ClosureExtractor extends CAstRewriterExt {
           CAstNode[] before = new CAstNode[tler.getStartInner()];
           for(i=0;i<tler.getStartInner();++i)
             before[i] = copyNodes(start.getChild(i), cfg, context, nodeMap);
-          for(int x = 0; x < before.length; x++) {
-            prologue.add(before[x]);
+          for (CAstNode element : before) {
+            prologue.add(element);
           }
           if(i+1 == start.getChildCount()) {
             fun_body_stmts.add(addSpuriousExnFlow(start.getChild(i), cfg));            
@@ -473,8 +473,8 @@ public class ClosureExtractor extends CAstRewriterExt {
             CAstNode[] after = new CAstNode[start.getChildCount()-i];
             for(int j=0;j+i<start.getChildCount();++j)
               after[j] = addSpuriousExnFlow(start.getChild(j+i), cfg);
-            for(int x = 0; x < after.length; x++) {
-              fun_body_stmts.add(after[x]);
+            for (CAstNode element : after) {
+              fun_body_stmts.add(element);
             }
           }
           for(i=context.getStart()+1;i<context.getEnd();++i)

--- a/com.ibm.wala.cast.test/harness-src/java/com/ibm/wala/cast/test/TestCAstTranslator.java
+++ b/com.ibm.wala.cast.test/harness-src/java/com/ibm/wala/cast/test/TestCAstTranslator.java
@@ -14,7 +14,6 @@ import java.io.File;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -78,8 +77,7 @@ public abstract class TestCAstTranslator extends WalaTestCase {
     }
 
     public TranslatorAssertions(Object[][] data) {
-      for (int dataIndex = 0; dataIndex < data.length; dataIndex++) {
-        Object[] entry = data[dataIndex];
+      for (Object[] entry : data) {
         String clsName = (String) entry[0];
         this.classes.add(clsName);
 
@@ -88,29 +86,29 @@ public abstract class TestCAstTranslator extends WalaTestCase {
 
         String[] instanceFields = (String[]) entry[2];
         if (instanceFields != null) {
-          for (int i = 0; i < instanceFields.length; i++) {
-            this.instanceFields.add(Pair.make(clsName, instanceFields[i]));
+          for (String instanceField : instanceFields) {
+            this.instanceFields.add(Pair.make(clsName, instanceField));
           }
         }
 
         String[] staticFields = (String[]) entry[3];
         if (staticFields != null) {
-          for (int i = 0; i < staticFields.length; i++) {
-            this.staticFields.add(Pair.make(clsName, staticFields[i]));
+          for (String staticField : staticFields) {
+            this.staticFields.add(Pair.make(clsName, staticField));
           }
         }
 
         Pair<?, ?>[] instanceMethods = (Pair[]) entry[4];
         if (instanceMethods != null) {
-          for (int i = 0; i < instanceMethods.length; i++) {
-            this.instanceMethods.put(Pair.make(clsName, (Object) instanceMethods[i].fst), instanceMethods[i].snd);
+          for (Pair<?, ?> instanceMethod : instanceMethods) {
+            this.instanceMethods.put(Pair.make(clsName, (Object) instanceMethod.fst), instanceMethod.snd);
           }
         }
 
         Pair<?, ?>[] staticMethods = (Pair[]) entry[5];
         if (staticMethods != null) {
-          for (int i = 0; i < staticMethods.length; i++) {
-            this.staticMethods.put(Pair.make(clsName, (Object) staticMethods[i].fst), staticMethods[i].snd);
+          for (Pair<?, ?> staticMethod : staticMethods) {
+            this.staticMethods.put(Pair.make(clsName, (Object) staticMethod.fst), staticMethod.snd);
           }
         }
       }
@@ -138,19 +136,19 @@ public abstract class TestCAstTranslator extends WalaTestCase {
   }
 
   protected void dump(ClassHierarchy cha) {
-    for (Iterator<?> clss = cha.iterator(); clss.hasNext();) {
-      IClass cls = (IClass) clss.next();
+    for (Object name : cha) {
+      IClass cls = (IClass) name;
       System.err.println(("class " + cls));
-      for (Iterator<?> flds = cls.getDeclaredInstanceFields().iterator(); flds.hasNext();) {
-        IField fld = (IField) flds.next();
+      for (Object name2 : cls.getDeclaredInstanceFields()) {
+        IField fld = (IField) name2;
         System.err.println(("instance field " + fld));
       }
-      for (Iterator<?> flds = cls.getDeclaredStaticFields().iterator(); flds.hasNext();) {
-        IField fld = (IField) flds.next();
+      for (Object name2 : cls.getDeclaredStaticFields()) {
+        IField fld = (IField) name2;
         System.err.println(("static field " + fld));
       }
-      for (Iterator<?> mths = cls.getDeclaredMethods().iterator(); mths.hasNext();) {
-        IMethod mth = (IMethod) mths.next();
+      for (Object name2 : cls.getDeclaredMethods()) {
+        IMethod mth = (IMethod) name2;
         if (mth.isStatic())
           System.err.print("static ");
         System.err.println(("method " + mth + " with " + mth.getNumberOfParameters() + " parameters"));
@@ -171,8 +169,8 @@ public abstract class TestCAstTranslator extends WalaTestCase {
     Map<Pair<String, Object>, Object> staticMethods = assertions.getStaticMethods();
 
     int clsCount = 0;
-    for (Iterator<?> clss = cha.iterator(); clss.hasNext();) {
-      IClass cls = (IClass) clss.next();
+    for (Object name : cha) {
+      IClass cls = (IClass) name;
       clsCount++;
       Assert.assertTrue("found class " + cls.getName().toString(), classes.contains(cls.getName().toString()));
 
@@ -183,20 +181,20 @@ public abstract class TestCAstTranslator extends WalaTestCase {
             .get(cls.getName().toString()).equals(cls.getSuperclass().getName().toString()));
       }
 
-      for (Iterator<?> flds = cls.getDeclaredInstanceFields().iterator(); flds.hasNext();) {
-        IField fld = (IField) flds.next();
+      for (Object name2 : cls.getDeclaredInstanceFields()) {
+        IField fld = (IField) name2;
         Assert.assertTrue(cls.getName() + " has field " + fld.getName(), instanceFields.contains(Pair.make(
             cls.getName().toString(), fld.getName().toString())));
       }
 
-      for (Iterator<?> flds = cls.getDeclaredStaticFields().iterator(); flds.hasNext();) {
-        IField fld = (IField) flds.next();
+      for (Object name2 : cls.getDeclaredStaticFields()) {
+        IField fld = (IField) name2;
         Assert.assertTrue(cls.getName() + " has static field " + fld.getName(), staticFields.contains(Pair.make(cls.getName()
             .toString(), fld.getName().toString())));
       }
 
-      for (Iterator<?> mths = cls.getDeclaredMethods().iterator(); mths.hasNext();) {
-        IMethod mth = (IMethod) mths.next();
+      for (Object name2 : cls.getDeclaredMethods()) {
+        IMethod mth = (IMethod) name2;
         Integer np = new Integer(mth.getNumberOfParameters());
         Pair<String, String> key = Pair.make(cls.getName().toString(), mth.getName().toString());
 

--- a/com.ibm.wala.cast.test/harness-src/java/com/ibm/wala/cast/test/TestCallGraphShape.java
+++ b/com.ibm.wala.cast.test/harness-src/java/com/ibm/wala/cast/test/TestCallGraphShape.java
@@ -100,26 +100,26 @@ public abstract class TestCallGraphShape extends WalaTestCase {
   }
 
   protected void verifyNameAssertions(CallGraph CG, Object[][] assertionData) {
-    for (int i = 0; i < assertionData.length; i++) {
-      Iterator<CGNode> NS = getNodes(CG, (String) assertionData[i][0]).iterator();
+    for (Object[] element : assertionData) {
+      Iterator<CGNode> NS = getNodes(CG, (String) element[0]).iterator();
       while (NS.hasNext()) {
         CGNode N = NS.next();
         IR ir = N.getIR();
-        Name[] names = (Name[]) assertionData[i][1];
-        for (int j = 0; j < names.length; j++) {
+        Name[] names = (Name[]) element[1];
+        for (Name name : names) {
 
-          System.err.println("looking for " + names[j].name + ", " + names[j].vn + " in " + N);
+          System.err.println("looking for " + name.name + ", " + name.vn + " in " + N);
 
-          String[] localNames = ir.getLocalNames(names[j].instructionIndex, names[j].vn);
+          String[] localNames = ir.getLocalNames(name.instructionIndex, name.vn);
 
           boolean found = false;
-          for (int k = 0; k < localNames.length; k++) {
-            if (localNames[k].equals(names[j].name)) {
+          for (String localName : localNames) {
+            if (localName.equals(name.name)) {
               found = true;
             }
           }
 
-          Assert.assertTrue("no name " + names[j].name + " for " + N + "\n" + ir, found);
+          Assert.assertTrue("no name " + name.name + " for " + N + "\n" + ir, found);
         }
       }
     }
@@ -159,8 +159,8 @@ public abstract class TestCallGraphShape extends WalaTestCase {
             
             while (dsts.hasNext()) {
               CGNode dst = dsts.next();
-              for (Iterator<CGNode> tos = CG.getPossibleTargets(src, sr).iterator(); tos.hasNext();) {
-                if (tos.next().equals(dst)) {
+              for (CGNode cgNode : CG.getPossibleTargets(src, sr)) {
+                if (cgNode.equals(dst)) {
                   if (checkAbsence) {
                     System.err.println(("found unexpected " + src + " --> " + dst + " at " + sr));
                     Assert.assertTrue("found edge " + assertionData[i][0] + " ---> " + targetName, false);

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/callgraph/AstCallGraph.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/callgraph/AstCallGraph.java
@@ -90,8 +90,8 @@ public class AstCallGraph extends ExplicitCallGraph {
         boolean done = false;
         while (!done) {
           try {
-            for (Iterator<Function<Object, Object>> x = callbacks.iterator(); x.hasNext();) {
-              x.next().apply(null);
+            for (Function<Object, Object> function : callbacks) {
+              function.apply(null);
             }
           } catch (ConcurrentModificationException e) {
             done = false;

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/callgraph/AstSSAPropagationCallGraphBuilder.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/callgraph/AstSSAPropagationCallGraphBuilder.java
@@ -384,9 +384,9 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
             if (contentsAreInvariant(lsymtab, ldu, lvn)) {
               InstanceKey[] ik = getInvariantContents(lsymtab, ldu, lnode, lvn);
               system.recordImplicitPointsToSet(lexicalKey);
-              for (int i = 0; i < ik.length; i++) {
-                system.findOrCreateIndexForInstanceKey(ik[i]);
-                system.newConstraint(lval, ik[i]);
+              for (InstanceKey element : ik) {
+                system.findOrCreateIndexForInstanceKey(element);
+                system.newConstraint(lval, element);
               }
 
               return;
@@ -407,9 +407,9 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
           if (contentsAreInvariant(symbolTable, du, vn)) {
             InstanceKey[] ik = getInvariantContents(vn);
             system.recordImplicitPointsToSet(rval);
-            for (int i = 0; i < ik.length; i++) {
-              system.findOrCreateIndexForInstanceKey(ik[i]);
-              system.newConstraint(lexicalKey, ik[i]);
+            for (InstanceKey element : ik) {
+              system.findOrCreateIndexForInstanceKey(element);
+              system.newConstraint(lexicalKey, element);
             }
           } else {
             system.newConstraint(lexicalKey, assignOperator, rval);
@@ -527,8 +527,8 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
 
       if (contentsAreInvariant(symbolTable, du, rval)) {
         InstanceKey objects[] = getInvariantContents(rval);
-        for (int i = 0; i < objects.length; i++) {
-          PointerKey catalog = getPointerKeyForObjectCatalog(objects[i]);
+        for (InstanceKey object : objects) {
+          PointerKey catalog = getPointerKeyForObjectCatalog(object);
           system.newConstraint(lk, assignOperator, catalog);
         }
       }
@@ -619,10 +619,10 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
        * .
        */
       private void doLexicalPointerKeys() {
-        for (int i = 0; i < accesses.length; i++) {
-          final String name = accesses[i].variableName;
-          final String definer = accesses[i].variableDefiner;
-          final int vn = accesses[i].valueNumber;
+        for (Access accesse : accesses) {
+          final String name = accesse.variableName;
+          final String definer = accesse.variableDefiner;
+          final int vn = accesse.valueNumber;
 
           if (AstTranslator.DEBUG_LEXICAL)
             System.err.println(("looking up lexical parent " + definer));
@@ -707,9 +707,9 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
         if (contentsAreInvariant(symtab, du, 1)) {
           system.recordImplicitPointsToSet(F);
           final InstanceKey[] functionKeys = getInvariantContents(symtab, du, opNode, 1);
-          for (int f = 0; f < functionKeys.length; f++) {
-            system.findOrCreateIndexForInstanceKey(functionKeys[f]);
-            ScopeMappingInstanceKey K = (ScopeMappingInstanceKey) functionKeys[f];
+          for (InstanceKey functionKey : functionKeys) {
+            system.findOrCreateIndexForInstanceKey(functionKey);
+            ScopeMappingInstanceKey K = (ScopeMappingInstanceKey) functionKey;
             Iterator<CGNode> x = K.getFunargNodes(definer);
             while (x.hasNext()) {
               result.add(x.next());
@@ -764,9 +764,9 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
             if (contentsAreInvariant(st, du, vn)) {
               system.recordImplicitPointsToSet(rhs);
               final InstanceKey[] objs = getInvariantContents(st, du, definingNode, vn);
-              for (int f = 0; f < objs.length; f++) {
-                system.findOrCreateIndexForInstanceKey(objs[f]);
-                system.newConstraint(lhs, objs[f]);
+              for (InstanceKey obj : objs) {
+                system.findOrCreateIndexForInstanceKey(obj);
+                system.newConstraint(lhs, obj);
               }
             } else {
               system.newConstraint(lhs, assignOperator, rhs);
@@ -861,8 +861,8 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
         if (contentsAreInvariant(symtab, du, objVn)) {
           System.err.print(" constant obj:");
           InstanceKey[] x = getInvariantContents(symtab, du, opNode, objVn);
-          for (int i = 0; i < x.length; i++) {
-            System.err.print((x[i].toString() + " "));
+          for (InstanceKey element : x) {
+            System.err.print((element.toString() + " "));
           }
         } else {
           System.err.print((" obj:" + system.findOrCreatePointsToSet(objKey)));
@@ -871,8 +871,8 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
         if (contentsAreInvariant(symtab, du, fieldsVn)) {
           System.err.print(" constant prop:");
           InstanceKey[] x = getInvariantContents(symtab, du, opNode, fieldsVn);
-          for (int i = 0; i < x.length; i++) {
-            System.err.print((x[i].toString() + " "));
+          for (InstanceKey element : x) {
+            System.err.print((element.toString() + " "));
           }
         } else {
           System.err.print((" props:" + system.findOrCreatePointsToSet(fieldKey)));
@@ -884,14 +884,14 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
       // make sure instance keys get mapped for PointerAnalysisImpl
       if (contentsAreInvariant(symtab, du, objVn)) {
         InstanceKey[] x = getInvariantContents(symtab, du, opNode, objVn);
-        for (int i = 0; i < x.length; i++) {
-          system.findOrCreateIndexForInstanceKey(x[i]);
+        for (InstanceKey element : x) {
+          system.findOrCreateIndexForInstanceKey(element);
         }
       }
       if (contentsAreInvariant(symtab, du, fieldsVn)) {
         InstanceKey[] x = getInvariantContents(symtab, du, opNode, fieldsVn);
-        for (int i = 0; i < x.length; i++) {
-          system.findOrCreateIndexForInstanceKey(x[i]);
+        for (InstanceKey element : x) {
+          system.findOrCreateIndexForInstanceKey(element);
         }
       }
 
@@ -1022,9 +1022,9 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
               public void act(int optr) {
                 InstanceKey object = system.getInstanceKey(optr);
                 PointerKey objCatalog = getPointerKeyForObjectCatalog(object);
-                for (int f = 0; f < fieldsKeys.length; f++) {
+                for (InstanceKey fieldsKey : fieldsKeys) {
                   if (isLoadOperation) {
-                    for (Iterator<PointerKey> keys = getPointerKeysForReflectedFieldRead(object, fieldsKeys[f]); keys.hasNext();) {
+                    for (Iterator<PointerKey> keys = getPointerKeysForReflectedFieldRead(object, fieldsKey); keys.hasNext();) {
                       AbstractFieldPointerKey key = (AbstractFieldPointerKey) keys.next();
                       if (DEBUG_PROPERTIES)
                         action.dump(key, true, false);
@@ -1032,9 +1032,9 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
                     }
                   } else {
                     if (objCatalog != null) {
-                      system.newConstraint(objCatalog, fieldsKeys[f]);
+                      system.newConstraint(objCatalog, fieldsKey);
                     }
-                    for (Iterator<PointerKey> keys = getPointerKeysForReflectedFieldWrite(object, fieldsKeys[f]); keys.hasNext();) {
+                    for (Iterator<PointerKey> keys = getPointerKeysForReflectedFieldWrite(object, fieldsKey); keys.hasNext();) {
                       AbstractFieldPointerKey key = (AbstractFieldPointerKey) keys.next();
                       if (DEBUG_PROPERTIES)
                         action.dump(key, true, false);
@@ -1068,8 +1068,8 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
     protected void newFieldOperationOnlyObjectConstant(final boolean isLoadOperation, final ReflectedFieldAction action,
         final PointerKey fieldKey, final InstanceKey[] objKeys) {
       if (!isLoadOperation) {
-        for (int o = 0; o < objKeys.length; o++) {
-          PointerKey objCatalog = getPointerKeyForObjectCatalog(objKeys[o]);
+        for (InstanceKey objKey : objKeys) {
+          PointerKey objCatalog = getPointerKeyForObjectCatalog(objKey);
           if (objCatalog != null) {
             system.newConstraint(objCatalog, assignOperator, fieldKey);
           }
@@ -1085,9 +1085,9 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
               @Override
               public void act(int fptr) {
                 InstanceKey field = system.getInstanceKey(fptr);
-                for (int o = 0; o < objKeys.length; o++) {
-                  for (Iterator<PointerKey> keys = isLoadOperation ? getPointerKeysForReflectedFieldRead(objKeys[o], field)
-                      : getPointerKeysForReflectedFieldWrite(objKeys[o], field); keys.hasNext();) {
+                for (InstanceKey objKey : objKeys) {
+                  for (Iterator<PointerKey> keys = isLoadOperation ? getPointerKeysForReflectedFieldRead(objKey, field)
+                      : getPointerKeysForReflectedFieldWrite(objKey, field); keys.hasNext();) {
                     AbstractFieldPointerKey key = (AbstractFieldPointerKey) keys.next();
                     if (DEBUG_PROPERTIES)
                       action.dump(key, false, true);
@@ -1119,11 +1119,11 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
 
     protected void newFieldOperationObjectAndFieldConstant(final boolean isLoadOperation, final ReflectedFieldAction action,
         final InstanceKey[] objKeys, InstanceKey[] fieldsKeys) {
-      for (int o = 0; o < objKeys.length; o++) {
-        PointerKey objCatalog = getPointerKeyForObjectCatalog(objKeys[o]);
-        for (int f = 0; f < fieldsKeys.length; f++) {
+      for (InstanceKey objKey : objKeys) {
+        PointerKey objCatalog = getPointerKeyForObjectCatalog(objKey);
+        for (InstanceKey fieldsKey : fieldsKeys) {
           if (isLoadOperation) {
-            for (Iterator<PointerKey> keys = getPointerKeysForReflectedFieldRead(objKeys[o], fieldsKeys[f]); keys.hasNext();) {
+            for (Iterator<PointerKey> keys = getPointerKeysForReflectedFieldRead(objKey, fieldsKey); keys.hasNext();) {
               AbstractFieldPointerKey key = (AbstractFieldPointerKey) keys.next();
               if (DEBUG_PROPERTIES)
                 action.dump(key, true, true);
@@ -1131,9 +1131,9 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
             }
           } else {
             if (objCatalog != null) {
-              system.newConstraint(objCatalog, fieldsKeys[f]);
+              system.newConstraint(objCatalog, fieldsKey);
             }
-            for (Iterator<PointerKey> keys = getPointerKeysForReflectedFieldWrite(objKeys[o], fieldsKeys[f]); keys.hasNext();) {
+            for (Iterator<PointerKey> keys = getPointerKeysForReflectedFieldWrite(objKey, fieldsKey); keys.hasNext();) {
               AbstractFieldPointerKey key = (AbstractFieldPointerKey) keys.next();
               if (DEBUG_PROPERTIES)
                 action.dump(key, true, true);
@@ -1167,17 +1167,17 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
       @Override
       public void dump(AbstractFieldPointerKey fieldKey, boolean constObj, boolean constProp) {
         System.err.println(("writing fixed rvals to " + fieldKey + " " + constObj + ", " + constProp));
-        for (int i = 0; i < rhsFixedValues.length; i++) {
-          System.err.println(("writing " + rhsFixedValues[i]));
+        for (InstanceKey rhsFixedValue : rhsFixedValues) {
+          System.err.println(("writing " + rhsFixedValue));
         }
       }
 
       @Override
       public void action(AbstractFieldPointerKey fieldKey) {
         if (!representsNullType(fieldKey.getInstanceKey())) {
-          for (int i = 0; i < rhsFixedValues.length; i++) {
-            system.findOrCreateIndexForInstanceKey(rhsFixedValues[i]);
-            system.newConstraint(fieldKey, rhsFixedValues[i]);
+          for (InstanceKey rhsFixedValue : rhsFixedValues) {
+            system.findOrCreateIndexForInstanceKey(rhsFixedValue);
+            system.newConstraint(fieldKey, rhsFixedValue);
           }
         }
       }

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/callgraph/CAstAnalysisScope.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/callgraph/CAstAnalysisScope.java
@@ -32,16 +32,16 @@ public class CAstAnalysisScope extends AnalysisScope {
 
   public CAstAnalysisScope(String[] sourceFileNames, SingleClassLoaderFactory loaders, Collection<Language> languages) {
     this(loaders, languages);
-    for (int i = 0; i < sourceFileNames.length; i++) {
-      File F = new File(sourceFileNames[i]);
+    for (String sourceFileName : sourceFileNames) {
+      File F = new File(sourceFileName);
       addSourceFileToScope(theLoader, F, F.getPath());
     }
   }
 
   public CAstAnalysisScope(Module[] sources, SingleClassLoaderFactory loaders, Collection<Language> languages) {
     this(loaders, languages);
-    for (int i = 0; i < sources.length; i++) {
-      addToScope(theLoader, sources[i]);
+    for (Module source : sources) {
+      addToScope(theLoader, source);
     }
   }
 

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/callgraph/MiscellaneousHacksContextSelector.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/callgraph/MiscellaneousHacksContextSelector.java
@@ -45,8 +45,7 @@ public class MiscellaneousHacksContextSelector implements ContextSelector {
     basePolicy = base;
     specialPolicy = special;
     methodsToSpecialize = HashSetFactory.make();
-    for (int i = 0; i < descriptors.length; i++) {
-      String[] descr = descriptors[i];
+    for (String[] descr : descriptors) {
       switch (descr.length) {
 
       // loader name, loader language, classname, method name, method descr

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/AstEchoInstruction.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/AstEchoInstruction.java
@@ -56,8 +56,8 @@ public class AstEchoInstruction extends SSAInstruction {
   @Override
   public int hashCode() {
     int v = 1;
-    for(int i = 0;i < rvals.length; i++) {
-      v *= rvals[i];
+    for (int rval : rvals) {
+      v *= rval;
     }
 
     return v;
@@ -66,8 +66,8 @@ public class AstEchoInstruction extends SSAInstruction {
   @Override
   public String toString(SymbolTable symbolTable) {
     StringBuffer result = new StringBuffer("echo/print ");
-    for(int i = 0; i < rvals.length; i++) {
-      result.append(getValueString(symbolTable, rvals[i])).append(" ");
+    for (int rval : rvals) {
+      result.append(getValueString(symbolTable, rval)).append(" ");
     }
 
     return result.toString();

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/AstLexicalAccess.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/AstLexicalAccess.java
@@ -116,8 +116,8 @@ public abstract class AstLexicalAccess extends SSAInstruction {
   @Override
   public int hashCode() {
     int v = 1;
-    for(int i = 0; i < accesses.length; i++) 
-      v *= accesses[i].variableName.hashCode();
+    for (Access accesse : accesses)
+      v *= accesse.variableName.hashCode();
 
     return v;
   }

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/SSAConversion.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/SSAConversion.java
@@ -209,8 +209,7 @@ public class SSAConversion extends AbstractSSAConversion {
       if (DEBUG_UNDO)
         System.err.println(("recreating assignment at " + instructionIndex + " as " + lhs + " = " + rhs));
 
-      for (Iterator<Object> uses = renamedUses.iterator(); uses.hasNext();) {
-        Object x = uses.next();
+      for (Object x : renamedUses) {
         if (x instanceof UseRecord) {
           UseRecord use = (UseRecord) x;
           int idx = use.instructionIndex;
@@ -235,8 +234,8 @@ public class SSAConversion extends AbstractSSAConversion {
         }
       }
 
-      for (Iterator<CopyPropagationRecord> cs = childRecords.iterator(); cs.hasNext();) {
-        cs.next().undo(lhs);
+      for (CopyPropagationRecord copyPropagationRecord : childRecords) {
+        copyPropagationRecord.undo(lhs);
       }
     }
 
@@ -545,9 +544,9 @@ public class SSAConversion extends AbstractSSAConversion {
     int[] exitLive = lexicalInfo.getExitExposedUses();
     BitVector v = new BitVector();
     if (exitLive != null) {
-      for (int i = 0; i < exitLive.length; i++) {
-        if (exitLive[i] > -1) {
-          v.set(exitLive[i]);
+      for (int element : exitLive) {
+        if (element > -1) {
+          v.set(element);
         }
       }
     }
@@ -624,8 +623,8 @@ public class SSAConversion extends AbstractSSAConversion {
           int[] lexicalUses = lexicalInfo.getExposedUses(i);
           if (lexicalUses != null) {
             System.err.print(("extra uses for " + instructions[i] + ": "));
-            for (int j = 0; j < lexicalUses.length; j++) {
-              System.err.print((new Integer(lexicalUses[j]).toString() + " "));
+            for (int lexicalUse : lexicalUses) {
+              System.err.print((new Integer(lexicalUse).toString() + " "));
             }
             System.err.println("");
           }
@@ -640,8 +639,7 @@ public class SSAConversion extends AbstractSSAConversion {
     SSAInstruction[] insts = ir.getInstructions();
     MutableIntSet foundOne = new BitVectorIntSet();
     MutableIntSet foundTwo = new BitVectorIntSet();
-    for (int i = 0; i < insts.length; i++) {
-      SSAInstruction inst = insts[i];
+    for (SSAInstruction inst : insts) {
       if (inst != null) {
         for (int j = 0; j < inst.getNumberOfDefs(); j++) {
           int def = inst.getDef(j);

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
@@ -944,8 +944,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
      */
     private void checkForRealizedEdges(CAstNode n) {
       if (delayedEdges.containsKey(n)) {
-        for (Iterator<Pair<PreBasicBlock, Boolean>> ss = delayedEdges.get(n).iterator(); ss.hasNext();) {
-          Pair<PreBasicBlock, Boolean> s = ss.next();
+        for (Pair<PreBasicBlock, Boolean> s : delayedEdges.get(n)) {
           PreBasicBlock src = s.fst;
           boolean exception = s.snd;
           if (unwind == null) {
@@ -965,8 +964,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
      */
     private void checkForRealizedExitEdges(PreBasicBlock exitBlock) {
       if (delayedEdges.containsKey(exitMarker)) {
-        for (Iterator<Pair<PreBasicBlock, Boolean>> ss = delayedEdges.get(exitMarker).iterator(); ss.hasNext();) {
-          Pair<PreBasicBlock, Boolean> s = ss.next();
+        for (Pair<PreBasicBlock, Boolean> s : delayedEdges.get(exitMarker)) {
           PreBasicBlock src = s.fst;
           boolean exception = s.snd;
           addEdge(src, exitBlock);
@@ -1362,8 +1360,8 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
       SSAInstruction[] insts = getInstructions();
       StringBuffer s = new StringBuffer("CAst CFG of " + functionName);
       int params[] = symtab.getParameterValueNumbers();
-      for (int i = 0; i < params.length; i++)
-        s.append(" ").append(params[i]);
+      for (int param : params)
+        s.append(" ").append(param);
       s.append("\n");
 
       for (int i = 0; i < getNumberOfNodes(); i++) {
@@ -2621,8 +2619,8 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
       } else {
         TypeReference[] data = catchTypes.get(bb);
 
-        for (int i = 0; i < data.length; i++) {
-          if (data[i] == catchType) {
+        for (TypeReference element : data) {
+          if (element == catchType) {
             return;
           }
         }
@@ -2881,8 +2879,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
 
       if (accesses != null) {
         Set<String> parents = new LinkedHashSet<>();
-        for (Iterator<Access> ACS = accesses.iterator(); ACS.hasNext();) {
-          Access AC = ACS.next();
+        for (Access AC : accesses) {
           if (AC.variableDefiner != null) {
             parents.add(AC.variableDefiner);
           }
@@ -2928,18 +2925,18 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
       if (allExposedUses == null) {
         allExposedUses = IntSetUtil.make();
         if (exitLexicalUses != null) {
-          for (int i = 0; i < exitLexicalUses.length; i++) {
-            if (exitLexicalUses[i] > 0) {
-              allExposedUses.add(exitLexicalUses[i]);
+          for (int exitLexicalUse : exitLexicalUses) {
+            if (exitLexicalUse > 0) {
+              allExposedUses.add(exitLexicalUse);
             }
           }
         }
         if (instructionLexicalUses != null) {
-          for (int i = 0; i < instructionLexicalUses.length; i++) {
-            if (instructionLexicalUses[i] != null) {
-              for (int j = 0; j < instructionLexicalUses[i].length; j++) {
-                if (instructionLexicalUses[i][j] > 0) {
-                  allExposedUses.add(instructionLexicalUses[i][j]);
+          for (int[] instructionLexicalUse : instructionLexicalUses) {
+            if (instructionLexicalUse != null) {
+              for (int j = 0; j < instructionLexicalUse.length; j++) {
+                if (instructionLexicalUse[j] > 0) {
+                  allExposedUses.add(instructionLexicalUse[j]);
                 }
               }
             }
@@ -3120,8 +3117,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
       System.err.println(("names array of size " + map.length));
     }
 
-    for (Iterator<Scope> S = scopes.iterator(); S.hasNext();) {
-      Scope scope = S.next();
+    for (Scope scope : scopes) {
       for (Iterator<String> I = scope.getAllNames(); I.hasNext();) {
         String nm = I.next();
         

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/loader/AstClass.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/loader/AstClass.java
@@ -13,7 +13,6 @@ package com.ibm.wala.cast.loader;
 import java.io.Reader;
 import java.net.URL;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -184,8 +183,7 @@ abstract public class AstClass implements IClass, ClassConstants {
   @Override
   public Collection<IField> getDeclaredInstanceFields() {
     Set<IField> result = HashSetFactory.make();
-    for (Iterator<IField> FS = declaredFields.values().iterator(); FS.hasNext();) {
-      IField F = FS.next();
+    for (IField F : declaredFields.values()) {
       if (!F.isStatic()) {
         result.add(F);
       }
@@ -197,8 +195,7 @@ abstract public class AstClass implements IClass, ClassConstants {
   @Override
   public Collection<IField> getDeclaredStaticFields() {
     Set<IField> result = HashSetFactory.make();
-    for (Iterator<IField> FS = declaredFields.values().iterator(); FS.hasNext();) {
-      IField F = FS.next();
+    for (IField F : declaredFields.values()) {
       if (F.isStatic()) {
         result.add(F);
       }
@@ -240,8 +237,8 @@ abstract public class AstClass implements IClass, ClassConstants {
   @Override
   public Collection<IMethod> getAllMethods() {
     Collection<IMethod> result = HashSetFactory.make();
-    for (Iterator<IMethod> ms = getDeclaredMethods().iterator(); ms.hasNext();) {
-      result.add(ms.next());
+    for (IMethod iMethod : getDeclaredMethods()) {
+      result.add(iMethod);
     }
     if (getSuperclass() != null) {
       result.addAll(getSuperclass().getAllMethods());

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/loader/CAstAbstractLoader.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/loader/CAstAbstractLoader.java
@@ -196,8 +196,7 @@ public abstract class CAstAbstractLoader implements IClassLoader {
   public void removeAll(Collection<IClass> toRemove) {
     Set<TypeName> keys = HashSetFactory.make();
 
-    for (Iterator<Map.Entry<TypeName,IClass>> EE = types.entrySet().iterator(); EE.hasNext();) {
-      Map.Entry<TypeName,IClass> E =  EE.next();
+    for (Entry<TypeName, IClass> E : types.entrySet()) {
       if (toRemove.contains(E.getValue())) {
         keys.add(E.getKey());
       }

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/loader/CAstAbstractModuleLoader.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/loader/CAstAbstractModuleLoader.java
@@ -96,15 +96,14 @@ public abstract class CAstAbstractModuleLoader extends CAstAbstractLoader {
 
     // convert everything to CAst
     final Set<Pair<CAstEntity, ModuleEntry>> topLevelEntities = new LinkedHashSet<>();
-    for (Iterator<Module> mes = modules.iterator(); mes.hasNext();) {
-      translateModuleToCAst(mes.next(), ast, topLevelEntities);
+    for (Module module : modules) {
+      translateModuleToCAst(module, ast, topLevelEntities);
     }
 
     // generate IR as needed
     final TranslatorToIR xlatorToIR = initTranslator();
 
-    for (Iterator<Pair<CAstEntity, ModuleEntry>> tles = topLevelEntities.iterator(); tles.hasNext();) {
-      Pair<CAstEntity, ModuleEntry> p = tles.next();
+    for (Pair<CAstEntity, ModuleEntry> p : topLevelEntities) {
       if (shouldTranslate(p.fst)) {
         xlatorToIR.translate(p.fst, p.snd);
       }

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/impl/CAstControlFlowRecorder.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/impl/CAstControlFlowRecorder.java
@@ -12,7 +12,6 @@ package com.ibm.wala.cast.tree.impl;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -127,8 +126,7 @@ public class CAstControlFlowRecorder implements CAstControlFlowMap {
     Collection<CAstNode> nodes = cachedMappedNodes;
     if (nodes == null) {
       nodes = new LinkedHashSet<>();
-      for (Iterator<Key> keys = table.keySet().iterator(); keys.hasNext();) {
-        Key key = keys.next();
+      for (Key key : table.keySet()) {
         nodes.add(nodeToCAst.get(key.from));
         nodes.add(nodeToCAst.get(table.get(key)));
       }

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/impl/CAstValueImpl.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/impl/CAstValueImpl.java
@@ -33,8 +33,8 @@ public class CAstValueImpl extends CAstImpl {
     @Override
     public int hashCode() {
       int value = 1237 * kind;
-      for(int i = 0; i < cs.length; i++) 
-	value *= cs[i].hashCode();
+      for (CAstNode element : cs)
+        value *= element.hashCode();
 
       return value;
     }

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/rewrite/CAstRewriter.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/rewrite/CAstRewriter.java
@@ -159,8 +159,7 @@ public abstract class CAstRewriter<C extends CAstRewriter.RewriteContext<K>, K e
     Set<CAstNode> allNewTargetNodes = HashSetFactory.make(1);
     Collection<CAstNode> oldSources = orig.getMappedNodes();
 
-    for (Iterator<Entry<Pair<CAstNode, K>, CAstNode>> NS = nodeMap.entrySet().iterator(); NS.hasNext();) {
-      Entry<Pair<CAstNode, K>, CAstNode> entry = NS.next();
+    for (Entry<Pair<CAstNode, K>, CAstNode> entry : nodeMap.entrySet()) {
       Pair<CAstNode, K> N = entry.getKey();
       CAstNode oldSource = N.fst;
       K key = N.snd;
@@ -272,8 +271,7 @@ public abstract class CAstRewriter<C extends CAstRewriter.RewriteContext<K>, K e
 
   protected CAstSourcePositionMap copySource(Map<Pair<CAstNode, K>, CAstNode> nodeMap, CAstSourcePositionMap orig) {
     CAstSourcePositionRecorder newMap = new CAstSourcePositionRecorder();
-    for (Iterator<Map.Entry<Pair<CAstNode, K>, CAstNode>> NS = nodeMap.entrySet().iterator(); NS.hasNext();) {
-      Map.Entry<Pair<CAstNode, K>, CAstNode> entry = NS.next();
+    for (Entry<Pair<CAstNode, K>, CAstNode> entry : nodeMap.entrySet()) {
       Pair<CAstNode, K> N = entry.getKey();
       CAstNode oldNode = N.fst;
 
@@ -290,8 +288,7 @@ public abstract class CAstRewriter<C extends CAstRewriter.RewriteContext<K>, K e
   protected CAstNodeTypeMap copyTypes(Map<Pair<CAstNode, K>, CAstNode> nodeMap, CAstNodeTypeMap orig) {
     if (orig != null) {
       CAstNodeTypeMapRecorder newMap = new CAstNodeTypeMapRecorder();
-      for (Iterator<Entry<Pair<CAstNode, K>, CAstNode>> NS = nodeMap.entrySet().iterator(); NS.hasNext();) {
-        Entry<Pair<CAstNode, K>, CAstNode> entry = NS.next();
+      for (Entry<Pair<CAstNode, K>, CAstNode> entry : nodeMap.entrySet()) {
         Pair<CAstNode, K> N = entry.getKey();
         CAstNode oldNode = N.fst;
 
@@ -312,8 +309,7 @@ public abstract class CAstRewriter<C extends CAstRewriter.RewriteContext<K>, K e
       Map<CAstNode, Collection<CAstEntity>> children) {
     final Map<CAstNode, Collection<CAstEntity>> newChildren = new LinkedHashMap<>();
 
-    for (Iterator<Entry<Pair<CAstNode, K>, CAstNode>> NS = nodeMap.entrySet().iterator(); NS.hasNext();) {
-      Entry<Pair<CAstNode, K>, CAstNode> entry = NS.next();
+    for (Entry<Pair<CAstNode, K>, CAstNode> entry : nodeMap.entrySet()) {
       Pair<CAstNode, K> N = entry.getKey();
       CAstNode oldNode = N.fst;
 
@@ -322,14 +318,13 @@ public abstract class CAstRewriter<C extends CAstRewriter.RewriteContext<K>, K e
       if (children.containsKey(oldNode)) {
         Set<CAstEntity> newEntities = new LinkedHashSet<>();
         newChildren.put(newNode, newEntities);
-        for (Iterator<CAstEntity> oldEntities = children.get(oldNode).iterator(); oldEntities.hasNext();) {
-          newEntities.add(rewrite(oldEntities.next()));
+        for (CAstEntity cAstEntity : children.get(oldNode)) {
+          newEntities.add(rewrite(cAstEntity));
         }
       }
     }
 
-    for (Iterator<Map.Entry<CAstNode, Collection<CAstEntity>>> keys = children.entrySet().iterator(); keys.hasNext();) {
-      Map.Entry<CAstNode, Collection<CAstEntity>> entry = keys.next();
+    for (Entry<CAstNode, Collection<CAstEntity>> entry : children.entrySet()) {
       CAstNode key = entry.getKey();
       if (key == null) {
         Set<CAstEntity> newEntities = new LinkedHashSet<>();
@@ -450,8 +445,7 @@ public abstract class CAstRewriter<C extends CAstRewriter.RewriteContext<K>, K e
 
       Map<CAstNode, Collection<CAstEntity>> children = root.getAllScopedEntities();
       final Map<CAstNode, Collection<CAstEntity>> newChildren = new LinkedHashMap<>();
-      for (Iterator<Map.Entry<CAstNode, Collection<CAstEntity>>> keys = children.entrySet().iterator(); keys.hasNext();) {
-        Map.Entry<CAstNode, Collection<CAstEntity>> entry = keys.next();
+      for (Entry<CAstNode, Collection<CAstEntity>> entry : children.entrySet()) {
         CAstNode key = entry.getKey();
         Set<CAstEntity> newValues = new LinkedHashSet<>();
         newChildren.put(key, newValues);

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/util/CAstPattern.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/util/CAstPattern.java
@@ -292,8 +292,8 @@ public class CAstPattern {
       return references.get(value).match(tree, s);
 
     } else if (kind == ALTERNATIVE_PATTERN_KIND) {
-      for (int i = 0; i < children.length; i++) {
-        if (children[i].tryMatch(tree, s)) {
+      for (CAstPattern element : children) {
+        if (element.tryMatch(tree, s)) {
 
           if (s != null && name != null)
             s.add(name, tree);

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/util/CAstPrinter.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/util/CAstPrinter.java
@@ -294,8 +294,8 @@ public class CAstPrinter {
 	if (e.getArgumentNames().length > 0) {
 	  w.write("(");
 	  String[] names = e.getArgumentNames();
-	  for(int i = 0; i < names.length; i++) {
-	    w.write("  " + names[i]);
+	  for (String name : names) {
+	    w.write("  " + name);
 	  }
 	  w.write("  )\n");
 	}

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/basic/PrimitivesTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/basic/PrimitivesTest.java
@@ -790,8 +790,8 @@ public class PrimitivesTest extends WalaTestCase {
     R.add(3, 11);
     R.add(5, 1);
     int count = 0;
-    for (Iterator<IntPair> it = R.iterator(); it.hasNext();) {
-      System.err.println(it.next());
+    for (IntPair intPair : R) {
+      System.err.println(intPair);
       count++;
     }
     Assert.assertTrue(count == 5);

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/basic/WelshPowellTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/basic/WelshPowellTest.java
@@ -61,14 +61,14 @@ public class WelshPowellTest {
   private <T> NumberedGraph<TypedNode<T>> buildGraph(T[][] data) {
     DelegatingNumberedGraph<TypedNode<T>> G = new DelegatingNumberedGraph<>();
     Map<T,TypedNode<T>> nodes = HashMapFactory.make();
-    for(int i = 0; i < data.length; i++) {
-      TypedNode<T> n = new TypedNode<>(data[i][0]);
-      nodes.put(data[i][0], n);
+    for (T[] element : data) {
+      TypedNode<T> n = new TypedNode<>(element[0]);
+      nodes.put(element[0], n);
       G.addNode(n);
     }
-    for(int i = 0; i < data.length; i++) {
-      for(int j = 1; j < data[i].length; j++) {
-        G.addEdge(nodes.get(data[i][0]), nodes.get(data[i][j]));
+    for (T[] element : data) {
+      for(int j = 1; j < element.length; j++) {
+        G.addEdge(nodes.get(element[0]), nodes.get(element[j]));
       }
     }
     

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/AcyclicCallGraphTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/AcyclicCallGraphTest.java
@@ -1,7 +1,6 @@
 package com.ibm.wala.core.tests.callGraph;
 
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -45,8 +44,7 @@ public class AcyclicCallGraphTest extends WalaTestCase {
     Assert.assertTrue("NList should have cycles", backEdges.iterator().hasNext()); 
     
     Map<CGNode, Set<CGNode>> cgBackEdges = HashMapFactory.make();
-    for (Iterator<IntPair> ps = backEdges.iterator(); ps.hasNext(); ) {
-      IntPair p = ps.next();
+    for (IntPair p : backEdges) {
       CGNode src = cg.getNode(p.getX());
       if (!cgBackEdges.containsKey(src)) {
         cgBackEdges.put(src, HashSetFactory.<CGNode>make());

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/CallGraphTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/CallGraphTest.java
@@ -406,8 +406,7 @@ public class CallGraphTest extends WalaTestCase {
     // perform a little icfg exercise
     @SuppressWarnings("unused")
     int count = 0;
-    for (Iterator<BasicBlockInContext<ISSABasicBlock>> it = icfg.iterator(); it.hasNext();) {
-      BasicBlockInContext<ISSABasicBlock> bb = it.next();
+    for (BasicBlockInContext<ISSABasicBlock> bb : icfg) {
       if (icfg.hasCall(bb)) {
         count++;
       }
@@ -468,8 +467,8 @@ public class CallGraphTest extends WalaTestCase {
       throw new IllegalArgumentException("cg is null");
     }
     final Set<MethodReference> nodes = HashSetFactory.make();
-    for (Iterator<CGNode> nodesI = cg.iterator(); nodesI.hasNext();) {
-      nodes.add((nodesI.next()).getMethod().getReference());
+    for (CGNode cgNode : cg) {
+      nodes.add((cgNode).getMethod().getReference());
     }
 
     return new Graph<MethodReference>() {
@@ -513,8 +512,8 @@ public class CallGraphTest extends WalaTestCase {
       public Iterator<MethodReference> getPredNodes(MethodReference N) {
         Set<MethodReference> pred = HashSetFactory.make(10);
         MethodReference methodReference = N;
-        for (Iterator<CGNode> i = cg.getNodes(methodReference).iterator(); i.hasNext();)
-          for (Iterator<? extends CGNode> ps = cg.getPredNodes(i.next()); ps.hasNext();)
+        for (CGNode cgNode : cg.getNodes(methodReference))
+          for (Iterator<? extends CGNode> ps = cg.getPredNodes(cgNode); ps.hasNext();)
             pred.add(((CGNode) ps.next()).getMethod().getReference());
 
         return pred.iterator();
@@ -538,8 +537,8 @@ public class CallGraphTest extends WalaTestCase {
       public Iterator<MethodReference> getSuccNodes(MethodReference N) {
         Set<MethodReference> succ = HashSetFactory.make(10);
         MethodReference methodReference = N;
-        for (Iterator<? extends CGNode> i = cg.getNodes(methodReference).iterator(); i.hasNext();)
-          for (Iterator<? extends CGNode> ps = cg.getSuccNodes(i.next()); ps.hasNext();)
+        for (CGNode node : cg.getNodes(methodReference))
+          for (Iterator<? extends CGNode> ps = cg.getSuccNodes(node); ps.hasNext();)
             succ.add(((CGNode) ps.next()).getMethod().getReference());
 
         return succ.iterator();

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/CloneTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/CloneTest.java
@@ -63,8 +63,8 @@ public class CloneTest extends WalaTestCase {
           Set<CGNode> targets = cg.getPossibleTargets(node, site);
           if (targets.size() != 1) {
             System.err.println(targets.size() + " targets found for " + site);
-            for (Iterator<CGNode> k = targets.iterator(); k.hasNext();) {
-              System.err.println("  " + k.next());
+            for (CGNode cgNode : targets) {
+              System.err.println("  " + cgNode);
             }
             Assert.fail("found " + targets.size() + " targets for " + site + " in " + node);
           }

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/demandpa/AbstractPtrTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/demandpa/AbstractPtrTest.java
@@ -116,8 +116,7 @@ public abstract class AbstractPtrTest {
   }
 
   public static CGNode findStaticMethod(CallGraph cg, Atom name, Descriptor args) {
-    for (Iterator<? extends CGNode> it = cg.iterator(); it.hasNext();) {
-      CGNode n = it.next();
+    for (CGNode n : cg) {
       // System.err.println(n.getMethod().getName() + " " +
       // n.getMethod().getDescriptor());
       if (n.getMethod().getName().equals(name) && n.getMethod().getDescriptor().equals(args)) {
@@ -129,8 +128,7 @@ public abstract class AbstractPtrTest {
   }
 
   public static CGNode findInstanceMethod(CallGraph cg, IClass declaringClass, Atom name, Descriptor args) {
-    for (Iterator<? extends CGNode> it = cg.iterator(); it.hasNext();) {
-      CGNode n = it.next();
+    for (CGNode n : cg) {
       // System.err.println(n.getMethod().getDeclaringClass() + " " +
       // n.getMethod().getName() + " " + n.getMethod().getDescriptor());
       if (n.getMethod().getDeclaringClass().equals(declaringClass) && n.getMethod().getName().equals(name)

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ir/DeterministicIRTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ir/DeterministicIRTest.java
@@ -109,8 +109,8 @@ public class DeterministicIRTest extends WalaTestCase {
    * @param instructions
    */
   private static void checkNotAllNull(SSAInstruction[] instructions) {
-    for (int i = 0; i < instructions.length; i++) {
-      if (instructions[i] != null) {
+    for (SSAInstruction instruction : instructions) {
+      if (instruction != null) {
         return;
       }
     }

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ptrs/MultiDimArrayTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ptrs/MultiDimArrayTest.java
@@ -11,8 +11,6 @@
 package com.ibm.wala.core.tests.ptrs;
 
 import java.io.IOException;
-import java.util.Iterator;
-
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -75,8 +73,7 @@ public class MultiDimArrayTest extends WalaTestCase {
   }
   
   private final static CGNode findDoNothingNode(CallGraph cg) {
-    for (Iterator<? extends CGNode> it = cg.iterator(); it.hasNext(); ) {
-      CGNode n = it.next();
+    for (CGNode n : cg) {
       if (n.getMethod().getName().toString().equals("doNothing")) {
         return n;
       }

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ptrs/TypeBasedArrayAliasTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ptrs/TypeBasedArrayAliasTest.java
@@ -11,8 +11,6 @@
 package com.ibm.wala.core.tests.ptrs;
 
 import java.io.IOException;
-import java.util.Iterator;
-
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -68,8 +66,7 @@ public class TypeBasedArrayAliasTest extends WalaTestCase {
   }
 
   private final static CGNode findNode(CallGraph cg, String methodName) {
-    for (Iterator<? extends CGNode> it = cg.iterator(); it.hasNext(); ) {
-      CGNode n = it.next();
+    for (CGNode n : cg) {
       if (n.getMethod().getName().toString().equals(methodName)) {
         return n;
       }

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/slicer/SlicerTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/slicer/SlicerTest.java
@@ -1090,8 +1090,7 @@ public class SlicerTest {
 
   public static CGNode findMethod(CallGraph cg, String name) {
     Atom a = Atom.findOrCreateUnicodeAtom(name);
-    for (Iterator<? extends CGNode> it = cg.iterator(); it.hasNext();) {
-      CGNode n = it.next();
+    for (CGNode n : cg) {
       if (n.getMethod().getName().equals(a)) {
         return n;
       }

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/demandpa/driver/CompareToZeroOneCFADriver.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/demandpa/driver/CompareToZeroOneCFADriver.java
@@ -43,8 +43,6 @@ package com.ibm.wala.demandpa.driver;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Iterator;
-
 import com.ibm.wala.analysis.reflection.InstanceKeyWithNode;
 import com.ibm.wala.analysis.typeInference.TypeAbstraction;
 import com.ibm.wala.analysis.typeInference.TypeInference;
@@ -206,8 +204,7 @@ public class CompareToZeroOneCFADriver {
 
     }
     Helper h = new Helper();
-    for (Iterator<? extends CGNode> nodeIter = cg.iterator(); nodeIter.hasNext();) {
-      CGNode node = nodeIter.next();
+    for (CGNode node : cg) {
       h.checkPointersInMethod(node);
     }
   }

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/demandpa/driver/TestAgainstSimpleDriver.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/demandpa/driver/TestAgainstSimpleDriver.java
@@ -42,8 +42,6 @@ package com.ibm.wala.demandpa.driver;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Iterator;
-
 import com.ibm.wala.analysis.typeInference.TypeAbstraction;
 import com.ibm.wala.analysis.typeInference.TypeInference;
 import com.ibm.wala.core.tests.callGraph.CallGraphTestUtil;
@@ -156,8 +154,8 @@ public class TestAgainstSimpleDriver {
       if (result.isEmpty()) {
         System.err.println("  EMPTY!");
       }
-      for (Iterator<InstanceKey> it = result.iterator(); it.hasNext();) {
-        System.err.println("  " + it.next());
+      for (InstanceKey instanceKey : result) {
+        System.err.println("  " + instanceKey);
       }
     }
   }

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/demandpa/driver/WalaUtil.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/demandpa/driver/WalaUtil.java
@@ -42,7 +42,6 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.Iterator;
 import java.util.Properties;
 
 import com.ibm.wala.ipa.callgraph.CGNode;
@@ -68,8 +67,7 @@ public class WalaUtil {
     System.err.print("dumping ir...");
     String irFile = p.getProperty(WalaProperties.OUTPUT_DIR) + File.separatorChar + benchName + "-ir.txt";
     try (final PrintWriter writer = new PrintWriter(new BufferedWriter(new FileWriter(irFile)))) {
-      for (Iterator<? extends CGNode> iter = cg.iterator(); iter.hasNext();) {
-        CGNode node = iter.next();
+      for (CGNode node : cg) {
         IR ir = node.getIR();
         if (ir == null)
           continue;

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/examples/analysis/SimpleThreadEscapeAnalysis.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/examples/analysis/SimpleThreadEscapeAnalysis.java
@@ -13,7 +13,6 @@ package com.ibm.wala.examples.analysis;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.Properties;
 import java.util.Set;
 import java.util.jar.JarFile;
@@ -99,8 +98,8 @@ public class SimpleThreadEscapeAnalysis extends AbstractAnalysisEngine<InstanceK
   private void collectJars(File f, Set<JarFile> result) throws IOException {
     if (f.isDirectory()) {
       File[] files = f.listFiles();
-      for (int i = 0; i < files.length; i++) {
-        collectJars(files[i], result);
+      for (File file : files) {
+        collectJars(file, result);
       }
     } else if (f.getAbsolutePath().endsWith(".jar")) {
       try (final JarFile jar = new JarFile(f, false)) {
@@ -148,8 +147,8 @@ public class SimpleThreadEscapeAnalysis extends AbstractAnalysisEngine<InstanceK
    */
   private Set<JarFileModule> getModuleFiles() {
     Set<JarFileModule> result = HashSetFactory.make();
-    for (Iterator<JarFile> jars = applicationJarFiles.iterator(); jars.hasNext();) {
-      result.add(new JarFileModule(jars.next()));
+    for (JarFile jarFile : applicationJarFiles) {
+      result.add(new JarFileModule(jarFile));
     }
 
     return result;
@@ -218,8 +217,7 @@ public class SimpleThreadEscapeAnalysis extends AbstractAnalysisEngine<InstanceK
     // 1) static fields
     for (IClass cls : cha) {
       Collection<IField> staticFields = cls.getDeclaredStaticFields();
-      for (Iterator<IField> sfs = staticFields.iterator(); sfs.hasNext();) {
-        IField sf = sfs.next();
+      for (IField sf : staticFields) {
         if (sf.getFieldTypeReference().isReferenceType()) {
           escapeAnalysisRoots.add(heapModel.getPointerKeyForStaticField(sf));
         }
@@ -232,14 +230,11 @@ public class SimpleThreadEscapeAnalysis extends AbstractAnalysisEngine<InstanceK
     // reachable from fields of types in these pointer keys, and all
     // Thread objects must be constructed somewhere)
     Collection<IClass> threads = cha.computeSubClasses(TypeReference.JavaLangThread);
-    for (Iterator<IClass> clss = threads.iterator(); clss.hasNext();) {
-      IClass cls = clss.next();
-      for (Iterator<IMethod> ms = cls.getDeclaredMethods().iterator(); ms.hasNext();) {
-        IMethod m = ms.next();
+    for (IClass cls : threads) {
+      for (IMethod m : cls.getDeclaredMethods()) {
         if (m.isInit()) {
           Set<CGNode> nodes = cg.getNodes(m.getReference());
-          for (Iterator<CGNode> ns = nodes.iterator(); ns.hasNext();) {
-            CGNode n = ns.next();
+          for (CGNode n : nodes) {
             escapeAnalysisRoots.add(heapModel.getPointerKeyForLocal(n, 1));
           }
         }
@@ -255,11 +250,9 @@ public class SimpleThreadEscapeAnalysis extends AbstractAnalysisEngine<InstanceK
     //
     // pass 1: get abstract objects (instance keys) for escaping locations
     //
-    for (Iterator<PointerKey> rts = escapeAnalysisRoots.iterator(); rts.hasNext();) {
-      PointerKey root = rts.next();
+    for (PointerKey root : escapeAnalysisRoots) {
       OrdinalSet<InstanceKey> objects = pa.getPointsToSet(root);
-      for (Iterator<InstanceKey> objs = objects.iterator(); objs.hasNext();) {
-        InstanceKey obj = objs.next();
+      for (InstanceKey obj : objects) {
         escapingInstanceKeys.add(obj);
       }
     }
@@ -270,16 +263,14 @@ public class SimpleThreadEscapeAnalysis extends AbstractAnalysisEngine<InstanceK
     Set<InstanceKey> newKeys = HashSetFactory.make();
     do {
       newKeys.clear();
-      for (Iterator<InstanceKey> keys = escapingInstanceKeys.iterator(); keys.hasNext();) {
-        InstanceKey key = keys.next();
+      for (InstanceKey key : escapingInstanceKeys) {
         IClass type = key.getConcreteType();
         if (type.isReferenceType()) {
           if (type.isArrayClass()) {
             if (((ArrayClass) type).getElementClass() != null) {
               PointerKey fk = heapModel.getPointerKeyForArrayContents(key);
               OrdinalSet<InstanceKey> fobjects = pa.getPointsToSet(fk);
-              for (Iterator<InstanceKey> fobjs = fobjects.iterator(); fobjs.hasNext();) {
-                InstanceKey fobj = fobjs.next();
+              for (InstanceKey fobj : fobjects) {
                 if (!escapingInstanceKeys.contains(fobj)) {
                   newKeys.add(fobj);
                 }
@@ -287,13 +278,11 @@ public class SimpleThreadEscapeAnalysis extends AbstractAnalysisEngine<InstanceK
             }
           } else {
             Collection<IField> fields = type.getAllInstanceFields();
-            for (Iterator<IField> fs = fields.iterator(); fs.hasNext();) {
-              IField f = fs.next();
+            for (IField f : fields) {
               if (f.getFieldTypeReference().isReferenceType()) {
                 PointerKey fk = heapModel.getPointerKeyForInstanceField(key, f);
                 OrdinalSet<InstanceKey> fobjects = pa.getPointsToSet(fk);
-                for (Iterator<InstanceKey> fobjs = fobjects.iterator(); fobjs.hasNext();) {
-                  InstanceKey fobj = fobjs.next();
+                for (InstanceKey fobj : fobjects) {
                   if (!escapingInstanceKeys.contains(fobj)) {
                     newKeys.add(fobj);
                   }
@@ -310,8 +299,7 @@ public class SimpleThreadEscapeAnalysis extends AbstractAnalysisEngine<InstanceK
     // get set of types from set of instance keys
     //
     Set<IClass> escapingTypes = HashSetFactory.make();
-    for (Iterator<InstanceKey> keys = escapingInstanceKeys.iterator(); keys.hasNext();) {
-      InstanceKey key = keys.next();
+    for (InstanceKey key : escapingInstanceKeys) {
       escapingTypes.add(key.getConcreteType());
     }
 
@@ -336,11 +324,9 @@ public class SimpleThreadEscapeAnalysis extends AbstractAnalysisEngine<InstanceK
 
     Set<IClass> escapingTypes = (new SimpleThreadEscapeAnalysis(jars, mainClassName)).gatherThreadEscapingClasses();
 
-    for (Iterator<IClass> types = escapingTypes.iterator(); types.hasNext();) {
-      IClass cls = types.next();
+    for (IClass cls : escapingTypes) {
       if (!cls.isArrayClass()) {
-        for (Iterator<IField> fs = cls.getAllFields().iterator(); fs.hasNext();) {
-          IField f = fs.next();
+        for (IField f : cls.getAllFields()) {
           if (!f.isVolatile() && !f.isFinal()) {
             System.err.println(f.getReference());
           }

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/examples/drivers/PDFCallGraph.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/examples/drivers/PDFCallGraph.java
@@ -55,9 +55,8 @@ public class PDFCallGraph {
 
   public static String findJarFiles(String[] directories) {
     Collection<String> result = HashSetFactory.make();
-    for (int i = 0; i < directories.length; i++) {
-      for (Iterator<File> it = FileUtil.listFiles(directories[i], ".*\\.jar", true).iterator(); it.hasNext();) {
-        File f = it.next();
+    for (String directorie : directories) {
+      for (File f : FileUtil.listFiles(directorie, ".*\\.jar", true)) {
         result.add(f.getAbsolutePath());
       }
     }

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/exceptionanalysis/IntraproceduralExceptionAnalysis.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/exceptionanalysis/IntraproceduralExceptionAnalysis.java
@@ -226,7 +226,7 @@ public class IntraproceduralExceptionAnalysis {
 
     if (pointerAnalysis != null) {
       PointerKey pointerKey = pointerAnalysis.getHeapModel().getPointerKeyForLocal(node, exceptionVariable);
-      Iterator it = pointerAnalysis.getHeapGraph().getSuccNodes(pointerKey);
+      Iterator<Object> it = pointerAnalysis.getHeapGraph().getSuccNodes(pointerKey);
       while (it.hasNext()) {
         Object next = it.next();
         if (next instanceof InstanceKey) {

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/pointers/BasicHeapGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/pointers/BasicHeapGraph.java
@@ -516,7 +516,7 @@ public class BasicHeapGraph<T extends InstanceKey> extends HeapGraphImpl<T> {
       Object node = getNode(i);
       if (node != null) {
         result.append(i).append(" -> ");
-        for (Iterator it = getSuccNodes(node); it.hasNext();) {
+        for (Iterator<Object> it = getSuccNodes(node); it.hasNext();) {
           Object s = it.next();
           result.append(getNumber(s)).append(" ");
         }

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/pointers/BasicHeapGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/pointers/BasicHeapGraph.java
@@ -245,8 +245,7 @@ public class BasicHeapGraph<T extends InstanceKey> extends HeapGraphImpl<T> {
   private OrdinalSetMapping<PointerKey> getPointerKeys() {
     MutableMapping<PointerKey> result = MutableMapping.make();
 
-    for (Iterator<PointerKey> it = getPointerAnalysis().getPointerKeys().iterator(); it.hasNext();) {
-      PointerKey p = it.next();
+    for (PointerKey p : getPointerAnalysis().getPointerKeys()) {
       result.add(p);
     }
     return result;
@@ -259,8 +258,8 @@ public class BasicHeapGraph<T extends InstanceKey> extends HeapGraphImpl<T> {
       OrdinalSet<T> S = getPointerAnalysis().getPointsToSet(P);
       int[] result = new int[S.size()];
       int i = 0;
-      for (Iterator<T> it = S.iterator(); it.hasNext();) {
-        result[i] = nodeManager.getNumber(it.next());
+      for (T t : S) {
+        result[i] = nodeManager.getNumber(t);
         i++;
       }
       return result;
@@ -280,8 +279,7 @@ public class BasicHeapGraph<T extends InstanceKey> extends HeapGraphImpl<T> {
         IClass klass = getHeapModel().getClassHierarchy().lookupClass(T);
         assert klass != null : "null klass for type " + T;
         MutableSparseIntSet result = MutableSparseIntSet.makeEmpty();
-        for (Iterator<IField> it = klass.getAllInstanceFields().iterator(); it.hasNext();) {
-          IField f = it.next();
+        for (IField f : klass.getAllInstanceFields()) {
           if (!f.getReference().getFieldType().isPrimitiveType()) {
             PointerKey p = getHeapModel().getPointerKeyForInstanceField(I, f);
             if (p != null && nodeManager.containsNode(p)) {
@@ -326,8 +324,7 @@ public class BasicHeapGraph<T extends InstanceKey> extends HeapGraphImpl<T> {
       if (!(n instanceof LocalPointerKey)) {
         int[] succ = computeSuccNodeNumbers(n, nodeManager);
         if (succ != null) {
-          for (int z = 0; z < succ.length; z++) {
-            int j = succ[z];
+          for (int j : succ) {
             R.add(j, i);
           }
         }
@@ -341,8 +338,7 @@ public class BasicHeapGraph<T extends InstanceKey> extends HeapGraphImpl<T> {
   private void computePredecessorsForLocals(NumberedNodeManager<Object> nodeManager, BasicNaturalRelation R) {
 
     ArrayList<LocalPointerKey> list = new ArrayList<LocalPointerKey>();
-    for (Iterator<Object> it = nodeManager.iterator(); it.hasNext();) {
-      Object n = it.next();
+    for (Object n : nodeManager) {
       if (n instanceof LocalPointerKey) {
         list.add((LocalPointerKey) n);
       }
@@ -360,8 +356,7 @@ public class BasicHeapGraph<T extends InstanceKey> extends HeapGraphImpl<T> {
       int num = nodeManager.getNumber(n);
       int[] succ = computeSuccNodeNumbers(n, nodeManager);
       if (succ != null) {
-        for (int z = 0; z < succ.length; z++) {
-          int j = succ[z];
+        for (int j : succ) {
           R.add(j, num);
         }
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/CloneInterpreter.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/CloneInterpreter.java
@@ -189,8 +189,7 @@ public class CloneInterpreter implements SSAContextInterpreter {
       // TODO:
       IClass k = klass;
       while (k != null) {
-        for (Iterator<IField> it = klass.getDeclaredInstanceFields().iterator(); it.hasNext();) {
-          IField f = it.next();
+        for (IField f : klass.getDeclaredInstanceFields()) {
           int tempValue = nextLocal++;
           SSAGetInstruction G = insts.GetInstruction(statements.size(), tempValue, 1, f.getReference());
           statements.add(G);

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/CloneInterpreter.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/CloneInterpreter.java
@@ -258,7 +258,7 @@ public class CloneInterpreter implements SSAContextInterpreter {
     return CodeScanner.hasObjectArrayStore(statements);
   }
 
-  public Iterator iterateCastTypes(CGNode node) {
+  public Iterator<TypeReference> iterateCastTypes(CGNode node) {
     SSAInstruction[] statements = getIR(node).getInstructions();
     return CodeScanner.iterateCastTypes(statements);
   }

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/FactoryBypassInterpreter.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/FactoryBypassInterpreter.java
@@ -157,8 +157,8 @@ public class FactoryBypassInterpreter extends AbstractReflectionInterpreter {
     }
     SpecializedFactoryMethod m = findOrCreateSpecializedFactoryMethod(node);
     HashSet<NewSiteReference> result = HashSetFactory.make(5);
-    for (Iterator<SSAInstruction> it = m.getAllocationStatements().iterator(); it.hasNext();) {
-      SSANewInstruction s = (SSANewInstruction) it.next();
+    for (SSAInstruction ssaInstruction : m.getAllocationStatements()) {
+      SSANewInstruction s = (SSANewInstruction) ssaInstruction;
       result.add(s.getNewSite());
     }
     return result.iterator();
@@ -393,8 +393,7 @@ public class FactoryBypassInterpreter extends AbstractReflectionInterpreter {
       // add original statements from the method summary
       nextLocal = addOriginalStatements(m);
 
-      for (Iterator<TypeReference> it = S.iterator(); it.hasNext();) {
-        TypeReference type = it.next();
+      for (TypeReference type : S) {
         TypeAbstraction T = typeRef2TypeAbstraction(m.getClassHierarchy(), type);
         addStatementsForTypeAbstraction(T);
       }
@@ -506,8 +505,7 @@ public class FactoryBypassInterpreter extends AbstractReflectionInterpreter {
       SSAInstruction[] original = m.getStatements(options.getSSAOptions());
       // local value number 1 is "this", so the next free value number is 2
       int nextLocal = 2;
-      for (int i = 0; i < original.length; i++) {
-        SSAInstruction s = original[i];
+      for (SSAInstruction s : original) {
         allInstructions.add(s);
         if (s instanceof SSAInvokeInstruction) {
           calls.add(s);
@@ -603,8 +601,8 @@ public class FactoryBypassInterpreter extends AbstractReflectionInterpreter {
     public SSAInstruction[] getStatements() {
       SSAInstruction[] result = new SSAInstruction[allInstructions.size()];
       int i = 0;
-      for (Iterator<SSAInstruction> it = allInstructions.iterator(); it.hasNext();) {
-        result[i++] = it.next();
+      for (SSAInstruction ssaInstruction : allInstructions) {
+        result[i++] = ssaInstruction;
       }
       return result;
     }

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/FactoryBypassInterpreter.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/FactoryBypassInterpreter.java
@@ -263,7 +263,7 @@ public class FactoryBypassInterpreter extends AbstractReflectionInterpreter {
   private SpecializedFactoryMethod findOrCreateSpecializedFactoryMethod(CGNode node) {
     SpecializedFactoryMethod m = syntheticMethodCache.get(node.getContext());
     if (m == null) {
-      Set types = getTypesForContext(node.getContext());
+      Set<TypeReference> types = getTypesForContext(node.getContext());
       m = new SpecializedFactoryMethod((SummarizedMethod) node.getMethod(), node.getContext(), types);
       syntheticMethodCache.put(node.getContext(), m);
     }
@@ -312,7 +312,7 @@ public class FactoryBypassInterpreter extends AbstractReflectionInterpreter {
     }
   }
 
-  public Iterator iterateCastTypes(CGNode node) {
+  public Iterator<TypeReference> iterateCastTypes(CGNode node) {
     if (node == null) {
       throw new IllegalArgumentException("node is null");
     }
@@ -378,7 +378,7 @@ public class FactoryBypassInterpreter extends AbstractReflectionInterpreter {
       }
     }
 
-    protected SpecializedFactoryMethod(final SummarizedMethod m, Context context, final Set S) {
+    protected SpecializedFactoryMethod(final SummarizedMethod m, Context context, final Set<TypeReference> S) {
       super(m, m.getDeclaringClass(), m.isStatic(), true);
 
       this.context = context;
@@ -393,8 +393,8 @@ public class FactoryBypassInterpreter extends AbstractReflectionInterpreter {
       // add original statements from the method summary
       nextLocal = addOriginalStatements(m);
 
-      for (Iterator it = S.iterator(); it.hasNext();) {
-        TypeReference type = (TypeReference) it.next();
+      for (Iterator<TypeReference> it = S.iterator(); it.hasNext();) {
+        TypeReference type = it.next();
         TypeAbstraction T = typeRef2TypeAbstraction(m.getClassHierarchy(), type);
         addStatementsForTypeAbstraction(T);
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/stackMachine/AbstractIntStackMachine.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/stackMachine/AbstractIntStackMachine.java
@@ -684,8 +684,8 @@ public abstract class AbstractIntStackMachine implements FixedPointConstants {
             return true;
 
       if (locals != null)
-        for (int i = 0; i < locals.length; i++)
-          if (locals[i] == val)
+        for (int local : locals)
+          if (local == val)
             return true;
 
       return false;

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/stackMachine/AbstractIntStackMachine.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/stackMachine/AbstractIntStackMachine.java
@@ -54,6 +54,7 @@ import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.CancelRuntimeException;
+import com.ibm.wala.util.graph.INodeWithNumber;
 import com.ibm.wala.util.shrike.ShrikeUtil;
 
 /**
@@ -215,7 +216,7 @@ public abstract class AbstractIntStackMachine implements FixedPointConstants {
         /*
          * Add only the entry variable to the work list.
          */
-        for (Iterator it = getFixedPointSystem().getStatementsThatUse(entry); it.hasNext();) {
+        for (Iterator<? extends INodeWithNumber> it = getFixedPointSystem().getStatementsThatUse(entry); it.hasNext();) {
           AbstractStatement s = (AbstractStatement) it.next();
           addToWorkList(s);
         }

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/typeInference/ConeType.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/typeInference/ConeType.java
@@ -106,7 +106,7 @@ public class ConeType extends TypeAbstraction {
   /**
    * @return an Iterator of IClass that implement this interface
    */
-  public Iterator iterateImplementors() {
+  public Iterator<IClass> iterateImplementors() {
     return type.getClassHierarchy().getImplementors(getType().getReference()).iterator();
   }
 

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/typeInference/TypeInference.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/typeInference/TypeInference.java
@@ -217,8 +217,7 @@ public class TypeInference extends SSAInference<TypeVariable> implements FixedPo
             x = new TypeReference[]{ language.getThrowableType() };
           }
           if (x != null) {
-            for (int i = 0; i < x.length; i++) {
-              TypeReference tx = x[i];
+            for (TypeReference tx : x) {
               IClass tc = cha.lookupClass(tx);
               if (tc != null) {
                 v.setType(v.getType().meet(new ConeType(tc)));
@@ -308,9 +307,8 @@ public class TypeInference extends SSAInference<TypeVariable> implements FixedPo
 
       TypeAbstraction lhsType = lhs.getType();
       TypeAbstraction meet = TypeAbstraction.TOP;
-      for (int i = 0; i < rhs.length; i++) {
-        if (rhs[i] != null && rhs[i].getType() != null) {
-          TypeVariable r = rhs[i];
+      for (TypeVariable r : rhs) {
+        if (r != null && r.getType() != null) {
           meet = meet.meet(r.getType());
         }
       }
@@ -386,9 +384,8 @@ public class TypeInference extends SSAInference<TypeVariable> implements FixedPo
     public byte evaluate(TypeVariable lhs, TypeVariable[] rhs) {
       TypeAbstraction lhsType = lhs.getType();
       TypeAbstraction meet = TypeAbstraction.TOP;
-      for (int i = 0; i < rhs.length; i++) {
-        if (rhs[i] != null  && rhs[i].getType() != null) {
-          TypeVariable r = rhs[i];
+      for (TypeVariable r : rhs) {
+        if (r != null  && r.getType() != null) {
           meet = meet.meet(r.getType());
         }
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/typeInference/TypeInference.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/typeInference/TypeInference.java
@@ -668,8 +668,8 @@ public class TypeInference extends SSAInference<TypeVariable> implements FixedPo
 
     private TypeAbstraction meetDeclaredExceptionTypes(SSAGetCaughtExceptionInstruction s) {
       ExceptionHandlerBasicBlock bb = (ExceptionHandlerBasicBlock) ir.getControlFlowGraph().getNode(s.getBasicBlockNumber());
-      Iterator it = bb.getCaughtExceptionTypes();
-      TypeReference t = (TypeReference) it.next();
+      Iterator<TypeReference> it = bb.getCaughtExceptionTypes();
+      TypeReference t = it.next();
       IClass klass = cha.lookupClass(t);
       TypeAbstraction result = null;
       if (klass == null) {
@@ -680,7 +680,7 @@ public class TypeInference extends SSAInference<TypeVariable> implements FixedPo
         result = new ConeType(klass);
       }
       while (it.hasNext()) {
-        t = (TypeReference) it.next();
+        t = it.next();
         IClass tClass = cha.lookupClass(t);
         if (tClass == null) {
           result = BOTTOM;

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/AbstractCFG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/AbstractCFG.java
@@ -547,8 +547,7 @@ public abstract class AbstractCFG<I, T extends IBasicBlock<I>> implements Contro
   @Override
   public String toString() {
     StringBuffer s = new StringBuffer("");
-    for (Iterator<T> it = iterator(); it.hasNext();) {
-      T bb = it.next();
+    for (T bb : this) {
       s.append("BB").append(getNumber(bb)).append("\n");
 
       Iterator<T> succNodes = getSuccNodes(bb);

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/CFGSanitizer.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/CFGSanitizer.java
@@ -53,10 +53,10 @@ public class CFGSanitizer {
     }
 
     // add all edges to the graph, except those that go to exit
-    for (Iterator it = cfg.iterator(); it.hasNext();) {
-      ISSABasicBlock b = (ISSABasicBlock) it.next();
-      for (Iterator it2 = cfg.getSuccNodes(b); it2.hasNext();) {
-        ISSABasicBlock b2 = (ISSABasicBlock) it2.next();
+    for (Iterator<ISSABasicBlock> it = cfg.iterator(); it.hasNext();) {
+      ISSABasicBlock b = it.next();
+      for (Iterator<ISSABasicBlock> it2 = cfg.getSuccNodes(b); it2.hasNext();) {
+        ISSABasicBlock b2 = it2.next();
 
         if (!b2.isExitBlock()) {
           g.addEdge(b, b2);
@@ -67,9 +67,9 @@ public class CFGSanitizer {
     // now add edges to exit, ignoring undeclared exceptions
     ISSABasicBlock exit = cfg.exit();
 
-    for (Iterator it = cfg.getPredNodes(exit); it.hasNext();) {
+    for (Iterator<ISSABasicBlock> it = cfg.getPredNodes(exit); it.hasNext();) {
       // for each predecessor of exit ...
-      ISSABasicBlock b = (ISSABasicBlock) it.next();
+      ISSABasicBlock b = it.next();
 
       SSAInstruction s = ir.getInstructions()[b.getLastInstructionIndex()];
       if (s == null) {
@@ -90,14 +90,14 @@ public class CFGSanitizer {
           Assertions.UNREACHABLE();
         }
         // remove any exceptions that are caught by catch blocks
-        for (Iterator it2 = cfg.getSuccNodes(b); it2.hasNext();) {
-          IBasicBlock c = (IBasicBlock) it2.next();
+        for (Iterator<ISSABasicBlock> it2 = cfg.getSuccNodes(b); it2.hasNext();) {
+          IBasicBlock c = it2.next();
 
           if (c.isCatchBlock()) {
             SSACFG.ExceptionHandlerBasicBlock cb = (ExceptionHandlerBasicBlock) c;
 
-            for (Iterator it3 = cb.getCaughtExceptionTypes(); it3.hasNext();) {
-              TypeReference ex = (TypeReference) it3.next();
+            for (Iterator<TypeReference> it3 = cb.getCaughtExceptionTypes(); it3.hasNext();) {
+              TypeReference ex = it3.next();
               IClass exClass = cha.lookupClass(ex);
               if (exClass == null) {
                 throw new WalaException("failed to find " + ex);
@@ -158,7 +158,7 @@ public class CFGSanitizer {
    * What are the exception types which s may throw?
    */
   private static TypeReference[] computeExceptions(IClassHierarchy cha, IR ir, SSAInstruction s) throws InvalidClassFileException {
-    Collection c = null;
+    Collection<TypeReference> c = null;
     Language l = ir.getMethod().getDeclaringClass().getClassLoader().getLanguage();
     if (s instanceof SSAInvokeInstruction) {
       SSAInvokeInstruction call = (SSAInvokeInstruction) s;
@@ -170,9 +170,9 @@ public class CFGSanitizer {
       return null;
     } else {
       TypeReference[] exceptions = new TypeReference[c.size()];
-      Iterator it = c.iterator();
+      Iterator<TypeReference> it = c.iterator();
       for (int i = 0; i < exceptions.length; i++) {
-        exceptions[i] = (TypeReference) it.next();
+        exceptions[i] = it.next();
       }
       return exceptions;
     }

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/CFGSanitizer.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/CFGSanitizer.java
@@ -48,13 +48,12 @@ public class CFGSanitizer {
     ControlFlowGraph<SSAInstruction, ISSABasicBlock> cfg = ir.getControlFlowGraph();
     Graph<ISSABasicBlock> g = SlowSparseNumberedGraph.make();
     // add all nodes to the graph
-    for (Iterator<? extends ISSABasicBlock> it = cfg.iterator(); it.hasNext();) {
-      g.addNode(it.next());
+    for (ISSABasicBlock basicBlock : cfg) {
+      g.addNode(basicBlock);
     }
 
     // add all edges to the graph, except those that go to exit
-    for (Iterator<ISSABasicBlock> it = cfg.iterator(); it.hasNext();) {
-      ISSABasicBlock b = it.next();
+    for (ISSABasicBlock b : cfg) {
       for (Iterator<ISSABasicBlock> it2 = cfg.getSuccNodes(b); it2.hasNext();) {
         ISSABasicBlock b2 = it2.next();
 
@@ -125,17 +124,17 @@ public class CFGSanitizer {
           Assertions.UNREACHABLE();
         }
         if (declared != null && exceptions != null) {
-          for (int i = 0; i < exceptions.length; i++) {
+          for (TypeReference exception : exceptions) {
             boolean isDeclared = false;
-            if (exceptions[i] != null) {
-              IClass exi = cha.lookupClass(exceptions[i]);
+            if (exception != null) {
+              IClass exi = cha.lookupClass(exception);
               if (exi == null) {
-                throw new WalaException("failed to find " + exceptions[i]);
+                throw new WalaException("failed to find " + exception);
               }
-              for (int j = 0; j < declared.length; j++) {
-                IClass dc = cha.lookupClass(declared[j]);
+              for (TypeReference element : declared) {
+                IClass dc = cha.lookupClass(element);
                 if (dc == null) {
-                  throw new WalaException("failed to find " + declared[j]);
+                  throw new WalaException("failed to find " + element);
                 }
                 if (cha.isSubclassOf(exi, dc)) {
                   isDeclared = true;

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/InducedCFG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/InducedCFG.java
@@ -120,8 +120,7 @@ public class InducedCFG extends AbstractCFG<SSAInstruction, InducedCFG.BasicBloc
    * Compute outgoing edges in the control flow graph.
    */
   private void computeEdges() {
-    for (Iterator<BasicBlock> it = iterator(); it.hasNext();) {
-      BasicBlock b = it.next();
+    for (BasicBlock b : this) {
       if (b.equals(exit()))
         continue;
       b.computeOutgoingEdges();
@@ -471,8 +470,7 @@ public class InducedCFG extends AbstractCFG<SSAInstruction, InducedCFG.BasicBloc
           int tgtNd = getIndexFromIIndex(tgt);  // index in instructions-array
           BasicBlock target = null;
 
-          for (Iterator<BasicBlock> it = InducedCFG.this.iterator(); it.hasNext();) {
-            final BasicBlock candid = it.next();
+          for (BasicBlock candid : InducedCFG.this) {
             if (candid.getFirstInstructionIndex() == tgtNd) {
               target = candid;
               break;
@@ -623,8 +621,7 @@ public class InducedCFG extends AbstractCFG<SSAInstruction, InducedCFG.BasicBloc
   @Override
   public String toString() {
     StringBuffer s = new StringBuffer("");
-    for (Iterator<BasicBlock> it = iterator(); it.hasNext();) {
-      BasicBlock bb = it.next();
+    for (BasicBlock bb : this) {
       s.append("BB").append(getNumber(bb)).append("\n");
       for (int j = bb.getFirstInstructionIndex(); j <= bb.getLastInstructionIndex(); j++) {
         s.append("  ").append(j).append("  ").append(getInstructions()[j]).append("\n");
@@ -697,8 +694,7 @@ public class InducedCFG extends AbstractCFG<SSAInstruction, InducedCFG.BasicBloc
 
   public Collection<SSAPhiInstruction> getAllPhiInstructions() {
     Collection<SSAPhiInstruction> result = HashSetFactory.make();
-    for (Iterator<BasicBlock> it = iterator(); it.hasNext();) {
-      BasicBlock b = it.next();
+    for (BasicBlock b : this) {
       result.addAll(b.getPhis());
     }
     return result;

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/InducedCFG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/InducedCFG.java
@@ -120,8 +120,8 @@ public class InducedCFG extends AbstractCFG<SSAInstruction, InducedCFG.BasicBloc
    * Compute outgoing edges in the control flow graph.
    */
   private void computeEdges() {
-    for (Iterator it = iterator(); it.hasNext();) {
-      BasicBlock b = (BasicBlock) it.next();
+    for (Iterator<BasicBlock> it = iterator(); it.hasNext();) {
+      BasicBlock b = it.next();
       if (b.equals(exit()))
         continue;
       b.computeOutgoingEdges();
@@ -471,8 +471,8 @@ public class InducedCFG extends AbstractCFG<SSAInstruction, InducedCFG.BasicBloc
           int tgtNd = getIndexFromIIndex(tgt);  // index in instructions-array
           BasicBlock target = null;
 
-          for (Iterator it = InducedCFG.this.iterator(); it.hasNext();) {
-            final BasicBlock candid = (BasicBlock) it.next();
+          for (Iterator<BasicBlock> it = InducedCFG.this.iterator(); it.hasNext();) {
+            final BasicBlock candid = it.next();
             if (candid.getFirstInstructionIndex() == tgtNd) {
               target = candid;
               break;
@@ -623,8 +623,8 @@ public class InducedCFG extends AbstractCFG<SSAInstruction, InducedCFG.BasicBloc
   @Override
   public String toString() {
     StringBuffer s = new StringBuffer("");
-    for (Iterator it = iterator(); it.hasNext();) {
-      BasicBlock bb = (BasicBlock) it.next();
+    for (Iterator<BasicBlock> it = iterator(); it.hasNext();) {
+      BasicBlock bb = it.next();
       s.append("BB").append(getNumber(bb)).append("\n");
       for (int j = bb.getFirstInstructionIndex(); j <= bb.getLastInstructionIndex(); j++) {
         s.append("  ").append(j).append("  ").append(getInstructions()[j]).append("\n");

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/ShrikeCFG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/ShrikeCFG.java
@@ -111,8 +111,8 @@ public class ShrikeCFG extends AbstractCFG<IInstruction, ShrikeCFG.BasicBlock> i
    */
   private void computeI2BMapping() {
     instruction2Block = new int[getInstructions().length];
-    for (Iterator it = iterator(); it.hasNext();) {
-      final BasicBlock b = (BasicBlock) it.next();
+    for (Iterator<BasicBlock> it = iterator(); it.hasNext();) {
+      final BasicBlock b = it.next();
       for (int j = b.getFirstInstructionIndex(); j <= b.getLastInstructionIndex(); j++) {
         instruction2Block[j] = getNumber(b);
       }
@@ -123,8 +123,8 @@ public class ShrikeCFG extends AbstractCFG<IInstruction, ShrikeCFG.BasicBlock> i
    * Compute outgoing edges in the control flow graph.
    */
   private void computeEdges() {
-    for (Iterator it = iterator(); it.hasNext();) {
-      BasicBlock b = (BasicBlock) it.next();
+    for (Iterator<BasicBlock> it = iterator(); it.hasNext();) {
+      BasicBlock b = it.next();
       if (b.equals(exit())) {
         continue;
       } else if (b.equals(entry())) {
@@ -502,8 +502,8 @@ public class ShrikeCFG extends AbstractCFG<IInstruction, ShrikeCFG.BasicBlock> i
   @Override
   public String toString() {
     StringBuffer s = new StringBuffer("");
-    for (Iterator it = iterator(); it.hasNext();) {
-      BasicBlock bb = (BasicBlock) it.next();
+    for (Iterator<BasicBlock> it = iterator(); it.hasNext();) {
+      BasicBlock bb = it.next();
       s.append("BB").append(getNumber(bb)).append("\n");
       for (int j = bb.getFirstInstructionIndex(); j <= bb.getLastInstructionIndex(); j++) {
         s.append("  ").append(j).append("  ").append(getInstructions()[j]).append("\n");

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/ShrikeCFG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/ShrikeCFG.java
@@ -111,8 +111,7 @@ public class ShrikeCFG extends AbstractCFG<IInstruction, ShrikeCFG.BasicBlock> i
    */
   private void computeI2BMapping() {
     instruction2Block = new int[getInstructions().length];
-    for (Iterator<BasicBlock> it = iterator(); it.hasNext();) {
-      final BasicBlock b = it.next();
+    for (BasicBlock b : this) {
       for (int j = b.getFirstInstructionIndex(); j <= b.getLastInstructionIndex(); j++) {
         instruction2Block[j] = getNumber(b);
       }
@@ -123,8 +122,7 @@ public class ShrikeCFG extends AbstractCFG<IInstruction, ShrikeCFG.BasicBlock> i
    * Compute outgoing edges in the control flow graph.
    */
   private void computeEdges() {
-    for (Iterator<BasicBlock> it = iterator(); it.hasNext();) {
-      BasicBlock b = it.next();
+    for (BasicBlock b : this) {
       if (b.equals(exit())) {
         continue;
       } else if (b.equals(entry())) {
@@ -238,8 +236,8 @@ public class ShrikeCFG extends AbstractCFG<IInstruction, ShrikeCFG.BasicBlock> i
 
       IInstruction last = getInstructions()[getLastInstructionIndex()];
       int[] targets = last.getBranchTargets();
-      for (int i = 0; i < targets.length; i++) {
-        BasicBlock b = getBlockForInstruction(targets[i]);
+      for (int target : targets) {
+        BasicBlock b = getBlockForInstruction(target);
         addNormalEdgeTo(b);
       }
       addExceptionalEdges(last);
@@ -310,11 +308,11 @@ public class ShrikeCFG extends AbstractCFG<IInstruction, ShrikeCFG.BasicBlock> i
           // this var gets set to false if goToAllHandlers is true but some enclosing exception handler catches all
           // exceptions.  in such a case, we need not add an exceptional edge to the method exit
           boolean needEdgeToExitForAllHandlers = true;
-          for (int j = 0; j < hs.length; j++) {
+          for (ExceptionHandler element : hs) {
             if (DEBUG) {
-              System.err.println(" handler " + hs[j]);
+              System.err.println(" handler " + element);
             }
-            BasicBlock b = getBlockForInstruction(hs[j].getHandler());
+            BasicBlock b = getBlockForInstruction(element.getHandler());
             if (DEBUG) {
               System.err.println(" target " + b);
             }
@@ -325,15 +323,15 @@ public class ShrikeCFG extends AbstractCFG<IInstruction, ShrikeCFG.BasicBlock> i
               }
               addExceptionalEdgeTo(b);
               // if the handler catches all exceptions, we don't need to add an edge to the exit or any other handlers
-              if (hs[j].getCatchClass() == null) {
+              if (element.getCatchClass() == null) {
                 needEdgeToExitForAllHandlers = false;
                 break;
               }
             } else {
               TypeReference caughtException = null;
-              if (hs[j].getCatchClass() != null) {
+              if (element.getCatchClass() != null) {
                 ClassLoaderReference loader = ShrikeCFG.this.getMethod().getDeclaringClass().getReference().getClassLoader();
-                caughtException = ShrikeUtil.makeTypeReference(loader, hs[j].getCatchClass());
+                caughtException = ShrikeUtil.makeTypeReference(loader, element.getCatchClass());
                 if (DEBUG) {
                   System.err.println(" caughtException " + caughtException);
                 }
@@ -502,8 +500,7 @@ public class ShrikeCFG extends AbstractCFG<IInstruction, ShrikeCFG.BasicBlock> i
   @Override
   public String toString() {
     StringBuffer s = new StringBuffer("");
-    for (Iterator<BasicBlock> it = iterator(); it.hasNext();) {
-      BasicBlock bb = it.next();
+    for (BasicBlock bb : this) {
       s.append("BB").append(getNumber(bb)).append("\n");
       for (int j = bb.getFirstInstructionIndex(); j <= bb.getLastInstructionIndex(); j++) {
         s.append("  ").append(j).append("  ").append(getInstructions()[j]).append("\n");

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/Util.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/Util.java
@@ -214,7 +214,7 @@ public class Util {
       throw new IllegalArgumentException("b is null");
     }
     int i = 0;
-    for (Iterator it = cfg.getPredNodes(b); it.hasNext();) {
+    for (Iterator<T> it = cfg.getPredNodes(b); it.hasNext();) {
       if (it.next().equals(a)) {
         return i;
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/cdg/ControlDependenceGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/cdg/ControlDependenceGraph.java
@@ -110,7 +110,7 @@ public class ControlDependenceGraph<T> extends AbstractNumberedGraph<T> {
         }
         for (Iterator<T> ps = forwardEdges.keySet().iterator(); ps.hasNext();) {
           T p = ps.next();
-          for (Iterator ns = ((Set) forwardEdges.get(p)).iterator(); ns.hasNext();) {
+          for (Iterator<T> ns = forwardEdges.get(p).iterator(); ns.hasNext();) {
             Object n = ns.next();
             backwardEdges.get(n).add(p);
           }
@@ -209,11 +209,11 @@ public class ControlDependenceGraph<T> extends AbstractNumberedGraph<T> {
     for (Iterator<? extends T> ns = iterator(); ns.hasNext();) {
       T n = ns.next();
       sb.append(n.toString()).append("\n");
-      for (Iterator ss = getSuccNodes(n); ss.hasNext();) {
+      for (Iterator<T> ss = getSuccNodes(n); ss.hasNext();) {
         Object s = ss.next();
         sb.append("  --> ").append(s);
         if (edgeLabels != null)
-          for (Iterator labels = ((Set) edgeLabels.get(Pair.make(n, s))).iterator(); labels.hasNext();)
+          for (Iterator<?> labels = edgeLabels.get(Pair.make(n, s)).iterator(); labels.hasNext();)
             sb.append("\n   label: ").append(labels.next());
         sb.append("\n");
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/cdg/ControlDependenceGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/cdg/ControlDependenceGraph.java
@@ -66,13 +66,12 @@ public class ControlDependenceGraph<T> extends AbstractNumberedGraph<T> {
       edgeLabels = HashMapFactory.make();
     }
 
-    for (Iterator<? extends T> ns = cfg.iterator(); ns.hasNext();) {
+    for (T name : cfg) {
       HashSet<T> s = HashSetFactory.make(2);
-      controlDependence.put(ns.next(), s);
+      controlDependence.put(name, s);
     }
 
-    for (Iterator<? extends T> ns = cfg.iterator(); ns.hasNext();) {
-      T y = ns.next();
+    for (T y : cfg) {
       for (Iterator<T> ns2 = RDF.getDominanceFrontier(y); ns2.hasNext();) {
         T x = ns2.next();
         controlDependence.get(x).add(y);
@@ -104,14 +103,13 @@ public class ControlDependenceGraph<T> extends AbstractNumberedGraph<T> {
     return new NumberedEdgeManager<T>() {
       Map<T, Set<T>> backwardEdges = HashMapFactory.make(forwardEdges.size());
       {
-        for (Iterator<? extends T> x = cfg.iterator(); x.hasNext();) {
+        for (T name : cfg) {
           Set<T> s = HashSetFactory.make();
-          backwardEdges.put(x.next(), s);
+          backwardEdges.put(name, s);
         }
-        for (Iterator<T> ps = forwardEdges.keySet().iterator(); ps.hasNext();) {
-          T p = ps.next();
-          for (Iterator<T> ns = forwardEdges.get(p).iterator(); ns.hasNext();) {
-            Object n = ns.next();
+        for (T p : forwardEdges.keySet()) {
+          for (T t : forwardEdges.get(p)) {
+            Object n = t;
             backwardEdges.get(n).add(p);
           }
         }
@@ -206,15 +204,14 @@ public class ControlDependenceGraph<T> extends AbstractNumberedGraph<T> {
   @Override
   public String toString() {
     StringBuffer sb = new StringBuffer();
-    for (Iterator<? extends T> ns = iterator(); ns.hasNext();) {
-      T n = ns.next();
+    for (T n : this) {
       sb.append(n.toString()).append("\n");
       for (Iterator<T> ss = getSuccNodes(n); ss.hasNext();) {
         Object s = ss.next();
         sb.append("  --> ").append(s);
         if (edgeLabels != null)
-          for (Iterator<?> labels = edgeLabels.get(Pair.make(n, s)).iterator(); labels.hasNext();)
-            sb.append("\n   label: ").append(labels.next());
+          for (Object name : edgeLabels.get(Pair.make(n, s)))
+            sb.append("\n   label: ").append(name);
         sb.append("\n");
       }
     }

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/NullPointerState.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/NullPointerState.java
@@ -221,8 +221,8 @@ public class NullPointerState extends AbstractVariable<NullPointerState> {
   @Override
   public String toString() {
     StringBuffer buf = new StringBuffer("<");
-    for (int i = 0; i < vars.length; i++) {
-      switch (vars[i]) {
+    for (State var : vars) {
+      switch (var) {
       case BOTH:
         buf.append('*');
         break;

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/BytecodeClass.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/BytecodeClass.java
@@ -503,8 +503,7 @@ public abstract class BytecodeClass<T extends IClassLoader> implements IClass {
   protected Collection<IClass> computeAllInterfacesAsCollection() {
     Collection<? extends IClass> c = getDirectInterfaces();
     Set<IClass> result = HashSetFactory.make();
-    for (Iterator<? extends IClass> it = c.iterator(); it.hasNext();) {
-      IClass klass = it.next();
+    for (IClass klass : c) {
       if (klass.isInterface()) {
         result.add(klass);
       } else {
@@ -538,8 +537,7 @@ public abstract class BytecodeClass<T extends IClassLoader> implements IClass {
    */
   private Collection<IClass> array2IClassSet(ImmutableByteArray[] interfaces) {
     ArrayList<IClass> result = new ArrayList<IClass>(interfaces.length);
-    for (int i = 0; i < interfaces.length; i++) {
-      ImmutableByteArray name = interfaces[i];
+    for (ImmutableByteArray name : interfaces) {
       IClass klass = null;
       klass = loader.lookupClass(TypeName.findOrCreate(name));
       if (klass == null) {
@@ -556,17 +554,17 @@ public abstract class BytecodeClass<T extends IClassLoader> implements IClass {
     List<IField> result = new ArrayList<IField>(1);
     
     if (instanceFields != null) {
-      for (int i = 0; i < instanceFields.length; i++) {
-        if (instanceFields[i].getName() == name) {
-          result.add(instanceFields[i]);
+      for (IField instanceField : instanceFields) {
+        if (instanceField.getName() == name) {
+          result.add(instanceField);
         }
       }
     }
 
     if (staticFields != null) {
-      for (int i = 0; i < staticFields.length; i++) {
-        if (staticFields[i].getName() == name) {
-          result.add(staticFields[i]);
+      for (IField staticField : staticFields) {
+        if (staticField.getName() == name) {
+          result.add(staticField);
         }
       }
     }
@@ -603,8 +601,7 @@ public abstract class BytecodeClass<T extends IClassLoader> implements IClass {
           } else {
             tmpMethodMap= new SmallMap<Selector, IMethod>();
           }
-          for (int i = 0; i < methods.length; i++) {
-            IMethod m = methods[i];
+          for (IMethod m : methods) {
             tmpMethodMap.put(m.getReference().getSelector(), m);
           }
           

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/ClassLoaderImpl.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/ClassLoaderImpl.java
@@ -183,13 +183,11 @@ public class ClassLoaderImpl implements IClassLoader {
    */
   private static void removeClassFiles(Set<ModuleEntry> s, Set<ModuleEntry> t) {
     Set<String> old = HashSetFactory.make();
-    for (Iterator<ModuleEntry> it = t.iterator(); it.hasNext();) {
-      ModuleEntry m = it.next();
+    for (ModuleEntry m : t) {
       old.add(m.getClassName());
     }
     HashSet<ModuleEntry> toRemove = HashSetFactory.make();
-    for (Iterator<ModuleEntry> it = s.iterator(); it.hasNext();) {
-      ModuleEntry m = it.next();
+    for (ModuleEntry m : s) {
       if (old.contains(m.getClassName())) {
         toRemove.add(m);
       }
@@ -243,8 +241,7 @@ public class ClassLoaderImpl implements IClassLoader {
    */
   @SuppressWarnings("unused")
   private void loadAllClasses(Collection<ModuleEntry> moduleEntries, Map<String, Object> fileContents) {
-    for (Iterator<ModuleEntry> it = moduleEntries.iterator(); it.hasNext();) {
-      ModuleEntry entry = it.next();
+    for (ModuleEntry entry : moduleEntries) {
       if (!entry.isClassFile()) {
         continue;
       }
@@ -411,8 +408,7 @@ public class ClassLoaderImpl implements IClassLoader {
    */
   @SuppressWarnings("unused")
   protected void loadAllSources(Set<ModuleEntry> sourceModules) {
-    for (Iterator<ModuleEntry> it = sourceModules.iterator(); it.hasNext();) {
-      ModuleEntry entry = it.next();
+    for (ModuleEntry entry : sourceModules) {
       String className = entry.getClassName().replace('.', '/');
       className = className.replace(File.separatorChar, '/');
       className = "L" + ((className.startsWith("/")) ? className.substring(1) : className);
@@ -489,8 +485,7 @@ public class ClassLoaderImpl implements IClassLoader {
     // module are loaded according to the given order (same as in Java VM)
     Set<ModuleEntry> classModuleEntries = HashSetFactory.make();
     Set<ModuleEntry> sourceModuleEntries = HashSetFactory.make();
-    for (Iterator<Module> it = modules.iterator(); it.hasNext();) {
-      Module archive = it.next();
+    for (Module archive : modules) {
       if (DEBUG_LEVEL > 0) {
         System.err.println("add archive: " + archive);
       }
@@ -524,12 +519,10 @@ public class ClassLoaderImpl implements IClassLoader {
       }
       loadAllClasses(classFiles, allClassAndSourceFileContents);
       loadAllSources(sourceFiles);
-      for (Iterator<ModuleEntry> it2 = classFiles.iterator(); it2.hasNext();) {
-        ModuleEntry file = it2.next();
+      for (ModuleEntry file : classFiles) {
         classModuleEntries.add(file);
       }
-      for (Iterator<ModuleEntry> it2 = sourceFiles.iterator(); it2.hasNext();) {
-        ModuleEntry file = it2.next();
+      for (ModuleEntry file : sourceFiles) {
         sourceModuleEntries.add(file);
       }
     }
@@ -703,8 +696,7 @@ public class ClassLoaderImpl implements IClassLoader {
     if (toRemove == null) {
       throw new IllegalArgumentException("toRemove is null");
     }
-    for (Iterator<IClass> it = toRemove.iterator(); it.hasNext();) {
-      IClass klass = it.next();
+    for (IClass klass : toRemove) {
       if (DEBUG_LEVEL > 0) {
         System.err.println("removing " + klass.getName());
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/ClassLoaderImpl.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/ClassLoaderImpl.java
@@ -125,8 +125,8 @@ public class ClassLoaderImpl implements IClassLoader {
       System.err.println("Get source files for " + M);
     }
     HashSet<ModuleEntry> result = HashSetFactory.make();
-    for (Iterator it = M.getEntries(); it.hasNext();) {
-      ModuleEntry entry = (ModuleEntry) it.next();
+    for (Iterator<? extends ModuleEntry> it = M.getEntries(); it.hasNext();) {
+      ModuleEntry entry = it.next();
       if (DEBUG_LEVEL > 0) {
         System.err.println("consider entry for source information: " + entry);
       }
@@ -155,8 +155,8 @@ public class ClassLoaderImpl implements IClassLoader {
       System.err.println("Get class files for " + M);
     }
     HashSet<ModuleEntry> result = HashSetFactory.make();
-    for (Iterator it = M.getEntries(); it.hasNext();) {
-      ModuleEntry entry = (ModuleEntry) it.next();
+    for (Iterator<? extends ModuleEntry> it = M.getEntries(); it.hasNext();) {
+      ModuleEntry entry = it.next();
       if (DEBUG_LEVEL > 0) {
         System.err.println("ClassLoaderImpl.getClassFiles:Got entry: " + entry);
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/CodeScanner.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/CodeScanner.java
@@ -161,7 +161,7 @@ public class CodeScanner {
    * @throws InvalidClassFileException
    * @throws IllegalArgumentException if m is null
    */
-  public static Iterator iterateCastTypes(IMethod m) throws InvalidClassFileException {
+  public static Iterator<TypeReference> iterateCastTypes(IMethod m) throws InvalidClassFileException {
     if (m == null) {
       throw new IllegalArgumentException("m is null");
     }
@@ -173,7 +173,7 @@ public class CodeScanner {
     }
   }
 
-  private static Iterator iterateShrikeBTCastTypes(ShrikeCTMethod wrapper) throws InvalidClassFileException {
+  private static Iterator<TypeReference> iterateShrikeBTCastTypes(ShrikeCTMethod wrapper) throws InvalidClassFileException {
     return wrapper.getCastTypes();
   }
 
@@ -182,8 +182,8 @@ public class CodeScanner {
   }
 
   private static boolean hasShrikeBTObjectArrayStore(ShrikeCTMethod M) throws InvalidClassFileException {
-    for (Iterator it = M.getArraysWritten(); it.hasNext();) {
-      TypeReference t = (TypeReference) it.next();
+    for (Iterator<TypeReference> it = M.getArraysWritten(); it.hasNext();) {
+      TypeReference t = it.next();
       if (t.isReferenceType()) {
         return true;
       }
@@ -232,8 +232,8 @@ public class CodeScanner {
   }
 
   private static boolean hasShrikeBTObjectArrayLoad(ShrikeCTMethod M) throws InvalidClassFileException {
-    for (Iterator it = M.getArraysRead(); it.hasNext();) {
-      TypeReference t = (TypeReference) it.next();
+    for (Iterator<TypeReference> it = M.getArraysRead(); it.hasNext();) {
+      TypeReference t = it.next();
       if (t.isReferenceType()) {
         return true;
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/CodeScanner.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/CodeScanner.java
@@ -257,8 +257,7 @@ public class CodeScanner {
         result.addAll(t);
       }
     };
-    for (int i = 0; i < statements.length; i++) {
-      SSAInstruction s = statements[i];
+    for (SSAInstruction s : statements) {
       if (s != null) {
         s.visit(v);
       }
@@ -274,10 +273,10 @@ public class CodeScanner {
       throw new IllegalArgumentException("statements == null");
     }
     final HashSet<TypeReference> result = HashSetFactory.make(10);
-    for (int i = 0; i < statements.length; i++) {
-      if (statements[i] != null) {
-        if (statements[i] instanceof SSACheckCastInstruction) {
-          SSACheckCastInstruction c = (SSACheckCastInstruction) statements[i];
+    for (SSAInstruction statement : statements) {
+      if (statement != null) {
+        if (statement instanceof SSACheckCastInstruction) {
+          SSACheckCastInstruction c = (SSACheckCastInstruction) statement;
           for(TypeReference t : c.getDeclaredResultTypes()) {
             result.add(t);
           }
@@ -299,8 +298,7 @@ public class CodeScanner {
         result.add(instruction.getCallSite());
       }
     };
-    for (int i = 0; i < statements.length; i++) {
-      SSAInstruction s = statements[i];
+    for (SSAInstruction s : statements) {
       if (s != null) {
         s.visit(v);
       }
@@ -320,8 +318,7 @@ public class CodeScanner {
         result.add(instruction.getNewSite());
       }
     };
-    for (int i = 0; i < statements.length; i++) {
-      SSAInstruction s = statements[i];
+    for (SSAInstruction s : statements) {
       if (s != null) {
         s.visit(v);
       }
@@ -345,8 +342,7 @@ public class CodeScanner {
         result.add(instruction.getDeclaredField());
       }
     };
-    for (int i = 0; i < statements.length; i++) {
-      SSAInstruction s = statements[i];
+    for (SSAInstruction s : statements) {
       if (s != null) {
         s.visit(v);
       }
@@ -370,8 +366,7 @@ public class CodeScanner {
         result.add(instruction.getDeclaredField());
       }
     };
-    for (int i = 0; i < statements.length; i++) {
-      SSAInstruction s = statements[i];
+    for (SSAInstruction s : statements) {
       if (s != null) {
         s.visit(v);
       }
@@ -397,8 +392,7 @@ public class CodeScanner {
       }
       
     };
-    for (int i = 0; i < statements.length; i++) {
-      SSAInstruction s = statements[i];
+    for (SSAInstruction s : statements) {
       if (s != null) {
         s.visit(v);
       }
@@ -422,8 +416,7 @@ public class CodeScanner {
       }
     }
     ScanVisitor v = new ScanVisitor();
-    for (int i = 0; i < statements.length; i++) {
-      SSAInstruction s = statements[i];
+    for (SSAInstruction s : statements) {
       if (s != null) {
         s.visit(v);
       }
@@ -450,8 +443,7 @@ public class CodeScanner {
       }
     }
     ScanVisitor v = new ScanVisitor();
-    for (int i = 0; i < statements.length; i++) {
-      SSAInstruction s = statements[i];
+    for (SSAInstruction s : statements) {
       if (s != null) {
         s.visit(v);
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/DirectoryTreeModule.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/DirectoryTreeModule.java
@@ -50,11 +50,11 @@ public abstract class DirectoryTreeModule implements Module {
     Set<FileModule> result = HashSetFactory.make();
     File[] files = dir.listFiles();
     if (files != null) {
-      for (int i = 0; i < files.length; i++) {
-        if (files[i].isDirectory()) {
-          result.addAll(getEntriesRecursive(files[i]));
-        } else if (includeFile(files[i])) {
-          FileModule fileModule = makeFile(files[i]);
+      for (File file : files) {
+        if (file.isDirectory()) {
+          result.addAll(getEntriesRecursive(file));
+        } else if (includeFile(file)) {
+          FileModule fileModule = makeFile(file);
           if (fileModule != null) {
             result.add(fileModule);
           }

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/ShrikeBTMethod.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/ShrikeBTMethod.java
@@ -309,7 +309,7 @@ public abstract class ShrikeBTMethod implements IMethod, BytecodeConstants {
    * @return Iterator of TypeReference
    * @throws InvalidClassFileException
    */
-  public Iterator getArraysRead() throws InvalidClassFileException {
+  public Iterator<TypeReference> getArraysRead() throws InvalidClassFileException {
     if (isNative()) {
       return EmptyIterator.instance();
     }
@@ -336,7 +336,7 @@ public abstract class ShrikeBTMethod implements IMethod, BytecodeConstants {
    * @return Iterator of TypeReference
    * @throws InvalidClassFileException
    */
-  public Iterator getCastTypes() throws InvalidClassFileException {
+  public Iterator<TypeReference> getCastTypes() throws InvalidClassFileException {
     if (isNative()) {
       return EmptyIterator.instance();
     }
@@ -541,8 +541,8 @@ public abstract class ShrikeBTMethod implements IMethod, BytecodeConstants {
 
     info.implicitExceptions = new TypeReference[simpleVisitor.implicitExceptions.size()];
     i = 0;
-    for (Iterator it = simpleVisitor.implicitExceptions.iterator(); it.hasNext();) {
-      info.implicitExceptions[i++] = (TypeReference) it.next();
+    for (Iterator<TypeReference> it = simpleVisitor.implicitExceptions.iterator(); it.hasNext();) {
+      info.implicitExceptions[i++] = it.next();
     }
 
     info.castTypes = new TypeReference[simpleVisitor.castTypes.size()];

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/ShrikeBTMethod.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/ShrikeBTMethod.java
@@ -499,56 +499,56 @@ public abstract class ShrikeBTMethod implements IMethod, BytecodeConstants {
   private static void copyVisitorSetsToArrays(SimpleVisitor simpleVisitor, BytecodeInfo info) {
     info.newSites = new NewSiteReference[simpleVisitor.newSites.size()];
     int i = 0;
-    for (Iterator<NewSiteReference> it = simpleVisitor.newSites.iterator(); it.hasNext();) {
-      info.newSites[i++] = it.next();
+    for (NewSiteReference newSiteReference : simpleVisitor.newSites) {
+      info.newSites[i++] = newSiteReference;
     }
 
     info.fieldsRead = new FieldReference[simpleVisitor.fieldsRead.size()];
     i = 0;
-    for (Iterator<FieldReference> it = simpleVisitor.fieldsRead.iterator(); it.hasNext();) {
-      info.fieldsRead[i++] = it.next();
+    for (FieldReference fieldReference : simpleVisitor.fieldsRead) {
+      info.fieldsRead[i++] = fieldReference;
     }
 
     info.fieldsRead = new FieldReference[simpleVisitor.fieldsRead.size()];
     i = 0;
-    for (Iterator<FieldReference> it = simpleVisitor.fieldsRead.iterator(); it.hasNext();) {
-      info.fieldsRead[i++] = it.next();
+    for (FieldReference fieldReference : simpleVisitor.fieldsRead) {
+      info.fieldsRead[i++] = fieldReference;
     }
 
     info.fieldsWritten = new FieldReference[simpleVisitor.fieldsWritten.size()];
     i = 0;
-    for (Iterator<FieldReference> it = simpleVisitor.fieldsWritten.iterator(); it.hasNext();) {
-      info.fieldsWritten[i++] = it.next();
+    for (FieldReference fieldReference : simpleVisitor.fieldsWritten) {
+      info.fieldsWritten[i++] = fieldReference;
     }
 
     info.callSites = new CallSiteReference[simpleVisitor.callSites.size()];
     i = 0;
-    for (Iterator<CallSiteReference> it = simpleVisitor.callSites.iterator(); it.hasNext();) {
-      info.callSites[i++] = it.next();
+    for (CallSiteReference callSiteReference : simpleVisitor.callSites) {
+      info.callSites[i++] = callSiteReference;
     }
 
     info.arraysRead = new TypeReference[simpleVisitor.arraysRead.size()];
     i = 0;
-    for (Iterator<TypeReference> it = simpleVisitor.arraysRead.iterator(); it.hasNext();) {
-      info.arraysRead[i++] = it.next();
+    for (TypeReference typeReference : simpleVisitor.arraysRead) {
+      info.arraysRead[i++] = typeReference;
     }
 
     info.arraysWritten = new TypeReference[simpleVisitor.arraysWritten.size()];
     i = 0;
-    for (Iterator<TypeReference> it = simpleVisitor.arraysWritten.iterator(); it.hasNext();) {
-      info.arraysWritten[i++] = it.next();
+    for (TypeReference typeReference : simpleVisitor.arraysWritten) {
+      info.arraysWritten[i++] = typeReference;
     }
 
     info.implicitExceptions = new TypeReference[simpleVisitor.implicitExceptions.size()];
     i = 0;
-    for (Iterator<TypeReference> it = simpleVisitor.implicitExceptions.iterator(); it.hasNext();) {
-      info.implicitExceptions[i++] = it.next();
+    for (TypeReference typeReference : simpleVisitor.implicitExceptions) {
+      info.implicitExceptions[i++] = typeReference;
     }
 
     info.castTypes = new TypeReference[simpleVisitor.castTypes.size()];
     i = 0;
-    for (Iterator<TypeReference> it = simpleVisitor.castTypes.iterator(); it.hasNext();) {
-      info.castTypes[i++] = it.next();
+    for (TypeReference typeReference : simpleVisitor.castTypes) {
+      info.castTypes[i++] = typeReference;
     }
 
     info.hasMonitorOp = simpleVisitor.hasMonitorOp;
@@ -842,9 +842,9 @@ public abstract class ShrikeBTMethod implements IMethod, BytecodeConstants {
     }
     HashSet<TypeReference> result = HashSetFactory.make(10);
     ClassLoaderReference loader = getReference().getDeclaringClass().getClassLoader();
-    for (int i = 0; i < handlers.length; i++) {
-      for (int j = 0; j < handlers[i].length; j++) {
-        TypeReference t = ShrikeUtil.makeTypeReference(loader, handlers[i][j].getCatchClass());
+    for (ExceptionHandler[] handler : handlers) {
+      for (int j = 0; j < handler.length; j++) {
+        TypeReference t = ShrikeUtil.makeTypeReference(loader, handler[j].getCatchClass());
         if (t == null) {
           t = TypeReference.JavaLangThrowable;
         }

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/ShrikeClass.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/ShrikeClass.java
@@ -12,7 +12,6 @@ package com.ibm.wala.classLoader;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 
 import com.ibm.wala.ipa.cha.IClassHierarchy;
@@ -228,8 +227,8 @@ public final class ShrikeClass extends JVMClass<IClassLoader> {
   public void clearSoftCaches() {
     // toss optional information from each method.
     if (methodMap != null) {
-      for (Iterator<IMethod> it = getDeclaredMethods().iterator(); it.hasNext();) {
-        ShrikeCTMethod m = (ShrikeCTMethod) it.next();
+      for (IMethod iMethod : getDeclaredMethods()) {
+        ShrikeCTMethod m = (ShrikeCTMethod) iMethod;
         m.clearCaches();
       }
     }

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/ShrikeClass.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/ShrikeClass.java
@@ -228,7 +228,7 @@ public final class ShrikeClass extends JVMClass<IClassLoader> {
   public void clearSoftCaches() {
     // toss optional information from each method.
     if (methodMap != null) {
-      for (Iterator it = getDeclaredMethods().iterator(); it.hasNext();) {
+      for (Iterator<IMethod> it = getDeclaredMethods().iterator(); it.hasNext();) {
         ShrikeCTMethod m = (ShrikeCTMethod) it.next();
         m.clearCaches();
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/client/AbstractAnalysisEngine.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/client/AbstractAnalysisEngine.java
@@ -215,7 +215,7 @@ public abstract class AbstractAnalysisEngine<I extends InstanceKey> implements A
    */
   protected void addApplicationModulesToScope() {
     ClassLoaderReference app = scope.getApplicationLoader();
-    for (Iterator it = moduleFiles.iterator(); it.hasNext();) {
+    for (Iterator<?> it = moduleFiles.iterator(); it.hasNext();) {
       Object o = it.next();
       if (!(o instanceof Module)) {
         Assertions.UNREACHABLE("Unexpected type: " + o.getClass());

--- a/com.ibm.wala.core/src/com/ibm/wala/client/AbstractAnalysisEngine.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/client/AbstractAnalysisEngine.java
@@ -12,7 +12,6 @@ package com.ibm.wala.client;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.jar.JarFile;
 
 import com.ibm.wala.analysis.pointers.BasicHeapGraph;
@@ -166,8 +165,8 @@ public abstract class AbstractAnalysisEngine<I extends InstanceKey> implements A
         .getClassLoader());
 
     // add standard libraries
-    for (int i = 0; i < j2seLibs.length; i++) {
-      scope.addToScope(scope.getPrimordialLoader(), j2seLibs[i]);
+    for (Module j2seLib : j2seLibs) {
+      scope.addToScope(scope.getPrimordialLoader(), j2seLib);
     }
 
     // add user stuff
@@ -215,8 +214,7 @@ public abstract class AbstractAnalysisEngine<I extends InstanceKey> implements A
    */
   protected void addApplicationModulesToScope() {
     ClassLoaderReference app = scope.getApplicationLoader();
-    for (Iterator<?> it = moduleFiles.iterator(); it.hasNext();) {
-      Object o = it.next();
+    for (Object o : moduleFiles) {
       if (!(o instanceof Module)) {
         Assertions.UNREACHABLE("Unexpected type: " + o.getClass());
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/LocalPathEdges.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/LocalPathEdges.java
@@ -334,10 +334,10 @@ public class LocalPathEdges {
       // this is convoluted on purpose for efficiency: to avoid random access to
       // the sparse vector, we do parallel iteration with the vector's indices
       // and contents. TODO: better data structure?
-      Iterator contents = paths.iterator();
+      Iterator<IBinaryNaturalRelation> contents = paths.iterator();
       for (IntIterator it = paths.iterateIndices(); it.hasNext();) {
         int d2 = it.next();
-        IBinaryNaturalRelation R = (IBinaryNaturalRelation) contents.next();
+        IBinaryNaturalRelation R = contents.next();
         if (R != null && R.contains(n, d1)) {
           result.add(d2);
         }
@@ -353,10 +353,10 @@ public class LocalPathEdges {
       // this is convoluted on purpose for efficiency: to avoid random access to
       // the sparse vector, we do parallel iteration with the vector's indices
       // and contents. TODO: better data structure?
-      Iterator contents = zeroPaths.iterator();
+      Iterator<IntSet> contents = zeroPaths.iterator();
       for (IntIterator it = zeroPaths.iterateIndices(); it.hasNext();) {
         int d2 = it.next();
-        BitVectorIntSet s = (BitVectorIntSet) contents.next();
+        IntSet s = contents.next();
         if (s != null && s.contains(n)) {
           result.add(d2);
         }
@@ -389,10 +389,10 @@ public class LocalPathEdges {
       // this is convoluted on purpose for efficiency: to avoid random access to
       // the sparse vector, we do parallel iteration with the vector's indices
       // and contents. TODO: better data structure?
-      Iterator contents = paths.iterator();
+      Iterator<IBinaryNaturalRelation> contents = paths.iterator();
       for (IntIterator it = paths.iterateIndices(); it.hasNext();) {
         int d2 = it.next();
-        IBinaryNaturalRelation R = (IBinaryNaturalRelation) contents.next();
+        IBinaryNaturalRelation R = contents.next();
         if (R != null && R.anyRelated(n)) {
           result.add(d2);
         }
@@ -402,10 +402,10 @@ public class LocalPathEdges {
       // this is convoluted on purpose for efficiency: to avoid random access to
       // the sparse vector, we do parallel iteration with the vector's indices
       // and contents. TODO: better data structure?
-      Iterator contents = identityPaths.iterator();
+      Iterator<IntSet> contents = identityPaths.iterator();
       for (IntIterator it = identityPaths.iterateIndices(); it.hasNext();) {
         int d1 = it.next();
-        BitVectorIntSet s = (BitVectorIntSet) contents.next();
+        IntSet s = contents.next();
         if (s != null && s.contains(n)) {
           result.add(d1);
         }
@@ -415,10 +415,10 @@ public class LocalPathEdges {
       // this is convoluted on purpose for efficiency: to avoid random access to
       // the sparse vector, we do parallel iteration with the vector's indices
       // and contents. TODO: better data structure?
-      Iterator contents = zeroPaths.iterator();
+      Iterator<IntSet> contents = zeroPaths.iterator();
       for (IntIterator it = zeroPaths.iterateIndices(); it.hasNext();) {
         int d2 = it.next();
-        BitVectorIntSet s = (BitVectorIntSet) contents.next();
+        IntSet s = contents.next();
         if (s != null && s.contains(n)) {
           result.add(d2);
         }

--- a/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/LocalSummaryEdges.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/LocalSummaryEdges.java
@@ -133,8 +133,8 @@ public class LocalSummaryEdges {
       return null;
     } else {
       MutableSparseIntSet result = MutableSparseIntSet.makeEmpty();
-      for (Iterator it = R.iterator(); it.hasNext();) {
-        IntPair p = (IntPair) it.next();
+      for (Iterator<IntPair> it = R.iterator(); it.hasNext();) {
+        IntPair p = it.next();
         if (p.getY() == d2) {
           result.add(p.getX());
         }

--- a/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/LocalSummaryEdges.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/LocalSummaryEdges.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package com.ibm.wala.dataflow.IFDS;
 
-import java.util.Iterator;
-
 import com.ibm.wala.util.collections.SparseVector;
 import com.ibm.wala.util.intset.BasicNaturalRelation;
 import com.ibm.wala.util.intset.IBinaryNaturalRelation;
@@ -133,8 +131,7 @@ public class LocalSummaryEdges {
       return null;
     } else {
       MutableSparseIntSet result = MutableSparseIntSet.makeEmpty();
-      for (Iterator<IntPair> it = R.iterator(); it.hasNext();) {
-        IntPair p = it.next();
+      for (IntPair p : R) {
         if (p.getY() == d2) {
           result.add(p.getX());
         }

--- a/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/TabulationSolver.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/TabulationSolver.java
@@ -498,8 +498,7 @@ public class TabulationSolver<T, P, F> {
           // with respect to one s_profOf(c), we have to propagate
           // for each
           // potential entry node s_p /in s_procof(c)
-          for (int i = 0; i < entries.length; i++) {
-            final T s_p = entries[i];
+          for (final T s_p : entries) {
             if (DEBUG_LEVEL > 1) {
               System.err.println(" do entry " + s_p);
             }
@@ -674,8 +673,7 @@ public class TabulationSolver<T, P, F> {
             // for each exit from the callee
             P p = supergraph.getProcOf(calleeEntry);
             T[] exits = supergraph.getExitsForProcedure(p);
-            for (int e = 0; e < exits.length; e++) {
-              final T exit = exits[e];
+            for (final T exit : exits) {
               if (DEBUG_LEVEL > 0) {
                 assert supergraph.containsNode(exit);
               }
@@ -959,8 +957,7 @@ public class TabulationSolver<T, P, F> {
           return bb1.getNumber() - bb2.getNumber();
         }
       };
-      for (Iterator<? extends T> it = supergraph.iterator(); it.hasNext();) {
-        T n = it.next();
+      for (T n : supergraph) {
         P proc = supergraph.getProcOf(n);
         TreeSet<T> s = map.get(proc);
         if (s == null) {
@@ -970,11 +967,9 @@ public class TabulationSolver<T, P, F> {
         s.add(n);
       }
 
-      for (Iterator<Map.Entry<Object, TreeSet<T>>> it = map.entrySet().iterator(); it.hasNext();) {
-        Map.Entry<Object, TreeSet<T>> e = it.next();
+      for (Entry<Object, TreeSet<T>> e : map.entrySet()) {
         Set<T> s = e.getValue();
-        for (Iterator<T> it2 = s.iterator(); it2.hasNext();) {
-          T o = it2.next();
+        for (T o : s) {
           result.append(o + " : " + getResult(o) + "\n");
         }
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/dataflow/ssa/SSAInference.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/dataflow/ssa/SSAInference.java
@@ -82,8 +82,7 @@ public abstract class SSAInference<T extends IVariable<T>> extends DefaultFixedP
 
   private void createEquations(OperatorFactory<T> opFactory) {
     SSAInstruction[] instructions = ir.getInstructions();
-    for (int i = 0; i < instructions.length; i++) {
-      SSAInstruction s = instructions[i];
+    for (SSAInstruction s : instructions) {
       makeEquationForInstruction(opFactory, s);
     }
     for (Iterator<? extends SSAInstruction> it = ir.iteratePhis(); it.hasNext();) {

--- a/com.ibm.wala.core/src/com/ibm/wala/dataflow/ssa/SSAInference.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/dataflow/ssa/SSAInference.java
@@ -86,16 +86,16 @@ public abstract class SSAInference<T extends IVariable<T>> extends DefaultFixedP
       SSAInstruction s = instructions[i];
       makeEquationForInstruction(opFactory, s);
     }
-    for (Iterator it = ir.iteratePhis(); it.hasNext();) {
-      SSAInstruction s = (SSAInstruction) it.next();
+    for (Iterator<? extends SSAInstruction> it = ir.iteratePhis(); it.hasNext();) {
+      SSAInstruction s = it.next();
       makeEquationForInstruction(opFactory, s);
     }
-    for (Iterator it = ir.iteratePis(); it.hasNext();) {
-      SSAInstruction s = (SSAInstruction) it.next();
+    for (Iterator<? extends SSAInstruction> it = ir.iteratePis(); it.hasNext();) {
+      SSAInstruction s = it.next();
       makeEquationForInstruction(opFactory, s);
     }
-    for (Iterator it = ir.iterateCatchInstructions(); it.hasNext();) {
-      SSAInstruction s = (SSAInstruction) it.next();
+    for (Iterator<? extends SSAInstruction> it = ir.iterateCatchInstructions(); it.hasNext();) {
+      SSAInstruction s = it.next();
       makeEquationForInstruction(opFactory, s);
     }
   }

--- a/com.ibm.wala.core/src/com/ibm/wala/demandpa/alg/DemandRefinementPointsTo.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/demandpa/alg/DemandRefinementPointsTo.java
@@ -1340,8 +1340,7 @@ public class DemandRefinementPointsTo extends AbstractDemandPointsTo {
                 // }
                 g.addSubgraphForNode(caller);
                 SSAAbstractInvokeInstruction[] callInstrs = getCallInstrs(caller, call);
-                for (int i = 0; i < callInstrs.length; i++) {
-                  SSAAbstractInvokeInstruction callInstr = callInstrs[i];
+                for (SSAAbstractInvokeInstruction callInstr : callInstrs) {
                   PointerKey actualPk = heapModel.getPointerKeyForLocal(caller, callInstr.getUse(paramPos));
                   assert g.containsNode(actualPk);
                   assert g.containsNode(localPk);
@@ -1628,8 +1627,7 @@ public class DemandRefinementPointsTo extends AbstractDemandPointsTo {
               // }
               g.addSubgraphForNode(caller);
               SSAAbstractInvokeInstruction[] callInstrs = getCallInstrs(caller, call);
-              for (int i = 0; i < callInstrs.length; i++) {
-                SSAAbstractInvokeInstruction callInstr = callInstrs[i];
+              for (SSAAbstractInvokeInstruction callInstr : callInstrs) {
                 PointerKey returnAtCallerKey = heapModel.getPointerKeyForLocal(caller, isExceptional ? callInstr.getException()
                     : callInstr.getDef());
                 assert g.containsNode(returnAtCallerKey);
@@ -2122,8 +2120,7 @@ public class DemandRefinementPointsTo extends AbstractDemandPointsTo {
                   // }
                   g.addSubgraphForNode(caller);
                   SSAAbstractInvokeInstruction[] callInstrs = getCallInstrs(caller, call);
-                  for (int i = 0; i < callInstrs.length; i++) {
-                    SSAAbstractInvokeInstruction callInstr = callInstrs[i];
+                  for (SSAAbstractInvokeInstruction callInstr : callInstrs) {
                     final PointerKey actualPk = heapModel.getPointerKeyForLocal(caller, callInstr.getUse(paramPos));
                     assert g.containsNode(actualPk);
                     assert g.containsNode(localPk);

--- a/com.ibm.wala.core/src/com/ibm/wala/demandpa/flowgraph/AbstractDemandFlowGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/demandpa/flowgraph/AbstractDemandFlowGraph.java
@@ -134,8 +134,7 @@ public abstract class AbstractDemandFlowGraph extends AbstractFlowGraph {
         CallSiteReference call = iterator.next();
         if (cg.getPossibleTargets(caller, call).contains(cgNode)) {
           SSAAbstractInvokeInstruction[] callInstrs = ir.getCalls(call);
-          for (int i = 0; i < callInstrs.length; i++) {
-            SSAAbstractInvokeInstruction callInstr = callInstrs[i];
+          for (SSAAbstractInvokeInstruction callInstr : callInstrs) {
             PointerKey actualPk = heapModel.getPointerKeyForLocal(caller, callInstr.getUse(paramPos));
             assert containsNode(actualPk);
             assert containsNode(pk);
@@ -224,8 +223,7 @@ public abstract class AbstractDemandFlowGraph extends AbstractFlowGraph {
         CallSiteReference call = iterator.next();
         if (cg.getPossibleTargets(caller, call).contains(cgNode)) {
           SSAAbstractInvokeInstruction[] callInstrs = ir.getCalls(call);
-          for (int i = 0; i < callInstrs.length; i++) {
-            SSAAbstractInvokeInstruction callInstr = callInstrs[i];
+          for (SSAAbstractInvokeInstruction callInstr : callInstrs) {
             PointerKey returnPk = heapModel.getPointerKeyForLocal(caller, isExceptional ? callInstr.getException() : callInstr
                 .getDef());
             assert containsNode(returnPk);
@@ -284,8 +282,7 @@ public abstract class AbstractDemandFlowGraph extends AbstractFlowGraph {
     v.setBasicBlock(b);
 
     // visit each instruction in the basic block.
-    for (Iterator<SSAInstruction> it = b.iterator(); it.hasNext();) {
-      SSAInstruction s = it.next();
+    for (SSAInstruction s : b) {
       if (s != null) {
         s.visit(v);
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/demandpa/flowgraph/AbstractFlowGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/demandpa/flowgraph/AbstractFlowGraph.java
@@ -385,13 +385,11 @@ public abstract class AbstractFlowGraph extends SlowSparseNumberedLabeledGraph<O
   protected Iterator<PointerKey> getArrayReads(PointerKey arrayRef) {
     arrayRef = convertPointerKeyToHeapModel(arrayRef, mam.getHeapModel());
     Collection<MemoryAccess> arrayReads = mam.getArrayReads(arrayRef);
-    for (Iterator<MemoryAccess> it = arrayReads.iterator(); it.hasNext();) {
-      MemoryAccess a = it.next();
+    for (MemoryAccess a : arrayReads) {
       addSubgraphForNode(a.getNode());
     }
     ArrayList<PointerKey> read = new ArrayList<PointerKey>();
-    for (Iterator<MemoryAccess> it = arrayReads.iterator(); it.hasNext();) {
-      MemoryAccess a = it.next();
+    for (MemoryAccess a : arrayReads) {
       IR ir = a.getNode().getIR();
       SSAArrayLoadInstruction s = (SSAArrayLoadInstruction) ir.getInstructions()[a.getInstructionIndex()];
       if (s == null) {
@@ -430,8 +428,7 @@ public abstract class AbstractFlowGraph extends SlowSparseNumberedLabeledGraph<O
    */
   protected void addExceptionDefConstraints(IR ir, CGNode node, List<ProgramCounter> peis, PointerKey exceptionVar,
       Set<IClass> catchClasses) {
-    for (Iterator<ProgramCounter> it = peis.iterator(); it.hasNext();) {
-      ProgramCounter peiLoc = it.next();
+    for (ProgramCounter peiLoc : peis) {
       SSAInstruction pei = ir.getPEI(peiLoc);
 
       if (pei instanceof SSAAbstractInvokeInstruction) {
@@ -454,8 +451,7 @@ public abstract class AbstractFlowGraph extends SlowSparseNumberedLabeledGraph<O
       // the pei, but just instance keys
       Collection<TypeReference> types = pei.getExceptionTypes();
       if (types != null) {
-        for (Iterator<TypeReference> it2 = types.iterator(); it2.hasNext();) {
-          TypeReference type = it2.next();
+        for (TypeReference type : types) {
           if (type != null) {
             InstanceKey ik = heapModel.getInstanceKeyForPEI(node, peiLoc, type);
             if (ik == null) {

--- a/com.ibm.wala.core/src/com/ibm/wala/demandpa/flowgraph/DemandPointerFlowGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/demandpa/flowgraph/DemandPointerFlowGraph.java
@@ -409,8 +409,7 @@ public class DemandPointerFlowGraph extends AbstractDemandFlowGraph implements I
      */
     protected void addExceptionDefConstraints(IR ir, CGNode node, List<ProgramCounter> peis, PointerKey exceptionVar,
         Set<IClass> catchClasses) {
-      for (Iterator<ProgramCounter> it = peis.iterator(); it.hasNext();) {
-        ProgramCounter peiLoc = it.next();
+      for (ProgramCounter peiLoc : peis) {
         SSAInstruction pei = ir.getPEI(peiLoc);
 
         if (pei instanceof SSAAbstractInvokeInstruction) {
@@ -433,8 +432,7 @@ public class DemandPointerFlowGraph extends AbstractDemandFlowGraph implements I
         // the pei, but just instance keys
         Collection<TypeReference> types = pei.getExceptionTypes();
         if (types != null) {
-          for (Iterator<TypeReference> it2 = types.iterator(); it2.hasNext();) {
-            TypeReference type = it2.next();
+          for (TypeReference type : types) {
             if (type != null) {
               InstanceKey ik = heapModel.getInstanceKeyForPEI(node, peiLoc, type);
               if (ik == null) {

--- a/com.ibm.wala.core/src/com/ibm/wala/demandpa/flowgraph/SimpleDemandPointerFlowGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/demandpa/flowgraph/SimpleDemandPointerFlowGraph.java
@@ -305,8 +305,7 @@ public class SimpleDemandPointerFlowGraph extends SlowSparseNumberedGraph<Object
         CallSiteReference call = iterator.next();
         if (cg.getPossibleTargets(caller, call).contains(node)) {
           SSAAbstractInvokeInstruction[] callInstrs = ir.getCalls(call);
-          for (int i = 0; i < callInstrs.length; i++) {
-            SSAAbstractInvokeInstruction callInstr = callInstrs[i];
+          for (SSAAbstractInvokeInstruction callInstr : callInstrs) {
             PointerKey actualPk = heapModel.getPointerKeyForLocal(caller, callInstr.getUse(paramPos));
             assert containsNode(actualPk);
             assert containsNode(pk);
@@ -483,8 +482,7 @@ public class SimpleDemandPointerFlowGraph extends SlowSparseNumberedGraph<Object
     v.setBasicBlock(b);
 
     // visit each instruction in the basic block.
-    for (Iterator<SSAInstruction> it = b.iterator(); it.hasNext();) {
-      SSAInstruction s = it.next();
+    for (SSAInstruction s : b) {
       if (s != null) {
         s.visit(v);
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/demandpa/util/SimpleMemoryAccessMap.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/demandpa/util/SimpleMemoryAccessMap.java
@@ -12,7 +12,6 @@ package com.ibm.wala.demandpa.util;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -94,8 +93,7 @@ public class SimpleMemoryAccessMap implements MemoryAccessMap {
   }
 
   private void populate(CallGraph cg) {
-    for (Iterator<CGNode> it = cg.iterator(); it.hasNext();) {
-      CGNode n = it.next();
+    for (CGNode n : cg) {
       populate(n);
     }
   }
@@ -387,21 +385,20 @@ public class SimpleMemoryAccessMap implements MemoryAccessMap {
     allFields.addAll(readMap.keySet());
     allFields.addAll(writeMap.keySet());
 
-    for (Iterator<IField> it = allFields.iterator(); it.hasNext();) {
-      IField f = it.next();
+    for (IField f : allFields) {
       result.append("FIELD ").append(f).append(":\n");
       Collection<MemoryAccess> reads = getFieldReads(null, f);
       if (!reads.isEmpty()) {
         result.append("  reads:\n");
-        for (Iterator<MemoryAccess> it2 = reads.iterator(); it2.hasNext();) {
-          result.append("  ").append(it2.next()).append("\n");
+        for (MemoryAccess memoryAccess : reads) {
+          result.append("  ").append(memoryAccess).append("\n");
         }
       }
       Collection<MemoryAccess> writes = getFieldWrites(null, f);
       if (!writes.isEmpty()) {
         result.append("  writes:\n");
-        for (Iterator<MemoryAccess> it2 = writes.iterator(); it2.hasNext();) {
-          result.append("  ").append(it2.next()).append("\n");
+        for (MemoryAccess memoryAccess : writes) {
+          result.append("  ").append(memoryAccess).append("\n");
         }
       }
     }
@@ -410,14 +407,14 @@ public class SimpleMemoryAccessMap implements MemoryAccessMap {
     result.append("ARRAY CONTENTS:\n");
     if (!arrayReads.isEmpty()) {
       result.append("  reads:\n");
-      for (Iterator<MemoryAccess> it2 = arrayReads.iterator(); it2.hasNext();) {
-        result.append("  ").append(it2.next()).append("\n");
+      for (MemoryAccess memoryAccess : arrayReads) {
+        result.append("  ").append(memoryAccess).append("\n");
       }
     }
     if (!arrayWrites.isEmpty()) {
       result.append("  writes:\n");
-      for (Iterator<MemoryAccess> it2 = arrayWrites.iterator(); it2.hasNext();) {
-        result.append("  ").append(it2.next()).append("\n");
+      for (MemoryAccess memoryAccess : arrayWrites) {
+        result.append("  ").append(memoryAccess).append("\n");
       }
     }
     return result.toString();

--- a/com.ibm.wala.core/src/com/ibm/wala/escape/FILiveObjectAnalysis.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/escape/FILiveObjectAnalysis.java
@@ -125,8 +125,8 @@ public class FILiveObjectAnalysis implements ILiveObjectAnalysis {
   }
 
   private boolean mayBeLiveInSomeCaller(InstanceKey ik, CGNode m) {
-    for (Iterator it = callGraph.getPredNodes(m); it.hasNext();) {
-      CGNode n = (CGNode) it.next();
+    for (Iterator<CGNode> it = callGraph.getPredNodes(m); it.hasNext();) {
+      CGNode n = it.next();
       if (mayBeLive(ik, n, -1)) {
         return true;
       }
@@ -144,7 +144,7 @@ public class FILiveObjectAnalysis implements ILiveObjectAnalysis {
     IR ir = m.getIR();
     DefUse du = m.getDU();
 
-    for (Iterator it = DFS.iterateDiscoverTime(GraphInverter.invert(heapGraph), ik); it.hasNext();) {
+    for (Iterator<Object> it = DFS.iterateDiscoverTime(GraphInverter.invert(heapGraph), ik); it.hasNext();) {
       Object p = it.next();
       if (p instanceof LocalPointerKey) {
         LocalPointerKey lpk = (LocalPointerKey) p;
@@ -164,7 +164,7 @@ public class FILiveObjectAnalysis implements ILiveObjectAnalysis {
    */
   private Set<CGNode> computeLiveNodes(InstanceKey ik) {
     Set<CGNode> localRootNodes = HashSetFactory.make();
-    for (Iterator it = DFS.iterateDiscoverTime(GraphInverter.invert(heapGraph), ik); it.hasNext();) {
+    for (Iterator<Object> it = DFS.iterateDiscoverTime(GraphInverter.invert(heapGraph), ik); it.hasNext();) {
       Object node = it.next();
       if (node instanceof StaticFieldKey) {
         liveEverywhere.add(ik);

--- a/com.ibm.wala.core/src/com/ibm/wala/escape/LocalLiveRangeAnalysis.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/escape/LocalLiveRangeAnalysis.java
@@ -99,10 +99,9 @@ public class LocalLiveRangeAnalysis {
   private static Collection<BasicBlock> findBlocks(IR ir, Iterator<SSAInstruction> statements) {
     Collection<SSAInstruction> s = Iterator2Collection.toSet(statements);
     Collection<BasicBlock> result = HashSetFactory.make();
-    outer: for (Iterator<ISSABasicBlock> it = ir.getControlFlowGraph().iterator(); it.hasNext();) {
-      SSACFG.BasicBlock b = (SSACFG.BasicBlock) it.next();
-      for (Iterator<SSAInstruction> it2 = b.iterator(); it2.hasNext();) {
-        SSAInstruction x = it2.next();
+    outer: for (ISSABasicBlock issaBasicBlock : ir.getControlFlowGraph()) {
+      SSACFG.BasicBlock b = (SSACFG.BasicBlock) issaBasicBlock;
+      for (SSAInstruction x : b) {
         if (s.contains(x)) {
           result.add(b);
           continue outer;
@@ -124,10 +123,9 @@ public class LocalLiveRangeAnalysis {
     if (s == null) {
       Assertions.UNREACHABLE();
     }
-    for (Iterator<ISSABasicBlock> it = ir.getControlFlowGraph().iterator(); it.hasNext();) {
-      SSACFG.BasicBlock b = (SSACFG.BasicBlock) it.next();
-      for (Iterator<SSAInstruction> it2 = b.iterator(); it2.hasNext();) {
-        SSAInstruction x = it2.next();
+    for (ISSABasicBlock issaBasicBlock : ir.getControlFlowGraph()) {
+      SSACFG.BasicBlock b = (SSACFG.BasicBlock) issaBasicBlock;
+      for (SSAInstruction x : b) {
         if (s.equals(x)) {
           return b;
         }
@@ -143,8 +141,8 @@ public class LocalLiveRangeAnalysis {
    * @return the basic block which contains the ith instruction
    */
   private static ISSABasicBlock findBlock(IR ir, int i) {
-    for (Iterator<ISSABasicBlock> it = ir.getControlFlowGraph().iterator(); it.hasNext();) {
-      SSACFG.BasicBlock b = (SSACFG.BasicBlock) it.next();
+    for (ISSABasicBlock issaBasicBlock : ir.getControlFlowGraph()) {
+      SSACFG.BasicBlock b = (SSACFG.BasicBlock) issaBasicBlock;
       if (i >= b.getFirstInstructionIndex() && i <= b.getLastInstructionIndex()) {
         return b;
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/escape/LocalLiveRangeAnalysis.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/escape/LocalLiveRangeAnalysis.java
@@ -99,10 +99,10 @@ public class LocalLiveRangeAnalysis {
   private static Collection<BasicBlock> findBlocks(IR ir, Iterator<SSAInstruction> statements) {
     Collection<SSAInstruction> s = Iterator2Collection.toSet(statements);
     Collection<BasicBlock> result = HashSetFactory.make();
-    outer: for (Iterator it = ir.getControlFlowGraph().iterator(); it.hasNext();) {
+    outer: for (Iterator<ISSABasicBlock> it = ir.getControlFlowGraph().iterator(); it.hasNext();) {
       SSACFG.BasicBlock b = (SSACFG.BasicBlock) it.next();
-      for (Iterator it2 = b.iterator(); it2.hasNext();) {
-        SSAInstruction x = (SSAInstruction) it2.next();
+      for (Iterator<SSAInstruction> it2 = b.iterator(); it2.hasNext();) {
+        SSAInstruction x = it2.next();
         if (s.contains(x)) {
           result.add(b);
           continue outer;
@@ -124,10 +124,10 @@ public class LocalLiveRangeAnalysis {
     if (s == null) {
       Assertions.UNREACHABLE();
     }
-    for (Iterator it = ir.getControlFlowGraph().iterator(); it.hasNext();) {
+    for (Iterator<ISSABasicBlock> it = ir.getControlFlowGraph().iterator(); it.hasNext();) {
       SSACFG.BasicBlock b = (SSACFG.BasicBlock) it.next();
-      for (Iterator it2 = b.iterator(); it2.hasNext();) {
-        SSAInstruction x = (SSAInstruction) it2.next();
+      for (Iterator<SSAInstruction> it2 = b.iterator(); it2.hasNext();) {
+        SSAInstruction x = it2.next();
         if (s.equals(x)) {
           return b;
         }
@@ -143,7 +143,7 @@ public class LocalLiveRangeAnalysis {
    * @return the basic block which contains the ith instruction
    */
   private static ISSABasicBlock findBlock(IR ir, int i) {
-    for (Iterator it = ir.getControlFlowGraph().iterator(); it.hasNext();) {
+    for (Iterator<ISSABasicBlock> it = ir.getControlFlowGraph().iterator(); it.hasNext();) {
       SSACFG.BasicBlock b = (SSACFG.BasicBlock) it.next();
       if (i >= b.getFirstInstructionIndex() && i <= b.getLastInstructionIndex()) {
         return b;

--- a/com.ibm.wala.core/src/com/ibm/wala/escape/TrivialMethodEscape.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/escape/TrivialMethodEscape.java
@@ -69,7 +69,7 @@ public class TrivialMethodEscape implements IMethodEscapeAnalysis, INodeEscapeAn
     }
 
     // allocN := set of call graph nodes representing method allocMethod
-    Set allocN = cg.getNodes(allocMethod);
+    Set<CGNode> allocN = cg.getNodes(allocMethod);
     if (allocN.size() == 0) {
       throw new WalaException("could not find call graph node for allocation method " + allocMethod);
     }
@@ -89,11 +89,11 @@ public class TrivialMethodEscape implements IMethodEscapeAnalysis, INodeEscapeAn
    *         { nodes }
    * @throws WalaException
    */
-  private boolean mayEscape(Set allocN, int allocPC, Set nodes) throws WalaException {
+  private boolean mayEscape(Set<CGNode> allocN, int allocPC, Set nodes) throws WalaException {
     Set<InstanceKey> instances = HashSetFactory.make();
     // instances := set of instance key allocated at &lt;allocMethod, allocPC>
-    for (Iterator it = allocN.iterator(); it.hasNext();) {
-      CGNode n = (CGNode) it.next();
+    for (Iterator<CGNode> it = allocN.iterator(); it.hasNext();) {
+      CGNode n = it.next();
       NewSiteReference site = findAlloc(n, allocPC);
       InstanceKey ik = hg.getHeapModel().getInstanceKeyForAllocation(n, site);
       if (ik == null) {
@@ -104,7 +104,7 @@ public class TrivialMethodEscape implements IMethodEscapeAnalysis, INodeEscapeAn
 
     for (Iterator<InstanceKey> it = instances.iterator(); it.hasNext();) {
       InstanceKey ik = it.next();
-      for (Iterator it2 = hg.getPredNodes(ik); it2.hasNext();) {
+      for (Iterator<Object> it2 = hg.getPredNodes(ik); it2.hasNext();) {
         PointerKey p = (PointerKey) it2.next();
         if (!(p instanceof AbstractLocalPointerKey)) {
           // a pointer from the heap. give up.
@@ -136,8 +136,8 @@ public class TrivialMethodEscape implements IMethodEscapeAnalysis, INodeEscapeAn
     if (n == null) {
       throw new IllegalArgumentException("null n");
     }
-    for (Iterator it = n.iterateNewSites(); it.hasNext();) {
-      NewSiteReference site = (NewSiteReference) it.next();
+    for (Iterator<NewSiteReference> it = n.iterateNewSites(); it.hasNext();) {
+      NewSiteReference site = it.next();
       if (site.getProgramCounter() == allocPC) {
         return site;
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/escape/TrivialMethodEscape.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/escape/TrivialMethodEscape.java
@@ -92,8 +92,7 @@ public class TrivialMethodEscape implements IMethodEscapeAnalysis, INodeEscapeAn
   private boolean mayEscape(Set<CGNode> allocN, int allocPC, Set nodes) throws WalaException {
     Set<InstanceKey> instances = HashSetFactory.make();
     // instances := set of instance key allocated at &lt;allocMethod, allocPC>
-    for (Iterator<CGNode> it = allocN.iterator(); it.hasNext();) {
-      CGNode n = it.next();
+    for (CGNode n : allocN) {
       NewSiteReference site = findAlloc(n, allocPC);
       InstanceKey ik = hg.getHeapModel().getInstanceKeyForAllocation(n, site);
       if (ik == null) {
@@ -102,8 +101,7 @@ public class TrivialMethodEscape implements IMethodEscapeAnalysis, INodeEscapeAn
       instances.add(ik);
     }
 
-    for (Iterator<InstanceKey> it = instances.iterator(); it.hasNext();) {
-      InstanceKey ik = it.next();
+    for (InstanceKey ik : instances) {
       for (Iterator<Object> it2 = hg.getPredNodes(ik); it2.hasNext();) {
         PointerKey p = (PointerKey) it2.next();
         if (!(p instanceof AbstractLocalPointerKey)) {

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/CallGraphStats.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/CallGraphStats.java
@@ -169,8 +169,8 @@ public class CallGraphStats {
       throw new IllegalArgumentException("cg is null");
     }
     HashSet<MethodReference> result = HashSetFactory.make();
-    for (Iterator it = cg.iterator(); it.hasNext();) {
-      CGNode N = (CGNode) it.next();
+    for (Iterator<CGNode> it = cg.iterator(); it.hasNext();) {
+      CGNode N = it.next();
       result.add(N.getMethod().getReference());
     }
     return result;

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/CallGraphStats.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/CallGraphStats.java
@@ -12,7 +12,6 @@ package com.ibm.wala.ipa.callgraph;
 
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Set;
 
 import com.ibm.wala.classLoader.IMethod;
@@ -116,8 +115,7 @@ public class CallGraphStats {
     Set<CGNode> reachableNodes = DFS.getReachableNodes(cg, Collections.singleton(cg.getFakeRootNode()));
     int nNodes = 0;
     int nEdges = 0;
-    for (Iterator<CGNode> it = reachableNodes.iterator(); it.hasNext();) {
-      CGNode n = it.next();
+    for (CGNode n : reachableNodes) {
       nNodes++;
       nEdges += cg.getSuccNodeCount(n);
     }
@@ -142,8 +140,7 @@ public class CallGraphStats {
     }
     int ret = 0;
     HashSet<IMethod> counted = HashSetFactory.make();
-    for (Iterator<? extends CGNode> iter = cg.iterator(); iter.hasNext();) {
-      CGNode node = iter.next();
+    for (CGNode node : cg) {
       IMethod method = node.getMethod();
       if (counted.add(method)) {
         if (method instanceof ShrikeCTMethod) {
@@ -169,8 +166,7 @@ public class CallGraphStats {
       throw new IllegalArgumentException("cg is null");
     }
     HashSet<MethodReference> result = HashSetFactory.make();
-    for (Iterator<CGNode> it = cg.iterator(); it.hasNext();) {
-      CGNode N = it.next();
+    for (CGNode N : cg) {
       result.add(N.getMethod().getReference());
     }
     return result;

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/CallGraphTransitiveClosure.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/CallGraphTransitiveClosure.java
@@ -11,7 +11,6 @@
 package com.ibm.wala.ipa.callgraph;
 
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -46,8 +45,7 @@ public class CallGraphTransitiveClosure {
       BitVectorSolver<CGNode> solver = new BitVectorSolver<CGNode>(gr);
       solver.solve(null);
       Map<CGNode, OrdinalSet<T>> result = HashMapFactory.make();
-      for (Iterator<? extends CGNode> it = cg.iterator(); it.hasNext();) {
-        CGNode n = it.next();
+      for (CGNode n : cg) {
         BitVectorVariable bv = solver.getOut(n);
         result.put(n, new OrdinalSet<T>(bv.getValue(), gr.getLatticeValues()));
       }
@@ -62,8 +60,7 @@ public class CallGraphTransitiveClosure {
    */
   public static <T> Map<CGNode, Collection<T>> collectNodeResults(CallGraph cg, Function<CGNode, Collection<T>> nodeResultComputer) {
     Map<CGNode, Collection<T>> result = HashMapFactory.make();
-    for (Iterator<? extends CGNode> it = cg.iterator(); it.hasNext();) {
-      CGNode n = it.next();
+    for (CGNode n : cg) {
       result.put(n, nodeResultComputer.apply(n));
     }
     return result;

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/AbstractRootMethod.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/AbstractRootMethod.java
@@ -100,8 +100,8 @@ public abstract class AbstractRootMethod extends SyntheticMethod {
   public SSAInstruction[] getStatements(SSAOptions options) {
     SSAInstruction[] result = new SSAInstruction[statements.size()];
     int i = 0;
-    for (Iterator<SSAInstruction> it = statements.iterator(); it.hasNext();) {
-      result[i++] = it.next();
+    for (SSAInstruction ssaInstruction : statements) {
+      result[i++] = ssaInstruction;
     }
 
     return result;
@@ -363,9 +363,9 @@ public abstract class AbstractRootMethod extends SyntheticMethod {
       public Iterator<NewSiteReference> iterateNewSites(CGNode node) {
         ArrayList<NewSiteReference> result = new ArrayList<NewSiteReference>();
         SSAInstruction[] statements = getStatements(options.getSSAOptions());
-        for (int i = 0; i < statements.length; i++) {
-          if (statements[i] instanceof SSANewInstruction) {
-            SSANewInstruction s = (SSANewInstruction) statements[i];
+        for (SSAInstruction statement : statements) {
+          if (statement instanceof SSANewInstruction) {
+            SSANewInstruction s = (SSANewInstruction) statement;
             result.add(s.getNewSite());
           }
         }
@@ -375,9 +375,9 @@ public abstract class AbstractRootMethod extends SyntheticMethod {
       public Iterator<SSAInstruction> getInvokeStatements() {
         ArrayList<SSAInstruction> result = new ArrayList<SSAInstruction>();
         SSAInstruction[] statements = getStatements(options.getSSAOptions());
-        for (int i = 0; i < statements.length; i++) {
-          if (statements[i] instanceof SSAInvokeInstruction) {
-            result.add(statements[i]);
+        for (SSAInstruction statement : statements) {
+          if (statement instanceof SSAInvokeInstruction) {
+            result.add(statement);
           }
         }
         return result.iterator();

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/AllApplicationEntrypoints.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/AllApplicationEntrypoints.java
@@ -11,8 +11,6 @@
 package com.ibm.wala.ipa.callgraph.impl;
 
 import java.util.HashSet;
-import java.util.Iterator;
-
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.ipa.callgraph.AnalysisScope;
@@ -40,8 +38,7 @@ public class AllApplicationEntrypoints extends HashSet<Entrypoint> {
     for (IClass klass : cha) {
       if (!klass.isInterface()) {
         if (isApplicationClass(scope, klass)) {
-          for (Iterator<IMethod> methodIt = klass.getDeclaredMethods().iterator(); methodIt.hasNext();) {
-            IMethod method = methodIt.next();
+          for (IMethod method : klass.getDeclaredMethods()) {
             if (!method.isAbstract()) {
               add(new ArgumentTypeEntrypoint(method, cha));
             }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/AllApplicationEntrypoints.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/AllApplicationEntrypoints.java
@@ -40,8 +40,8 @@ public class AllApplicationEntrypoints extends HashSet<Entrypoint> {
     for (IClass klass : cha) {
       if (!klass.isInterface()) {
         if (isApplicationClass(scope, klass)) {
-          for (Iterator methodIt = klass.getDeclaredMethods().iterator(); methodIt.hasNext();) {
-            IMethod method = (IMethod) methodIt.next();
+          for (Iterator<IMethod> methodIt = klass.getDeclaredMethods().iterator(); methodIt.hasNext();) {
+            IMethod method = methodIt.next();
             if (!method.isAbstract()) {
               add(new ArgumentTypeEntrypoint(method, cha));
             }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/ArgumentTypeEntrypoint.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/ArgumentTypeEntrypoint.java
@@ -11,7 +11,6 @@
 package com.ibm.wala.ipa.callgraph.impl;
 
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.Set;
 
 import com.ibm.wala.classLoader.ArrayClass;
@@ -82,8 +81,7 @@ public class ArgumentTypeEntrypoint extends Entrypoint {
 
   private TypeReference chooseAConcreteSubClass(IClass klass) {
     Collection<IClass> subclasses = cha.computeSubClasses(klass.getReference());
-    for (Iterator<IClass> it = subclasses.iterator(); it.hasNext();) {
-      IClass c = it.next();
+    for (IClass c : subclasses) {
       if (!c.isAbstract()) {
         return c.getReference();
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/ArgumentTypeEntrypoint.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/ArgumentTypeEntrypoint.java
@@ -81,9 +81,9 @@ public class ArgumentTypeEntrypoint extends Entrypoint {
   }
 
   private TypeReference chooseAConcreteSubClass(IClass klass) {
-    Collection subclasses = cha.computeSubClasses(klass.getReference());
-    for (Iterator it = subclasses.iterator(); it.hasNext();) {
-      IClass c = (IClass) it.next();
+    Collection<IClass> subclasses = cha.computeSubClasses(klass.getReference());
+    for (Iterator<IClass> it = subclasses.iterator(); it.hasNext();) {
+      IClass c = it.next();
       if (!c.isAbstract()) {
         return c.getReference();
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/BasicCallGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/BasicCallGraph.java
@@ -231,8 +231,8 @@ public abstract class BasicCallGraph<T> extends AbstractNumberedGraph<CGNode> im
   @Override
   public String toString() {
     StringBuffer result = new StringBuffer("");
-    for (Iterator i = DFS.iterateDiscoverTime(this, new NonNullSingletonIterator<CGNode>(getFakeRootNode())); i.hasNext();) {
-      CGNode n = (CGNode) i.next();
+    for (Iterator<CGNode> i = DFS.iterateDiscoverTime(this, new NonNullSingletonIterator<CGNode>(getFakeRootNode())); i.hasNext();) {
+      CGNode n = i.next();
       result.append(nodeToString(this, n) + "\n");
     }
     return result.toString();
@@ -241,14 +241,14 @@ public abstract class BasicCallGraph<T> extends AbstractNumberedGraph<CGNode> im
   public static String nodeToString(CallGraph CG, CGNode n) {
     StringBuffer result = new StringBuffer(n.toString() +  "\n");
      if (n.getMethod() != null) {
-      for (Iterator sites = n.iterateCallSites(); sites.hasNext();) {
-        CallSiteReference site = (CallSiteReference) sites.next();
-        Iterator targets = CG.getPossibleTargets(n, site).iterator();
+      for (Iterator<CallSiteReference> sites = n.iterateCallSites(); sites.hasNext();) {
+        CallSiteReference site = sites.next();
+        Iterator<CGNode> targets = CG.getPossibleTargets(n, site).iterator();
         if (targets.hasNext()) {
           result.append(" - " + site + "\n");
         }
         for (; targets.hasNext();) {
-          CGNode target = (CGNode) targets.next();
+          CGNode target = targets.next();
           result.append("     -> " + target + "\n");
         }
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/ComposedEntrypoints.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/ComposedEntrypoints.java
@@ -31,11 +31,11 @@ public class ComposedEntrypoints implements Iterable<Entrypoint> {
     if (B == null) {
       throw new IllegalArgumentException("B is null");
     }
-    for (Iterator<Entrypoint> it = A.iterator(); it.hasNext(); ) {
-      entrypoints.add(it.next());
+    for (Entrypoint entrypoint : A) {
+      entrypoints.add(entrypoint);
     }
-    for (Iterator<Entrypoint> it = B.iterator(); it.hasNext(); ) {
-      entrypoints.add(it.next());
+    for (Entrypoint entrypoint : B) {
+      entrypoints.add(entrypoint);
     }
   }
 

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/PartialCallGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/PartialCallGraph.java
@@ -105,8 +105,8 @@ public class PartialCallGraph extends DelegatingGraph<CGNode> implements CallGra
   @Override
   public Set<CGNode> getNodes(MethodReference m) {
     Set<CGNode> result = HashSetFactory.make();
-    for (Iterator xs = cg.getNodes(m).iterator(); xs.hasNext();) {
-      CGNode x = (CGNode) xs.next();
+    for (Iterator<CGNode> xs = cg.getNodes(m).iterator(); xs.hasNext();) {
+      CGNode x = xs.next();
       if (containsNode(x)) {
         result.add(x);
       }
@@ -149,8 +149,8 @@ public class PartialCallGraph extends DelegatingGraph<CGNode> implements CallGra
   public IntSet getSuccNodeNumbers(CGNode node) {
     assert containsNode(node);
     MutableIntSet x = IntSetUtil.make();
-    for (Iterator ns = getSuccNodes(node); ns.hasNext();) {
-      CGNode succ = (CGNode) ns.next();
+    for (Iterator<CGNode> ns = getSuccNodes(node); ns.hasNext();) {
+      CGNode succ = ns.next();
       if (containsNode(succ)) {
         x.add(getNumber(succ));
       }
@@ -163,8 +163,8 @@ public class PartialCallGraph extends DelegatingGraph<CGNode> implements CallGra
   public IntSet getPredNodeNumbers(CGNode node) {
     assert containsNode(node);
     MutableIntSet x = IntSetUtil.make();
-    for (Iterator ns = getPredNodes(node); ns.hasNext();) {
-      CGNode pred = (CGNode) ns.next();
+    for (Iterator<CGNode> ns = getPredNodes(node); ns.hasNext();) {
+      CGNode pred = ns.next();
       if (containsNode(pred)) {
         x.add(getNumber(pred));
       }
@@ -189,8 +189,8 @@ public class PartialCallGraph extends DelegatingGraph<CGNode> implements CallGra
       return null;
     }
     Set<CGNode> result = HashSetFactory.make();
-    for (Iterator ns = cg.getPossibleTargets(node, site).iterator(); ns.hasNext();) {
-      CGNode target = (CGNode) ns.next();
+    for (Iterator<CGNode> ns = cg.getPossibleTargets(node, site).iterator(); ns.hasNext();) {
+      CGNode target = ns.next();
       if (containsNode(target)) {
         result.add(target);
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/PartialCallGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/PartialCallGraph.java
@@ -105,8 +105,7 @@ public class PartialCallGraph extends DelegatingGraph<CGNode> implements CallGra
   @Override
   public Set<CGNode> getNodes(MethodReference m) {
     Set<CGNode> result = HashSetFactory.make();
-    for (Iterator<CGNode> xs = cg.getNodes(m).iterator(); xs.hasNext();) {
-      CGNode x = xs.next();
+    for (CGNode x : cg.getNodes(m)) {
       if (containsNode(x)) {
         result.add(x);
       }
@@ -189,8 +188,7 @@ public class PartialCallGraph extends DelegatingGraph<CGNode> implements CallGra
       return null;
     }
     Set<CGNode> result = HashSetFactory.make();
-    for (Iterator<CGNode> ns = cg.getPossibleTargets(node, site).iterator(); ns.hasNext();) {
-      CGNode target = ns.next();
+    for (CGNode target : cg.getPossibleTargets(node, site)) {
       if (containsNode(target)) {
         result.add(target);
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/Util.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/Util.java
@@ -209,12 +209,12 @@ public class Util {
       throw new IllegalArgumentException("(0 < classNames.length) and (classNames[0] == null)");
     }
 
-    for (int i = 0; i < classNames.length; i++) {
-      if (classNames[i].indexOf("L") != 0) {
-        throw new IllegalArgumentException("Expected class name to start with L " + classNames[i]);
+    for (String className : classNames) {
+      if (className.indexOf("L") != 0) {
+        throw new IllegalArgumentException("Expected class name to start with L " + className);
       }
-      if (classNames[i].indexOf(".") > 0) {
-        Assertions.productionAssertion(false, "Expected class name formatted with /, not . " + classNames[i]);
+      if (className.indexOf(".") > 0) {
+        Assertions.productionAssertion(false, "Expected class name formatted with /, not . " + className);
       }
     }
 
@@ -282,15 +282,13 @@ public class Util {
       System.err.println("subgraph: ");
       System.err.println(subG.toString());
       System.err.println("nodeDiff: ");
-      for (Iterator<T> it = nodeDiff.iterator(); it.hasNext();) {
-        System.err.println(it.next().toString());
+      for (T t : nodeDiff) {
+        System.err.println(t.toString());
       }
       Assertions.productionAssertion(nodeDiff.isEmpty(), "bad superset, see tracefile\n");
     }
 
-    for (Iterator<? extends T> subNodes = subG.iterator(); subNodes.hasNext();) {
-      T m = subNodes.next();
-
+    for (T m : subG) {
       Set<T> succDiff = setify(subG.getSuccNodes(m));
       succDiff.removeAll(setify(supG.getSuccNodes(m)));
       if (!succDiff.isEmpty()) {
@@ -305,8 +303,8 @@ public class Util {
         System.err.println("subgraph: ");
         System.err.println(subG.toString());
         System.err.println("predDiff: ");
-        for (Iterator<T> it = predDiff.iterator(); it.hasNext();) {
-          System.err.println(it.next().toString());
+        for (T t : predDiff) {
+          System.err.println(t.toString());
         }
         Assertions.UNREACHABLE("bad superset for predecessors of " + m + ":" + predDiff);
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/Util.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/Util.java
@@ -282,7 +282,7 @@ public class Util {
       System.err.println("subgraph: ");
       System.err.println(subG.toString());
       System.err.println("nodeDiff: ");
-      for (Iterator it = nodeDiff.iterator(); it.hasNext();) {
+      for (Iterator<T> it = nodeDiff.iterator(); it.hasNext();) {
         System.err.println(it.next().toString());
       }
       Assertions.productionAssertion(nodeDiff.isEmpty(), "bad superset, see tracefile\n");
@@ -305,7 +305,7 @@ public class Util {
         System.err.println("subgraph: ");
         System.err.println(subG.toString());
         System.err.println("predDiff: ");
-        for (Iterator it = predDiff.iterator(); it.hasNext();) {
+        for (Iterator<T> it = predDiff.iterator(); it.hasNext();) {
           System.err.println(it.next().toString());
         }
         Assertions.UNREACHABLE("bad superset for predecessors of " + m + ":" + predDiff);

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/ConcreteTypeKey.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/ConcreteTypeKey.java
@@ -86,15 +86,15 @@ public final class ConcreteTypeKey implements InstanceKey {
     if (pei == null) {
       throw new IllegalArgumentException("pei is null");
     }
-    Collection types = pei.getExceptionTypes();
+    Collection<TypeReference> types = pei.getExceptionTypes();
     // TODO: institute a cache?
     if (types == null) {
       return null;
     }
     InstanceKey[] result = new InstanceKey[types.size()];
     int i = 0;
-    for (Iterator it = types.iterator(); it.hasNext();) {
-      TypeReference type = (TypeReference) it.next();
+    for (Iterator<TypeReference> it = types.iterator(); it.hasNext();) {
+      TypeReference type = it.next();
       assert type != null;
       IClass klass = cha.lookupClass(type);
       result[i++] = new ConcreteTypeKey(klass);

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/ConcreteTypeKey.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/ConcreteTypeKey.java
@@ -93,8 +93,7 @@ public final class ConcreteTypeKey implements InstanceKey {
     }
     InstanceKey[] result = new InstanceKey[types.size()];
     int i = 0;
-    for (Iterator<TypeReference> it = types.iterator(); it.hasNext();) {
-      TypeReference type = it.next();
+    for (TypeReference type : types) {
       assert type != null;
       IClass klass = cha.lookupClass(type);
       result[i++] = new ConcreteTypeKey(klass);

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PointerAnalysisImpl.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PointerAnalysisImpl.java
@@ -93,8 +93,8 @@ public class PointerAnalysisImpl extends AbstractPointerAnalysis {
       PointerKey p = it.next();
       OrdinalSet<InstanceKey> O = getPointsToSet(p);
       result.append("  ").append(p).append(" ->\n");
-      for (Iterator<InstanceKey> it2 = O.iterator(); it2.hasNext();) {
-        result.append("     ").append(it2.next()).append("\n");
+      for (InstanceKey instanceKey : O) {
+        result.append("     ").append(instanceKey).append("\n");
       }
     }
     return result.toString();
@@ -284,8 +284,7 @@ public class PointerAnalysisImpl extends AbstractPointerAnalysis {
     PointerKey arrayRef = pointerKeys.getPointerKeyForLocal(node, instruction.getArrayRef());
     MutableSparseIntSet S = MutableSparseIntSet.makeEmpty();
     OrdinalSet<InstanceKey> refs = getPointsToSet(arrayRef);
-    for (Iterator<InstanceKey> it = refs.iterator(); it.hasNext();) {
-      InstanceKey ik = it.next();
+    for (InstanceKey ik : refs) {
       PointerKey key = pointerKeys.getPointerKeyForArrayContents(ik);
       OrdinalSet pointees = getPointsToSet(key);
       IntSet set = pointees.getBackingSet();
@@ -312,8 +311,7 @@ public class PointerAnalysisImpl extends AbstractPointerAnalysis {
       PointerKey ref = pointerKeys.getPointerKeyForLocal(node, refVn);
       MutableSparseIntSet S = MutableSparseIntSet.makeEmpty();
       OrdinalSet<InstanceKey> refs = getPointsToSet(ref);
-      for (Iterator<InstanceKey> it = refs.iterator(); it.hasNext();) {
-        InstanceKey ik = it.next();
+      for (InstanceKey ik : refs) {
         PointerKey fkey = pointerKeys.getPointerKeyForInstanceField(ik, f);
         if (fkey != null) {
           OrdinalSet pointees = getPointsToSet(fkey);
@@ -333,8 +331,7 @@ public class PointerAnalysisImpl extends AbstractPointerAnalysis {
     Set<IClass> caughtTypes = SSAPropagationCallGraphBuilder.getCaughtExceptionTypes(instruction, ir);
     MutableSparseIntSet S = MutableSparseIntSet.makeEmpty();
     // add the instances from each incoming pei ...
-    for (Iterator<ProgramCounter> it = peis.iterator(); it.hasNext();) {
-      ProgramCounter peiLoc = it.next();
+    for (ProgramCounter peiLoc : peis) {
       SSAInstruction pei = ir.getPEI(peiLoc);
       PointerKey e = null;
       // first deal with exception variables from calls and throws.
@@ -347,8 +344,7 @@ public class PointerAnalysisImpl extends AbstractPointerAnalysis {
       }
       if (e != null) {
         OrdinalSet<InstanceKey> ep = getPointsToSet(e);
-        for (Iterator<InstanceKey> it2 = ep.iterator(); it2.hasNext();) {
-          InstanceKey ik = it2.next();
+        for (InstanceKey ik : ep) {
           if (PropagationCallGraphBuilder.catches(caughtTypes, ik.getConcreteType(), getCallGraph().getClassHierarchy())) {
             S.add(instanceKeys.getMappedIndex(ik));
           }
@@ -360,8 +356,7 @@ public class PointerAnalysisImpl extends AbstractPointerAnalysis {
       // the pei, but just instance keys
       Collection<TypeReference> types = pei.getExceptionTypes();
       if (types != null) {
-        for (Iterator<TypeReference> it2 = types.iterator(); it2.hasNext();) {
-          TypeReference type = it2.next();
+        for (TypeReference type : types) {
           if (type != null) {
             InstanceKey ik = SSAPropagationCallGraphBuilder.getInstanceKeyForPEI(node, peiLoc, type, iKeyFactory);
             ConcreteTypeKey ck = (ConcreteTypeKey) ik;
@@ -388,15 +383,13 @@ public class PointerAnalysisImpl extends AbstractPointerAnalysis {
         return rhsSet;
       } else {
         if (klass.isInterface()) {
-          for (Iterator<InstanceKey> it = rhsSet.iterator(); it.hasNext();) {
-            InstanceKey ik = it.next();
+          for (InstanceKey ik : rhsSet) {
             if (getCallGraph().getClassHierarchy().implementsInterface(ik.getConcreteType(), klass)) {
               S.add(getInstanceKeyMapping().getMappedIndex(ik));
             }
           }
         } else {
-          for (Iterator<InstanceKey> it = rhsSet.iterator(); it.hasNext();) {
-            InstanceKey ik = it.next();
+          for (InstanceKey ik : rhsSet) {
             if (getCallGraph().getClassHierarchy().isSubclassOf(ik.getConcreteType(), klass)) {
               S.add(getInstanceKeyMapping().getMappedIndex(ik));
             }
@@ -419,12 +412,12 @@ public class PointerAnalysisImpl extends AbstractPointerAnalysis {
 
   private OrdinalSet<InstanceKey> toOrdinalSet(InstanceKey[] ik) {
     MutableSparseIntSet s = MutableSparseIntSet.makeEmpty();
-    for (int i = 0; i < ik.length; i++) {
-      int index = instanceKeys.getMappedIndex(ik[i]);
+    for (InstanceKey element : ik) {
+      int index = instanceKeys.getMappedIndex(element);
       if (index != -1) {
         s.add(index);
       } else {
-        assert index != -1 : "instance " + ik[i] + " not mapped!";
+        assert index != -1 : "instance " + element + " not mapped!";
       }
     }
     return new OrdinalSet<InstanceKey>(s, instanceKeys);
@@ -435,8 +428,7 @@ public class PointerAnalysisImpl extends AbstractPointerAnalysis {
    */
   private OrdinalSet<InstanceKey> computeImplicitExceptionsForCall(CGNode node, SSAInvokeInstruction call) {
     MutableSparseIntSet S = MutableSparseIntSet.makeEmpty();
-    for (Iterator<CGNode> it = getCallGraph().getPossibleTargets(node, call.getCallSite()).iterator(); it.hasNext();) {
-      CGNode target = it.next();
+    for (CGNode target : getCallGraph().getPossibleTargets(node, call.getCallSite())) {
       PointerKey retVal = pointerKeys.getPointerKeyForExceptionalReturnValue(target);
       IntSet set = getPointsToSet(retVal).getBackingSet();
       if (set != null) {

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PointerAnalysisImpl.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PointerAnalysisImpl.java
@@ -89,11 +89,11 @@ public class PointerAnalysisImpl extends AbstractPointerAnalysis {
   @Override
   public String toString() {
     StringBuffer result = new StringBuffer("PointerAnalysis:\n");
-    for (Iterator it = pointsToMap.iterateKeys(); it.hasNext();) {
-      PointerKey p = (PointerKey) it.next();
-      OrdinalSet O = getPointsToSet(p);
+    for (Iterator<PointerKey> it = pointsToMap.iterateKeys(); it.hasNext();) {
+      PointerKey p = it.next();
+      OrdinalSet<InstanceKey> O = getPointsToSet(p);
       result.append("  ").append(p).append(" ->\n");
-      for (Iterator it2 = O.iterator(); it2.hasNext();) {
+      for (Iterator<InstanceKey> it2 = O.iterator(); it2.hasNext();) {
         result.append("     ").append(it2.next()).append("\n");
       }
     }
@@ -283,9 +283,9 @@ public class PointerAnalysisImpl extends AbstractPointerAnalysis {
   private OrdinalSet<InstanceKey> computeImplicitPointsToSetAtALoad(CGNode node, SSAArrayLoadInstruction instruction) {
     PointerKey arrayRef = pointerKeys.getPointerKeyForLocal(node, instruction.getArrayRef());
     MutableSparseIntSet S = MutableSparseIntSet.makeEmpty();
-    OrdinalSet refs = getPointsToSet(arrayRef);
-    for (Iterator it = refs.iterator(); it.hasNext();) {
-      InstanceKey ik = (InstanceKey) it.next();
+    OrdinalSet<InstanceKey> refs = getPointsToSet(arrayRef);
+    for (Iterator<InstanceKey> it = refs.iterator(); it.hasNext();) {
+      InstanceKey ik = it.next();
       PointerKey key = pointerKeys.getPointerKeyForArrayContents(ik);
       OrdinalSet pointees = getPointsToSet(key);
       IntSet set = pointees.getBackingSet();
@@ -311,9 +311,9 @@ public class PointerAnalysisImpl extends AbstractPointerAnalysis {
     } else {
       PointerKey ref = pointerKeys.getPointerKeyForLocal(node, refVn);
       MutableSparseIntSet S = MutableSparseIntSet.makeEmpty();
-      OrdinalSet refs = getPointsToSet(ref);
-      for (Iterator it = refs.iterator(); it.hasNext();) {
-        InstanceKey ik = (InstanceKey) it.next();
+      OrdinalSet<InstanceKey> refs = getPointsToSet(ref);
+      for (Iterator<InstanceKey> it = refs.iterator(); it.hasNext();) {
+        InstanceKey ik = it.next();
         PointerKey fkey = pointerKeys.getPointerKeyForInstanceField(ik, f);
         if (fkey != null) {
           OrdinalSet pointees = getPointsToSet(fkey);
@@ -346,9 +346,9 @@ public class PointerAnalysisImpl extends AbstractPointerAnalysis {
         e = pointerKeys.getPointerKeyForLocal(node, s.getException());
       }
       if (e != null) {
-        OrdinalSet ep = getPointsToSet(e);
-        for (Iterator it2 = ep.iterator(); it2.hasNext();) {
-          InstanceKey ik = (InstanceKey) it2.next();
+        OrdinalSet<InstanceKey> ep = getPointsToSet(e);
+        for (Iterator<InstanceKey> it2 = ep.iterator(); it2.hasNext();) {
+          InstanceKey ik = it2.next();
           if (PropagationCallGraphBuilder.catches(caughtTypes, ik.getConcreteType(), getCallGraph().getClassHierarchy())) {
             S.add(instanceKeys.getMappedIndex(ik));
           }
@@ -358,10 +358,10 @@ public class PointerAnalysisImpl extends AbstractPointerAnalysis {
       // Account for those exceptions for which we do not actually have a
       // points-to set for
       // the pei, but just instance keys
-      Collection types = pei.getExceptionTypes();
+      Collection<TypeReference> types = pei.getExceptionTypes();
       if (types != null) {
-        for (Iterator it2 = types.iterator(); it2.hasNext();) {
-          TypeReference type = (TypeReference) it2.next();
+        for (Iterator<TypeReference> it2 = types.iterator(); it2.hasNext();) {
+          TypeReference type = it2.next();
           if (type != null) {
             InstanceKey ik = SSAPropagationCallGraphBuilder.getInstanceKeyForPEI(node, peiLoc, type, iKeyFactory);
             ConcreteTypeKey ck = (ConcreteTypeKey) ik;
@@ -388,15 +388,15 @@ public class PointerAnalysisImpl extends AbstractPointerAnalysis {
         return rhsSet;
       } else {
         if (klass.isInterface()) {
-          for (Iterator it = rhsSet.iterator(); it.hasNext();) {
-            InstanceKey ik = (InstanceKey) it.next();
+          for (Iterator<InstanceKey> it = rhsSet.iterator(); it.hasNext();) {
+            InstanceKey ik = it.next();
             if (getCallGraph().getClassHierarchy().implementsInterface(ik.getConcreteType(), klass)) {
               S.add(getInstanceKeyMapping().getMappedIndex(ik));
             }
           }
         } else {
-          for (Iterator it = rhsSet.iterator(); it.hasNext();) {
-            InstanceKey ik = (InstanceKey) it.next();
+          for (Iterator<InstanceKey> it = rhsSet.iterator(); it.hasNext();) {
+            InstanceKey ik = it.next();
             if (getCallGraph().getClassHierarchy().isSubclassOf(ik.getConcreteType(), klass)) {
               S.add(getInstanceKeyMapping().getMappedIndex(ik));
             }
@@ -435,8 +435,8 @@ public class PointerAnalysisImpl extends AbstractPointerAnalysis {
    */
   private OrdinalSet<InstanceKey> computeImplicitExceptionsForCall(CGNode node, SSAInvokeInstruction call) {
     MutableSparseIntSet S = MutableSparseIntSet.makeEmpty();
-    for (Iterator it = getCallGraph().getPossibleTargets(node, call.getCallSite()).iterator(); it.hasNext();) {
-      CGNode target = (CGNode) it.next();
+    for (Iterator<CGNode> it = getCallGraph().getPossibleTargets(node, call.getCallSite()).iterator(); it.hasNext();) {
+      CGNode target = it.next();
       PointerKey retVal = pointerKeys.getPointerKeyForExceptionalReturnValue(target);
       IntSet set = getPointsToSet(retVal).getBackingSet();
       if (set != null) {

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PointsToMap.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PointsToMap.java
@@ -188,8 +188,8 @@ public class PointsToMap {
    * Wipe out the cached transitive closure information
    */
   public void revertToPreTransitive() {
-    for (Iterator it = iterateKeys(); it.hasNext();) {
-      PointerKey key = (PointerKey) it.next();
+    for (Iterator<PointerKey> it = iterateKeys(); it.hasNext();) {
+      PointerKey key = it.next();
       if (!isTransitiveRoot(key) && !isImplicit(key) && !isUnified(key)) {
         PointsToSetVariable v = getPointsToSet(key);
         v.removeAll();

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PropagationCallGraphBuilder.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PropagationCallGraphBuilder.java
@@ -244,8 +244,8 @@ public abstract class PropagationCallGraphBuilder implements CallGraphBuilder<In
     discoveredNodes.add(callGraph.getFakeRootNode());
 
     // Set up the initially reachable methods and classes
-    for (Iterator it = options.getEntrypoints().iterator(); it.hasNext();) {
-      Entrypoint E = (Entrypoint) it.next();
+    for (Iterator<? extends Entrypoint> it = options.getEntrypoints().iterator(); it.hasNext();) {
+      Entrypoint E = it.next();
       if (DEBUG_ENTRYPOINTS) {
         System.err.println("Entrypoint: " + E);
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PropagationCallGraphBuilder.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PropagationCallGraphBuilder.java
@@ -244,8 +244,7 @@ public abstract class PropagationCallGraphBuilder implements CallGraphBuilder<In
     discoveredNodes.add(callGraph.getFakeRootNode());
 
     // Set up the initially reachable methods and classes
-    for (Iterator<? extends Entrypoint> it = options.getEntrypoints().iterator(); it.hasNext();) {
-      Entrypoint E = it.next();
+    for (Entrypoint E : options.getEntrypoints()) {
       if (DEBUG_ENTRYPOINTS) {
         System.err.println("Entrypoint: " + E);
       }
@@ -927,8 +926,7 @@ public abstract class PropagationCallGraphBuilder implements CallGraphBuilder<In
 
       List<InstanceKey> instances = system.getInstances(rhs.getValue());
       boolean sideEffect = false;
-      for (Iterator<InstanceKey> it = instances.iterator(); it.hasNext();) {
-        InstanceKey I = it.next();
+      for (InstanceKey I : instances) {
         if (!I.getConcreteType().isArrayClass()) {
           continue;
         }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PropagationGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PropagationGraph.java
@@ -733,8 +733,7 @@ public class PropagationGraph implements IFixedPointSystem<PointsToSetVariable> 
       return 0;
     }
     int result = delegateGraph.getSuccNodeCount(v);
-    for (Iterator<UnaryOperator<PointsToSetVariable>> it = invImplicitUnaryMap.keySet().iterator(); it.hasNext();) {
-      UnaryOperator<PointsToSetVariable> op = it.next();
+    for (UnaryOperator<PointsToSetVariable> op : invImplicitUnaryMap.keySet()) {
       IBinaryNaturalRelation R = invImplicitUnaryMap.get(op);
       IntSet s = R.getRelated(number);
       if (s != null) {
@@ -754,8 +753,7 @@ public class PropagationGraph implements IFixedPointSystem<PointsToSetVariable> 
       return 0;
     }
     int result = delegateGraph.getPredNodeCount(v);
-    for (Iterator<UnaryOperator<PointsToSetVariable>> it = implicitUnaryMap.keySet().iterator(); it.hasNext();) {
-      UnaryOperator<PointsToSetVariable> op = it.next();
+    for (UnaryOperator<PointsToSetVariable> op : implicitUnaryMap.keySet()) {
       IBinaryNaturalRelation R = implicitUnaryMap.get(op);
       IntSet s = R.getRelated(number);
       if (s != null) {
@@ -788,9 +786,9 @@ public class PropagationGraph implements IFixedPointSystem<PointsToSetVariable> 
       System.err.println("implicit map:");
       int count = 0;
       int totalBytes = 0;
-      for (Iterator<Entry<UnaryOperator<PointsToSetVariable>, IBinaryNaturalRelation>> it = implicitUnaryMap.entrySet().iterator(); it.hasNext();) {
+      for (Entry<UnaryOperator<PointsToSetVariable>, IBinaryNaturalRelation> entry : implicitUnaryMap.entrySet()) {
         count++;
-        Map.Entry<?, IBinaryNaturalRelation> e = it.next();
+        Map.Entry<?, IBinaryNaturalRelation> e = entry;
         IBinaryNaturalRelation R = e.getValue();
         System.err.println(("entry " + count));
         R.performVerboseAction();

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PropagationSystem.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PropagationSystem.java
@@ -147,8 +147,8 @@ public class PropagationSystem extends DefaultFixedPointSolver<PointsToSetVariab
   protected void updateSideEffects(PointsToSetVariable p, PointsToSetVariable rep) {
     Set<UnarySideEffect> set = fixedSetMap.get(p);
     if (set != null) {
-      for (Iterator it = set.iterator(); it.hasNext();) {
-        UnarySideEffect s = (UnarySideEffect) it.next();
+      for (Iterator<UnarySideEffect> it = set.iterator(); it.hasNext();) {
+        UnarySideEffect s = it.next();
         s.replaceFixedSet(rep);
       }
       Set<UnarySideEffect> s2 = MapUtil.findOrCreateSet(fixedSetMap, rep);
@@ -484,10 +484,10 @@ public class PropagationSystem extends DefaultFixedPointSolver<PointsToSetVariab
   }
 
   private void registerArrayInstanceWithAllInterfacesOfElement(int index, IClass elementClass, int dim) {
-    Collection ifaces = null;
+    Collection<IClass> ifaces = null;
     ifaces = elementClass.getAllImplementedInterfaces();
-    for (Iterator it = ifaces.iterator(); it.hasNext();) {
-      IClass I = (IClass) it.next();
+    for (Iterator<IClass> it = ifaces.iterator(); it.hasNext();) {
+      IClass I = it.next();
       TypeReference iArrayRef = makeArray(I.getReference(), dim);
       IClass iArrayClass = null;
       iArrayClass = I.getClassLoader().lookupClass(iArrayRef.getName());
@@ -530,9 +530,9 @@ public class PropagationSystem extends DefaultFixedPointSolver<PointsToSetVariab
    * @throws ClassHierarchyException
    */
   private void registerInstanceWithAllInterfaces(IClass klass, int index) throws ClassHierarchyException {
-    Collection ifaces = klass.getAllImplementedInterfaces();
-    for (Iterator it = ifaces.iterator(); it.hasNext();) {
-      IClass I = (IClass) it.next();
+    Collection<IClass> ifaces = klass.getAllImplementedInterfaces();
+    for (Iterator<IClass> it = ifaces.iterator(); it.hasNext();) {
+      IClass I = it.next();
       MutableIntSet set = findOrCreateSparseSetForClass(I);
       set.add(index);
       if (DEBUG) {
@@ -724,7 +724,7 @@ public class PropagationSystem extends DefaultFixedPointSolver<PointsToSetVariab
     pointsToMap.revertToPreTransitive();
   }
 
-  public Iterator getTransitiveRoots() {
+  public Iterator<PointerKey> getTransitiveRoots() {
     return pointsToMap.getTransitiveRoots();
   }
 
@@ -819,8 +819,8 @@ public class PropagationSystem extends DefaultFixedPointSolver<PointsToSetVariab
       if (p != pRef) {
         // pRef is the representative for p.
         // be careful: cache the defs before mucking with the underlying system
-        for (Iterator d = Iterator2Collection.toSet(getStatementsThatDef(p)).iterator(); d.hasNext();) {
-          AbstractStatement as = (AbstractStatement) d.next();
+        for (Iterator<AbstractStatement> d = Iterator2Collection.toSet(getStatementsThatDef(p)).iterator(); d.hasNext();) {
+          AbstractStatement as = d.next();
 
           if (as instanceof AssignEquation) {
             AssignEquation assign = (AssignEquation) as;
@@ -836,8 +836,8 @@ public class PropagationSystem extends DefaultFixedPointSolver<PointsToSetVariab
           }
         }
         // be careful: cache the defs before mucking with the underlying system
-        for (Iterator u = Iterator2Collection.toSet(getStatementsThatUse(p)).iterator(); u.hasNext();) {
-          AbstractStatement as = (AbstractStatement) u.next();
+        for (Iterator<AbstractStatement> u = Iterator2Collection.toSet(getStatementsThatUse(p)).iterator(); u.hasNext();) {
+          AbstractStatement as = u.next();
           if (as instanceof AssignEquation) {
             AssignEquation assign = (AssignEquation) as;
             PointsToSetVariable lhs = assign.getLHS();

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PropagationSystem.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PropagationSystem.java
@@ -147,8 +147,7 @@ public class PropagationSystem extends DefaultFixedPointSolver<PointsToSetVariab
   protected void updateSideEffects(PointsToSetVariable p, PointsToSetVariable rep) {
     Set<UnarySideEffect> set = fixedSetMap.get(p);
     if (set != null) {
-      for (Iterator<UnarySideEffect> it = set.iterator(); it.hasNext();) {
-        UnarySideEffect s = it.next();
+      for (UnarySideEffect s : set) {
         s.replaceFixedSet(rep);
       }
       Set<UnarySideEffect> s2 = MapUtil.findOrCreateSet(fixedSetMap, rep);
@@ -486,8 +485,7 @@ public class PropagationSystem extends DefaultFixedPointSolver<PointsToSetVariab
   private void registerArrayInstanceWithAllInterfacesOfElement(int index, IClass elementClass, int dim) {
     Collection<IClass> ifaces = null;
     ifaces = elementClass.getAllImplementedInterfaces();
-    for (Iterator<IClass> it = ifaces.iterator(); it.hasNext();) {
-      IClass I = it.next();
+    for (IClass I : ifaces) {
       TypeReference iArrayRef = makeArray(I.getReference(), dim);
       IClass iArrayClass = null;
       iArrayClass = I.getClassLoader().lookupClass(iArrayRef.getName());
@@ -531,8 +529,7 @@ public class PropagationSystem extends DefaultFixedPointSolver<PointsToSetVariab
    */
   private void registerInstanceWithAllInterfaces(IClass klass, int index) throws ClassHierarchyException {
     Collection<IClass> ifaces = klass.getAllImplementedInterfaces();
-    for (Iterator<IClass> it = ifaces.iterator(); it.hasNext();) {
-      IClass I = it.next();
+    for (IClass I : ifaces) {
       MutableIntSet set = findOrCreateSparseSetForClass(I);
       set.add(index);
       if (DEBUG) {
@@ -798,8 +795,7 @@ public class PropagationSystem extends DefaultFixedPointSolver<PointsToSetVariab
    */
   private void updateSideEffectsForUnification(HashSet<PointsToSetVariable> s, int rep) {
     PointsToSetVariable pRef = pointsToMap.getPointsToSet(rep);
-    for (Iterator<PointsToSetVariable> it = s.iterator(); it.hasNext();) {
-      PointsToSetVariable p = it.next();
+    for (PointsToSetVariable p : s) {
       updateSideEffects(p, pRef);
     }
   }
@@ -813,15 +809,11 @@ public class PropagationSystem extends DefaultFixedPointSolver<PointsToSetVariab
   @SuppressWarnings("unchecked")
   private void updateEquationsForUnification(HashSet<PointsToSetVariable> s, int rep) {
     PointsToSetVariable pRef = pointsToMap.getPointsToSet(rep);
-    for (Iterator<PointsToSetVariable> it = s.iterator(); it.hasNext();) {
-      PointsToSetVariable p = it.next();
-
+    for (PointsToSetVariable p : s) {
       if (p != pRef) {
         // pRef is the representative for p.
         // be careful: cache the defs before mucking with the underlying system
-        for (Iterator<AbstractStatement> d = Iterator2Collection.toSet(getStatementsThatDef(p)).iterator(); d.hasNext();) {
-          AbstractStatement as = d.next();
-
+        for (AbstractStatement as : Iterator2Collection.toSet(getStatementsThatDef(p))) {
           if (as instanceof AssignEquation) {
             AssignEquation assign = (AssignEquation) as;
             PointsToSetVariable rhs = assign.getRightHandSide();
@@ -836,8 +828,7 @@ public class PropagationSystem extends DefaultFixedPointSolver<PointsToSetVariab
           }
         }
         // be careful: cache the defs before mucking with the underlying system
-        for (Iterator<AbstractStatement> u = Iterator2Collection.toSet(getStatementsThatUse(p)).iterator(); u.hasNext();) {
-          AbstractStatement as = u.next();
+        for (AbstractStatement as : Iterator2Collection.toSet(getStatementsThatUse(p))) {
           if (as instanceof AssignEquation) {
             AssignEquation assign = (AssignEquation) as;
             PointsToSetVariable lhs = assign.getLHS();

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/ReflectionHandler.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/ReflectionHandler.java
@@ -93,8 +93,8 @@ public class ReflectionHandler {
   private Collection<Statement> computeFactoryReturnStatements() {
     // todo: clean up logic with inheritance, delegation.
     HashSet<Statement> result = HashSetFactory.make();
-    for (Iterator it = builder.getCallGraph().iterator(); it.hasNext();) {
-      CGNode n = (CGNode) it.next();
+    for (Iterator<CGNode> it = builder.getCallGraph().iterator(); it.hasNext();) {
+      CGNode n = it.next();
       if (n.getMethod() instanceof SyntheticMethod) {
         SyntheticMethod m = (SyntheticMethod) n.getMethod();
         if (m.isFactoryMethod()) {

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/ReflectionHandler.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/ReflectionHandler.java
@@ -12,7 +12,6 @@ package com.ibm.wala.ipa.callgraph.propagation;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -83,8 +82,8 @@ public class ReflectionHandler {
       Collection<Statement> casts = Iterator2Collection.toSet(new FilterIterator<>(slice.iterator(), f));
       changedNodes.addAll(modifyFactoryInterpreter(st, casts, builder.getContextInterpreter(), builder.getClassHierarchy()));
     }
-    for (Iterator<CGNode> it = changedNodes.iterator(); it.hasNext();) {
-      builder.addConstraintsFromChangedNode(it.next(), monitor);
+    for (CGNode cgNode : changedNodes) {
+      builder.addConstraintsFromChangedNode(cgNode, monitor);
     }
     return changedNodes.size() > 0;
 
@@ -93,8 +92,7 @@ public class ReflectionHandler {
   private Collection<Statement> computeFactoryReturnStatements() {
     // todo: clean up logic with inheritance, delegation.
     HashSet<Statement> result = HashSetFactory.make();
-    for (Iterator<CGNode> it = builder.getCallGraph().iterator(); it.hasNext();) {
-      CGNode n = it.next();
+    for (CGNode n : builder.getCallGraph()) {
       if (n.getMethod() instanceof SyntheticMethod) {
         SyntheticMethod m = (SyntheticMethod) n.getMethod();
         if (m.isFactoryMethod()) {

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/SSAPropagationCallGraphBuilder.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/SSAPropagationCallGraphBuilder.java
@@ -301,7 +301,7 @@ public abstract class SSAPropagationCallGraphBuilder extends PropagationCallGrap
   private void addPhiConstraints(CGNode node, ControlFlowGraph<SSAInstruction, ISSABasicBlock> controlFlowGraph, BasicBlock b,
       ConstraintVisitor v) {
     // visit each phi instruction in each successor block
-    for (Iterator sbs = controlFlowGraph.getSuccNodes(b); sbs.hasNext();) {
+    for (Iterator<ISSABasicBlock> sbs = controlFlowGraph.getSuccNodes(b); sbs.hasNext();) {
       BasicBlock sb = (BasicBlock) sbs.next();
       if (!sb.hasPhi()) {
         continue;
@@ -487,7 +487,7 @@ public abstract class SSAPropagationCallGraphBuilder extends PropagationCallGrap
     }
     ControlFlowGraph<SSAInstruction, ISSABasicBlock> g = ir.getControlFlowGraph();
     List<ProgramCounter> result = new ArrayList<ProgramCounter>(g.getPredNodeCount(bb));
-    for (Iterator it = g.getPredNodes(bb); it.hasNext();) {
+    for (Iterator<ISSABasicBlock> it = g.getPredNodes(bb); it.hasNext();) {
       BasicBlock pred = (BasicBlock) it.next();
       if (DEBUG) {
         System.err.println("pred: " + pred);
@@ -2059,8 +2059,8 @@ public abstract class SSAPropagationCallGraphBuilder extends PropagationCallGrap
     // todo: enhance this by solving a dead-code elimination
     // problem.
     InterestingVisitor v = makeInterestingVisitor(node, vn);
-    for (Iterator it = du.getUses(v.vn); it.hasNext();) {
-      SSAInstruction s = (SSAInstruction) it.next();
+    for (Iterator<SSAInstruction> it = du.getUses(v.vn); it.hasNext();) {
+      SSAInstruction s = it.next();
       s.visit(v);
       if (v.bingo) {
         return false;

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/SSAPropagationCallGraphBuilder.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/SSAPropagationCallGraphBuilder.java
@@ -284,9 +284,8 @@ public abstract class SSAPropagationCallGraphBuilder extends PropagationCallGrap
     v.setBasicBlock(b);
 
     // visit each instruction in the basic block.
-    for (Iterator<SSAInstruction> it = b.iterator(); it.hasNext();) {
+    for (SSAInstruction s : b) {
       MonitorUtil.throwExceptionIfCanceled(monitor);      
-      SSAInstruction s = it.next();
       if (s != null) {
         s.visit(v);
         if (wasChanged(node)) {
@@ -329,8 +328,8 @@ public abstract class SSAPropagationCallGraphBuilder extends PropagationCallGrap
             if (contentsAreInvariant(v.symbolTable, v.du, phi.getUse(n))) {
               system.recordImplicitPointsToSet(use);
               InstanceKey[] ik = getInvariantContents(v.symbolTable, v.du, node, phi.getUse(n), this);
-              for (int i = 0; i < ik.length; i++) {
-                system.newConstraint(def, ik[i]);
+              for (InstanceKey element : ik) {
+                system.newConstraint(def, element);
               }
             } else {
               system.newConstraint(def, assignOperator, use);
@@ -371,8 +370,7 @@ public abstract class SSAPropagationCallGraphBuilder extends PropagationCallGrap
     if (DEBUG) {
       System.err.println("Add exception def constraints for node " + node);
     }
-    for (Iterator<ProgramCounter> it = peis.iterator(); it.hasNext();) {
-      ProgramCounter peiLoc = it.next();
+    for (ProgramCounter peiLoc : peis) {
       if (DEBUG) {
         System.err.println("peiLoc: " + peiLoc);
       }
@@ -398,9 +396,9 @@ public abstract class SSAPropagationCallGraphBuilder extends PropagationCallGrap
 
         if (contentsAreInvariant(ir.getSymbolTable(), du, s.getException())) {
           InstanceKey[] ik = getInvariantContents(ir.getSymbolTable(), du, node, s.getException(), this);
-          for (int i = 0; i < ik.length; i++) {
-            system.findOrCreateIndexForInstanceKey(ik[i]);
-            assignInstanceToCatch(exceptionVar, catchClasses, ik[i]);
+          for (InstanceKey element : ik) {
+            system.findOrCreateIndexForInstanceKey(element);
+            assignInstanceToCatch(exceptionVar, catchClasses, element);
           }
         } else {
           addAssignmentsForCatchPointerKey(exceptionVar, catchClasses, e);
@@ -412,8 +410,7 @@ public abstract class SSAPropagationCallGraphBuilder extends PropagationCallGrap
       // the pei, but just instance keys
       Collection<TypeReference> types = pei.getExceptionTypes();
       if (types != null) {
-        for (Iterator<TypeReference> it2 = types.iterator(); it2.hasNext();) {
-          TypeReference type = it2.next();
+        for (TypeReference type : types) {
           if (type != null) {
             InstanceKey ik = getInstanceKeyForPEI(node, peiLoc, type, instanceKeyFactory);
             if (ik == null) {
@@ -536,9 +533,9 @@ public abstract class SSAPropagationCallGraphBuilder extends PropagationCallGrap
         InstanceKey[] ik = invariants != null ? invariants[p] : null;
         if (ik != null) {
           if (ik.length > 0) {
-            for (int i = 0; i < ik.length; i++) {
-              system.findOrCreateIndexForInstanceKey(ik[i]);
-              keys[pi] = ik[i];
+            for (InstanceKey element : ik) {
+              system.findOrCreateIndexForInstanceKey(element);
+              keys[pi] = element;
               rec(pi + 1, rhsi);
             }
           } /* else {
@@ -794,11 +791,11 @@ public abstract class SSAPropagationCallGraphBuilder extends PropagationCallGrap
               if (contentsAreInvariant(symbolTable, du, value)) {
                 system.recordImplicitPointsToSet(valuePtrKey);
                 InstanceKey[] vk = getInvariantContents(value);
-                for (int j = 0; j < vk.length; j++) {
-                  system.findOrCreateIndexForInstanceKey(vk[j]);
-                  if (vk[j].getConcreteType() != null) {
-                    if (getClassHierarchy().isAssignableFrom(contents, vk[j].getConcreteType())) {
-                      system.newConstraint(p, vk[j]);
+                for (InstanceKey element : vk) {
+                  system.findOrCreateIndexForInstanceKey(element);
+                  if (element.getConcreteType() != null) {
+                    if (getClassHierarchy().isAssignableFrom(contents, element.getConcreteType())) {
+                      system.newConstraint(p, element);
                     }
                   }
                 }
@@ -816,10 +813,10 @@ public abstract class SSAPropagationCallGraphBuilder extends PropagationCallGrap
         if (contentsAreInvariant(symbolTable, du, value)) {
           system.recordImplicitPointsToSet(valuePtrKey);
           InstanceKey[] ik = getInvariantContents(value);
-          for (int i = 0; i < ik.length; i++) {
-            system.findOrCreateIndexForInstanceKey(ik[i]);
+          for (InstanceKey element : ik) {
+            system.findOrCreateIndexForInstanceKey(element);
             assert !system.isUnified(arrayRefPtrKey);
-            system.newSideEffect(getBuilder().new InstanceArrayStoreOperator(ik[i]), arrayRefPtrKey);
+            system.newSideEffect(getBuilder().new InstanceArrayStoreOperator(element), arrayRefPtrKey);
           }
         } else {
           system.newSideEffect(getBuilder().new ArrayStoreOperator(system.findOrCreatePointsToSet(valuePtrKey)), arrayRefPtrKey);
@@ -871,17 +868,17 @@ public abstract class SSAPropagationCallGraphBuilder extends PropagationCallGrap
             IClass cls = getClassHierarchy().lookupClass(t);
 
             if (cls.isInterface()) {
-              for (int i = 0; i < ik.length; i++) {
-                system.findOrCreateIndexForInstanceKey(ik[i]);
-                if (getClassHierarchy().implementsInterface(ik[i].getConcreteType(), cls)) {
-                  system.newConstraint(result, ik[i]);
+              for (InstanceKey element : ik) {
+                system.findOrCreateIndexForInstanceKey(element);
+                if (getClassHierarchy().implementsInterface(element.getConcreteType(), cls)) {
+                  system.newConstraint(result, element);
                 }
               }
             } else {
-              for (int i = 0; i < ik.length; i++) {
-                system.findOrCreateIndexForInstanceKey(ik[i]);
-                if (getClassHierarchy().isSubclassOf(ik[i].getConcreteType(), cls)) {
-                  system.newConstraint(result, ik[i]);
+              for (InstanceKey element : ik) {
+                system.findOrCreateIndexForInstanceKey(element);
+                if (getClassHierarchy().isSubclassOf(element.getConcreteType(), cls)) {
+                  system.newConstraint(result, element);
                 }
               }
             }
@@ -915,11 +912,11 @@ public abstract class SSAPropagationCallGraphBuilder extends PropagationCallGrap
       if (contentsAreInvariant(symbolTable, du, instruction.getResult())) {
         system.recordImplicitPointsToSet(result);
         InstanceKey[] ik = getInvariantContents(instruction.getResult());
-        for (int i = 0; i < ik.length; i++) {
+        for (InstanceKey element : ik) {
           if (DEBUG) {
-            System.err.println("invariant contents: " + returnValue + " " + ik[i]);
+            System.err.println("invariant contents: " + returnValue + " " + element);
           }
-          system.newConstraint(returnValue, ik[i]);
+          system.newConstraint(returnValue, element);
         }
       } else {
         system.newConstraint(returnValue, assignOperator, result);
@@ -1047,15 +1044,15 @@ public abstract class SSAPropagationCallGraphBuilder extends PropagationCallGrap
             if (!representsNullType(refk[j])) {
               system.findOrCreateIndexForInstanceKey(refk[j]);
               PointerKey p = getPointerKeyForInstanceField(refk[j], f);
-              for (int i = 0; i < ik.length; i++) {
-                system.newConstraint(p, ik[i]);
+              for (InstanceKey element : ik) {
+                system.newConstraint(p, element);
               }
             }
           }
         } else {
-          for (int i = 0; i < ik.length; i++) {
-            system.findOrCreateIndexForInstanceKey(ik[i]);
-            system.newSideEffect(getBuilder().new InstancePutFieldOperator(f, ik[i]), refKey);
+          for (InstanceKey element : ik) {
+            system.findOrCreateIndexForInstanceKey(element);
+            system.newSideEffect(getBuilder().new InstancePutFieldOperator(f, element), refKey);
           }
         }
       } else {
@@ -1087,8 +1084,8 @@ public abstract class SSAPropagationCallGraphBuilder extends PropagationCallGrap
       if (contentsAreInvariant(symbolTable, du, rval)) {
         system.recordImplicitPointsToSet(rvalKey);
         InstanceKey[] ik = getInvariantContents(rval);
-        for (int i = 0; i < ik.length; i++) {
-          system.newConstraint(fKey, ik[i]);
+        for (InstanceKey element : ik) {
+          system.newConstraint(fKey, element);
         }
       } else {
         system.newConstraint(fKey, assignOperator, rvalKey);
@@ -1337,8 +1334,8 @@ public abstract class SSAPropagationCallGraphBuilder extends PropagationCallGrap
             if (contentsAreInvariant(symbolTable, du, instruction.getUse(i))) {
               system.recordImplicitPointsToSet(use);
               InstanceKey[] ik = getInvariantContents(instruction.getUse(i));
-              for (int j = 0; j < ik.length; j++) {
-                system.newConstraint(dst, ik[j]);
+              for (InstanceKey element : ik) {
+                system.newConstraint(dst, element);
               }
             } else {
               system.newConstraint(dst, assignOperator, use);
@@ -1385,10 +1382,10 @@ public abstract class SSAPropagationCallGraphBuilder extends PropagationCallGrap
                 if (contentsAreInvariant(symbolTable, du, val)) {
                   system.recordImplicitPointsToSet(src);
                   InstanceKey[] ik = getInvariantContents(val);
-                  for (int j = 0; j < ik.length; j++) {
-                    boolean assignable = getClassHierarchy().isAssignableFrom(cls, ik[j].getConcreteType());
+                  for (InstanceKey element : ik) {
+                    boolean assignable = getClassHierarchy().isAssignableFrom(cls, element.getConcreteType());
                     if ((assignable && useFilter) || (!assignable && !useFilter)) {
-                      system.newConstraint(dst, ik[j]);
+                      system.newConstraint(dst, element);
                     }
                   }
                 } else {
@@ -1422,8 +1419,8 @@ public abstract class SSAPropagationCallGraphBuilder extends PropagationCallGrap
       if (contentsAreInvariant(symbolTable, du, src)) {
         system.recordImplicitPointsToSet(srcKey);
         InstanceKey[] ik = getInvariantContents(src);
-        for (int j = 0; j < ik.length; j++) {
-          system.newConstraint(dst, ik[j]);
+        for (InstanceKey element : ik) {
+          system.newConstraint(dst, element);
         }
       } else {
         system.newConstraint(dst, assignOperator, srcKey);
@@ -1648,8 +1645,8 @@ public abstract class SSAPropagationCallGraphBuilder extends PropagationCallGrap
         PointerKey formal = getTargetPointerKey(target, i);
         if (constParams != null && constParams[i] != null) {
           InstanceKey[] ik = constParams[i];
-          for (int j = 0; j < ik.length; j++) {
-              system.newConstraint(formal, ik[j]);
+          for (InstanceKey element : ik) {
+              system.newConstraint(formal, element);
           }
         } else {
           if (instruction.getUse(i) < 0) {
@@ -2331,8 +2328,8 @@ public abstract class SSAPropagationCallGraphBuilder extends PropagationCallGrap
     }
 
     if (ensureIndexes) {
-      for (int i = 0; i < result.length; i++) {
-        system.findOrCreateIndexForInstanceKey(result[i]);
+      for (InstanceKey element : result) {
+        system.findOrCreateIndexForInstanceKey(element);
       }
     }
 

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/cfa/ZeroXCFABuilder.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/cfa/ZeroXCFABuilder.java
@@ -76,8 +76,8 @@ public class ZeroXCFABuilder extends SSAPropagationCallGraphBuilder {
       throw new IllegalArgumentException("options is null");
     }
     Util.addDefaultSelectors(options, cha);
-    for (int i = 0; i < xmlFiles.length; i++) {
-      Util.addBypassLogic(options, scope, cl, xmlFiles[i], cha);
+    for (String xmlFile : xmlFiles) {
+      Util.addBypassLogic(options, scope, cl, xmlFile, cha);
     }
 
     return new ZeroXCFABuilder(cha, options, cache, null, null, instancePolicy);

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/cfa/ZeroXInstanceKeys.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/cfa/ZeroXInstanceKeys.java
@@ -214,8 +214,7 @@ public class ZeroXInstanceKeys implements InstanceKeyFactory {
     if (s == null) {
       Map<IClass, Integer> count = countAllocsByType(node);
       HashSet<IClass> smushees = HashSetFactory.make(5);
-      for (Iterator<Map.Entry<IClass, Integer>> it = count.entrySet().iterator(); it.hasNext();) {
-        Map.Entry<IClass, Integer> e = it.next();
+      for (Map.Entry<IClass, Integer> e : count.entrySet()) {
         Integer i = e.getValue();
         if (i.intValue() > SMUSH_LIMIT) {
           smushees.add(e.getKey());
@@ -336,8 +335,7 @@ public class ZeroXInstanceKeys implements InstanceKeyFactory {
       if (c.getReference().equals(TypeReference.JavaLangObject)) {
         return true;
       } else {
-        for (Iterator<IField> it = c.getDeclaredInstanceFields().iterator(); it.hasNext();) {
-          IField f = it.next();
+        for (IField f : c.getDeclaredInstanceFields()) {
           if (f.getReference().getFieldType().isReferenceType()) {
             return false;
           }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/cfa/ZeroXInstanceKeys.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/cfa/ZeroXInstanceKeys.java
@@ -232,8 +232,8 @@ public class ZeroXInstanceKeys implements InstanceKeyFactory {
    */
   private Map<IClass, Integer> countAllocsByType(CGNode node) {
     Map<IClass, Integer> count = HashMapFactory.make();
-    for (Iterator it = contextInterpreter.iterateNewSites(node); it.hasNext();) {
-      NewSiteReference n = (NewSiteReference) it.next();
+    for (Iterator<NewSiteReference> it = contextInterpreter.iterateNewSites(node); it.hasNext();) {
+      NewSiteReference n = it.next();
       IClass alloc = cha.lookupClass(n.getDeclaredType());
       if (alloc != null) {
         Integer old = count.get(alloc);

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/AbstractRTABuilder.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/AbstractRTABuilder.java
@@ -349,8 +349,8 @@ public abstract class AbstractRTABuilder extends PropagationCallGraphBuilder {
 
     FakeRootMethod m = (FakeRootMethod) getCallGraph().getFakeRootNode().getMethod();
 
-    for (int i = 0; i < PRE_ALLOC.length; i++) {
-      SSANewInstruction n = m.addAllocation(PRE_ALLOC[i]);
+    for (TypeReference element : PRE_ALLOC) {
+      SSANewInstruction n = m.addAllocation(element);
       // visit now to ensure java.lang.Object is visited first
       visitNew(getCallGraph().getFakeRootNode(), n.getNewSite());
     }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/AbstractRTABuilder.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/AbstractRTABuilder.java
@@ -136,8 +136,8 @@ public abstract class AbstractRTABuilder extends PropagationCallGraphBuilder {
    * Add a constraint for each allocate
    */
   private void addNewConstraints(CGNode node) {
-    for (Iterator it = getRTAContextInterpreter().iterateNewSites(node); it.hasNext();) {
-      NewSiteReference n = (NewSiteReference) it.next();
+    for (Iterator<NewSiteReference> it = getRTAContextInterpreter().iterateNewSites(node); it.hasNext();) {
+      NewSiteReference n = it.next();
       visitNew(node, n);
     }
   }
@@ -146,8 +146,8 @@ public abstract class AbstractRTABuilder extends PropagationCallGraphBuilder {
    * Add a constraint for each invoke
    */
   private void addCallConstraints(CGNode node) {
-    for (Iterator it = getRTAContextInterpreter().iterateCallSites(node); it.hasNext();) {
-      CallSiteReference c = (CallSiteReference) it.next();
+    for (Iterator<CallSiteReference> it = getRTAContextInterpreter().iterateCallSites(node); it.hasNext();) {
+      CallSiteReference c = it.next();
       visitInvoke(node, c);
     }
   }
@@ -156,12 +156,12 @@ public abstract class AbstractRTABuilder extends PropagationCallGraphBuilder {
    * Handle accesses to static fields
    */
   private void addFieldConstraints(CGNode node) {
-    for (Iterator it = getRTAContextInterpreter().iterateFieldsRead(node); it.hasNext();) {
-      FieldReference f = (FieldReference) it.next();
+    for (Iterator<FieldReference> it = getRTAContextInterpreter().iterateFieldsRead(node); it.hasNext();) {
+      FieldReference f = it.next();
       processFieldAccess(f);
     }
-    for (Iterator it = getRTAContextInterpreter().iterateFieldsWritten(node); it.hasNext();) {
-      FieldReference f = (FieldReference) it.next();
+    for (Iterator<FieldReference> it = getRTAContextInterpreter().iterateFieldsWritten(node); it.hasNext();) {
+      FieldReference f = it.next();
       processFieldAccess(f);
     }
   }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/BasicRTABuilder.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/BasicRTABuilder.java
@@ -55,8 +55,8 @@ public class BasicRTABuilder extends AbstractRTABuilder {
     // set up the selector map to record each method that class implements
     registerImplementedMethods(klass, iKey);
 
-    for (Iterator ifaces = klass.getAllImplementedInterfaces().iterator(); ifaces.hasNext();) {
-      IClass c = (IClass) ifaces.next();
+    for (Iterator<IClass> ifaces = klass.getAllImplementedInterfaces().iterator(); ifaces.hasNext();) {
+      IClass c = ifaces.next();
       registerImplementedMethods(c, iKey);
     }
     klass = klass.getSuperclass();
@@ -73,8 +73,8 @@ public class BasicRTABuilder extends AbstractRTABuilder {
     if (DEBUG) {
       System.err.println(("registerImplementedMethods: " + declarer + " " + iKey));
     }
-    for (Iterator it = declarer.getDeclaredMethods().iterator(); it.hasNext();) {
-      IMethod M = (IMethod) it.next();
+    for (Iterator<IMethod> it = declarer.getDeclaredMethods().iterator(); it.hasNext();) {
+      IMethod M = it.next();
       Selector selector = M.getReference().getSelector();
       PointerKey sKey = getKeyForSelector(selector);
       if (DEBUG) {

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/BasicRTABuilder.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/BasicRTABuilder.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package com.ibm.wala.ipa.callgraph.propagation.rta;
 
-import java.util.Iterator;
-
 import com.ibm.wala.analysis.reflection.CloneInterpreter;
 import com.ibm.wala.classLoader.CallSiteReference;
 import com.ibm.wala.classLoader.IClass;
@@ -55,8 +53,7 @@ public class BasicRTABuilder extends AbstractRTABuilder {
     // set up the selector map to record each method that class implements
     registerImplementedMethods(klass, iKey);
 
-    for (Iterator<IClass> ifaces = klass.getAllImplementedInterfaces().iterator(); ifaces.hasNext();) {
-      IClass c = ifaces.next();
+    for (IClass c : klass.getAllImplementedInterfaces()) {
       registerImplementedMethods(c, iKey);
     }
     klass = klass.getSuperclass();
@@ -73,8 +70,7 @@ public class BasicRTABuilder extends AbstractRTABuilder {
     if (DEBUG) {
       System.err.println(("registerImplementedMethods: " + declarer + " " + iKey));
     }
-    for (Iterator<IMethod> it = declarer.getDeclaredMethods().iterator(); it.hasNext();) {
-      IMethod M = it.next();
+    for (IMethod M : declarer.getDeclaredMethods()) {
       Selector selector = M.getReference().getSelector();
       PointerKey sKey = getKeyForSelector(selector);
       if (DEBUG) {

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/DelegatingExplicitCallGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/DelegatingExplicitCallGraph.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package com.ibm.wala.ipa.callgraph.propagation.rta;
 
-import java.util.Iterator;
 import java.util.Set;
 
 import com.ibm.wala.classLoader.CallSiteReference;
@@ -73,8 +72,7 @@ public class DelegatingExplicitCallGraph extends ExplicitCallGraph {
     @Override
     public MutableSharedBitVectorIntSet getAllTargetNumbers() {
       MutableSharedBitVectorIntSet result = new MutableSharedBitVectorIntSet(super.getAllTargetNumbers());
-      for (Iterator<Object> it = targets.iterator(); it.hasNext();) {
-        Object n = it.next();
+      for (Object n : targets) {
         if (n instanceof CallSite) {
           ExplicitNode delegate = (ExplicitNode) ((CallSite) n).getNode();
           IntSet s = DelegatingExplicitCallGraph.this.getPossibleTargetNumbers(delegate, ((CallSite) n).getSite());
@@ -119,8 +117,7 @@ public class DelegatingExplicitCallGraph extends ExplicitCallGraph {
       if (super.getAllTargetNumbers().contains(y)) {
         return true;
       } else {
-        for (Iterator<Object> it = targets.iterator(); it.hasNext();) {
-          Object n = it.next();
+        for (Object n : targets) {
           if (n instanceof CallSite) {
             ExplicitNode delegate = (ExplicitNode) ((CallSite) n).getNode();
             IntSet s = DelegatingExplicitCallGraph.this.getPossibleTargetNumbers(delegate,((CallSite) n).getSite());

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/DelegatingExplicitCallGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/DelegatingExplicitCallGraph.java
@@ -73,7 +73,7 @@ public class DelegatingExplicitCallGraph extends ExplicitCallGraph {
     @Override
     public MutableSharedBitVectorIntSet getAllTargetNumbers() {
       MutableSharedBitVectorIntSet result = new MutableSharedBitVectorIntSet(super.getAllTargetNumbers());
-      for (Iterator it = targets.iterator(); it.hasNext();) {
+      for (Iterator<Object> it = targets.iterator(); it.hasNext();) {
         Object n = it.next();
         if (n instanceof CallSite) {
           ExplicitNode delegate = (ExplicitNode) ((CallSite) n).getNode();
@@ -119,7 +119,7 @@ public class DelegatingExplicitCallGraph extends ExplicitCallGraph {
       if (super.getAllTargetNumbers().contains(y)) {
         return true;
       } else {
-        for (Iterator it = targets.iterator(); it.hasNext();) {
+        for (Iterator<Object> it = targets.iterator(); it.hasNext();) {
           Object n = it.next();
           if (n instanceof CallSite) {
             ExplicitNode delegate = (ExplicitNode) ((CallSite) n).getNode();

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/TypeBasedHeapModel.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/TypeBasedHeapModel.java
@@ -89,12 +89,10 @@ public class TypeBasedHeapModel implements HeapModel {
     if (pKeys == null) {
       pKeys = HashMapFactory.make();
     }
-    for (Iterator<IClass> it = klasses.iterator(); it.hasNext();) {
-      IClass klass = it.next();
+    for (IClass klass : klasses) {
       pKeys.putAll(computePointerKeys(klass));
     }
-    for (Iterator<CGNode> it = cg.iterator(); it.hasNext();) {
-      CGNode node = it.next();
+    for (CGNode node : cg) {
       initPKeysForNode(node);
     }
   }
@@ -159,8 +157,7 @@ public class TypeBasedHeapModel implements HeapModel {
         result.put(p, p);
       }
     } else {
-      for (Iterator<IField> it = klass.getAllFields().iterator(); it.hasNext();) {
-        IField f = it.next();
+      for (IField f : klass.getAllFields()) {
         if (!f.getFieldTypeReference().isPrimitiveType()) {
           if (f.isStatic()) {
             PointerKey p = pointerKeys.getPointerKeyForStaticField(f);

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/TypeBasedHeapModel.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/TypeBasedHeapModel.java
@@ -93,8 +93,8 @@ public class TypeBasedHeapModel implements HeapModel {
       IClass klass = it.next();
       pKeys.putAll(computePointerKeys(klass));
     }
-    for (Iterator it = cg.iterator(); it.hasNext();) {
-      CGNode node = (CGNode) it.next();
+    for (Iterator<CGNode> it = cg.iterator(); it.hasNext();) {
+      CGNode node = it.next();
       initPKeysForNode(node);
     }
   }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/TypeBasedPointerAnalysis.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/TypeBasedPointerAnalysis.java
@@ -139,10 +139,10 @@ public class TypeBasedPointerAnalysis extends AbstractPointerAnalysis {
     return result;
   }
 
-  private OrdinalSet<InstanceKey> toOrdinalInstanceKeySet(Collection c) {
+  private OrdinalSet<InstanceKey> toOrdinalInstanceKeySet(Collection<IClass> c) {
     BimodalMutableIntSet s = new BimodalMutableIntSet();
-    for (Iterator it = c.iterator(); it.hasNext();) {
-      IClass klass = (IClass) it.next();
+    for (Iterator<IClass> it = c.iterator(); it.hasNext();) {
+      IClass klass = it.next();
       int index = getInstanceKeyMapping().add(new ConcreteTypeKey(klass));
       s.add(index);
     }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/TypeBasedPointerAnalysis.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/TypeBasedPointerAnalysis.java
@@ -11,7 +11,6 @@
 package com.ibm.wala.ipa.callgraph.propagation.rta;
 
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.Map;
 
 import com.ibm.wala.classLoader.IClass;
@@ -71,8 +70,7 @@ public class TypeBasedPointerAnalysis extends AbstractPointerAnalysis {
       throw new IllegalArgumentException("null c");
     }
     MutableMapping<InstanceKey> result = MutableMapping.make();
-    for (Iterator<IClass> it = c.iterator(); it.hasNext();) {
-      IClass klass = it.next();
+    for (IClass klass : c) {
       if (!klass.isAbstract() && !klass.isInterface()) {
         result.add(new ConcreteTypeKey(klass));
       }
@@ -141,8 +139,7 @@ public class TypeBasedPointerAnalysis extends AbstractPointerAnalysis {
 
   private OrdinalSet<InstanceKey> toOrdinalInstanceKeySet(Collection<IClass> c) {
     BimodalMutableIntSet s = new BimodalMutableIntSet();
-    for (Iterator<IClass> it = c.iterator(); it.hasNext();) {
-      IClass klass = it.next();
+    for (IClass klass : c) {
       int index = getInstanceKeyMapping().add(new ConcreteTypeKey(klass));
       s.add(index);
     }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/cfg/AbstractInterproceduralCFG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/cfg/AbstractInterproceduralCFG.java
@@ -159,8 +159,7 @@ public abstract class AbstractInterproceduralCFG<T extends ISSABasicBlock> imple
         addNodeForEachBasicBlock(cfg, n);
         SSAInstruction[] instrs = cfg.getInstructions();
         // create edges for node n.
-        for (Iterator<T> bbs = cfg.iterator(); bbs.hasNext();) {
-          T bb = bbs.next();
+        for (T bb : cfg) {
           if (bb != cfg.entry())
             addEdgesToNonEntryBlock(n, cfg, instrs, bb);
         }
@@ -352,8 +351,7 @@ public abstract class AbstractInterproceduralCFG<T extends ISSABasicBlock> imple
    */
   @SuppressWarnings("unused")
   private void addNodeForEachBasicBlock(ControlFlowGraph<? extends SSAInstruction, ? extends T> cfg, CGNode N) {
-    for (Iterator<? extends T> bbs = cfg.iterator(); bbs.hasNext();) {
-      T bb = bbs.next();
+    for (T bb : cfg) {
       if (DEBUG_LEVEL > 1) {
         System.err.println("IPCFG Add basic block " + bb);
       }
@@ -456,8 +454,7 @@ public abstract class AbstractInterproceduralCFG<T extends ISSABasicBlock> imple
   private void addEdgesToCallees(CGNode n) {
     ControlFlowGraph<SSAInstruction, T> cfg = getCFG(n);
     if (cfg != null) {
-      for (Iterator<T> bbs = cfg.iterator(); bbs.hasNext();) {
-        T bb = bbs.next();
+      for (T bb : cfg) {
         BasicBlockInContext<T> block = new BasicBlockInContext<T>(n, bb);
         if (hasCall(block)) {
           addCalleeEdgesForCall(n, block);
@@ -499,8 +496,7 @@ public abstract class AbstractInterproceduralCFG<T extends ISSABasicBlock> imple
         System.err.println("got Site: " + site);
       }
       boolean irrelevantTargets = false;
-      for (Iterator<CGNode> ts = cg.getPossibleTargets(n, site).iterator(); ts.hasNext();) {
-        CGNode tn = ts.next();
+      for (CGNode tn : cg.getPossibleTargets(n, site)) {
         if (!relevant.test(tn)) {
           if (DEBUG_LEVEL > 1) {
             System.err.println("Irrelevant target: " + tn);

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/cfg/AbstractInterproceduralCFG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/cfg/AbstractInterproceduralCFG.java
@@ -290,8 +290,8 @@ public abstract class AbstractInterproceduralCFG<T extends ISSABasicBlock> imple
       System.err.println("addInterproceduralEdgesForEntryAndExitBlocks " + n);
     }
 
-    for (Iterator callers = cg.getPredNodes(n); callers.hasNext();) {
-      CGNode caller = (CGNode) callers.next();
+    for (Iterator<CGNode> callers = cg.getPredNodes(n); callers.hasNext();) {
+      CGNode caller = callers.next();
       if (DEBUG_LEVEL > 1) {
         System.err.println("got caller " + caller);
       }
@@ -499,8 +499,8 @@ public abstract class AbstractInterproceduralCFG<T extends ISSABasicBlock> imple
         System.err.println("got Site: " + site);
       }
       boolean irrelevantTargets = false;
-      for (Iterator ts = cg.getPossibleTargets(n, site).iterator(); ts.hasNext();) {
-        CGNode tn = (CGNode) ts.next();
+      for (Iterator<CGNode> ts = cg.getPossibleTargets(n, site).iterator(); ts.hasNext();) {
+        CGNode tn = ts.next();
         if (!relevant.test(tn)) {
           if (DEBUG_LEVEL > 1) {
             System.err.println("Irrelevant target: " + tn);

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/cfg/PrunedCFG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/cfg/PrunedCFG.java
@@ -215,8 +215,7 @@ public class PrunedCFG<I, T extends IBasicBlock<I>> extends AbstractNumberedGrap
     @Override
     public int getMaxNumber() {
       int max = -1;
-      for (Iterator<? extends T> NS = nodes.iterator(); NS.hasNext();) {
-        T N = NS.next();
+      for (T N : nodes) {
         if (subset.contains(N) && getNumber(N) > max) {
           max = getNumber(N);
         }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/cfg/PrunedCFG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/cfg/PrunedCFG.java
@@ -150,7 +150,7 @@ public class PrunedCFG<I, T extends IBasicBlock<I>> extends AbstractNumberedGrap
 
     @Override
     public boolean hasEdge(T src, T dst) {
-      for (Iterator EE = getSuccNodes(src); EE.hasNext();) {
+      for (Iterator<T> EE = getSuccNodes(src); EE.hasNext();) {
         if (EE.next().equals(dst)) {
           return true;
         }
@@ -225,7 +225,7 @@ public class PrunedCFG<I, T extends IBasicBlock<I>> extends AbstractNumberedGrap
       return max;
     }
 
-    private Iterator<T> filterNodes(Iterator nodeIterator) {
+    private Iterator<T> filterNodes(Iterator<T> nodeIterator) {
       return new FilterIterator<T>(nodeIterator, new Predicate() {
         @Override public boolean test(Object o) {
           return subset.contains(o);

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/cha/ClassHierarchy.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/cha/ClassHierarchy.java
@@ -307,7 +307,7 @@ public class ClassHierarchy implements IClassHierarchy {
       System.err.println(("Attempt to add class " + klass));
     }
     Set<IClass> loadedSuperclasses;
-    Collection loadedSuperInterfaces;
+    Collection<IClass> loadedSuperInterfaces;
     try {
       loadedSuperclasses = computeSuperclasses(klass);
       loadedSuperInterfaces = klass.getAllImplementedInterfaces();
@@ -352,8 +352,8 @@ public class ClassHierarchy implements IClassHierarchy {
     }
 
     if (loadedSuperInterfaces != null) {
-      for (Iterator it3 = loadedSuperInterfaces.iterator(); it3.hasNext();) {
-        final IClass iface = (IClass) it3.next();
+      for (Iterator<IClass> it3 = loadedSuperInterfaces.iterator(); it3.hasNext();) {
+        final IClass iface = it3.next();
         try {
           // make sure we'll be able to load the interface!
           computeSuperclasses(iface);
@@ -454,13 +454,13 @@ public class ClassHierarchy implements IClassHierarchy {
     }
     if (declaredClass.isInterface()) {
       HashSet<IMethod> result = HashSetFactory.make(3);
-      Set impls = implementors.get(declaredClass);
+      Set<IClass> impls = implementors.get(declaredClass);
       if (impls == null) {
         // give up and return no receivers
         return Collections.emptySet();
       }
-      for (Iterator it = impls.iterator(); it.hasNext();) {
-        IClass klass = (IClass) it.next();
+      for (Iterator<IClass> it = impls.iterator(); it.hasNext();) {
+        IClass klass = it.next();
         if (!klass.isInterface() && !klass.isAbstract()) {
           result.addAll(computeTargetsNotInterface(ref, klass));
         }
@@ -1014,8 +1014,8 @@ public class ClassHierarchy implements IClassHierarchy {
     if (subTypeRefsOfError == null) {
       computeSubClasses(TypeReference.JavaLangError);
       subTypeRefsOfError = HashSetFactory.make(subclassesOfError.size());
-      for (Iterator it = subclassesOfError.iterator(); it.hasNext();) {
-        IClass klass = (IClass) it.next();
+      for (Iterator<IClass> it = subclassesOfError.iterator(); it.hasNext();) {
+        IClass klass = it.next();
         subTypeRefsOfError.add(klass.getReference());
       }
     }
@@ -1032,8 +1032,8 @@ public class ClassHierarchy implements IClassHierarchy {
     if (runtimeExceptionTypeRefs == null) {
       computeSubClasses(TypeReference.JavaLangRuntimeException);
       runtimeExceptionTypeRefs = HashSetFactory.make(runtimeExceptionClasses.size());
-      for (Iterator it = runtimeExceptionClasses.iterator(); it.hasNext();) {
-        IClass klass = (IClass) it.next();
+      for (Iterator<IClass> it = runtimeExceptionClasses.iterator(); it.hasNext();) {
+        IClass klass = it.next();
         runtimeExceptionTypeRefs.add(klass.getReference());
       }
     }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/cha/ClassHierarchy.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/cha/ClassHierarchy.java
@@ -352,8 +352,7 @@ public class ClassHierarchy implements IClassHierarchy {
     }
 
     if (loadedSuperInterfaces != null) {
-      for (Iterator<IClass> it3 = loadedSuperInterfaces.iterator(); it3.hasNext();) {
-        final IClass iface = it3.next();
+      for (IClass iface : loadedSuperInterfaces) {
         try {
           // make sure we'll be able to load the interface!
           computeSuperclasses(iface);
@@ -459,8 +458,7 @@ public class ClassHierarchy implements IClassHierarchy {
         // give up and return no receivers
         return Collections.emptySet();
       }
-      for (Iterator<IClass> it = impls.iterator(); it.hasNext();) {
-        IClass klass = it.next();
+      for (IClass klass : impls) {
         if (!klass.isInterface() && !klass.isAbstract()) {
           result.addAll(computeTargetsNotInterface(ref, klass));
         }
@@ -663,8 +661,7 @@ public class ClassHierarchy implements IClassHierarchy {
 
   private void visitForNumbering(Node N) {
     N.left = nextNumber++;
-    for (Iterator<Node> it = N.children.iterator(); it.hasNext();) {
-      Node C = it.next();
+    for (Node C : N.children) {
       visitForNumbering(C);
     }
     N.right = nextNumber++;
@@ -1014,8 +1011,7 @@ public class ClassHierarchy implements IClassHierarchy {
     if (subTypeRefsOfError == null) {
       computeSubClasses(TypeReference.JavaLangError);
       subTypeRefsOfError = HashSetFactory.make(subclassesOfError.size());
-      for (Iterator<IClass> it = subclassesOfError.iterator(); it.hasNext();) {
-        IClass klass = it.next();
+      for (IClass klass : subclassesOfError) {
         subTypeRefsOfError.add(klass.getReference());
       }
     }
@@ -1032,8 +1028,7 @@ public class ClassHierarchy implements IClassHierarchy {
     if (runtimeExceptionTypeRefs == null) {
       computeSubClasses(TypeReference.JavaLangRuntimeException);
       runtimeExceptionTypeRefs = HashSetFactory.make(runtimeExceptionClasses.size());
-      for (Iterator<IClass> it = runtimeExceptionClasses.iterator(); it.hasNext();) {
-        IClass klass = it.next();
+      for (IClass klass : runtimeExceptionClasses) {
         runtimeExceptionTypeRefs.add(klass.getReference());
       }
     }
@@ -1109,9 +1104,9 @@ public class ClassHierarchy implements IClassHierarchy {
 
   @Override
   public IClassLoader getLoader(ClassLoaderReference loaderRef) {
-    for (int i = 0; i < loaders.length; i++) {
-      if (loaders[i].getReference().equals(loaderRef)) {
-        return loaders[i];
+    for (IClassLoader loader : loaders) {
+      if (loader.getReference().equals(loaderRef)) {
+        return loader;
       }
     }
     Assertions.UNREACHABLE();

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/cha/ClassHierarchyStats.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/cha/ClassHierarchyStats.java
@@ -25,10 +25,10 @@ public class ClassHierarchyStats {
       throw new IllegalArgumentException("cha cannot be null");
     }
     IClassLoader[] loaders = cha.getLoaders();
-    for (int i = 0; i < loaders.length; i++) {
-      System.out.println("loader: " + loaders[i]);
-      System.out.println("  classes: " + loaders[i].getNumberOfClasses());
-      System.out.println("  methods: " + loaders[i].getNumberOfMethods());
+    for (IClassLoader loader : loaders) {
+      System.out.println("loader: " + loader);
+      System.out.println("  classes: " + loader.getNumberOfClasses());
+      System.out.println("  methods: " + loader.getNumberOfMethods());
     }
   }
 }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/PDG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/PDG.java
@@ -293,8 +293,7 @@ public class PDG<T extends InstanceKey> implements NumberedGraph<Statement> {
       if (src != null) {
         for (Iterator<? extends ISSABasicBlock> succ = cdg.getSuccNodes(bb); succ.hasNext();) {
           ISSABasicBlock bb2 = succ.next();
-          for (Iterator<SSAInstruction> it2 = bb2.iterator(); it2.hasNext();) {
-            SSAInstruction st = it2.next();
+          for (SSAInstruction st : bb2) {
             if (st != null) {
               Statement dest = ssaInstruction2Statement(st, ir, instructionIndices);
               assert src != null;
@@ -437,8 +436,7 @@ public class PDG<T extends InstanceKey> implements NumberedGraph<Statement> {
       }
     }
 
-    for (Iterator<? extends Statement> it = iterator(); it.hasNext();) {
-      Statement s = it.next();
+    for (Statement s : this) {
       switch (s.getKind()) {
       case NORMAL:
       case CATCH:

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/SDG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/SDG.java
@@ -180,8 +180,8 @@ public class SDG<T extends InstanceKey> extends AbstractNumberedGraph<Statement>
     if (!statementsAdded.contains(node)) {
       statementsAdded.add(node);
       PDG<?> pdg = getPDG(node);
-      for (Iterator<? extends Statement> it = pdg.iterator(); it.hasNext();) {
-        addNode(it.next());
+      for (Statement statement : pdg) {
+        addNode(statement);
       }
     }
   }
@@ -190,8 +190,7 @@ public class SDG<T extends InstanceKey> extends AbstractNumberedGraph<Statement>
    * force computation of all PDGs in the SDG
    */
   private void computeAllPDGs() {
-    for (Iterator<? extends CGNode> it = cg.iterator(); it.hasNext();) {
-      CGNode n = it.next();
+    for (CGNode n : cg) {
       getPDG(n);
     }
   }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/BypassSyntheticClassLoader.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/BypassSyntheticClassLoader.java
@@ -188,8 +188,7 @@ public class BypassSyntheticClassLoader implements IClassLoader {
     if (toRemove == null) {
       throw new IllegalArgumentException("toRemove is null");
     }
-    for (Iterator<IClass> it = toRemove.iterator(); it.hasNext();) {
-      IClass klass = it.next();
+    for (IClass klass : toRemove) {
       syntheticClasses.remove(klass.getName());
     }
   }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/ReflectionSummary.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/ReflectionSummary.java
@@ -51,14 +51,14 @@ public class ReflectionSummary {
     if (cha == null) {
       throw new IllegalArgumentException("null cha");
     }
-    Set S = map.get(new Integer(bcIndex));
+    Set<TypeReference> S = map.get(new Integer(bcIndex));
     if (S == null) {
       return null;
     } else {
       PointType[] p = new PointType[S.size()];
-      Iterator it = S.iterator();
+      Iterator<TypeReference> it = S.iterator();
       for (int i = 0; i < p.length; i++) {
-        TypeReference T = (TypeReference) it.next();
+        TypeReference T = it.next();
         IClass klass = cha.lookupClass(T);
         assert klass != null : "null type for " + T;
         p[i] = new PointType(klass);

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/SyntheticIR.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/SyntheticIR.java
@@ -80,9 +80,8 @@ public class SyntheticIR extends IR {
     SymbolTable symbolTable = new SymbolTable(method.getNumberOfParameters());
 
     // simulate allocation of value numbers
-    for (int i = 0; i < instructions.length; i++) {
-      if (instructions[i] != null) {
-        SSAInstruction s = instructions[i];
+    for (SSAInstruction s : instructions) {
+      if (s != null) {
         updateForInstruction(constants, symbolTable, s);
       }
     }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/XMLMethodSummaryReader.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/XMLMethodSummaryReader.java
@@ -417,8 +417,8 @@ public class XMLMethodSummaryReader implements BytecodeConstants {
       Assertions.productionAssertion(governingMethod.getReturnType() != null);
       if (governingMethod.getReturnType().isReferenceType()) {
         SSAInstruction[] statements = governingMethod.getStatements();
-        for (int i = 0; i < statements.length; i++) {
-          if (statements[i] instanceof SSAReturnInstruction) {
+        for (SSAInstruction statement : statements) {
+          if (statement instanceof SSAReturnInstruction) {
             return;
           }
         }

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/AuxiliaryCache.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/AuxiliaryCache.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.ipa.callgraph.Context;
@@ -69,8 +70,8 @@ public class AuxiliaryCache implements IAuxiliaryCache {
       Map.Entry<Pair<IMethod, Context>, Map<SSAOptions, Object>> e = it.next();
       Map<SSAOptions, Object> m = e.getValue();
       HashSet<Object> toRemove = HashSetFactory.make();
-      for (Iterator it2 = m.entrySet().iterator(); it2.hasNext();) {
-        Map.Entry e2 = (Map.Entry) it2.next();
+      for (Iterator<Entry<SSAOptions, Object>> it2 = m.entrySet().iterator(); it2.hasNext();) {
+        Map.Entry<SSAOptions, Object> e2 = it2.next();
         Object key = e2.getKey();
         Object val = e2.getValue();
         if (CacheReference.get(val) == null) {

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/AuxiliaryCache.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/AuxiliaryCache.java
@@ -12,7 +12,6 @@ package com.ibm.wala.ssa;
 
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -65,26 +64,23 @@ public class AuxiliaryCache implements IAuxiliaryCache {
     dictionary = HashMapFactory.make();
     nItems = 0;
 
-    for (Iterator<Map.Entry<Pair<IMethod, Context>, Map<SSAOptions, Object>>> it = oldDictionary.entrySet().iterator(); it
-        .hasNext();) {
-      Map.Entry<Pair<IMethod, Context>, Map<SSAOptions, Object>> e = it.next();
-      Map<SSAOptions, Object> m = e.getValue();
-      HashSet<Object> toRemove = HashSetFactory.make();
-      for (Iterator<Entry<SSAOptions, Object>> it2 = m.entrySet().iterator(); it2.hasNext();) {
-        Map.Entry<SSAOptions, Object> e2 = it2.next();
-        Object key = e2.getKey();
-        Object val = e2.getValue();
-        if (CacheReference.get(val) == null) {
-          toRemove.add(key);
-        }
-      }
-      for (Iterator<Object> it2 = toRemove.iterator(); it2.hasNext();) {
-        m.remove(it2.next());
-      }
-      if (m.size() > 0) {
-        dictionary.put(e.getKey(), m);
-      }
+    for (Entry<Pair<IMethod, Context>, Map<SSAOptions, Object>> e : oldDictionary.entrySet()) {
+   Map<SSAOptions, Object> m = e.getValue();
+   HashSet<Object> toRemove = HashSetFactory.make();
+   for (Entry<SSAOptions, Object> e2 : m.entrySet()) {
+    Object key = e2.getKey();
+    Object val = e2.getValue();
+    if (CacheReference.get(val) == null) {
+      toRemove.add(key);
     }
+   }
+   for (Object object : toRemove) {
+    m.remove(object);
+   }
+   if (m.size() > 0) {
+    dictionary.put(e.getKey(), m);
+   }
+  }
   }
 
   /* 

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/DefUse.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/DefUse.java
@@ -63,9 +63,9 @@ public class DefUse {
     if (DEBUG) {
       System.err.println(("DefUse: defs.length " + defs.length));
     }
-    Iterator it = allInstructions.iterator();
+    Iterator<SSAInstruction> it = allInstructions.iterator();
     for (int i = 0; i < allInstructions.size(); i++) {
-      SSAInstruction s = (SSAInstruction) it.next();
+      SSAInstruction s = it.next();
       if (s == null) {
         continue;
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/IR.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/IR.java
@@ -699,8 +699,8 @@ public abstract class IR implements IRView {
     if (instructions == null)
       return true;
 
-    for (int i = 0; i < instructions.length; i++)
-      if (instructions[i] != null)
+    for (SSAInstruction instruction : instructions)
+      if (instruction != null)
         return false;
 
     return true;

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/IR.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/IR.java
@@ -167,8 +167,8 @@ public abstract class IR implements IRView {
         result.append(")");
       }
       result.append("\n");
-      for (Iterator it = bb.iteratePhis(); it.hasNext();) {
-        SSAPhiInstruction phi = (SSAPhiInstruction) it.next();
+      for (Iterator<SSAPhiInstruction> it = bb.iteratePhis(); it.hasNext();) {
+        SSAPhiInstruction phi = it.next();
         if (phi != null) {
           result.append("           " + phi.toString(symbolTable)).append("\n");
         }
@@ -234,8 +234,8 @@ public abstract class IR implements IRView {
           }
         }
       }
-      for (Iterator it = bb.iteratePis(); it.hasNext();) {
-        SSAPiInstruction pi = (SSAPiInstruction) it.next();
+      for (Iterator<SSAPiInstruction> it = bb.iteratePis(); it.hasNext();) {
+        SSAPiInstruction pi = it.next();
         if (pi != null) {
           result.append("           " + pi.toString(symbolTable)).append("\n");
         }
@@ -464,8 +464,8 @@ public abstract class IR implements IRView {
    * visit each normal (non-phi, non-pi, non-catch) instruction in this IR
    */
   public void visitNormalInstructions(SSAInstruction.Visitor v) {
-    for (Iterator i = iterateNormalInstructions(); i.hasNext();) {
-      ((SSAInstruction) i.next()).visit(v);
+    for (Iterator<SSAInstruction> i = iterateNormalInstructions(); i.hasNext();) {
+      i.next().visit(v);
     }
   }
 
@@ -473,8 +473,8 @@ public abstract class IR implements IRView {
    * visit each instruction in this IR
    */
   public void visitAllInstructions(SSAInstruction.Visitor v) {
-    for (Iterator i = iterateAllInstructions(); i.hasNext();) {
-      ((SSAInstruction) i.next()).visit(v);
+    for (Iterator<SSAInstruction> i = iterateAllInstructions(); i.hasNext();) {
+      i.next().visit(v);
     }
   }
 

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/SSABuilder.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/SSABuilder.java
@@ -965,8 +965,8 @@ public class SSABuilder extends AbstractIntStackMachine {
      * Finish populating the map of local variable information
      */
     private void finishLocalMap(SSABuilder builder) {
-      for (Iterator it = shrikeCFG.iterator(); it.hasNext();) {
-        ShrikeCFG.BasicBlock bb = (ShrikeCFG.BasicBlock) it.next();
+      for (Iterator<BasicBlock> it = shrikeCFG.iterator(); it.hasNext();) {
+        ShrikeCFG.BasicBlock bb = it.next();
         MachineState S = builder.getIn(bb);
         int number = bb.getNumber();
         block2LocalState[number] = S.getLocals();

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/SSABuilder.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/SSABuilder.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package com.ibm.wala.ssa;
 
-import java.util.Iterator;
-
 import com.ibm.wala.analysis.stackMachine.AbstractIntStackMachine;
 import com.ibm.wala.cfg.IBasicBlock;
 import com.ibm.wala.cfg.ShrikeCFG;
@@ -144,9 +142,9 @@ public class SSABuilder extends AbstractIntStackMachine {
       }
 
       if (allTheSame(rhs)) {
-        for (int i = 0; i < rhs.length; i++) {
-          if (rhs[i] != TOP) {
-            return rhs[i];
+        for (int rh : rhs) {
+          if (rh != TOP) {
+            return rh;
           }
         }
         // didn't find anything but TOP
@@ -178,9 +176,9 @@ public class SSABuilder extends AbstractIntStackMachine {
     @Override
     public int meetLocal(int n, int[] rhs, BasicBlock bb) {
       if (allTheSame(rhs)) {
-        for (int i = 0; i < rhs.length; i++) {
-          if (rhs[i] != TOP) {
-            return rhs[i];
+        for (int rh : rhs) {
+          if (rh != TOP) {
+            return rh;
           }
         }
         // didn't find anything but TOP
@@ -782,8 +780,8 @@ public class SSABuilder extends AbstractIntStackMachine {
       }
 
       private void doIndirectReads(int[] locals) {
-        for(int i = 0; i < locals.length; i++) {
-          ssaIndirections.setUse(getCurrentInstructionIndex(), new ShrikeLocalName(locals[i]), workingState.getLocal(locals[i]));
+        for (int local : locals) {
+          ssaIndirections.setUse(getCurrentInstructionIndex(), new ShrikeLocalName(local), workingState.getLocal(local));
         }
       }
       
@@ -798,13 +796,13 @@ public class SSABuilder extends AbstractIntStackMachine {
       }
 
       private void doIndirectWrites(int[] locals, int rval) {
-        for(int i = 0; i < locals.length; i++) {
-          ShrikeLocalName name = new ShrikeLocalName(locals[i]);
+        for (int local : locals) {
+          ShrikeLocalName name = new ShrikeLocalName(local);
           int idx = getCurrentInstructionIndex();
           if (ssaIndirections.getDef(idx, name) == -1) {
             ssaIndirections.setDef(idx, name, rval==-1? symbolTable.newSymbol(): rval);
           }
-          workingState.setLocal(locals[i], ssaIndirections.getDef(idx, name));
+          workingState.setLocal(local, ssaIndirections.getDef(idx, name));
         }        
       }
       
@@ -965,8 +963,7 @@ public class SSABuilder extends AbstractIntStackMachine {
      * Finish populating the map of local variable information
      */
     private void finishLocalMap(SSABuilder builder) {
-      for (Iterator<BasicBlock> it = shrikeCFG.iterator(); it.hasNext();) {
-        ShrikeCFG.BasicBlock bb = it.next();
+      for (BasicBlock bb : shrikeCFG) {
         MachineState S = builder.getIn(bb);
         int number = bb.getNumber();
         block2LocalState[number] = S.getLocals();
@@ -1053,8 +1050,8 @@ public class SSABuilder extends AbstractIntStackMachine {
     private static int[] extractIndices(int[] x, int y) {
       assert x != null;
       int count = 0;
-      for (int i = 0; i < x.length; i++) {
-        if (x[i] == y) {
+      for (int element : x) {
+        if (element == y) {
           count++;
         }
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/SSACFG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/SSACFG.java
@@ -120,8 +120,7 @@ public class SSACFG implements ControlFlowGraph<SSAInstruction, ISSABasicBlock>,
    * SSABasicBlocks
    */
   private void addPisFromInducedCFG(InducedCFG cfg) {
-    for (Iterator<? extends InducedCFG.BasicBlock> it = cfg.iterator(); it.hasNext();) {
-      InducedCFG.BasicBlock ib = it.next();
+    for (com.ibm.wala.cfg.InducedCFG.BasicBlock ib : cfg) {
       // we rely on the invariant that basic blocks in this cfg are numbered identically as in the source
       // InducedCFG
       BasicBlock b = getBasicBlock(ib.getNumber());
@@ -137,8 +136,7 @@ public class SSACFG implements ControlFlowGraph<SSAInstruction, ISSABasicBlock>,
    * SSABasicBlocks
    */
   private void addPhisFromInducedCFG(InducedCFG cfg) {
-    for (Iterator<? extends InducedCFG.BasicBlock> it = cfg.iterator(); it.hasNext();) {
-      InducedCFG.BasicBlock ib = it.next();
+    for (com.ibm.wala.cfg.InducedCFG.BasicBlock ib : cfg) {
       // we rely on the invariant that basic blocks in this cfg are numbered identically as in the source
       // InducedCFG
       BasicBlock b = getBasicBlock(ib.getNumber());
@@ -164,8 +162,7 @@ public class SSACFG implements ControlFlowGraph<SSAInstruction, ISSABasicBlock>,
   }
 
   private void recordExceptionTypes(Set<ExceptionHandler> set, IClassLoader loader) {
-    for (Iterator<ExceptionHandler> it = set.iterator(); it.hasNext();) {
-      ExceptionHandler handler = it.next();
+    for (ExceptionHandler handler : set) {
       TypeReference t = null;
       if (handler.getCatchClass() == null) {
         // by convention, in ShrikeCT this means catch everything
@@ -417,9 +414,9 @@ public class SSACFG implements ControlFlowGraph<SSAInstruction, ISSABasicBlock>,
           SSAPhiInstruction[] old = stackSlotPhis;
           stackSlotPhis = new SSAPhiInstruction[newLength];
           int j = 0;
-          for (int i = 0; i < old.length; i++) {
-            if (old[i] != null) {
-              stackSlotPhis[j++] = old[i];
+          for (SSAPhiInstruction element : old) {
+            if (element != null) {
+              stackSlotPhis[j++] = element;
             }
           }
         }
@@ -441,9 +438,9 @@ public class SSACFG implements ControlFlowGraph<SSAInstruction, ISSABasicBlock>,
           SSAPhiInstruction[] old = localPhis;
           localPhis = new SSAPhiInstruction[newLength];
           int j = 0;
-          for (int i = 0; i < old.length; i++) {
-            if (old[i] != null) {
-              localPhis[j++] = old[i];
+          for (SSAPhiInstruction element : old) {
+            if (element != null) {
+              localPhis[j++] = element;
             }
           }
         }
@@ -541,9 +538,9 @@ public class SSACFG implements ControlFlowGraph<SSAInstruction, ISSABasicBlock>,
           SSAPhiInstruction[] old = stackSlotPhis;
           stackSlotPhis = new SSAPhiInstruction[size];
           int j = 0;
-          for (int i = 0; i < old.length; i++) {
-            if (old[i] != null) {
-              stackSlotPhis[j++] = old[i];
+          for (SSAPhiInstruction element : old) {
+            if (element != null) {
+              stackSlotPhis[j++] = element;
             }
           }
         }
@@ -556,9 +553,9 @@ public class SSACFG implements ControlFlowGraph<SSAInstruction, ISSABasicBlock>,
           SSAPhiInstruction[] old = localPhis;
           localPhis = new SSAPhiInstruction[size];
           int j = 0;
-          for (int i = 0; i < old.length; i++) {
-            if (old[i] != null) {
-              localPhis[j++] = old[i];
+          for (SSAPhiInstruction element : old) {
+            if (element != null) {
+              localPhis[j++] = element;
             }
           }
         }
@@ -567,8 +564,8 @@ public class SSACFG implements ControlFlowGraph<SSAInstruction, ISSABasicBlock>,
 
     private int countNonNull(SSAPhiInstruction[] a) {
       int result = 0;
-      for (int i = 0; i < a.length; i++) {
-        if (a[i] != null) {
+      for (SSAPhiInstruction element : a) {
+        if (element != null) {
           result++;
         }
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/SSACFG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/SSACFG.java
@@ -767,7 +767,7 @@ public class SSACFG implements ControlFlowGraph<SSAInstruction, ISSABasicBlock>,
       s.append("BB").append(i).append("[").append(bb.getFirstInstructionIndex()).append("..").append(bb.getLastInstructionIndex())
           .append("]\n");
 
-      Iterator succNodes = getSuccNodes(bb);
+      Iterator<ISSABasicBlock> succNodes = getSuccNodes(bb);
       while (succNodes.hasNext()) {
         s.append("    -> BB").append(((BasicBlock) succNodes.next()).getNumber()).append("\n");
       }
@@ -861,7 +861,7 @@ public class SSACFG implements ControlFlowGraph<SSAInstruction, ISSABasicBlock>,
       throw new IllegalArgumentException("b == null");
     }
     IBasicBlock<IInstruction> n = delegate.getNode(b.getNumber());
-    final Iterator i = delegate.getPredNodes(n);
+    final Iterator<IBasicBlock<IInstruction>> i = delegate.getPredNodes(n);
     return new Iterator<ISSABasicBlock>() {
       @Override
       public boolean hasNext() {
@@ -870,7 +870,7 @@ public class SSACFG implements ControlFlowGraph<SSAInstruction, ISSABasicBlock>,
 
       @Override
       public BasicBlock next() {
-        IBasicBlock n = (IBasicBlock) i.next();
+        IBasicBlock n = i.next();
         int number = n.getNumber();
         return basicBlocks[number];
       }
@@ -903,7 +903,7 @@ public class SSACFG implements ControlFlowGraph<SSAInstruction, ISSABasicBlock>,
       throw new IllegalArgumentException("b == null");
     }
     IBasicBlock<IInstruction> n = delegate.getNode(b.getNumber());
-    final Iterator i = delegate.getSuccNodes(n);
+    final Iterator<IBasicBlock<IInstruction>> i = delegate.getSuccNodes(n);
     return new Iterator<ISSABasicBlock>() {
       @Override
       public boolean hasNext() {
@@ -912,7 +912,7 @@ public class SSACFG implements ControlFlowGraph<SSAInstruction, ISSABasicBlock>,
 
       @Override
       public ISSABasicBlock next() {
-        IBasicBlock n = (IBasicBlock) i.next();
+        IBasicBlock n = i.next();
         int number = n.getNumber();
         return basicBlocks[number];
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/SSANewInstruction.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/SSANewInstruction.java
@@ -82,8 +82,8 @@ public abstract class SSANewInstruction extends SSAInstruction {
 
   private String array2String(int[] params, SymbolTable symbolTable) {
     StringBuffer result = new StringBuffer();
-    for (int i = 0; i < params.length; i++) {
-      result.append(getValueString(symbolTable, params[i]));
+    for (int param : params) {
+      result.append(getValueString(symbolTable, param));
       result.append(" ");
     }
     return result.toString();

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/analysis/DeadAssignmentElimination.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/analysis/DeadAssignmentElimination.java
@@ -13,16 +13,14 @@ package com.ibm.wala.ssa.analysis;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import com.ibm.wala.cfg.ControlFlowGraph;
 import com.ibm.wala.fixedpoint.impl.DefaultFixedPointSolver;
 import com.ibm.wala.fixpoint.BooleanVariable;
 import com.ibm.wala.fixpoint.UnaryOr;
-import com.ibm.wala.ssa.DefUse;
-import com.ibm.wala.ssa.IR;
+import com.ibm.wala.ssa.*;
 import com.ibm.wala.ssa.SSACFG.BasicBlock;
-import com.ibm.wala.ssa.SSAInstruction;
-import com.ibm.wala.ssa.SSAPhiInstruction;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.CancelRuntimeException;
 import com.ibm.wala.util.collections.HashMapFactory;
@@ -59,16 +57,16 @@ public class DeadAssignmentElimination {
    * @param solution dataflow solution for dead assignment elimination
    */
   private static void doTransformation(IR ir, DeadValueSystem solution) {
-    ControlFlowGraph cfg = ir.getControlFlowGraph();
-    for (Iterator x = cfg.iterator(); x.hasNext();) {
+    ControlFlowGraph<?, ISSABasicBlock> cfg = ir.getControlFlowGraph();
+    for (Iterator<ISSABasicBlock> x = cfg.iterator(); x.hasNext();) {
       BasicBlock b = (BasicBlock) x.next();
       if (DEBUG) {
         System.err.println("eliminateDeadPhis: " + b);
       }
       if (b.hasPhi()) {
         HashSet<SSAPhiInstruction> toRemove = HashSetFactory.make(5);
-        for (Iterator it = b.iteratePhis(); it.hasNext();) {
-          SSAPhiInstruction phi = (SSAPhiInstruction) it.next();
+        for (Iterator<SSAPhiInstruction> it = b.iteratePhis(); it.hasNext();) {
+          SSAPhiInstruction phi = it.next();
           if (phi != null) {
             int def = phi.getDef();
             if (solution.isDead(def)) {
@@ -105,7 +103,7 @@ public class DeadAssignmentElimination {
      */
     DeadValueSystem(IR ir, DefUse DU) {
       // create a variable for each potentially dead phi instruction.
-      for (Iterator it = ir.iteratePhis(); it.hasNext();) {
+      for (Iterator<? extends SSAInstruction> it = ir.iteratePhis(); it.hasNext();) {
         SSAPhiInstruction phi = (SSAPhiInstruction) it.next();
         if (phi == null) {
           continue;
@@ -116,8 +114,8 @@ public class DeadAssignmentElimination {
           trivialDead.add(new Integer(def));
         } else {
           boolean maybeDead = true;
-          for (Iterator uses = DU.getUses(def); uses.hasNext();) {
-            SSAInstruction u = (SSAInstruction) uses.next();
+          for (Iterator<SSAInstruction> uses = DU.getUses(def); uses.hasNext();) {
+            SSAInstruction u = uses.next();
             if (!(u instanceof SSAPhiInstruction)) {
               // certainly not dead
               maybeDead = false;
@@ -133,11 +131,11 @@ public class DeadAssignmentElimination {
       }
 
       // Now create dataflow equations; v is live iff any phi that uses v is live
-      for (Iterator it = vars.entrySet().iterator(); it.hasNext();) {
-        Map.Entry E = (Map.Entry) it.next();
-        Integer def = (Integer) E.getKey();
-        BooleanVariable B = (BooleanVariable) E.getValue();
-        for (Iterator uses = DU.getUses(def.intValue()); uses.hasNext();) {
+      for (Iterator<Entry<Integer, BooleanVariable>> it = vars.entrySet().iterator(); it.hasNext();) {
+        Map.Entry<Integer, BooleanVariable> E = it.next();
+        Integer def = E.getKey();
+        BooleanVariable B = E.getValue();
+        for (Iterator<SSAInstruction> uses = DU.getUses(def.intValue()); uses.hasNext();) {
           SSAPhiInstruction u = (SSAPhiInstruction) uses.next();
           Integer ud = new Integer(u.getDef());
           if (trivialDead.contains(ud)) {

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/analysis/DeadAssignmentElimination.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/analysis/DeadAssignmentElimination.java
@@ -58,8 +58,8 @@ public class DeadAssignmentElimination {
    */
   private static void doTransformation(IR ir, DeadValueSystem solution) {
     ControlFlowGraph<?, ISSABasicBlock> cfg = ir.getControlFlowGraph();
-    for (Iterator<ISSABasicBlock> x = cfg.iterator(); x.hasNext();) {
-      BasicBlock b = (BasicBlock) x.next();
+    for (ISSABasicBlock issaBasicBlock : cfg) {
+      BasicBlock b = (BasicBlock) issaBasicBlock;
       if (DEBUG) {
         System.err.println("eliminateDeadPhis: " + b);
       }
@@ -131,8 +131,7 @@ public class DeadAssignmentElimination {
       }
 
       // Now create dataflow equations; v is live iff any phi that uses v is live
-      for (Iterator<Entry<Integer, BooleanVariable>> it = vars.entrySet().iterator(); it.hasNext();) {
-        Map.Entry<Integer, BooleanVariable> E = it.next();
+      for (Entry<Integer, BooleanVariable> E : vars.entrySet()) {
         Integer def = E.getKey();
         BooleanVariable B = E.getValue();
         for (Iterator<SSAInstruction> uses = DU.getUses(def.intValue()); uses.hasNext();) {

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/analysis/ExplodedControlFlowGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/analysis/ExplodedControlFlowGraph.java
@@ -644,8 +644,7 @@ public class ExplodedControlFlowGraph implements ControlFlowGraph<SSAInstruction
   @Override
   public String toString() {
     StringBuffer s = new StringBuffer("");
-    for (Iterator<IExplodedBasicBlock> it = iterator(); it.hasNext();) {
-      IExplodedBasicBlock bb = it.next();
+    for (IExplodedBasicBlock bb : this) {
       s.append("BB").append(getNumber(bb)).append("\n");
 
       Iterator<? extends IExplodedBasicBlock> succNodes = getSuccNodes(bb);

--- a/com.ibm.wala.core/src/com/ibm/wala/types/Descriptor.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/types/Descriptor.java
@@ -206,8 +206,7 @@ public final class Descriptor {
       StringBuffer result = new StringBuffer();
       result.append("(");
       if (parameters != null) {
-        for (int i = 0; i < parameters.length; i++) {
-          TypeName p = parameters[i];
+        for (TypeName p : parameters) {
           result.append(p);
           appendSemicolonIfNeeded(result, p);
         }
@@ -222,8 +221,7 @@ public final class Descriptor {
       StringBuffer result = new StringBuffer();
       result.append("(");
       if (parameters != null) {
-        for (int i = 0; i < parameters.length; i++) {
-          TypeName p = parameters[i];
+        for (TypeName p : parameters) {
           result.append(p.toUnicodeString());
           appendSemicolonIfNeeded(result, p);
         }

--- a/com.ibm.wala.core/src/com/ibm/wala/util/config/AnalysisScopeReader.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/config/AnalysisScopeReader.java
@@ -175,8 +175,8 @@ public class AnalysisScopeReader {
       scope.setLoaderImpl(walaLoader, entryPathname);
     } else if ("stdlib".equals(entryType)) {
       String[] stdlibs = WalaProperties.getJ2SEJarFiles();
-      for (int i = 0; i < stdlibs.length; i++) {
-        scope.addToScope(walaLoader, new JarFile(stdlibs[i], false));
+      for (String stdlib : stdlibs) {
+        scope.addToScope(walaLoader, new JarFile(stdlib, false));
       }
     } else {
       Assertions.UNREACHABLE();

--- a/com.ibm.wala.core/src/com/ibm/wala/util/ref/ReferenceCleanser.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/ref/ReferenceCleanser.java
@@ -81,8 +81,8 @@ public class ReferenceCleanser {
           ShrikeClass c = (ShrikeClass) klass;
           c.clearSoftCaches();
         } else {
-          for (Iterator it2 = klass.getDeclaredMethods().iterator(); it2.hasNext(); ) {
-            IMethod m = (IMethod)it2.next();
+          for (Iterator<IMethod> it2 = klass.getDeclaredMethods().iterator(); it2.hasNext(); ) {
+            IMethod m = it2.next();
             if (m instanceof ShrikeCTMethod) {
               ((ShrikeCTMethod)m).clearCaches();
             }

--- a/com.ibm.wala.core/src/com/ibm/wala/util/ref/ReferenceCleanser.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/ref/ReferenceCleanser.java
@@ -11,8 +11,6 @@
 package com.ibm.wala.util.ref;
 
 import java.lang.ref.WeakReference;
-import java.util.Iterator;
-
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.classLoader.ShrikeCTMethod;
@@ -81,8 +79,7 @@ public class ReferenceCleanser {
           ShrikeClass c = (ShrikeClass) klass;
           c.clearSoftCaches();
         } else {
-          for (Iterator<IMethod> it2 = klass.getDeclaredMethods().iterator(); it2.hasNext(); ) {
-            IMethod m = it2.next();
+          for (IMethod m : klass.getDeclaredMethods()) {
             if (m instanceof ShrikeCTMethod) {
               ((ShrikeCTMethod)m).clearCaches();
             }

--- a/com.ibm.wala.core/src/com/ibm/wala/util/scope/JUnitEntryPoints.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/scope/JUnitEntryPoints.java
@@ -54,11 +54,11 @@ public class JUnitEntryPoints {
           System.out.println("application class: " + klass);
 
           // return all the tests methods
-          Collection methods = klass.getAllMethods();
-          Iterator methodsIt = methods.iterator();
+          Collection<IMethod> methods = klass.getAllMethods();
+          Iterator<IMethod> methodsIt = methods.iterator();
 
           while (methodsIt.hasNext()) {
-            IMethod m = (IMethod) methodsIt.next();
+            IMethod m = methodsIt.next();
             if (isJUnitMethod(m)) {
               result.add(new DefaultEntrypoint(m, cha));
               System.out.println("- adding test method as entry point: " + m.getName().toString());
@@ -104,8 +104,8 @@ public class JUnitEntryPoints {
           System.err.println("found test class");
         }
         // add entry point corresponding to the target method
-        for (Iterator methodsIt = klass.getDeclaredMethods().iterator(); methodsIt.hasNext();) {
-          IMethod method = (IMethod) methodsIt.next();
+        for (Iterator<IMethod> methodsIt = klass.getDeclaredMethods().iterator(); methodsIt.hasNext();) {
+          IMethod method = methodsIt.next();
           Atom methodAtom = method.getName();
           if (methodAtom.equals(targetMethodAtom)) {
             entryPts.add(new DefaultEntrypoint(method, cha));
@@ -191,9 +191,9 @@ public class JUnitEntryPoints {
     IClass currClass = testClass;
     while (currClass != null && !currClass.getName().equals(junitTestCaseType) && !currClass.getName().equals(junitTestSuiteType)) {
 
-      for (Iterator methodsIt = currClass.getDeclaredMethods().iterator(); methodsIt.hasNext();) {
+      for (Iterator<IMethod> methodsIt = currClass.getDeclaredMethods().iterator(); methodsIt.hasNext();) {
 
-        IMethod method = (IMethod) methodsIt.next();
+        IMethod method = methodsIt.next();
         final Atom methodAtom = method.getName();
         if (methodAtom.equals(setUpMethodAtom) || methodAtom.equals(tearDownMethodAtom) || method.isClinit() || method.isInit()) {
           result.add(method);

--- a/com.ibm.wala.core/src/com/ibm/wala/util/scope/JUnitEntryPoints.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/scope/JUnitEntryPoints.java
@@ -104,8 +104,7 @@ public class JUnitEntryPoints {
           System.err.println("found test class");
         }
         // add entry point corresponding to the target method
-        for (Iterator<IMethod> methodsIt = klass.getDeclaredMethods().iterator(); methodsIt.hasNext();) {
-          IMethod method = methodsIt.next();
+        for (IMethod method : klass.getDeclaredMethods()) {
           Atom methodAtom = method.getName();
           if (methodAtom.equals(targetMethodAtom)) {
             entryPts.add(new DefaultEntrypoint(method, cha));
@@ -191,9 +190,8 @@ public class JUnitEntryPoints {
     IClass currClass = testClass;
     while (currClass != null && !currClass.getName().equals(junitTestCaseType) && !currClass.getName().equals(junitTestSuiteType)) {
 
-      for (Iterator<IMethod> methodsIt = currClass.getDeclaredMethods().iterator(); methodsIt.hasNext();) {
+      for (IMethod method : currClass.getDeclaredMethods()) {
 
-        IMethod method = methodsIt.next();
         final Atom methodAtom = method.getName();
         if (methodAtom.equals(setUpMethodAtom) || methodAtom.equals(tearDownMethodAtom) || method.isClinit() || method.isInit()) {
           result.add(method);

--- a/com.ibm.wala.core/src/com/ibm/wala/util/strings/Atom.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/strings/Atom.java
@@ -411,8 +411,8 @@ public final class Atom implements Serializable {
    * @return true iff this atom contains the specified byte
    */
   public boolean contains(byte b) {
-    for (int i = 0; i < val.length; i++) {
-      if (val[i] == b) {
+    for (byte element : val) {
+      if (element == b) {
         return true;
       }
     }

--- a/com.ibm.wala.core/src/com/ibm/wala/viz/PDFViewUtil.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/viz/PDFViewUtil.java
@@ -75,7 +75,7 @@ public class PDFViewUtil {
       throw new IllegalArgumentException("ir is null");
     }
     final HashMap<ISSABasicBlock,String> labelMap = HashMapFactory.make();
-    for (Iterator it = ir.getControlFlowGraph().iterator(); it.hasNext();) {
+    for (Iterator<ISSABasicBlock> it = ir.getControlFlowGraph().iterator(); it.hasNext();) {
       SSACFG.BasicBlock bb = (SSACFG.BasicBlock) it.next();
       labelMap.put(bb, getNodeLabel(ir, bb));
     }
@@ -125,8 +125,8 @@ public class PDFViewUtil {
       result.append("<Handler>");
     }
     result.append("\\n");
-    for (Iterator it = bb.iteratePhis(); it.hasNext();) {
-      SSAPhiInstruction phi = (SSAPhiInstruction) it.next();
+    for (Iterator<SSAPhiInstruction> it = bb.iteratePhis(); it.hasNext();) {
+      SSAPhiInstruction phi = it.next();
       if (phi != null) {
         result.append("           " + phi.toString(ir.getSymbolTable())).append("\\l");
       }
@@ -149,8 +149,8 @@ public class PDFViewUtil {
         result.append("\\l");
       }
     }
-    for (Iterator it = bb.iteratePis(); it.hasNext();) {
-      SSAPiInstruction pi = (SSAPiInstruction) it.next();
+    for (Iterator<SSAPiInstruction> it = bb.iteratePis(); it.hasNext();) {
+      SSAPiInstruction pi = it.next();
       if (pi != null) {
         result.append("           " + pi.toString(ir.getSymbolTable())).append("\\l");
       }

--- a/com.ibm.wala.core/src/com/ibm/wala/viz/PDFViewUtil.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/viz/PDFViewUtil.java
@@ -75,8 +75,8 @@ public class PDFViewUtil {
       throw new IllegalArgumentException("ir is null");
     }
     final HashMap<ISSABasicBlock,String> labelMap = HashMapFactory.make();
-    for (Iterator<ISSABasicBlock> it = ir.getControlFlowGraph().iterator(); it.hasNext();) {
-      SSACFG.BasicBlock bb = (SSACFG.BasicBlock) it.next();
+    for (ISSABasicBlock issaBasicBlock : ir.getControlFlowGraph()) {
+      SSACFG.BasicBlock bb = (SSACFG.BasicBlock) issaBasicBlock;
       labelMap.put(bb, getNodeLabel(ir, bb));
     }
     NodeDecorator<ISSABasicBlock> labels = new NodeDecorator<ISSABasicBlock>() {

--- a/com.ibm.wala.dalvik/.settings/org.eclipse.jdt.core.prefs
+++ b/com.ibm.wala.dalvik/.settings/org.eclipse.jdt.core.prefs
@@ -78,7 +78,7 @@ org.eclipse.jdt.core.compiler.problem.pessimisticNullAnalysisForFreeTypeVariable
 org.eclipse.jdt.core.compiler.problem.possibleAccidentalBooleanAssignment=error
 org.eclipse.jdt.core.compiler.problem.potentialNullReference=ignore
 org.eclipse.jdt.core.compiler.problem.potentiallyUnclosedCloseable=error
-org.eclipse.jdt.core.compiler.problem.rawTypeReference=warning
+org.eclipse.jdt.core.compiler.problem.rawTypeReference=error
 org.eclipse.jdt.core.compiler.problem.redundantNullAnnotation=error
 org.eclipse.jdt.core.compiler.problem.redundantNullCheck=error
 org.eclipse.jdt.core.compiler.problem.redundantSpecificationOfTypeArguments=error

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/DexCFG.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/DexCFG.java
@@ -111,8 +111,7 @@ public class DexCFG extends AbstractCFG<Instruction, DexCFG.BasicBlock> implemen
      */
     private void computeI2BMapping() {
         instruction2Block = new int[getInstructions().length];
-        for (Iterator<BasicBlock> it = iterator(); it.hasNext();) {
-            final BasicBlock b = it.next();
+        for (BasicBlock b : this) {
             for (int j = b.getFirstInstructionIndex(); j <= b.getLastInstructionIndex(); j++) {
                 instruction2Block[j] = getNumber(b);
             }
@@ -123,8 +122,7 @@ public class DexCFG extends AbstractCFG<Instruction, DexCFG.BasicBlock> implemen
      * Compute outgoing edges in the control flow graph.
      */
     private void computeEdges() {
-        for (Iterator<BasicBlock> it = iterator(); it.hasNext();) {
-            BasicBlock b = it.next();
+        for (BasicBlock b : this) {
             if (b.equals(exit())) {
                 continue;
             } else if (b.equals(entry())) {
@@ -240,8 +238,8 @@ public class DexCFG extends AbstractCFG<Instruction, DexCFG.BasicBlock> implemen
 
             Instruction last = getInstructions()[getLastInstructionIndex()];
             int[] targets = last.getBranchTargets();
-            for (int i = 0; i < targets.length; i++) {
-                BasicBlock b = getBlockForInstruction(targets[i]);
+            for (int target : targets) {
+                BasicBlock b = getBlockForInstruction(target);
                 addNormalEdgeTo(b);
             }
             addExceptionalEdges(last);
@@ -310,11 +308,11 @@ public class DexCFG extends AbstractCFG<Instruction, DexCFG.BasicBlock> implemen
                         exceptionTypes = HashSetFactory.make(exceptionTypes);
                     }
 
-                    for (int j = 0; j < hs.length; j++) {
+                    for (ExceptionHandler element : hs) {
                         if (DEBUG) {
-                            System.err.println(" handler " + hs[j]);
+                            System.err.println(" handler " + element);
                         }
-                        BasicBlock b = getBlockForInstruction(hs[j].getHandler());
+                        BasicBlock b = getBlockForInstruction(element.getHandler());
                         if (DEBUG) {
                             System.err.println(" target " + b);
                         }
@@ -326,9 +324,9 @@ public class DexCFG extends AbstractCFG<Instruction, DexCFG.BasicBlock> implemen
                             addExceptionalEdgeTo(b);
                         } else {
                             TypeReference caughtException = null;
-                            if (hs[j].getCatchClass() != null) {
+                            if (element.getCatchClass() != null) {
                                 ClassLoaderReference loader = DexCFG.this.getMethod().getDeclaringClass().getReference().getClassLoader();
-                                caughtException = ShrikeUtil.makeTypeReference(loader, hs[j].getCatchClass());
+                                caughtException = ShrikeUtil.makeTypeReference(loader, element.getCatchClass());
                                 if (DEBUG) {
                                     System.err.println(" caughtException " + caughtException);
                                 }
@@ -651,8 +649,7 @@ public class DexCFG extends AbstractCFG<Instruction, DexCFG.BasicBlock> implemen
     public String toString() {
         StringBuffer s = new StringBuffer("");
         BitVector catches = this.getCatchBlocks();
-        for (Iterator<BasicBlock> it = iterator(); it.hasNext();) {
-            BasicBlock bb = it.next();
+        for (BasicBlock bb : this) {
             s.append("BB").append(getNumber(bb));
             if (catches.contains(bb.getNumber())) {
             	s.append("<Handler>");

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/WDexClassLoaderImpl.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/WDexClassLoaderImpl.java
@@ -101,15 +101,13 @@ public class WDexClassLoaderImpl extends ClassLoaderImpl {
         // module are loaded according to the given order (same as in Java VM)
         Set<ModuleEntry> classModuleEntries = HashSetFactory.make();
         
-        for (Iterator<Module> it = modules.iterator(); it.hasNext();) {
-            Module archive = it.next();
+        for (Module archive : modules) {
             Set<ModuleEntry> classFiles = getDexFiles(archive);
             
             removeClassFiles(classFiles, classModuleEntries);
             loadAllDexClasses(classFiles);
             
-            for (Iterator<ModuleEntry> it2 = classFiles.iterator(); it2.hasNext();) {
-            	ModuleEntry file = it2.next();
+            for (ModuleEntry file : classFiles) {
             	classModuleEntries.add(file);
             }
         }                       
@@ -121,13 +119,11 @@ public class WDexClassLoaderImpl extends ClassLoaderImpl {
      */
     private static void removeClassFiles(Set<ModuleEntry> s, Set<ModuleEntry> t) {
     	Set<String> old = HashSetFactory.make();
-    	for (Iterator<ModuleEntry> it = t.iterator(); it.hasNext();) {
-    		ModuleEntry m = it.next();
+    	for (ModuleEntry m : t) {
     		old.add(m.getClassName());
     	}
     	HashSet<ModuleEntry> toRemove = HashSetFactory.make();
-    	for (Iterator<ModuleEntry> it = s.iterator(); it.hasNext();) {
-    		ModuleEntry m = it.next();
+    	for (ModuleEntry m : s) {
     		if (old.contains(m.getClassName())) {
     			toRemove.add(m);
     		}
@@ -150,9 +146,7 @@ public class WDexClassLoaderImpl extends ClassLoaderImpl {
     @SuppressWarnings("unused")
 	private void loadAllDexClasses(Collection<ModuleEntry> moduleEntries) {
     	
-    	for (Iterator<ModuleEntry> it = moduleEntries.iterator(); it.hasNext();) {
-    		ModuleEntry entry = it.next();
-
+    	for (ModuleEntry entry : moduleEntries) {
     		// Dalvik class
     		if (entry instanceof DexModuleEntry) {
     			DexModuleEntry dexEntry = ((DexModuleEntry) entry);

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/ReuseParameters.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/ReuseParameters.java
@@ -127,8 +127,8 @@ public class ReuseParameters {
                     }
                     
                     // Assert the rest of the types have the same name
-                    for (int j = 0; j < types.length; ++j) {
-                        final TypeName paramType = types[j].getName();
+                    for (TypeReference type : types) {
+                        final TypeName paramType = type.getName();
 
                         if (isReuse(paramType, ALL_TARGETS)) {
                             if (! reuseParameters.contains(paramType)) {    // XXX: Why not use a Set?

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/impl/DexFakeRootMethod.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/impl/DexFakeRootMethod.java
@@ -215,12 +215,12 @@ public class DexFakeRootMethod extends AbstractRootMethod {
 						}
 					}
 					if (allocSites!=null)
-					for (int p=0;p<allocSites.length; p++) {
-						if (allocSites[p] == -1) {
-							Warnings.add(AllocationFailure.create(T));
-							return null;
+						for (int allocSite : allocSites) {
+							if (allocSite == -1) {
+								Warnings.add(AllocationFailure.create(T));
+								return null;
+							}
 						}
-					}
 					addInvocation(allocSites==null?new int[] {instance}:allocSites, CallSiteReference.make(statements.size(), ctor.getReference(),
 							IInvokeInstruction.Dispatch.SPECIAL));
 				}

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentContextSelector.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentContextSelector.java
@@ -126,8 +126,8 @@ public class IntentContextSelector implements ContextSelector {
 
             Intent intent = null;
             { // Seach intent
-                for (int j = 0; j < actualParameters.length; ++j) {
-                    final InstanceKey param = actualParameters[j];
+                for (InstanceKey actualParameter : actualParameters) {
+                    final InstanceKey param = actualParameter;
                     if (param == null) {
                         continue;
                     } else if (param.getConcreteType().getName().equals(AndroidTypes.IntentName)) {
@@ -376,8 +376,8 @@ public class IntentContextSelector implements ContextSelector {
             final int[] relevant = info.getRelevant();
 
             if (relevant != null) {
-                for (int i = 0; i < relevant.length; ++i) {
-                    ret = IntSetUtil.add(ret, relevant[i]);
+                for (int element : relevant) {
+                    ret = IntSetUtil.add(ret, element);
                 }
             }
 

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/AbstractIntRegisterMachine.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/AbstractIntRegisterMachine.java
@@ -60,6 +60,7 @@ import com.ibm.wala.shrikeBT.ThrowInstruction;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.CancelRuntimeException;
 import com.ibm.wala.util.debug.UnimplementedError;
+import com.ibm.wala.util.graph.INodeWithNumber;
 
 /**
  * Skeleton of functionality to propagate information through the Java bytecode stack machine using ShrikeBT.
@@ -232,7 +233,7 @@ public abstract class AbstractIntRegisterMachine implements FixedPointConstants 
                 /*
                  * Add only the entry variable to the work list.
                  */
-                 for (Iterator it = getFixedPointSystem().getStatementsThatUse(entry); it.hasNext();) {
+                 for (Iterator<? extends INodeWithNumber> it = getFixedPointSystem().getStatementsThatUse(entry); it.hasNext();) {
                      AbstractStatement s = (AbstractStatement) it.next();
                      addToWorkList(s);
                  }

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/DexSSABuilder.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/DexSSABuilder.java
@@ -195,9 +195,9 @@ public class DexSSABuilder extends AbstractIntRegisterMachine {
         @Override
         public int meetLocal(int n, int[] rhs, DexCFG.BasicBlock bb) {
             if (allTheSame(rhs)) {
-                for (int i = 0; i < rhs.length; i++) {
-                    if (rhs[i] != TOP) {
-                        return rhs[i];
+                for (int rh : rhs) {
+                    if (rh != TOP) {
+                        return rh;
                     }
                 }
                 // didn't find anything but TOP
@@ -1430,8 +1430,7 @@ public class DexSSABuilder extends AbstractIntRegisterMachine {
          * Finish populating the map of local variable information
          */
         private void finishLocalMap(DexSSABuilder builder) {
-            for (Iterator<BasicBlock> it = dexCFG.iterator(); it.hasNext();) {
-                BasicBlock bb = it.next();
+            for (BasicBlock bb : dexCFG) {
                 MachineState S = builder.getIn(bb);
                 int number = bb.getNumber();
                 block2LocalState[number] = S.getLocals();
@@ -1505,8 +1504,8 @@ public class DexSSABuilder extends AbstractIntRegisterMachine {
          */
         private static int[] extractIndices(int[] x, int y) {
             int count = 0;
-            for (int i = 0; i < x.length; i++) {
-                if (x[i] == y) {
+            for (int element : x) {
+                if (element == y) {
                     count++;
                 }
             }

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidAnalysisScope.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidAnalysisScope.java
@@ -82,14 +82,14 @@ public class AndroidAnalysisScope {
 		try {
 			String[] paths = classPath.split(File.pathSeparator);
 
-			for (int i = 0; i < paths.length; i++) {
-				if (paths[i].endsWith(".jar")
-						|| paths[i].endsWith(".apk")
-						|| paths[i].endsWith(".dex")) { // Handle android file.
-					File f = new File(paths[i]);
+			for (String path : paths) {
+				if (path.endsWith(".jar")
+						|| path.endsWith(".apk")
+						|| path.endsWith(".dex")) { // Handle android file.
+					File f = new File(path);
 					scope.addToScope(loader, DexFileModule.make(f));
 				} else {
-					File f = new File(paths[i]);
+					File f = new File(path);
 					if (f.isDirectory()) { // handle directory FIXME not working
 											// for .dex and .apk files into that
 											// directory

--- a/com.ibm.wala.ide.jdt.test/source/com/ibm/wala/demandpa/driver/DemandCastChecker.java
+++ b/com.ibm.wala.ide.jdt.test/source/com/ibm/wala/demandpa/driver/DemandCastChecker.java
@@ -43,7 +43,6 @@ package com.ibm.wala.demandpa.driver;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
 import java.util.function.Predicate;
@@ -227,8 +226,7 @@ public class DemandCastChecker {
     List<Pair<CGNode, SSACheckCastInstruction>> failing = new ArrayList<>();
 
     int numSafe = 0, numMightFail = 0;
-    outer: for (Iterator<? extends CGNode> nodeIter = cg.iterator(); nodeIter.hasNext();) {
-      CGNode node = nodeIter.next();
+    outer: for (CGNode node : cg) {
       TypeReference declaringClass = node.getMethod().getReference().getDeclaringClass();
       // skip library classes
       if (declaringClass.getClassLoader().equals(ClassLoaderReference.Primordial)) {

--- a/com.ibm.wala.ide.jdt/source/com/ibm/wala/cast/java/translator/jdt/JDTSourceModuleTranslator.java
+++ b/com.ibm.wala.ide.jdt/source/com/ibm/wala/cast/java/translator/jdt/JDTSourceModuleTranslator.java
@@ -39,7 +39,6 @@ package com.ibm.wala.cast.java.translator.jdt;
 
 import java.io.File;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -131,9 +130,7 @@ public class JDTSourceModuleTranslator implements SourceModuleTranslator {
     while (cl != null) {
       List<Module> modules = scope.getModules(cl);
 
-      for (Iterator<Module> iter = modules.iterator(); iter.hasNext();) {
-        Module m = iter.next();
-
+      for (Module m : modules) {
         if (buf.length() > 0)
           buf.append(File.pathSeparator);
         if (m instanceof JarFileModule) {

--- a/com.ibm.wala.ide/src/com/ibm/wala/ide/ui/SWTTreeViewer.java
+++ b/com.ibm.wala.ide/src/com/ibm/wala/ide/ui/SWTTreeViewer.java
@@ -203,8 +203,8 @@ public class SWTTreeViewer extends AbstractJFaceRunner {
       if (getPopUpActions().size() > 0) {
         MenuManager mm = new MenuManager();
         treeViewer.getTree().setMenu(mm.createContextMenu(treeViewer.getTree()));
-        for (Iterator<IAction> it = getPopUpActions().iterator(); it.hasNext();) {
-          mm.add(it.next());
+        for (IAction iAction : getPopUpActions()) {
+          mm.add(iAction);
         }
       }
       return treeViewer.getTree();

--- a/com.ibm.wala.ide/src/com/ibm/wala/ide/ui/SWTTreeViewer.java
+++ b/com.ibm.wala.ide/src/com/ibm/wala/ide/ui/SWTTreeViewer.java
@@ -171,7 +171,7 @@ public class SWTTreeViewer extends AbstractJFaceRunner {
     /**
      * Graph to visualize
      */
-    private final Graph graph;
+    private final Graph<Object> graph;
 
     /**
      * JFace component implementing the tree viewer
@@ -181,7 +181,7 @@ public class SWTTreeViewer extends AbstractJFaceRunner {
     /**
      * @throws WalaException
      */
-    public GraphViewer(Graph graph) throws WalaException {
+    public GraphViewer(Graph<Object> graph) throws WalaException {
       super(null);
       this.graph = graph;
       if (graph == null) {
@@ -242,7 +242,7 @@ public class SWTTreeViewer extends AbstractJFaceRunner {
 
         Object[] result = new Object[graph.getSuccNodeCount(parentElement)];
         int i = 0;
-        for (Iterator it = graph.getSuccNodes(parentElement); it.hasNext();) {
+        for (Iterator<Object> it = graph.getSuccNodes(parentElement); it.hasNext();) {
           result[i++] = it.next();
         }
         return result;

--- a/com.ibm.wala.scandroid/.settings/org.eclipse.jdt.core.prefs
+++ b/com.ibm.wala.scandroid/.settings/org.eclipse.jdt.core.prefs
@@ -63,7 +63,7 @@ org.eclipse.jdt.core.compiler.problem.pessimisticNullAnalysisForFreeTypeVariable
 org.eclipse.jdt.core.compiler.problem.possibleAccidentalBooleanAssignment=error
 org.eclipse.jdt.core.compiler.problem.potentialNullReference=ignore
 org.eclipse.jdt.core.compiler.problem.potentiallyUnclosedCloseable=error
-org.eclipse.jdt.core.compiler.problem.rawTypeReference=warning
+org.eclipse.jdt.core.compiler.problem.rawTypeReference=error
 org.eclipse.jdt.core.compiler.problem.redundantNullAnnotation=error
 org.eclipse.jdt.core.compiler.problem.redundantNullCheck=error
 org.eclipse.jdt.core.compiler.problem.redundantSpecificationOfTypeArguments=warning

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/FlowAnalysis.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/FlowAnalysis.java
@@ -149,9 +149,9 @@ public class FlowAnalysis {
                 for(CodeElement taintElement:bbTaints.get(taintType))
                 {
                 	BasicBlockInContext<E>[] entryBlocks = graph.getEntriesForProcedure(taintBB.getNode());
-                	for (int i = 0; i < entryBlocks.length; i++) {
+                	for (BasicBlockInContext<E> entryBlock : entryBlocks) {
                 		//Add PathEdge <s_p,0> -> <n,d1>
-                		initialEdges.add(PathEdge.createPathEdge(entryBlocks[i], 0, taintBB, domain.getMappedIndex(new DomainElement(taintElement,taintType))));
+                		initialEdges.add(PathEdge.createPathEdge(entryBlock, 0, taintBB, domain.getMappedIndex(new DomainElement(taintElement,taintType))));
                 	}
                     //initialEdges.add(PathEdge.createPathEdge(e.getKey(), 0, e.getKey(), domain.getMappedIndex(new DomainElement(o,e2.getKey()))));
                 }
@@ -160,8 +160,8 @@ public class FlowAnalysis {
         //Add PathEdges to the entry points of the supergraph <s_main,0> -> <s_main,0>
         for (CGNode entry : cg.getEntrypointNodes()) {
         	BasicBlockInContext<E>[] bbic = graph.getEntriesForProcedure(entry);
-        	for (int i = 0; i < bbic.length; i++)
-        		initialEdges.add(PathEdge.createPathEdge(bbic[i], 0, bbic[i], 0));
+        	for (BasicBlockInContext<E> element : bbic)
+				initialEdges.add(PathEdge.createPathEdge(element, 0, element, 0));
         }
         
         final TabulationProblem<BasicBlockInContext<E>, CGNode, DomainElement>

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/InflowAnalysis.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/InflowAnalysis.java
@@ -234,13 +234,13 @@ public class InflowAnalysis {
         SourceSpec[] ss = s.getSourceSpecs();
         
         ArrayList<SourceSpec> ssAL = new ArrayList<>();
-        for (int i = 0; i < ss.length; i++) {
-        	if (ss[i] instanceof EntryArgSourceSpec)
-        		processInputSource(ctx, taintMap, ss[i], cg, graph, cha, pa);
-        	else if (ss[i] instanceof CallRetSourceSpec || ss[i] instanceof CallArgSourceSpec)
-        		ssAL.add(ss[i]);
-        	else if (ss[i] instanceof StaticFieldSourceSpec) {
-        		processStaticFieldSource(ctx, taintMap, (StaticFieldSourceSpec)ss[i], cg, graph, pa);
+        for (SourceSpec element : ss) {
+        	if (element instanceof EntryArgSourceSpec)
+        		processInputSource(ctx, taintMap, element, cg, graph, cha, pa);
+        	else if (element instanceof CallRetSourceSpec || element instanceof CallArgSourceSpec)
+        		ssAL.add(element);
+        	else if (element instanceof StaticFieldSourceSpec) {
+        		processStaticFieldSource(ctx, taintMap, (StaticFieldSourceSpec)element, cg, graph, pa);
         	} else 
         		throw new UnsupportedOperationException("Unrecognized SourceSpec");
         } 

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/OutflowAnalysis.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/OutflowAnalysis.java
@@ -185,13 +185,13 @@ public class OutflowAnalysis {
 						CGNode node = block.getNode();
 
 						IntSet resultSet = flowResult.getResult(block);
-						for (int j = 0; j < argNums.length; j++) {
+						for (int argNum : argNums) {
 
 							// The set of flow types we're looking for:
 							Set<FlowType<IExplodedBasicBlock>> taintTypeSet = HashSetFactory.make();
 
 							LocalElement le = new LocalElement(
-									invInst.getUse(argNums[j]));
+									invInst.getUse(argNum));
 							Set<DomainElement> elements = domain
 									.getPossibleElements(le);
 							if (elements != null) {
@@ -204,7 +204,7 @@ public class OutflowAnalysis {
 							}
 
 							LocalPointerKey lpkey = new LocalPointerKey(node,
-									invInst.getUse(argNums[j]));
+									invInst.getUse(argNum));
 							for (InstanceKey ik : pa.getPointsToSet(lpkey)) {
 								for (DomainElement de : domain
 										.getPossibleElements(new InstanceKeyElement(
@@ -275,12 +275,12 @@ public class OutflowAnalysis {
 			//
 			// }
 			// }
-			for (int i = 0; i < newArgNums.length; i++) {
+			for (int newArgNum : newArgNums) {
 
 				// see if anything flowed into the args as sinks:
 				for (DomainElement de : domain
 						.getPossibleElements(new LocalElement(node.getIR()
-								.getParameter(newArgNums[i])))) {
+								.getParameter(newArgNum)))) {
 
 					for (BasicBlockInContext<IExplodedBasicBlock> block : graph
 							.getExitsForProcedure(node)) {
@@ -289,7 +289,7 @@ public class OutflowAnalysis {
 						if (flowResult.getResult(block).contains(mappedIndex)) {
 							addEdge(flowGraph, de.taintSource,
 									new ParameterFlow<IExplodedBasicBlock>(
-											entryBlock, newArgNums[i], false));
+											entryBlock, newArgNum, false));
 						}
 					}
 
@@ -297,12 +297,12 @@ public class OutflowAnalysis {
 					if (flowResult.getResult(entryBlock).contains(mappedIndex)) {
 						addEdge(flowGraph, de.taintSource,
 								new ParameterFlow<IExplodedBasicBlock>(
-										entryBlock, newArgNums[i], false));
+										entryBlock, newArgNum, false));
 					}
 
 				}
 				for (InstanceKey ik : pa.getPointsToSet(new LocalPointerKey(
-						node, node.getIR().getParameter(newArgNums[i])))) {
+						node, node.getIR().getParameter(newArgNum)))) {
 					for (DomainElement de : domain
 							.getPossibleElements(new InstanceKeyElement(ik))) {
 						if (flowResult.getResult(entryBlock).contains(
@@ -310,7 +310,7 @@ public class OutflowAnalysis {
 							
 							addEdge(flowGraph, de.taintSource,
 									new ParameterFlow<IExplodedBasicBlock>(
-											entryBlock, newArgNums[i], false));
+											entryBlock, newArgNum, false));
 						}
 					}
 				}
@@ -425,15 +425,15 @@ public class OutflowAnalysis {
 		SinkSpec[] ss = s.getSinkSpecs();
 		
 
-		for (int i = 0; i < ss.length; i++) {
-			if (ss[i] instanceof EntryArgSinkSpec)
-				processSinkSpec(flowResult, domain, taintFlow, ss[i]);
-			else if (ss[i] instanceof CallArgSinkSpec)
-				processSinkSpec(flowResult, domain, taintFlow, ss[i]);
-			else if (ss[i] instanceof EntryRetSinkSpec)
-				processSinkSpec(flowResult, domain, taintFlow, ss[i]);
-			else if (ss[i] instanceof StaticFieldSinkSpec)
-				processSinkSpec(flowResult, domain, taintFlow, ss[i]);
+		for (SinkSpec element : ss) {
+			if (element instanceof EntryArgSinkSpec)
+				processSinkSpec(flowResult, domain, taintFlow, element);
+			else if (element instanceof CallArgSinkSpec)
+				processSinkSpec(flowResult, domain, taintFlow, element);
+			else if (element instanceof EntryRetSinkSpec)
+				processSinkSpec(flowResult, domain, taintFlow, element);
+			else if (element instanceof StaticFieldSinkSpec)
+				processSinkSpec(flowResult, domain, taintFlow, element);
 			else
 				throw new UnsupportedOperationException(
 						"SinkSpec not yet Implemented");

--- a/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/UriPrefixTransferGraph.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/UriPrefixTransferGraph.java
@@ -232,8 +232,7 @@ public class UriPrefixTransferGraph implements Graph<InstanceKeySite> {
 					final OrdinalSet<InstanceKey> returnSet =
 							pa.getPointsToSet(new LocalPointerKey(caller, invoke.getReturnValue(0)));
 					
-					for (final Iterator<InstanceKey> rIK = returnSet.iterator(); rIK.hasNext(); ) {
-						final InstanceKey returnIK = rIK.next();
+					for (InstanceKey returnIK : returnSet) {
 						final UriAppendString node = new UriAppendString(mapping.getMappedIndex(returnIK),
 							mapping.getMappedIndex(uriKey), mapping.getMappedIndex(stringKey));
 												

--- a/com.ibm.wala.scandroid/source/org/scandroid/spec/CallArgSourceSpec.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/spec/CallArgSourceSpec.java
@@ -97,12 +97,12 @@ public class CallArgSourceSpec extends SourceSpec {
 			ISupergraph<BasicBlockInContext<E>, CGNode> graph,
 			PointerAnalysis<InstanceKey> pa, CallGraph cg) {
 
-		for (int j = 0; j < newArgNums.length; j++) {
+		for (int newArgNum : newArgNums) {
 			for (FlowType<E> ft : getFlowType(block)) {
 				// a collection of a LocalElement for this argument's SSA value,
 				// along with a set of InstanceKeyElements for each instance
 				// that this SSA value might point to
-				final int ssaVal = invInst.getUse(newArgNums[j]);
+				final int ssaVal = invInst.getUse(newArgNum);
 				final CGNode node = block.getNode();
 				Set<CodeElement> valueElements = CodeElement.valueElements(ssaVal);
 				PointerKey pk = pa.getHeapModel().getPointerKeyForLocal(node, ssaVal);

--- a/com.ibm.wala.scandroid/source/org/scandroid/util/CGAnalysisContext.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/util/CGAnalysisContext.java
@@ -210,8 +210,8 @@ public class CGAnalysisContext<E extends ISSABasicBlock> {
 		} else {
 
 			Collection<CGNode> nodes = HashSetFactory.make();
-			for (Iterator<CGNode> nIter = partialGraph.iterator(); nIter.hasNext();) {
-				nodes.add(nIter.next());
+			for (CGNode cgNode : partialGraph) {
+				nodes.add(cgNode);
 			}
 			CallGraph pcg = PartialCallGraph.make(cg, cg.getEntrypointNodes(), nodes);
 			graph = (ISupergraph) ICFGSupergraph.make(pcg);

--- a/com.ibm.wala.scandroid/source/org/scandroid/util/DexDotUtil.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/util/DexDotUtil.java
@@ -209,8 +209,7 @@ public class DexDotUtil extends DotUtil {
 
         outputNodes(labels, result, dotNodes);
 
-        for (Iterator<? extends T> it = g.iterator(); it.hasNext();) {
-          T n = it.next();
+        for (T n : g) {
           for (Iterator<? extends T> it2 = g.getSuccNodes(n); it2.hasNext();) {
             T s = it2.next();
             result.append(" ");
@@ -226,8 +225,8 @@ public class DexDotUtil extends DotUtil {
       }
 
       private static <T> void outputNodes(NodeDecorator<T> labels, StringBuffer result, Collection<T> dotNodes) throws WalaException {
-        for (Iterator<T> it = dotNodes.iterator(); it.hasNext();) {
-          outputNode(labels, result, it.next());
+        for (T t : dotNodes) {
+          outputNode(labels, result, t);
         }
       }
 

--- a/com.ibm.wala.scandroid/source/org/scandroid/util/EntryPoints.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/util/EntryPoints.java
@@ -137,9 +137,9 @@ public class EntryPoints {
 //            "android.app.Service.onTransact(ILandroid/os/Parcel;Landroid/os/Parcel;I)B"
          };
 
-        for (int i = 0; i < methodReferences.length; i++) {
+        for (String methodReference : methodReferences) {
             MethodReference mr =
-                    StringStuff.makeMethodReference(methodReferences[i]);
+                    StringStuff.makeMethodReference(methodReference);
             
             for (IMethod im : cha.getPossibleTargets(mr)) {
                 
@@ -165,9 +165,9 @@ public class EntryPoints {
     			"android.view.View.setOnClickListener(Landroid/view/View$OnClickListener;)V",
     	};
 
-    	for (int i = 0; i < methodReferences.length; i++) {
+    	for (String methodReference : methodReferences) {
     		MethodReference mr =
-    				StringStuff.makeMethodReference(methodReferences[i]);
+    				StringStuff.makeMethodReference(methodReference);
 
     		for (IMethod im : cha.getPossibleTargets(mr)) {
     			

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrike/bench/AddBytecodeDebug.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrike/bench/AddBytecodeDebug.java
@@ -73,9 +73,9 @@ public class AddBytecodeDebug {
         me.beginPass();
         ExceptionHandler[][] handlers = me.getHandlers();
         boolean[] putDumperAt = new boolean[handlers.length];
-        for (int i = 0; i < handlers.length; i++) {
-          for (int j = 0; j < handlers[i].length; j++) {
-            int offset = handlers[i][j].getHandler();
+        for (ExceptionHandler[] handler : handlers) {
+          for (int j = 0; j < handler.length; j++) {
+            int offset = handler[j].getHandler();
             if (!putDumperAt[offset]) {
               putDumperAt[offset] = true;
               me.insertBefore(offset, new MethodEditor.Patch() {

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrike/bench/InterfaceAnalyzer.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrike/bench/InterfaceAnalyzer.java
@@ -14,8 +14,6 @@ import java.io.BufferedWriter;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.HashMap;
-import java.util.Iterator;
-
 import com.ibm.wala.shrikeBT.Constants;
 import com.ibm.wala.shrikeBT.Util;
 import com.ibm.wala.shrikeBT.shrikeCT.ClassInstrumenter;
@@ -55,8 +53,7 @@ public class InterfaceAnalyzer {
       instrumenter.close();
 
       w.write("Type\t# Total\t# Method\t# Public Method\t# Public Method as Foreign\n");
-      for (Iterator<String> i = typeStats.keySet().iterator(); i.hasNext();) {
-        String k = i.next();
+      for (String k : typeStats.keySet()) {
         TypeStats t = typeStats.get(k);
         w.write(k + "\t" + t.totalOccurrences + "\t" + t.methodOccurrences + "\t" + t.publicMethodOccurrences + "\t"
             + t.foreignPublicMethodOccurrences + "\n");
@@ -77,8 +74,8 @@ public class InterfaceAnalyzer {
         String[] params = Util.getParamsTypes(null, sig);
         int flags = reader.getMethodAccessFlags(m);
         int mUID = methodUID++;
-        for (int p = 0; p < params.length; p++) {
-          doType(flags, params[p], cType, mUID);
+        for (String param : params) {
+          doType(flags, param, cType, mUID);
         }
         doType(flags, Util.getReturnType(sig), cType, mUID);
       }

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrike/bench/Statistics.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrike/bench/Statistics.java
@@ -79,9 +79,9 @@ public class Statistics {
 
         int constructorCalls = 0;
         IInstruction[] instrs = d.getInstructions();
-        for (int i = 0; i < instrs.length; i++) {
-          if (instrs[i] instanceof InvokeInstruction) {
-            InvokeInstruction invoke = (InvokeInstruction) instrs[i];
+        for (IInstruction instr : instrs) {
+          if (instr instanceof InvokeInstruction) {
+            InvokeInstruction invoke = (InvokeInstruction) instr;
             if (invoke.getMethodName().equals("<init>") && invoke.getClassType().equals(Util.makeType(className))) {
               constructorCalls++;
             }

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrike/copywriter/CopyWriter.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrike/copywriter/CopyWriter.java
@@ -13,7 +13,6 @@ package com.ibm.wala.shrike.copywriter;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.zip.ZipEntry;
 
 import com.ibm.wala.shrikeBT.Compiler;
@@ -118,8 +117,7 @@ public class CopyWriter {
 
     Writer w = new OutputStreamWriter(instrumenter.addOutputJarEntry(new ZipEntry("IBM-Copyright")));
     w.write(copyright + "\n");
-    for (Iterator<ZipEntry> iter = entries.iterator(); iter.hasNext();) {
-      ZipEntry ze = iter.next();
+    for (ZipEntry ze : entries) {
       w.write("  " + ze.getName() + "\n");
     }
     w.write(copyright + "\n");

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Compiler.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Compiler.java
@@ -13,8 +13,6 @@ package com.ibm.wala.shrikeBT;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
-import java.util.Iterator;
-
 import com.ibm.wala.shrikeBT.ConstantInstruction.ClassToken;
 import com.ibm.wala.shrikeBT.IBinaryOpInstruction.Operator;
 import com.ibm.wala.shrikeBT.analysis.ClassHierarchyProvider;
@@ -182,8 +180,8 @@ public abstract class Compiler implements Constants {
     IInstruction.Visitor visitor = new IInstruction.Visitor() {
       private void visitTargets(IInstruction instr) {
         int[] ts = instr.getBranchTargets();
-        for (int k = 0; k < ts.length; k++) {
-          s.set(ts[k]);
+        for (int element : ts) {
+          s.set(element);
         }
       }
 
@@ -212,14 +210,13 @@ public abstract class Compiler implements Constants {
       }
     };
 
-    for (int i = 0; i < instructions.length; i++) {
-      instructions[i].visit(visitor);
+    for (IInstruction instruction : instructions) {
+      instruction.visit(visitor);
     }
 
     String[] paramTypes = Util.getParamsTypes(isStatic ? null : TYPE_Object, signature);
     int index = 0;
-    for (int i = 0; i < paramTypes.length; i++) {
-      String t = paramTypes[i];
+    for (String t : paramTypes) {
       localsUsed.set(index);
       if (t.equals(TYPE_long) || t.equals(TYPE_double)) {
         localsWide.set(index);
@@ -230,11 +227,10 @@ public abstract class Compiler implements Constants {
     }
 
     ExceptionHandler[] lastHS = null;
-    for (int i = 0; i < handlers.length; i++) {
-      ExceptionHandler[] hs = handlers[i];
+    for (ExceptionHandler[] hs : handlers) {
       if (hs != lastHS) {
-        for (int j = 0; j < hs.length; j++) {
-          s.set(hs[j].handler);
+        for (ExceptionHandler element : hs) {
+          s.set(element.handler);
         }
         lastHS = hs;
       }
@@ -359,20 +355,20 @@ public abstract class Compiler implements Constants {
       }
 
       int[] bt = instr.getBranchTargets();
-      for (int j = 0; j < bt.length; j++) {
-        int t = bt[j];
+      for (int element : bt) {
+        int t = element;
         if (t < 0 || t >= visited.length) {
           throw new IllegalArgumentException("Branch target at offset " + i + " is out of bounds: " + t + " (max " + visited.length
               + ")");
         }
         if (!visited[t]) {
-          computeStackWordsAt(bt[j], stackLen, stackWords.clone(), visited);
+          computeStackWordsAt(element, stackLen, stackWords.clone(), visited);
         }
       }
 
       ExceptionHandler[] hs = handlers[i];
-      for (int j = 0; j < hs.length; j++) {
-        int t = hs[j].handler;
+      for (ExceptionHandler element : hs) {
+        int t = element.handler;
         if (!visited[t]) {
           byte[] newWords = stackWords.clone();
           newWords[0] = 1;
@@ -449,8 +445,7 @@ public abstract class Compiler implements Constants {
   }
 
   private static boolean applyPatches(ArrayList<Patch> patches) {
-    for (Iterator<Patch> i = patches.iterator(); i.hasNext();) {
-      Patch p = i.next();
+    for (Patch p : patches) {
       if (!p.apply()) {
         return false;
       }
@@ -1149,8 +1144,7 @@ public abstract class Compiler implements Constants {
 
       int[] rawHandlers = new int[4 * rawHandlerList.size()];
       int count = 0;
-      for (Iterator<int[]> iter = rawHandlerList.iterator(); iter.hasNext();) {
-        int[] element = iter.next();
+      for (int[] element : rawHandlerList) {
         System.arraycopy(element, 0, rawHandlers, count, 4);
         count += 4;
       }
@@ -1244,8 +1238,8 @@ public abstract class Compiler implements Constants {
       liveLocals[instruction].set(index);
       int[] back = backEdges[instruction];
       if (back != null) {
-        for (int i = 0; i < back.length; i++) {
-          addLiveVar(back[i], index);
+        for (int element : back) {
+          addLiveVar(element, index);
         }
       }
 
@@ -1264,12 +1258,12 @@ public abstract class Compiler implements Constants {
     for (int i = 0; i < instructions.length; i++) {
       IInstruction instr = instructions[i];
       int[] targets = instr.getBranchTargets();
-      for (int j = 0; j < targets.length; j++) {
-        addBackEdge(targets[j], i);
+      for (int target : targets) {
+        addBackEdge(target, i);
       }
       ExceptionHandler[] hs = handlers[i];
-      for (int j = 0; j < hs.length; j++) {
-        addBackEdge(hs[j].handler, i);
+      for (ExceptionHandler element : hs) {
+        addBackEdge(element.handler, i);
       }
       liveLocals[i] = new BitSet();
     }
@@ -1410,10 +1404,10 @@ public abstract class Compiler implements Constants {
 
     ExceptionHandler[] startHS = handlers[start];
     ArrayList<ExceptionHandler> newHS = new ArrayList<>();
-    for (int i = 0; i < startHS.length; i++) {
-      int t = startHS[i].handler;
+    for (ExceptionHandler element : startHS) {
+      int t = element.handler;
       if (t < start || t >= start + len) {
-        newHS.add(startHS[i]);
+        newHS.add(element);
       }
     }
     ExceptionHandler[] patchHS = new ExceptionHandler[newHS.size()];
@@ -1458,8 +1452,8 @@ public abstract class Compiler implements Constants {
         if (instructions[i] instanceof ReturnInstruction) {
           outsideBranch = true;
         }
-        for (int j = 0; j < targets.length; j++) {
-          if (targets[j] < start || targets[j] >= start + len) {
+        for (int target : targets) {
+          if (target < start || target >= start + len) {
             outsideBranch = true;
           }
         }
@@ -1479,15 +1473,14 @@ public abstract class Compiler implements Constants {
       for (int i = start; i < start + len; i++) {
         boolean out = false;
         ExceptionHandler[] hs = handlers[i];
-        for (int j = 0; j < hs.length; j++) {
-          int h = hs[j].handler;
+        for (ExceptionHandler element : hs) {
+          int h = element.handler;
           if (h < start || h >= start + len) {
             out = true;
           }
         }
         int[] targets = instructions[i].getBranchTargets();
-        for (int j = 0; j < targets.length; j++) {
-          int t = targets[j];
+        for (int t : targets) {
           if (t < start || t >= start + len) {
             out = true;
           }
@@ -1606,8 +1599,8 @@ public abstract class Compiler implements Constants {
       // make sure that the same external handlers are used all the way through
       ExceptionHandler[] startHS = handlers[start];
       int numOuts = 0;
-      for (int j = 0; j < startHS.length; j++) {
-        int t = startHS[j].handler;
+      for (ExceptionHandler element : startHS) {
+        int t = element.handler;
         if (t < start || t >= start + len) {
           numOuts++;
         }
@@ -1617,12 +1610,12 @@ public abstract class Compiler implements Constants {
       for (int i = start + 1; i < start + len; i++) {
         ExceptionHandler[] hs = handlers[i];
         int matchingOuts = 0;
-        for (int j = 0; j < hs.length; j++) {
-          int t = hs[j].handler;
+        for (ExceptionHandler element : hs) {
+          int t = element.handler;
           if (t < start || t >= start + len) {
             boolean match = false;
-            for (int k = 0; k < startHS.length; k++) {
-              if (startHS[k].equals(hs[j])) {
+            for (ExceptionHandler element2 : startHS) {
+              if (element2.equals(element)) {
                 match = true;
                 break;
               }
@@ -1680,9 +1673,7 @@ public abstract class Compiler implements Constants {
       }
     }
 
-    for (Iterator<HelperPatch> i = patches.iterator(); i.hasNext();) {
-      HelperPatch p = i.next();
-
+    for (HelperPatch p : patches) {
       System.arraycopy(p.code, 0, instructions, p.start, p.code.length);
       for (int j = 0; j < p.length; j++) {
         int index = j + p.start;

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Decoder.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Decoder.java
@@ -255,8 +255,8 @@ public abstract class Decoder implements Constants {
   }
 
   private boolean doesSubroutineReturn(int sub) {
-    for (int j = 0; j < retInfo.length; j++) {
-      if (retInfo[j] != null && retInfo[j].sub == sub) {
+    for (RetInfo element : retInfo) {
+      if (element != null && element.sub == sub) {
         return true;
       }
     }
@@ -314,9 +314,9 @@ public abstract class Decoder implements Constants {
             }
 
             int[] targets = instr.getBranchTargets();
-            for (int k = 0; k < targets.length; k++) {
-              if (targets[k] >= 0) {
-                int r = findReturnToVar(v, targets[k], visited);
+            for (int target : targets) {
+              if (target >= 0) {
+                int r = findReturnToVar(v, target, visited);
                 if (r != 0) {
                   return r;
                 }
@@ -407,10 +407,10 @@ public abstract class Decoder implements Constants {
         int offset = decodedOffset[addr];
         instr = decoded.get(offset + size - 1);
         int[] targets = instr.getBranchTargets();
-        for (int k = 0; k < targets.length; k++) {
-          if (targets[k] >= 0) {
+        for (int target : targets) {
+          if (target >= 0) {
             // only chase real gotos; ignore rets
-            assignReachablesToSubroutine(targets[k], sub);
+            assignReachablesToSubroutine(target, sub);
           }
         }
       }
@@ -761,9 +761,7 @@ public abstract class Decoder implements Constants {
           Instruction instr = decoded.get(s + instrCount - 1);
           int[] targets = instr.getBranchTargets();
 
-          for (int i = 0; i < targets.length; i++) {
-            int t = targets[i];
-
+          for (int t : targets) {
             if (t >= 0) {
               decodeAt(t, stackLen, stackWords.clone());
             }

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/MethodEditor.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/MethodEditor.java
@@ -643,8 +643,8 @@ public final class MethodEditor {
           adjustedHandlers = new IdentityHashMap<>();
         }
 
-        for (int j = 0; j < hs.length; j++) {
-          ExceptionHandler h = hs[j];
+        for (ExceptionHandler element : hs) {
+          ExceptionHandler h = element;
           if (!adjustedHandlers.containsKey(h)) {
             adjustedHandlers.put(h, null);
             h.handler = labelDefs[h.handler]; // breaks invariant of ExceptionHandler: immutable!

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/SwitchInstruction.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/SwitchInstruction.java
@@ -131,9 +131,9 @@ public final class SwitchInstruction extends Instruction {
   public String toString() {
     StringBuffer b = new StringBuffer("Switch(");
     b.append(defaultLabel);
-    for (int i = 0; i < casesAndLabels.length; i++) {
+    for (int casesAndLabel : casesAndLabels) {
       b.append(',');
-      b.append(casesAndLabels[i]);
+      b.append(casesAndLabel);
     }
     b.append(")");
     return b.toString();

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Util.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Util.java
@@ -372,8 +372,8 @@ public final class Util {
     }
     StringBuffer buf = new StringBuffer();
     buf.append("(");
-    for (int i = 0; i < params.length; i++) {
-      buf.append(makeType(params[i]));
+    for (Class<?> param : params) {
+      buf.append(makeType(param));
     }
     buf.append(")");
     buf.append(makeType(result));
@@ -447,8 +447,7 @@ public final class Util {
     }
     Method[] methods = c.getMethods();
     Method result = null;
-    for (int i = 0; i < methods.length; i++) {
-      Method m = methods[i];
+    for (Method m : methods) {
       if (m.getName().equals(name) && (paramTypes == null || Arrays.equals(m.getParameterTypes(), paramTypes))) {
         if (result != null) {
           throw new IllegalArgumentException("Method " + makeName(name, paramTypes) + " is ambiguous in class " + c);
@@ -473,8 +472,7 @@ public final class Util {
 
     if (name.equals("<init>")) {
       Constructor<?>[] cs = c.getConstructors();
-      for (int i = 0; i < cs.length; i++) {
-        Constructor<?> con = cs[i];
+      for (Constructor<?> con : cs) {
         if (paramTypes == null || Arrays.equals(con.getParameterTypes(), paramTypes)) {
           if (result != null) {
             throw new IllegalArgumentException("Constructor " + makeName(name, paramTypes) + " is ambiguous in class " + c);

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/analysis/Analyzer.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/analysis/Analyzer.java
@@ -156,12 +156,12 @@ public class Analyzer {
     for (int i = 0; i < instructions.length; i++) {
       IInstruction instr = instructions[i];
       int[] targets = instr.getBranchTargets();
-      for (int j = 0; j < targets.length; j++) {
-        addBackEdge(targets[j], i);
+      for (int target : targets) {
+        addBackEdge(target, i);
       }
       ExceptionHandler[] hs = handlers[i];
-      for (int j = 0; j < hs.length; j++) {
-        addBackEdge(hs[j].getHandler(), i);
+      for (ExceptionHandler element : hs) {
+        addBackEdge(element.getHandler(), i);
       }
     }
 
@@ -235,18 +235,17 @@ public class Analyzer {
     BitSet r = new BitSet(instructions.length);
 
     r.set(0);
-    for (int i = 0; i < instructions.length; i++) {
-      int[] targets = instructions[i].getBranchTargets();
+    for (IInstruction instruction : instructions) {
+      int[] targets = instruction.getBranchTargets();
 
-      for (int j = 0; j < targets.length; j++) {
-        r.set(targets[j]);
+      for (int target : targets) {
+        r.set(target);
       }
     }
-    for (int i = 0; i < handlers.length; i++) {
-      ExceptionHandler[] hs = handlers[i];
+    for (ExceptionHandler[] hs : handlers) {
       if (hs != null) {
-        for (int j = 0; j < hs.length; j++) {
-          r.set(hs[j].getHandler());
+        for (ExceptionHandler element : hs) {
+          r.set(element.getHandler());
         }
       }
     }
@@ -275,14 +274,14 @@ public class Analyzer {
 
       IInstruction instr = instructions[from];
       int[] targets = instr.getBranchTargets();
-      for (int i = 0; i < targets.length; i++) {
-        getReachableRecursive(targets[i], reachable, followHandlers, mask);
+      for (int target : targets) {
+        getReachableRecursive(target, reachable, followHandlers, mask);
       }
 
       if (followHandlers) {
         ExceptionHandler[] hs = handlers[from];
-        for (int i = 0; i < hs.length; i++) {
-          getReachableRecursive(hs[i].getHandler(), reachable, followHandlers, mask);
+        for (ExceptionHandler element : hs) {
+          getReachableRecursive(element.getHandler(), reachable, followHandlers, mask);
         }
       }
 
@@ -324,8 +323,8 @@ public class Analyzer {
       reaching.set(to);
 
       int[] targets = backEdges[to];
-      for (int i = 0; i < targets.length; i++) {
-        getReachingRecursive(targets[i], reaching, mask);
+      for (int target : targets) {
+        getReachingRecursive(target, reaching, mask);
       }
 
       if (to > 0 && instructions[to - 1].isFallThrough()) {
@@ -339,8 +338,8 @@ public class Analyzer {
 
   private void getReachingBase(int to, BitSet reaching, BitSet mask) {
     int[] targets = backEdges[to];
-    for (int i = 0; i < targets.length; i++) {
-      getReachingRecursive(targets[i], reaching, mask);
+    for (int target : targets) {
+      getReachingRecursive(target, reaching, mask);
     }
 
     if (to > 0 && instructions[to - 1].isFallThrough()) {
@@ -390,12 +389,12 @@ public class Analyzer {
       }
 
       int[] targets = instr.getBranchTargets();
-      for (int j = 0; j < targets.length; j++) {
-        computeStackSizesAt(stackSizes, targets[j], size);
+      for (int target : targets) {
+        computeStackSizesAt(stackSizes, target, size);
       }
       ExceptionHandler[] hs = handlers[i];
-      for (int j = 0; j < hs.length; j++) {
-        computeStackSizesAt(stackSizes, hs[j].getHandler(), 1);
+      for (ExceptionHandler element : hs) {
+        computeStackSizesAt(stackSizes, element.getHandler(), 1);
       }
 
       if (!instr.isFallThrough()) {
@@ -719,9 +718,9 @@ public class Analyzer {
         }
 
         ExceptionHandler[] handler = handlers[i];
-        for(int h = 0; h < handler.length; h++) {
-          int target = handler[h].getHandler();
-          String cls = handler[h].getCatchClass();
+        for (ExceptionHandler element : handler) {
+          int target = element.getHandler();
+          String cls = element.getCatchClass();
           if (cls == null) {
             cls = "Ljava/lang/Throwable;";
           }
@@ -732,9 +731,9 @@ public class Analyzer {
         }
         
         int[] targets = instr.getBranchTargets();
-        for (int j = 0; j < targets.length; j++) {
-          if (mergeTypes(targets[j], curStack, curStackSize, curLocals, curLocalsSize[0], path)) {
-            computeTypes(targets[j], visitor, makeTypesAt, path);
+        for (int target : targets) {
+          if (mergeTypes(target, curStack, curStackSize, curLocals, curLocalsSize[0], path)) {
+            computeTypes(target, visitor, makeTypesAt, path);
           }
         }
 
@@ -780,8 +779,7 @@ public class Analyzer {
 
   private void computeMaxLocals() {
     maxLocals = locals[0].length;
-    for (int i = 0; i < instructions.length; i++) {
-      IInstruction instr = instructions[i];
+    for (IInstruction instr : instructions) {
       if (instr instanceof LoadInstruction) {
         maxLocals = Math.max(maxLocals, ((LoadInstruction) instr).getVarIndex() + 1);
       } else if (instr instanceof StoreInstruction) {
@@ -812,8 +810,8 @@ public class Analyzer {
     }
     int[] stackSizes = getStackSizes();
     maxStack = 0;
-    for (int i = 0; i < stackSizes.length; i++) {
-      maxStack = Math.max(maxStack, stackSizes[i]);
+    for (int stackSize : stackSizes) {
+      maxStack = Math.max(maxStack, stackSize);
     }
     computeMaxLocals();
   }

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/analysis/ClassHierarchy.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/analysis/ClassHierarchy.java
@@ -47,8 +47,8 @@ public final class ClassHierarchy {
     }
 
     int r = NO;
-    for (int i = 0; i < ifaces.length; i++) {
-      String iface = ifaces[i];
+    for (String iface2 : ifaces) {
+      String iface = iface2;
       if (!visited.contains(iface)) {
         visited.add(iface);
         if (iface.equals(t2)) {
@@ -114,8 +114,8 @@ public final class ClassHierarchy {
     }
 
     int r = NO;
-    for (int i = 0; i < subtypes.length; i++) {
-      String subt = subtypes[i];
+    for (String subtype : subtypes) {
+      String subt = subtype;
       if (!visited.contains(subt)) {
         visited.add(subt);
         if (subt.equals(t2)) {
@@ -318,8 +318,7 @@ public final class ClassHierarchy {
       String element = iter.next();
       boolean subsumed = false;
 
-      for (Iterator<String> iterator = t2Supers.iterator(); iterator.hasNext();) {
-        String element2 = iterator.next();
+      for (String element2 : t2Supers) {
         if (element != element2 && isSubtypeOf(hierarchy, element2, element) == YES) {
           subsumed = true;
           break;

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/info/InstructionTypeCounter.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/info/InstructionTypeCounter.java
@@ -265,8 +265,8 @@ public class InstructionTypeCounter implements MethodData.Results {
       }
     };
 
-    for (int i = 0; i < instructions.length; i++) {
-      instructions[i].visit(visitor);
+    for (IInstruction instruction : instructions) {
+      instruction.visit(visitor);
     }
   }
 

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/info/LocalAllocator.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/info/LocalAllocator.java
@@ -52,8 +52,8 @@ public class LocalAllocator implements MethodData.Results {
       }
     };
 
-    for (int i = 0; i < instructions.length; i++) {
-      instructions[i].visit(visitor);
+    for (IInstruction instruction : instructions) {
+      instruction.visit(visitor);
     }
 
     nextLocal = max[0];

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/info/ThisAssignmentChecker.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/info/ThisAssignmentChecker.java
@@ -33,8 +33,7 @@ public class ThisAssignmentChecker implements MethodData.Results {
     if (!info.getIsStatic()) {
       IInstruction[] instructions = info.getInstructions();
 
-      for (int i = 0; i < instructions.length; i++) {
-        IInstruction instr = instructions[i];
+      for (IInstruction instr : instructions) {
         if (instr instanceof StoreInstruction) {
           StoreInstruction st = (StoreInstruction) instr;
           if (st.getVarIndex() == 0) {

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/ClassInstrumenter.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/ClassInstrumenter.java
@@ -315,8 +315,7 @@ final public class ClassInstrumenter {
           w.addMethod(flags, cr.getMethodNameIndex(i), cr.getMethodTypeIndex(i), makeMethodAttributes(i, w, oc, comp.getOutput(), md));
           Compiler.Output[] aux = comp.getAuxiliaryMethods();
           if (aux != null) {
-            for (int j = 0; j < aux.length; j++) {
-              Compiler.Output a = aux[j];
+            for (Compiler.Output a : aux) {
               w.addMethod(a.getAccessFlags(), a.getMethodName(), a.getMethodSignature(), makeMethodAttributes(i, w, oc, a, md));
             }
           }

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/tools/AddSerialVersion.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/tools/AddSerialVersion.java
@@ -103,8 +103,8 @@ public class AddSerialVersion {
         // step 3
         String[] interfaces = r.getInterfaceNames();
         Arrays.sort(interfaces);
-        for (int i = 0; i < interfaces.length; i++) {
-          out.writeUTF(interfaces[i]);
+        for (String interface1 : interfaces) {
+          out.writeUTF(interface1);
         }
   
         // step 4

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/tools/BatchVerifier.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/tools/BatchVerifier.java
@@ -51,8 +51,8 @@ public class BatchVerifier {
     OfflineInstrumenter oi = new OfflineInstrumenter();
     args = oi.parseStandardArgs(args);
 
-    for (int i = 0; i < args.length; i++) {
-      if (args[i].equals("-d")) {
+    for (String arg : args) {
+      if (arg.equals("-d")) {
         disasm = true;
       }
     }

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/tools/ClassPrinter.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/tools/ClassPrinter.java
@@ -132,12 +132,12 @@ public class ClassPrinter {
     StringBuffer buf = new StringBuffer();
     Class<Constants> c = Constants.class;
     Field[] fs = c.getDeclaredFields();
-    for (int i = 0; i < fs.length; i++) {
-      String name = fs[i].getName();
+    for (Field element : fs) {
+      String name = element.getName();
       if (name.startsWith("ACC_")) {
         int val;
         try {
-          val = fs[i].getInt(null);
+          val = element.getInt(null);
         } catch (IllegalArgumentException e) {
           throw new Error(e.getMessage());
         } catch (IllegalAccessException e) {

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/tools/MethodOptimizer.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/tools/MethodOptimizer.java
@@ -134,14 +134,14 @@ public final class MethodOptimizer {
 
     for (int i = 0; i < instructions.length; i++) {
       int[] targets = instructions[i].getBranchTargets();
-      for (int j = 0; j < targets.length; j++) {
-        int target = targets[j];
+      for (int target2 : targets) {
+        int target = target2;
         backEdges[target][backEdgeCount[target]] = i;
         backEdgeCount[target]++;
       }
       ExceptionHandler[] hs = handlers[i];
-      for (int j = 0; j < hs.length; j++) {
-        int target = hs[j].getHandler();
+      for (ExceptionHandler element : hs) {
+        int target = element.getHandler();
         backEdges[target][backEdgeCount[target]] = i;
         backEdgeCount[target]++;
       }
@@ -155,8 +155,8 @@ public final class MethodOptimizer {
     checkStackSizesAt(0, 0);
 
     int result = 0;
-    for (int i = 0; i < stackSizes.length; i++) {
-      result = Math.max(result, stackSizes[i]);
+    for (int stackSize : stackSizes) {
+      result = Math.max(result, stackSize);
     }
     return result;
   }
@@ -189,13 +189,13 @@ public final class MethodOptimizer {
       }
 
       int[] targets = instr.getBranchTargets();
-      for (int i = 0; i < targets.length; i++) {
-        checkStackSizesAt(targets[i], stackSize);
+      for (int target : targets) {
+        checkStackSizesAt(target, stackSize);
       }
 
       ExceptionHandler[] hs = handlers[instruction];
-      for (int i = 0; i < hs.length; i++) {
-        checkStackSizesAt(hs[i].getHandler(), 1);
+      for (ExceptionHandler element : hs) {
+        checkStackSizesAt(element.getHandler(), 1);
       }
 
       if (!instr.isFallThrough()) {
@@ -384,13 +384,13 @@ public final class MethodOptimizer {
       }
 
       int[] targets = instructions[instruction].getBranchTargets();
-      for (int i = 0; i < targets.length; i++) {
-        followStackDef(abstractDefStacks, def, targets[i], stackPointer);
+      for (int target : targets) {
+        followStackDef(abstractDefStacks, def, target, stackPointer);
       }
 
       ExceptionHandler[] hs = handlers[instruction];
-      for (int i = 0; i < hs.length; i++) {
-        followStackDef(abstractDefStacks, -1, hs[i].getHandler(), 0);
+      for (ExceptionHandler element : hs) {
+        followStackDef(abstractDefStacks, -1, element.getHandler(), 0);
       }
 
       if (!instructions[instruction].isFallThrough()) {
@@ -418,8 +418,8 @@ public final class MethodOptimizer {
       }
 
       int[] back = backEdges[instruction];
-      for (int i = 0; i < back.length; i++) {
-        followStackUse(abstractUseStacks, use, back[i], stackPointer);
+      for (int element : back) {
+        followStackUse(abstractUseStacks, use, element, stackPointer);
       }
 
       if (instruction == 0 || !instructions[instruction - 1].isFallThrough()) {
@@ -447,8 +447,8 @@ public final class MethodOptimizer {
       bits.set(from);
 
       int[] targets = instructions[from].getBranchTargets();
-      for (int i = 0; i < targets.length; i++) {
-        getReachableInstructions(bits, targets[i], to);
+      for (int target : targets) {
+        getReachableInstructions(bits, target, to);
       }
 
       if (!instructions[from].isFallThrough()) {
@@ -467,8 +467,8 @@ public final class MethodOptimizer {
       bits.set(to);
 
       int[] targets = backEdges[to];
-      for (int i = 0; i < targets.length; i++) {
-        getReachingInstructions(bits, from, targets[i]);
+      for (int target : targets) {
+        getReachingInstructions(bits, from, target);
       }
 
       if (to == 0 || !instructions[to - 1].isFallThrough()) {

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/tools/OfflineInstrumenterBase.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/tools/OfflineInstrumenterBase.java
@@ -272,8 +272,7 @@ public abstract class OfflineInstrumenterBase {
     if (fs == null) {
       throw new IllegalArgumentException("bad directory " + d.getAbsolutePath());
     }
-    for (int i = 0; i < fs.length; i++) {
-      File f = fs[i];
+    for (File f : fs) {
       if (f.isDirectory()) {
         addInputDirectory(baseDirectory, f);
       } else {

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/ClassWriter.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/ClassWriter.java
@@ -471,8 +471,7 @@ public class ClassWriter implements ClassConstants {
       if (ifaces.length > 0xFFFF) {
         throw new IllegalArgumentException("Too many interfaces implemented: " + ifaces.length);
       }
-      for (int i = 0; i < ifaces.length; i++) {
-        int c = ifaces[i];
+      for (int c : ifaces) {
         if (c < 1 || c > 0xFFFF) {
           throw new IllegalArgumentException("Interface name index out of range: " + c);
         }
@@ -637,8 +636,8 @@ public class ClassWriter implements ClassConstants {
     public int getSize() {
       int size = 8;
       if (attributes != null) {
-        for (int i = 0; i < attributes.length; i++) {
-          size += attributes[i].getSize();
+        for (Element attribute : attributes) {
+          size += attribute.getSize();
         }
       }
       return size;
@@ -652,8 +651,8 @@ public class ClassWriter implements ClassConstants {
       if (attributes != null) {
         setUShort(buf, offset + 6, attributes.length);
         offset += 8;
-        for (int i = 0; i < attributes.length; i++) {
-          offset = attributes[i].copyInto(buf, offset);
+        for (Element attribute : attributes) {
+          offset = attribute.copyInto(buf, offset);
         }
       } else {
         setUShort(buf, offset + 6, 0);

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/CodeWriter.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/CodeWriter.java
@@ -65,8 +65,8 @@ public final class CodeWriter extends ClassWriter.Element {
 
     int size = 14 + code.length + 2 + (exnHandlers == null ? 0 : exnHandlers.length) * 2 + 2;
     if (attributes != null) {
-      for (int i = 0; i < attributes.length; i++) {
-        size += attributes[i].getSize();
+      for (ClassWriter.Element attribute : attributes) {
+        size += attribute.getSize();
       }
     }
     return size;
@@ -87,8 +87,8 @@ public final class CodeWriter extends ClassWriter.Element {
     ClassWriter.setUShort(buf, offset, (exnHandlers == null ? 0 : exnHandlers.length) / 4);
     offset += 2;
     if (exnHandlers != null) {
-      for (int i = 0; i < exnHandlers.length; i++) {
-        ClassWriter.setUShort(buf, offset, exnHandlers[i]);
+      for (int exnHandler : exnHandlers) {
+        ClassWriter.setUShort(buf, offset, exnHandler);
         offset += 2;
       }
     }
@@ -96,8 +96,8 @@ public final class CodeWriter extends ClassWriter.Element {
     ClassWriter.setUShort(buf, offset, (attributes == null ? 0 : attributes.length));
     offset += 2;
     if (attributes != null) {
-      for (int i = 0; i < attributes.length; i++) {
-        offset = attributes[i].copyInto(buf, offset);
+      for (ClassWriter.Element attribute : attributes) {
+        offset = attribute.copyInto(buf, offset);
       }
     }
     ClassWriter.setInt(buf, start + 2, offset - start - 6);

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/ExceptionsWriter.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/ExceptionsWriter.java
@@ -42,8 +42,8 @@ public final class ExceptionsWriter extends ClassWriter.Element {
     ClassWriter.setUShort(buf, offset + 6, table == null ? 0 : table.length);
     offset += 8;
     if (table != null) {
-      for (int i = 0; i < table.length; i++) {
-        ClassWriter.setUShort(buf, offset, table[i]);
+      for (int element : table) {
+        ClassWriter.setUShort(buf, offset, element);
         offset += 2;
       }
     }
@@ -60,9 +60,9 @@ public final class ExceptionsWriter extends ClassWriter.Element {
     if (exceptions == null) {
       throw new IllegalArgumentException("exceptions is null");
     }
-    for (int i = 0; i < exceptions.length; i++) {
-      if (exceptions[i] < 1 || exceptions[i] > 0xFFFF) {
-        throw new IllegalArgumentException("Invalid CP index: " + exceptions[i]);
+    for (int exception : exceptions) {
+      if (exception < 1 || exception > 0xFFFF) {
+        throw new IllegalArgumentException("Invalid CP index: " + exception);
       }
     }
 

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/InnerClassesWriter.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/InnerClassesWriter.java
@@ -47,8 +47,8 @@ public final class InnerClassesWriter extends ClassWriter.Element {
     ClassWriter.setUShort(buf, offset + 6, table == null ? 0 : table.length);
     offset += 8;
     if (table != null) {
-      for (int i = 0; i < table.length; i++) {
-        ClassWriter.setUShort(buf, offset, table[i]);
+      for (int element : table) {
+        ClassWriter.setUShort(buf, offset, element);
         offset += 2;
       }
     }

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/LineNumberTableWriter.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/LineNumberTableWriter.java
@@ -69,8 +69,8 @@ public final class LineNumberTableWriter extends ClassWriter.Element {
     ClassWriter.setInt(buf, offset + 2, 2 + rawTable.length * 2);
     ClassWriter.setUShort(buf, offset + 6, rawTable.length / 2);
     offset += 8;
-    for (int i = 0; i < rawTable.length; i++) {
-      ClassWriter.setUShort(buf, offset, rawTable[i]);
+    for (int element : rawTable) {
+      ClassWriter.setUShort(buf, offset, element);
       offset += 2;
     }
 
@@ -89,8 +89,7 @@ public final class LineNumberTableWriter extends ClassWriter.Element {
     }
     int rawCount = 0;
     int last = -1;
-    for (int i = 0; i < newLineMap.length; i++) {
-      int next = newLineMap[i];
+    for (int next : newLineMap) {
       if (next != last) {
         rawCount++;
       }

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/LocalVariableTableWriter.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/LocalVariableTableWriter.java
@@ -73,8 +73,8 @@ public final class LocalVariableTableWriter extends ClassWriter.Element {
     ClassWriter.setInt(buf, offset + 2, 2 + rawTable.length * 2);
     ClassWriter.setUShort(buf, offset + 6, rawTable.length / 5);
     offset += 8;
-    for (int i = 0; i < rawTable.length; i++) {
-      ClassWriter.setUShort(buf, offset, rawTable[i]);
+    for (int element : rawTable) {
+      ClassWriter.setUShort(buf, offset, element);
       offset += 2;
     }
 
@@ -95,9 +95,9 @@ public final class LocalVariableTableWriter extends ClassWriter.Element {
     }
     try {
       int varCount = 0;
-      for (int i = 0; i < varMap.length; i++) {
-        if (varMap[i] != null) {
-          varCount = Math.max(varCount, varMap[i].length);
+      for (int[] element : varMap) {
+        if (element != null) {
+          varCount = Math.max(varCount, element.length);
         }
       }
       varCount /= 2;

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/SourceDebugExtensionWriter.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/SourceDebugExtensionWriter.java
@@ -35,8 +35,8 @@ public class SourceDebugExtensionWriter extends ClassWriter.Element {
     ClassWriter.setInt(buf, offset + 2, getSize() - 6);
     offset += 6;
     if (table != null) {
-      for (int i = 0; i < table.length; i++) {
-        ClassWriter.setUByte(buf, offset, table[i]);
+      for (byte element : table) {
+        ClassWriter.setUByte(buf, offset, element);
         offset++;
       }
     }
@@ -47,9 +47,9 @@ public class SourceDebugExtensionWriter extends ClassWriter.Element {
     if (sourceDebug == null) {
       throw new IllegalArgumentException("sourceDebug is null");
     }
-    for (int i = 0; i < sourceDebug.length; i++) {
-      if (sourceDebug[i] < 1) {
-        throw new IllegalArgumentException("Invalid CP index: " + sourceDebug[i]);
+    for (byte element : sourceDebug) {
+      if (element < 1) {
+        throw new IllegalArgumentException("Invalid CP index: " + element);
       }
     }
     this.table = sourceDebug;

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/StackMapConstants.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/StackMapConstants.java
@@ -195,13 +195,13 @@ public class StackMapConstants {
       sb.append("  offset: ").append(offset).append("\n");
       
       sb.append("  locals\n");
-      for(int i = 0; i < localTypes.length; i++) {
-        sb.append("  ").append(localTypes[i]).append("\n");
+      for (StackMapType localType : localTypes) {
+        sb.append("  ").append(localType).append("\n");
       }
 
       sb.append("  stack\n");
-      for(int i = 0; i < stackTypes.length; i++) {
-        sb.append("  ").append(stackTypes[i]).append("\n");
+      for (StackMapType stackType : stackTypes) {
+        sb.append("  ").append(stackType).append("\n");
       }
 
       return sb.toString();

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/TypeAnnotationsReader.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/TypeAnnotationsReader.java
@@ -363,8 +363,8 @@ public class TypeAnnotationsReader extends AnnotationsReader {
     static {
       final TargetType[] targetTypes = TargetType.values();
       fromValue = HashMapFactory.make(targetTypes.length);
-      for (int i = 0; i < targetTypes.length; i++) {
-        fromValue.put(targetTypes[i].target_type, targetTypes[i]);
+      for (TargetType targetType : targetTypes) {
+        fromValue.put(targetType.target_type, targetType);
       }
     }
     
@@ -710,8 +710,8 @@ public class TypeAnnotationsReader extends AnnotationsReader {
     static {
       final TypePathKind[] typePathKinds = TypePathKind.values();
       fromValue = HashMapFactory.make(typePathKinds.length);
-      for (int i = 0; i < typePathKinds.length; i++) {
-        fromValue.put(typePathKinds[i].type_path_kind, typePathKinds[i]);
+      for (TypePathKind typePathKind : typePathKinds) {
+        fromValue.put(typePathKind.type_path_kind, typePathKind);
       }
     }
     

--- a/com.ibm.wala.util/.settings/org.eclipse.jdt.core.prefs
+++ b/com.ibm.wala.util/.settings/org.eclipse.jdt.core.prefs
@@ -77,7 +77,7 @@ org.eclipse.jdt.core.compiler.problem.pessimisticNullAnalysisForFreeTypeVariable
 org.eclipse.jdt.core.compiler.problem.possibleAccidentalBooleanAssignment=error
 org.eclipse.jdt.core.compiler.problem.potentialNullReference=ignore
 org.eclipse.jdt.core.compiler.problem.potentiallyUnclosedCloseable=error
-org.eclipse.jdt.core.compiler.problem.rawTypeReference=warning
+org.eclipse.jdt.core.compiler.problem.rawTypeReference=error
 org.eclipse.jdt.core.compiler.problem.redundantNullAnnotation=error
 org.eclipse.jdt.core.compiler.problem.redundantNullCheck=error
 org.eclipse.jdt.core.compiler.problem.redundantSpecificationOfTypeArguments=warning

--- a/com.ibm.wala.util/src/com/ibm/wala/dataflow/graph/BitVectorUnion.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/dataflow/graph/BitVectorUnion.java
@@ -57,8 +57,7 @@ public class BitVectorUnion extends AbstractMeetOperator<BitVectorVariable> {
     }
     BitVectorVariable U = new BitVectorVariable();
     U.copyState(lhs);
-    for (int i = 0; i < rhs.length; i++) {
-      BitVectorVariable R = rhs[i];
+    for (BitVectorVariable R : rhs) {
       U.addAll(R);
     }
     if (!lhs.sameValue(U)) {

--- a/com.ibm.wala.util/src/com/ibm/wala/dataflow/graph/BooleanUnion.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/dataflow/graph/BooleanUnion.java
@@ -51,8 +51,7 @@ public class BooleanUnion extends AbstractMeetOperator<BooleanVariable> {
     }
     BooleanVariable U = new BooleanVariable();
     U.copyState(lhs);
-    for (int i = 0; i < rhs.length; i++) {
-      BooleanVariable R = rhs[i];
+    for (BooleanVariable R : rhs) {
       if (R != null) {
         U.or(R);
       }

--- a/com.ibm.wala.util/src/com/ibm/wala/dataflow/graph/DataflowSolver.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/dataflow/graph/DataflowSolver.java
@@ -69,8 +69,7 @@ public abstract class DataflowSolver<T, V extends IVariable<V>> extends DefaultF
     Graph<T> G = problem.getFlowGraph();
     ITransferFunctionProvider<T,V> functions = problem.getTransferFunctionProvider();
     // create a variable for each node.
-    for (Iterator<? extends T> it = G.iterator(); it.hasNext();) {
-      T N = it.next();
+    for (T N : G) {
       assert N != null;
       V v = makeNodeVariable(N, true);
       node2In.put(N, v);
@@ -128,8 +127,7 @@ public abstract class DataflowSolver<T, V extends IVariable<V>> extends DefaultF
     final private Object[] allKeys;
 
     private int mapIt(int i, Object[] allVars, Map<Object, V> varMap) {
-      for (Iterator<Object> it = varMap.keySet().iterator(); it.hasNext();) {
-        Object key = it.next();
+      for (Object key : varMap.keySet()) {
         allKeys[i] = key;
         allVars[i++] = varMap.get(key);
       }
@@ -195,8 +193,7 @@ public abstract class DataflowSolver<T, V extends IVariable<V>> extends DefaultF
 
     // add meet operations
     int meetThreshold = (meet.isUnaryNoOp() ? 2 : 1);
-    for (Iterator<? extends T> it = G.iterator(); it.hasNext();) {
-      T node = it.next();
+    for (T node : G) {
       int nPred = G.getPredNodeCount(node);
       if (nPred >= meetThreshold) {
         // todo: optimize further using unary operators when possible?
@@ -211,8 +208,7 @@ public abstract class DataflowSolver<T, V extends IVariable<V>> extends DefaultF
 
     // add node transfer operations, if requested
     if (functions.hasNodeTransferFunctions()) {
-      for (Iterator<? extends T> it = G.iterator(); it.hasNext();) {
-        T node = it.next();
+      for (T node : G) {
         UnaryOperator<V> f = functions.getNodeTransferFunction(node);
         if (!f.isIdentity()) {
           newStatement(getOut(node), f, getIn(node), toWorkList, eager);
@@ -222,8 +218,7 @@ public abstract class DataflowSolver<T, V extends IVariable<V>> extends DefaultF
 
     // add edge transfer operations, if requested
     if (functions.hasEdgeTransferFunctions()) {
-      for (Iterator<? extends T> it = G.iterator(); it.hasNext();) {
-        T node = it.next();
+      for (T node : G) {
         for (Iterator<? extends T> it2 = G.getSuccNodes(node); it2.hasNext();) {
           T succ = it2.next();
           UnaryOperator<V> f = functions.getEdgeTransferFunction(node, succ);
@@ -241,8 +236,7 @@ public abstract class DataflowSolver<T, V extends IVariable<V>> extends DefaultF
    */
   private void shortCircuitIdentities(Graph<T> G, ITransferFunctionProvider<T, V> functions, UnionFind uf) {
     if (functions.hasNodeTransferFunctions()) {
-      for (Iterator<? extends T> it = G.iterator(); it.hasNext();) {
-        T node = it.next();
+      for (T node : G) {
         UnaryOperator<V> f = functions.getNodeTransferFunction(node);
         if (f.isIdentity()) {
           uf.union(getIn(node), getOut(node));
@@ -251,8 +245,7 @@ public abstract class DataflowSolver<T, V extends IVariable<V>> extends DefaultF
     }
 
     if (functions.hasEdgeTransferFunctions()) {
-      for (Iterator<? extends T> it = G.iterator(); it.hasNext();) {
-        T node = it.next();
+      for (T node : G) {
         for (Iterator<? extends T> it2 = G.getSuccNodes(node); it2.hasNext();) {
           T succ = it2.next();
           UnaryOperator<V> f = functions.getEdgeTransferFunction(node, succ);
@@ -305,8 +298,7 @@ public abstract class DataflowSolver<T, V extends IVariable<V>> extends DefaultF
   }
 
   private void shortCircuitUnaryMeets(Graph<T> G, ITransferFunctionProvider<T,V> functions, UnionFind uf) {
-    for (Iterator<? extends T> it = G.iterator(); it.hasNext();) {
-      T node = it.next();
+    for (T node : G) {
       assert node != null;
       int nPred = G.getPredNodeCount(node);
       if (nPred == 1) {

--- a/com.ibm.wala.util/src/com/ibm/wala/fixedpoint/impl/AbstractFixedPointSolver.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/fixedpoint/impl/AbstractFixedPointSolver.java
@@ -25,6 +25,7 @@ import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.MonitorUtil;
 import com.ibm.wala.util.MonitorUtil.IProgressMonitor;
 import com.ibm.wala.util.debug.VerboseAction;
+import com.ibm.wala.util.graph.INodeWithNumber;
 
 /**
  * Represents a set of {@link IFixedPointStatement}s to be solved by a {@link IFixedPointSolver}
@@ -215,13 +216,13 @@ public abstract class AbstractFixedPointSolver<T extends IVariable<T>> implement
   @Override
   public String toString() {
     StringBuffer result = new StringBuffer("Fixed Point System:\n");
-    for (Iterator it = getStatements(); it.hasNext();) {
+    for (Iterator<? extends INodeWithNumber> it = getStatements(); it.hasNext();) {
       result.append(it.next()).append("\n");
     }
     return result.toString();
   }
 
-  public Iterator getStatements() {
+  public Iterator<? extends INodeWithNumber> getStatements() {
     return getFixedPointSystem().getStatements();
   }
 
@@ -238,7 +239,7 @@ public abstract class AbstractFixedPointSolver<T extends IVariable<T>> implement
    * Add all to the work list.
    */
   public void addAllStatementsToWorkList() {
-    for (Iterator i = getStatements(); i.hasNext();) {
+    for (Iterator<? extends INodeWithNumber> i = getStatements(); i.hasNext();) {
       AbstractStatement eq = (AbstractStatement) i.next();
       addToWorkList(eq);
     }
@@ -251,7 +252,7 @@ public abstract class AbstractFixedPointSolver<T extends IVariable<T>> implement
    * @param v the variable that has changed
    */
   public void changedVariable(T v) {
-    for (Iterator it = getFixedPointSystem().getStatementsThatUse(v); it.hasNext();) {
+    for (Iterator<? extends INodeWithNumber> it = getFixedPointSystem().getStatementsThatUse(v); it.hasNext();) {
       AbstractStatement s = (AbstractStatement) it.next();
       addToWorkList(s);
     }

--- a/com.ibm.wala.util/src/com/ibm/wala/fixedpoint/impl/AbstractFixedPointSolver.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/fixedpoint/impl/AbstractFixedPointSolver.java
@@ -517,8 +517,7 @@ public abstract class AbstractFixedPointSolver<T extends IVariable<T>> implement
     getFixedPointSystem().reorder();
 
     // re-populate worklist
-    for (Iterator<AbstractStatement> it = temp.iterator(); it.hasNext();) {
-      AbstractStatement s = it.next();
+    for (AbstractStatement s : temp) {
       workList.insertStatement(s);
     }
   }

--- a/com.ibm.wala.util/src/com/ibm/wala/fixedpoint/impl/DefaultFixedPointSystem.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/fixedpoint/impl/DefaultFixedPointSystem.java
@@ -133,8 +133,7 @@ public class DefaultFixedPointSystem<T extends IVariable<T>> implements IFixedPo
       graph.addNode(lhs);
       graph.addEdge(s, lhs);
     }
-    for (int i = 0; i < rhs.length; i++) {
-      IVariable<?> v = rhs[i];
+    for (IVariable<?> v : rhs) {
       IVariable<?> variable = v;
       if (variable != null) {
         variables.add(variable);

--- a/com.ibm.wala.util/src/com/ibm/wala/fixedpoint/impl/DefaultFixedPointSystem.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/fixedpoint/impl/DefaultFixedPointSystem.java
@@ -233,12 +233,12 @@ public class DefaultFixedPointSystem<T extends IVariable<T>> implements IFixedPo
   }
 
   @Override
-  public Iterator<?> getStatementsThatUse(T v) {
+  public Iterator<INodeWithNumber> getStatementsThatUse(T v) {
     return (graph.containsNode(v) ? graph.getSuccNodes(v) : EmptyIterator.instance());
   }
 
   @Override
-  public Iterator<?> getStatementsThatDef(T v) {
+  public Iterator<INodeWithNumber> getStatementsThatDef(T v) {
     return (graph.containsNode(v) ? graph.getPredNodes(v) : EmptyIterator.instance());
   }
 

--- a/com.ibm.wala.util/src/com/ibm/wala/fixedpoint/impl/GeneralStatement.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/fixedpoint/impl/GeneralStatement.java
@@ -61,8 +61,8 @@ public abstract class GeneralStatement<T extends IVariable<T>> extends AbstractS
     if (lhs == cell) {
       return true;
     }
-    for (int i = 0; i < rhs.length; i++) {
-      if (rhs[i] == cell)
+    for (T rh : rhs) {
+      if (rh == cell)
         return true;
     }
     return false;

--- a/com.ibm.wala.util/src/com/ibm/wala/fixpoint/IFixedPointSystem.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/fixpoint/IFixedPointSystem.java
@@ -12,10 +12,11 @@ package com.ibm.wala.fixpoint;
 
 import java.util.Iterator;
 
+import com.ibm.wala.util.graph.INodeWithNumber;
+
 /**
  * Represents a set of {@link IFixedPointStatement}s to be solved by a {@link IFixedPointSolver}
  */
-@SuppressWarnings("rawtypes")
 public interface IFixedPointSystem<T extends IVariable<T>> {
 
   /**
@@ -33,14 +34,14 @@ public interface IFixedPointSystem<T extends IVariable<T>> {
    * 
    * @return {@link Iterator}&lt;Constraint&gt;
    */
-  public Iterator getStatements();
+  public Iterator<? extends INodeWithNumber> getStatements();
 
   /**
    * Return an Iterator of the variables in this graph
    * 
    * @return {@link Iterator}&lt;{@link IVariable}&gt;
    */
-  public Iterator getVariables();
+  public Iterator<T> getVariables();
 
   /**
    * @return true iff this system already contains an equation that is equal() to s
@@ -55,12 +56,12 @@ public interface IFixedPointSystem<T extends IVariable<T>> {
   /**
    * @return {@link Iterator}&lt;statement&gt;, the statements that use the variable
    */
-  Iterator getStatementsThatUse(T v);
+  Iterator<? extends INodeWithNumber> getStatementsThatUse(T v);
 
   /**
    * @return {@link Iterator}&lt;statement&gt;, the statements that def the variable
    */
-  Iterator getStatementsThatDef(T v);
+  Iterator<? extends INodeWithNumber> getStatementsThatDef(T v);
 
   int getNumberOfStatementsThatUse(T v);
 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/collections/BimodalMap.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/collections/BimodalMap.java
@@ -12,7 +12,6 @@ package com.ibm.wala.util.collections;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
@@ -110,8 +109,7 @@ public class BimodalMap<K, V> implements Map<K, V> {
     assert backingStore instanceof SmallMap;
     SmallMap<K, V> S = (SmallMap<K, V>) backingStore;
     backingStore = HashMapFactory.make(2 * S.size());
-    for (Iterator<K> it = S.keySet().iterator(); it.hasNext();) {
-      K key = it.next();
+    for (K key : S.keySet()) {
       V value = S.get(key);
       backingStore.put(key, value);
     }

--- a/com.ibm.wala.util/src/com/ibm/wala/util/collections/ImmutableStack.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/collections/ImmutableStack.java
@@ -176,8 +176,8 @@ public class ImmutableStack<T> implements Iterable<T> {
 		if (entry == null) {
 			return false;
 		}
-		for (int i = 0; i < entries.length; i++) {
-			if (entries[i] != null && entries[i].equals(entry))
+		for (T entrie : entries) {
+			if (entrie != null && entrie.equals(entry))
 				return true;
 		}
 		return false;

--- a/com.ibm.wala.util/src/com/ibm/wala/util/collections/MapUtil.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/collections/MapUtil.java
@@ -12,7 +12,6 @@ package com.ibm.wala.util.collections;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -162,12 +161,10 @@ public class MapUtil {
       throw new IllegalArgumentException("m is null");
     }
     Map<V, Set<K>> result = HashMapFactory.make(m.size());
-    for (Iterator<Map.Entry<K, Set<V>>> it = m.entrySet().iterator(); it.hasNext();) {
-      Map.Entry<K, Set<V>> E = it.next();
+    for (Map.Entry<K, Set<V>> E : m.entrySet()) {
       K key = E.getKey();
       Set<V> values = E.getValue();
-      for (Iterator<V> it2 = values.iterator(); it2.hasNext();) {
-        V v = it2.next();
+      for (V v : values) {
         Set<K> s = findOrCreateSet(result, v);
         s.add(key);
       }
@@ -203,14 +200,12 @@ public class MapUtil {
     }
     Map<Set<K>, V> result = HashMapFactory.make();
     Map<V, Set<K>> valueToKeys = HashMapFactory.make();
-    for (Iterator<Map.Entry<K, V>> it = m.entrySet().iterator(); it.hasNext();) {
-      Map.Entry<K, V> E = it.next();
+    for (Map.Entry<K, V> E : m.entrySet()) {
       K key = E.getKey();
       V value = E.getValue();
       findOrCreateSet(valueToKeys, value).add(key);
     }
-    for (Iterator<Map.Entry<V, Set<K>>> it = valueToKeys.entrySet().iterator(); it.hasNext();) {
-      Map.Entry<V, Set<K>> E = it.next();
+    for (Map.Entry<V, Set<K>> E : valueToKeys.entrySet()) {
       V value = E.getKey();
       Set<K> keys = E.getValue();
       result.put(keys, value);

--- a/com.ibm.wala.util/src/com/ibm/wala/util/collections/ParanoidHashSet.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/collections/ParanoidHashSet.java
@@ -12,7 +12,6 @@ package com.ibm.wala.util.collections;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -45,8 +44,8 @@ public class ParanoidHashSet<T> extends LinkedHashSet<T> {
   public ParanoidHashSet(Collection<T> s) throws NullPointerException {
     super(s.size());
     hcFreq = HashMapFactory.make(s.size());
-    for (Iterator<T> it = s.iterator(); it.hasNext();) {
-      add(it.next());
+    for (T t : s) {
+      add(t);
     }
   }
 
@@ -85,8 +84,8 @@ public class ParanoidHashSet<T> extends LinkedHashSet<T> {
         hcFreq.put(hc, h);
       } else {
         if (s.size() == BAD_HC) {
-          for (Iterator<T> it = s.iterator(); it.hasNext();) {
-            Object o = it.next();
+          for (T t : s) {
+            Object o = t;
             System.err.println(o + " " + o.hashCode());
           }
           assert false : "bad hc " + arg0.getClass() + " " + arg0;

--- a/com.ibm.wala.util/src/com/ibm/wala/util/collections/SimpleVector.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/collections/SimpleVector.java
@@ -94,8 +94,8 @@ public class SimpleVector<T> implements IVector<T> {
    */
   private double computeOccupancy() {
     int count = 0;
-    for (int i = 0; i < store.length; i++) {
-      if (store[i] != null) {
+    for (Object element : store) {
+      if (element != null) {
         count++;
       }
     }

--- a/com.ibm.wala.util/src/com/ibm/wala/util/collections/Util.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/collections/Util.java
@@ -48,7 +48,6 @@ import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
@@ -118,8 +117,7 @@ public class Util {
     if (c == null) {
       throw new IllegalArgumentException("c == null");
     }
-    for (Iterator<T> iter = c.iterator(); iter.hasNext();) {
-      T obj = iter.next();
+    for (T obj : c) {
       if (p.test(obj))
         return obj;
     }
@@ -151,8 +149,8 @@ public class Util {
     if (c == null) {
       throw new IllegalArgumentException("c == null");
     }
-    for (Iterator<T> iter = c.iterator(); iter.hasNext();)
-      v.visit(iter.next());
+    for (T t : c)
+      v.visit(t);
   }
 
   /**
@@ -167,8 +165,8 @@ public class Util {
       throw new IllegalArgumentException("srcList == null");
     }
     ArrayList<U> result = new ArrayList<>();
-    for (Iterator<T> srcIter = srcList.iterator(); srcIter.hasNext();) {
-      result.add(f.apply(srcIter.next()));
+    for (T t : srcList) {
+      result.add(f.apply(t));
     }
     return result;
   }
@@ -185,8 +183,8 @@ public class Util {
       throw new IllegalArgumentException("srcSet == null");
     }
     HashSet<U> result = HashSetFactory.make();
-    for (Iterator<T> srcIter = srcSet.iterator(); srcIter.hasNext();) {
-      result.add(f.apply(srcIter.next()));
+    for (T t : srcSet) {
+      result.add(f.apply(t));
     }
     return result;
   }

--- a/com.ibm.wala.util/src/com/ibm/wala/util/graph/AbstractGraph.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/graph/AbstractGraph.java
@@ -189,8 +189,7 @@ public abstract class AbstractGraph<T> implements Graph<T> {
   @Override
   public String toString() {
     StringBuffer sb = new StringBuffer();
-    for (Iterator<? extends T> ns = iterator(); ns.hasNext();) {
-      T n = ns.next();
+    for (T n : this) {
       sb.append(n.toString()).append("\n");
       for (Iterator<? extends T> ss = getSuccNodes(n); ss.hasNext();) {
         T s = ss.next();

--- a/com.ibm.wala.util/src/com/ibm/wala/util/graph/GraphIntegrity.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/graph/GraphIntegrity.java
@@ -43,8 +43,7 @@ public class GraphIntegrity {
   }
 
   private static <T> void checkEdgeCounts(Graph<T> G) throws UnsoundGraphException {
-    for (Iterator<? extends T> it = G.iterator(); it.hasNext();) {
-      T N = it.next();
+    for (T N : G) {
       int count1 = G.getSuccNodeCount(N);
       int count2 = 0;
       for (Iterator<T> it2 = G.getSuccNodes(N); it2.hasNext();) {
@@ -68,8 +67,7 @@ public class GraphIntegrity {
   }
 
   private static <T> void checkEdges(Graph<T> G) throws UnsoundGraphException {
-    for (Iterator<? extends T> it = G.iterator(); it.hasNext();) {
-      T N = it.next();
+    for (T N : G) {
       if (!G.containsNode(N)) {
         throw new UnsoundGraphException(N + " is not contained in the the graph " + G.containsNode(N));
       }
@@ -117,8 +115,8 @@ public class GraphIntegrity {
     try {
       n1 = G.getNumberOfNodes();
       n2 = 0;
-      for (Iterator<T> it = G.iterator(); it.hasNext();) {
-        Object n = it.next();
+      for (T t : G) {
+        Object n = t;
         if (DEBUG_LEVEL > 1) {
           System.err.println(("n2 loop: " + n));
         }
@@ -224,8 +222,8 @@ public class GraphIntegrity {
     if (c.isEmpty()) {
       System.err.println("none\n");
     } else {
-      for (Iterator<?> it = c.iterator(); it.hasNext();) {
-        System.err.println(it.next().toString());
+      for (Object name : c) {
+        System.err.println(name.toString());
       }
       System.err.println("\n");
     }

--- a/com.ibm.wala.util/src/com/ibm/wala/util/graph/GraphPrint.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/graph/GraphPrint.java
@@ -24,11 +24,10 @@ public class GraphPrint {
       throw new IllegalArgumentException("G is null");
     }
     SlowSparseNumberedGraph<T> sg = SlowSparseNumberedGraph.make();
-    for (Iterator<? extends T> it = G.iterator(); it.hasNext(); ) {
-      sg.addNode(it.next());
+    for (T name : G) {
+      sg.addNode(name);
     }
-    for (Iterator<? extends T> it = G.iterator(); it.hasNext(); ) {
-      T n = it.next();
+    for (T n : G) {
       for (Iterator<? extends T> it2 = G.getSuccNodes(n); it2.hasNext(); ) {
         T d = it2.next();
         sg.addEdge(n,d);

--- a/com.ibm.wala.util/src/com/ibm/wala/util/graph/GraphSlicer.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/graph/GraphSlicer.java
@@ -46,8 +46,7 @@ public class GraphSlicer {
       throw new IllegalArgumentException("g is null");
     }
     HashSet<T> roots = HashSetFactory.make();
-    for (Iterator<? extends T> it = g.iterator(); it.hasNext();) {
-      T o = it.next();
+    for (T o : g) {
       if (p.test(o)) {
         roots.add(o);
       }

--- a/com.ibm.wala.util/src/com/ibm/wala/util/graph/InferGraphRoots.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/graph/InferGraphRoots.java
@@ -12,7 +12,6 @@ package com.ibm.wala.util.graph;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Iterator;
 
 import com.ibm.wala.util.collections.HashSetFactory;
 
@@ -26,8 +25,7 @@ public class InferGraphRoots {
       throw new IllegalArgumentException("g is null");
     }
     HashSet<T> s = HashSetFactory.make();
-    for (Iterator<? extends T> it = g.iterator(); it.hasNext();) {
-      T node = it.next();
+    for (T node : g) {
       if (g.getPredNodeCount(node) == 0) {
         s.add(node);
       }

--- a/com.ibm.wala.util/src/com/ibm/wala/util/graph/dominators/Dominators.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/graph/dominators/Dominators.java
@@ -156,8 +156,7 @@ public abstract class Dominators<T> {
         private final Map<T, Set<T>> nextMap = HashMapFactory.make();
 
         {
-          for (Iterator<? extends T> ns = G.iterator(); ns.hasNext();) {
-            T n = ns.next();
+          for (T n : G) {
             if (n != root) {
               T prev = getIdom(n);
               Set<T> next = nextMap.get(prev);
@@ -585,8 +584,7 @@ public abstract class Dominators<T> {
   @Override
   public String toString() {
     StringBuffer sb = new StringBuffer();
-    for (Iterator<? extends T> i = G.iterator(); i.hasNext();) {
-      T node = i.next();
+    for (T node : G) {
       sb.append("Dominators of " + node + ":\n");
       for (Iterator<T> j = dominators(node); j.hasNext();)
         sb.append("   " + j.next() + "\n");

--- a/com.ibm.wala.util/src/com/ibm/wala/util/graph/impl/SlowSparseNumberedGraph.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/graph/impl/SlowSparseNumberedGraph.java
@@ -73,11 +73,10 @@ public class SlowSparseNumberedGraph<T> extends AbstractNumberedGraph<T> impleme
     if (g == null) {
       throw new IllegalArgumentException("g is null");
     }
-    for (Iterator<? extends T> it = g.iterator(); it.hasNext();) {
-      into.addNode(it.next());
+    for (T name : g) {
+      into.addNode(name);
     }
-    for (Iterator<? extends T> it = g.iterator(); it.hasNext();) {
-      T n = it.next();
+    for (T n : g) {
       for (Iterator<? extends T> it2 = g.getSuccNodes(n); it2.hasNext();) {
         into.addEdge(n, it2.next());
       }

--- a/com.ibm.wala.util/src/com/ibm/wala/util/graph/labeled/SlowSparseNumberedLabeledGraph.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/graph/labeled/SlowSparseNumberedLabeledGraph.java
@@ -71,11 +71,10 @@ public class SlowSparseNumberedLabeledGraph<T, U> extends AbstractNumberedLabele
     if (g == null) {
       throw new IllegalArgumentException("g is null");
     }
-    for (Iterator<? extends T> it = g.iterator(); it.hasNext();) {
-      into.addNode(it.next());
+    for (T name : g) {
+      into.addNode(name);
     }
-    for (Iterator<? extends T> it = g.iterator(); it.hasNext();) {
-      T n = it.next();
+    for (T n : g) {
       for (Iterator<? extends T> it2 = g.getSuccNodes(n); it2.hasNext();) {
         T s = it2.next();
         for(U l : g.getEdgeLabels(n, s)) {

--- a/com.ibm.wala.util/src/com/ibm/wala/util/graph/labeled/SparseNumberedLabeledEdgeManager.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/graph/labeled/SparseNumberedLabeledEdgeManager.java
@@ -178,8 +178,7 @@ public class SparseNumberedLabeledEdgeManager<T, U> implements Serializable, Num
    */
   @Override
   public void removeIncomingEdges(T node) throws IllegalArgumentException {
-    for (Iterator<U> inLabelIter = nodeToPredLabels.get(node).iterator(); inLabelIter.hasNext();) {
-      U label = inLabelIter.next();
+    for (U label : nodeToPredLabels.get(node)) {
       getManagerForLabel(label).removeIncomingEdges(node);
     }
 
@@ -190,8 +189,7 @@ public class SparseNumberedLabeledEdgeManager<T, U> implements Serializable, Num
    */
   @Override
   public void removeOutgoingEdges(T node) throws IllegalArgumentException {
-    for (Iterator<U> outLabelIter = nodeToSuccLabels.get(node).iterator(); outLabelIter.hasNext();) {
-      U label = outLabelIter.next();
+    for (U label : nodeToSuccLabels.get(node)) {
       getManagerForLabel(label).removeOutgoingEdges(node);
     }
 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/graph/traverse/DFSPathFinder.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/graph/traverse/DFSPathFinder.java
@@ -125,8 +125,8 @@ public class DFSPathFinder<T> extends ArrayList<T> {
 
   protected List<T> currentPath() {
     ArrayList<T> result = new ArrayList<>();
-    for (Iterator<T> path = iterator(); path.hasNext();) {
-      result.add(0, path.next());
+    for (T t : this) {
+      result.add(0, t);
     }
     return result;
   }

--- a/com.ibm.wala.util/src/com/ibm/wala/util/heapTrace/HeapTracer.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/heapTrace/HeapTracer.java
@@ -157,8 +157,8 @@ public class HeapTracer {
 	String classpath = System.getProperty("java.class.path");
 	Object[] binDirectories = extractBinDirectories(classpath);
 	HashSet<String> classFileNames = HashSetFactory.make();
-	for (int i = 0; i < binDirectories.length; i++) {
-	    String dir = (String) binDirectories[i];
+	for (Object binDirectorie : binDirectories) {
+	    String dir = (String) binDirectorie;
 	    File fdir = new File(dir);
 	    classFileNames.addAll(findClassNames(dir, fdir));
 	}
@@ -186,8 +186,8 @@ public class HeapTracer {
 	HashSet<String> result = HashSetFactory.make();
 	if (f.isDirectory()) {
 	    File[] files = f.listFiles();
-	    for (int i = 0; i < files.length; i++) {
-		result.addAll(findClassNames(rootDir, files[i]));
+	    for (File file : files) {
+		result.addAll(findClassNames(rootDir, file));
 	    }
 	} else {
 	    if (f.getName().indexOf(".class") > 0) {
@@ -226,22 +226,20 @@ public class HeapTracer {
 	Result result = new Result();
 	IdentityHashMap<Object, Object> objectsVisited = new IdentityHashMap<>();
 	if (traceStatics) {
-	    for (int i = 0; i < rootClasses.length; i++) {
-		Class<?> c = Class.forName(rootClasses[i]);
+	    for (String rootClasse : rootClasses) {
+		Class<?> c = Class.forName(rootClasse);
 		Field[] fields = c.getDeclaredFields();
-		for (int j = 0; j < fields.length; j++) {
-		    if (isStatic(fields[j])) {
-			traverse(fields[j], result, objectsVisited);
+		for (Field field : fields) {
+		    if (isStatic(field)) {
+			traverse(field, result, objectsVisited);
 		    }
 		}
 	    }
 	}
-	for (Iterator<?> it = rootInstances.iterator(); it.hasNext();) {
-	    Object instance = it.next();
+	for (Object instance : rootInstances) {
 	    Class<?> c = instance.getClass();
 	    Set<Field> fields = getAllInstanceFields(c);
-	    for (Iterator<Field> it2 = fields.iterator(); it2.hasNext();) {
-		Field f = it2.next();
+	    for (Field f : fields) {
 		traverse(f, instance, result, objectsVisited);
 	    }
 	}
@@ -264,8 +262,7 @@ public class HeapTracer {
 	    throw new Error();
 	} else {
 	    Collection<Field> fields = getAllInstanceFields(c);
-	    for (Iterator<Field> it = fields.iterator(); it.hasNext();) {
-		Field f = it.next();
+	    for (Field f : fields) {
 		result += sizeOfSlot(f.getType());
 	    }
 	}
@@ -416,8 +413,8 @@ public class HeapTracer {
 	    System.err.println(("traverse scalar " + c));
 	}
 	Field[] fields = getAllReferenceInstanceFields(c);
-	for (int i = 0; i < fields.length; i++) {
-	    traverseFieldOfScalar(root, fields[i], scalar, container,
+	for (Field field : fields) {
+	    traverseFieldOfScalar(root, field, scalar, container,
 		    objectsVisited, result);
 	}
     }
@@ -676,8 +673,7 @@ public class HeapTracer {
 	    result.append("Totals: " + totalInstances + " " + totalSize + "\n");
 	    TreeSet<Object> sorted = new TreeSet<>(new SizeComparator());
 	    sorted.addAll(instanceCount.keySet());
-	    for (Iterator<Object> it = sorted.iterator(); it.hasNext();) {
-		Object key = it.next();
+	    for (Object key : sorted) {
 		Integer I = instanceCount.get(key);
 		Integer bytes = sizeCount.get(key);
 		result.append("  ").append(I).append("   ").append(bytes)
@@ -757,11 +753,9 @@ public class HeapTracer {
 
 	public int getTotalSize() {
 	    int totalSize = 0;
-	    for (Iterator<Demographics> it = roots.values().iterator(); it
-		    .hasNext();) {
-		Demographics d = it.next();
-		totalSize += d.getTotalSize();
-	    }
+	    for (Demographics d : roots.values()) {
+totalSize += d.getTotalSize();
+  }
 	    return totalSize;
 	}
 
@@ -772,19 +766,17 @@ public class HeapTracer {
 		    + " header bytes per object\n");
 	    int totalInstances = 0;
 	    int totalSize = 0;
-	    for (Iterator<Demographics> it = roots.values().iterator(); it
-		    .hasNext();) {
-		Demographics d = it.next();
-		totalInstances += d.getTotalInstances();
-		totalSize += d.getTotalSize();
-	    }
+	    for (Demographics d : roots.values()) {
+totalInstances += d.getTotalInstances();
+totalSize += d.getTotalSize();
+  }
 	    result.append("Total instances: " + totalInstances + "\n");
 	    result.append("Total size(bytes): " + totalSize + "\n");
 
 	    TreeSet<Field> sortedDemo = new TreeSet<>(new SizeComparator());
 	    sortedDemo.addAll(roots.keySet());
-	    for (Iterator<Field> it = sortedDemo.iterator(); it.hasNext();) {
-		Object root = it.next();
+	    for (Field field : sortedDemo) {
+		Object root = field;
 		Demographics d = roots.get(root);
 		if (d.getTotalSize() > 10000) {
 		    result.append(" root: ").append(root).append("\n");

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/BasicNaturalRelation.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/BasicNaturalRelation.java
@@ -155,8 +155,7 @@ public final class BasicNaturalRelation implements IBinaryNaturalRelation, Seria
         if (i == ssLength) {
           MutableIntSet s = new BimodalMutableIntSet(ssLength + 1, 1.1f);
           delegateStore.set(x, s);
-          for (int j = 0; j < smallStore.length; j++) {
-            IntVector vv = smallStore[j];
+          for (IntVector vv : smallStore) {
             s.add(vv.get(x));
             vv.set(x, DELEGATE_CODE);
           }
@@ -304,11 +303,11 @@ public final class BasicNaturalRelation implements IBinaryNaturalRelation, Seria
             return SparseIntSet.singleton(ss0);
           } else {
             MutableSparseIntSet result = MutableSparseIntSet.createMutableSparseIntSet(ssLength);
-            for (int i = 0; i < smallStore.length; i++) {
-              if (smallStore[i].get(x) == EMPTY_CODE) {
+            for (IntVector element : smallStore) {
+              if (element.get(x) == EMPTY_CODE) {
                 break;
               }
-              result.add(smallStore[i].get(x));
+              result.add(element.get(x));
             }
             return result;
           }
@@ -332,8 +331,8 @@ public final class BasicNaturalRelation implements IBinaryNaturalRelation, Seria
         return getDelegate(x).size();
       } else {
         int result = 0;
-        for (int i = 0; i < smallStore.length; i++) {
-          if (smallStore[i].get(x) == EMPTY_CODE) {
+        for (IntVector element : smallStore) {
+          if (element.get(x) == EMPTY_CODE) {
             break;
           }
           result++;
@@ -357,8 +356,8 @@ public final class BasicNaturalRelation implements IBinaryNaturalRelation, Seria
       s.remove(y);
       if (s.size() == 0) {
         delegateStore.set(x, null);
-        for (int i = 0; i < smallStore.length; i++) {
-          smallStore[i].set(x, EMPTY_CODE);
+        for (IntVector element : smallStore) {
+          element.set(x, EMPTY_CODE);
         }
       }
     } else {
@@ -379,8 +378,8 @@ public final class BasicNaturalRelation implements IBinaryNaturalRelation, Seria
 
   @Override
   public void removeAll(int x) {
-    for (int i = 0; i < smallStore.length; i++) {
-      smallStore[i].set(x, EMPTY_CODE);
+    for (IntVector element : smallStore) {
+      element.set(x, EMPTY_CODE);
     }
     delegateStore.set(x, null);
   }
@@ -408,8 +407,7 @@ public final class BasicNaturalRelation implements IBinaryNaturalRelation, Seria
    */
   private int countPairs() {
     int result = 0;
-    for (Iterator<?> it = iterator(); it.hasNext();) {
-      it.next();
+    for (@SuppressWarnings("unused") Object name : this) {
       result++;
     }
     return result;
@@ -426,8 +424,8 @@ public final class BasicNaturalRelation implements IBinaryNaturalRelation, Seria
     if (usingDelegate(x)) {
       return getDelegate(x).contains(y);
     } else {
-      for (int i = 0; i < smallStore.length; i++) {
-        if (smallStore[i].get(x) == y) {
+      for (IntVector element : smallStore) {
+        if (element.get(x) == y) {
           return true;
         }
       }

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/BitVectorBase.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/BitVectorBase.java
@@ -85,8 +85,8 @@ abstract public class BitVectorBase<T extends BitVectorBase> implements Cloneabl
    */
   public final int populationCount() {
     int count = 0;
-    for (int i = 0; i < bits.length; i++) {
-      count += Bits.populationCount(bits[i]);
+    for (int bit : bits) {
+      count += Bits.populationCount(bit);
     }
     return count;
   }
@@ -165,8 +165,8 @@ abstract public class BitVectorBase<T extends BitVectorBase> implements Cloneabl
     int top = bits[lastWord];
 
     int j = 0;
-    for (int i = 0; i < masks.length; i++) {
-      if ((top & masks[i][j]) != 0) {
+    for (int[] mask2 : masks) {
+      if ((top & mask2[j]) != 0) {
         j <<= 1;
       } else {
         j <<= 1;

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/BitVectorIntSetFactory.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/BitVectorIntSetFactory.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package com.ibm.wala.util.intset;
 
-import java.util.Iterator;
 import java.util.TreeSet;
 
 /**
@@ -31,12 +30,11 @@ public class BitVectorIntSetFactory implements MutableIntSetFactory<BitVectorInt
     } else {
       // XXX not very efficient.
       TreeSet<Integer> T = new TreeSet<>();
-      for (int i = 0; i < set.length; i++) {
-        T.add(set[i]);
+      for (int element : set) {
+        T.add(element);
       }
       BitVectorIntSet result = new BitVectorIntSet();
-      for (Iterator<Integer> it = T.iterator(); it.hasNext();) {
-        Integer I = it.next();
+      for (Integer I : T) {
         result.add(I.intValue());
       }
       return result;
@@ -50,8 +48,8 @@ public class BitVectorIntSetFactory implements MutableIntSetFactory<BitVectorInt
   public BitVectorIntSet parse(String string) throws NumberFormatException {
     int[] data = SparseIntSet.parseIntArray(string);
     BitVectorIntSet result = new BitVectorIntSet();
-    for (int i = 0; i < data.length; i++) {
-      result.add(data[i]);
+    for (int element : data) {
+      result.add(element);
     }
     return result;
   }

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/FixedSizeBitVector.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/FixedSizeBitVector.java
@@ -268,8 +268,8 @@ public final class FixedSizeBitVector implements Cloneable, java.io.Serializable
    */
   public int populationCount() {
     int count = 0;
-    for (int i = 0; i < bits.length; i++) {
-      count += Bits.populationCount(bits[i]);
+    for (int bit : bits) {
+      count += Bits.populationCount(bit);
     }
     return count;
   }

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/MultiModalIntVector.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/MultiModalIntVector.java
@@ -253,14 +253,14 @@ public class MultiModalIntVector implements IntVector {
 
   public void print() {
     String str = "";
-    for (int i = 0; i < byteStore.length; i++) {
-      str += byteStore[i] + ",";
+    for (byte element : byteStore) {
+      str += element + ",";
     }
-    for (int i = 0; i < shortStore.length; i++) {
-      str += shortStore[i] + ",";
+    for (short element : shortStore) {
+      str += element + ",";
     }
-    for (int i = 0; i < intStore.length; i++) {
-      str += intStore[i] + ",";
+    for (int element : intStore) {
+      str += element + ",";
     }
     System.out.println(str);
   }

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/MutableSparseIntSetFactory.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/MutableSparseIntSetFactory.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package com.ibm.wala.util.intset;
 
-import java.util.Iterator;
 import java.util.TreeSet;
 
 /**
@@ -31,13 +30,12 @@ public class MutableSparseIntSetFactory implements MutableIntSetFactory<MutableS
     } else {
       // XXX not very efficient.
       TreeSet<Integer> T = new TreeSet<>();
-      for (int i = 0; i < set.length; i++) {
-        T.add(set[i]);
+      for (int element : set) {
+        T.add(element);
       }
       int[] copy = new int[T.size()];
       int i = 0;
-      for (Iterator<Integer> it = T.iterator(); it.hasNext();) {
-        Integer I = it.next();
+      for (Integer I : T) {
         copy[i++] = I.intValue();
       }
       MutableSparseIntSet result = new MutableSparseIntSet(copy);

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/MutableSparseLongSetFactory.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/MutableSparseLongSetFactory.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package com.ibm.wala.util.intset;
 
-import java.util.Iterator;
 import java.util.TreeSet;
 
 /**
@@ -32,13 +31,12 @@ public class MutableSparseLongSetFactory implements MutableLongSetFactory {
     } else {
       // XXX not very efficient.
       TreeSet<Long> T = new TreeSet<>();
-      for (int i = 0; i < set.length; i++) {
-        T.add(Long.valueOf(set[i]));
+      for (long element : set) {
+        T.add(Long.valueOf(element));
       }
       long[] copy = new long[T.size()];
       int i = 0;
-      for (Iterator<Long> it = T.iterator(); it.hasNext();) {
-        Long I = it.next();
+      for (Long I : T) {
         copy[i++] = I.longValue();
       }
       MutableSparseLongSet result = new MutableSparseLongSet(copy);

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/OrdinalSet.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/OrdinalSet.java
@@ -203,8 +203,8 @@ public class OrdinalSet<T> implements Iterable<T> {
       throw new IllegalArgumentException("m is null");
     }
     MutableSparseIntSet s = MutableSparseIntSet.makeEmpty();
-    for (Iterator<T> it = c.iterator(); it.hasNext();) {
-      int index = m.getMappedIndex(it.next());
+    for (T t : c) {
+      int index = m.getMappedIndex(t);
       assert index >= 0;
       s.add(index);
     }

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/SemiSparseMutableIntSetFactory.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/SemiSparseMutableIntSetFactory.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package com.ibm.wala.util.intset;
 
-import java.util.Iterator;
 import java.util.TreeSet;
 
 /**
@@ -31,12 +30,11 @@ public class SemiSparseMutableIntSetFactory implements MutableIntSetFactory<Semi
     } else {
       // XXX not very efficient.
       TreeSet<Integer> T = new TreeSet<>();
-      for (int i = 0; i < set.length; i++) {
-        T.add(Integer.valueOf(set[i]));
+      for (int element : set) {
+        T.add(Integer.valueOf(element));
       }
       SemiSparseMutableIntSet result = new SemiSparseMutableIntSet();
-      for (Iterator<Integer> it = T.iterator(); it.hasNext();) {
-        Integer I = it.next();
+      for (Integer I : T) {
         result.add(I.intValue());
       }
       return result;
@@ -50,8 +48,8 @@ public class SemiSparseMutableIntSetFactory implements MutableIntSetFactory<Semi
   public SemiSparseMutableIntSet parse(String string) throws NumberFormatException {
     int[] data = SparseIntSet.parseIntArray(string);
     SemiSparseMutableIntSet result = new SemiSparseMutableIntSet();
-    for (int i = 0; i < data.length; i++)
-      result.add(data[i]);
+    for (int element : data)
+      result.add(element);
     return result;
   }
 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/SimpleIntVector.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/SimpleIntVector.java
@@ -121,8 +121,8 @@ public class SimpleIntVector implements IntVector, Serializable {
    */
   private double computeOccupancy() {
     int count1 = 0;
-    for (int i = 0; i < store.length; i++) {
-      if (store[i] != -1) {
+    for (int element : store) {
+      if (element != -1) {
         count1++;
       }
     }

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/SparseIntSet.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/SparseIntSet.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package com.ibm.wala.util.intset;
 
-import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.StringTokenizer;
 import java.util.TreeSet;
@@ -324,8 +323,7 @@ public class SparseIntSet implements IntSet {
     }
     int[] result = new int[set.size()];
     int i = 0;
-    for (Iterator<Integer> it = set.iterator(); it.hasNext();) {
-      Integer I = it.next();
+    for (Integer I : set) {
       result[i++] = I.intValue();
     }
     return result;

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/SparseLongSet.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/SparseLongSet.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package com.ibm.wala.util.intset;
 
-import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.StringTokenizer;
 import java.util.TreeSet;
@@ -323,8 +322,7 @@ public class SparseLongSet implements LongSet {
     }
     long[] result = new long[set.size()];
     int i = 0;
-    for (Iterator<Long> it = set.iterator(); it.hasNext();) {
-      Long L = it.next();
+    for (Long L : set) {
       result[i++] = L.longValue();
     }
     return result;

--- a/com.ibm.wala.util/src/com/ibm/wala/util/io/FileUtil.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/io/FileUtil.java
@@ -61,12 +61,12 @@ public class FileUtil {
       return Collections.emptyList();
     }
     HashSet<File> result = HashSetFactory.make();
-    for (int i = 0; i < files.length; i++) {
-      if (p == null || p.matcher(files[i].getAbsolutePath()).matches()) {
-        result.add(files[i]);
+    for (File file : files) {
+      if (p == null || p.matcher(file.getAbsolutePath()).matches()) {
+        result.add(file);
       }
-      if (recurse && files[i].isDirectory()) {
-        result.addAll(listFiles(files[i], recurse, p));
+      if (recurse && file.isDirectory()) {
+        result.addAll(listFiles(file, recurse, p));
       }
     }
     return result;

--- a/com.ibm.wala.util/src/com/ibm/wala/util/processes/Launcher.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/processes/Launcher.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.logging.Logger;
 
@@ -130,8 +129,7 @@ public abstract class Launcher {
   private static String[] buildEnv(Map<String,String> ev) {
     String[] result = new String[ev.size()];
     int i = 0;
-    for (Iterator<Map.Entry<String,String>> it = ev.entrySet().iterator(); it.hasNext();) {
-      Map.Entry<String,String> e = it.next();
+    for (Map.Entry<String, String> e : ev.entrySet()) {
       result[i++] = e.getKey() + "=" + e.getValue();
     }
     return result;

--- a/com.ibm.wala.util/src/com/ibm/wala/viz/DotUtil.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/viz/DotUtil.java
@@ -213,8 +213,7 @@ public class DotUtil {
 
     outputNodes(labels, result, dotNodes);
 
-    for (Iterator<? extends T> it = g.iterator(); it.hasNext();) {
-      T n = it.next();
+    for (T n : g) {
       for (Iterator<? extends T> it2 = g.getSuccNodes(n); it2.hasNext();) {
         T s = it2.next();
         result.append(" ");
@@ -230,8 +229,8 @@ public class DotUtil {
   }
 
   private static <T> void outputNodes(NodeDecorator<T> labels, StringBuffer result, Collection<T> dotNodes) throws WalaException {
-    for (Iterator<T> it = dotNodes.iterator(); it.hasNext();) {
-      outputNode(labels, result, it.next());
+    for (T t : dotNodes) {
+      outputNode(labels, result, t);
     }
   }
 


### PR DESCRIPTION
Use modern `for`-each loops where possible, thereby eliminating many explicit uses of `Iterator`. Where an `Iterator` is still needed, add generic type parameters and eliminate casts that proper parameterization makes statically redundant.

This pull request will have some merge conflicts with #269. I don't care which one the maintainers decide to merge first. After either is merged, I will go back and fix up the other as needed.