### PR TITLE
Fix various Javadoc errors

### DIFF
--- a/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/JDT2CAstUtils.java
+++ b/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/JDT2CAstUtils.java
@@ -174,7 +174,6 @@ public class JDT2CAstUtils {
    * Returns true if type is char, byte, short, int, or long. Return false otherwise (including boolean!)
    * 
    * @param type
-   * @return
    */
   public static boolean isLongOrLess(ITypeBinding type) {
     String t = type.getBinaryName();
@@ -186,7 +185,6 @@ public class JDT2CAstUtils {
    * CAstSymbol.NULL_DEFAULT_VALUE.
    * 
    * @param type
-   * @return
    */
   public static Object defaultValueForType(ITypeBinding type) {
     if (isLongOrLess(type))
@@ -237,7 +235,6 @@ public class JDT2CAstUtils {
    * 
    * @param returnType
    * @param ast
-   * @return
    */
   public static ITypeBinding getErasedType(ITypeBinding returnType, AST ast) {
     if (returnType.isTypeVariable() || returnType.isCapture())

--- a/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
+++ b/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
@@ -2438,7 +2438,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
   /**
    * Expands the form: for ( [final] Type var: iterable ) { ... } Into something equivalent to: for ( Iterator iter =
    * iterable.iter(); iter.hasNext(); ) { [final] Type var = (Type) iter.next(); ... } Or, in the case of an array: for ( int idx =
-   * 0; i < iterable.length; i++ ) { [final] Type var = iterable[idx]; ... } Except that the expression "iterable" is only evaluate
+   * 0; i &lt; iterable.length; i++ ) { [final] Type var = iterable[idx]; ... } Except that the expression "iterable" is only evaluate
    * once (or is it?)
    * 
    * @param n

--- a/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
+++ b/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
@@ -411,7 +411,6 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
    * @param typeBinding
    * @param name Used in creating default constructor, and passed into new ClassEntity()
    * @param context
-   * @return
    */
   private CAstEntity createClassDeclaration(ASTNode n, List<BodyDeclaration> bodyDecls,
       List<EnumConstantDeclaration> enumConstants, ITypeBinding typeBinding, String name, int modifiers, 
@@ -649,7 +648,6 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
    *          constructor.
    * @param context
    * @param inits
-   * @return
    */
   private CAstNode createConstructorBody(MethodDeclaration n, ITypeBinding classBinding, WalkContext context,
       ArrayList<ASTNode> inits) {
@@ -721,7 +719,6 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
    * @param overriding Declaration of the overriding method.
    * @param overridden Binding of the overridden method, in a a superclass or implemented interface.
    * @param oldContext
-   * @return
    */
   private CAstEntity makeSyntheticCovariantRedirect(MethodDeclaration overriding, IMethodBinding overridingBinding,
       IMethodBinding overridden, WalkContext oldContext) {
@@ -1665,7 +1662,6 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
    * the code into an assignment and binary operation.
    * 
    * @param context
-   * @return
    */
   private CAstNode doFunkyGenericAssignPreOpHack(Assignment assign, WalkContext context) {
     Expression left = assign.getLeftHandSide();
@@ -1751,7 +1747,6 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
    * 
    * @param n
    * @param context
-   * @return
    */
   private CAstNode visit(SimpleName n, WalkContext context) {
     // class name, handled above in either method invocation, qualified name, or qualified this
@@ -1818,7 +1813,6 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
    * 
    * @param typeOfThis
    * @param isPrivate
-   * @return
    */
   private static ITypeBinding findClosestEnclosingClassSubclassOf(ITypeBinding typeOfThis, ITypeBinding owningType, boolean isPrivate) {
     // GENERICS
@@ -1866,7 +1860,6 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
    * 
    * @param n
    * @param context
-   * @return
    */
   private CAstNode visit(FieldAccess n, WalkContext context) {
     CAstNode targetNode = visitNode(n.getExpression(), context);
@@ -1883,7 +1876,6 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
    * @param fieldName Name of the field.
    * @param positioningNode Used only for making a JdtPosition.
    * @param context
-   * @return
    */
   private CAstNode createFieldAccess(CAstNode targetNode, String fieldName, IVariableBinding possiblyParameterizedBinding,
       ASTNode positioningNode, WalkContext context) {
@@ -1978,7 +1970,6 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
    * 
    * @param n
    * @param context
-   * @return
    */
   private CAstNode visit(QualifiedName n, WalkContext context) {
     // "package.Class" is a QualifiedName, but also is "Class.staticField"
@@ -2443,7 +2434,6 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
    * 
    * @param n
    * @param context
-   * @return
    */
   private CAstNode visit(EnhancedForStatement n, WalkContext context) {
     if (n.getExpression().resolveTypeBinding().isArray())
@@ -2791,7 +2781,6 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
    * Giant switch statement.
    * 
    * @param n
-   * @return
    */
   private CAstEntity visit(AbstractTypeDeclaration n, WalkContext context) {
     // handling of compilationunit in translate()
@@ -2811,7 +2800,6 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
    * Giant switch statement, part deux
    * 
    * @param context
-   * @return
    */
   private CAstNode visitNode(ASTNode n, WalkContext context) {
     if (n == null)
@@ -3320,7 +3308,6 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
    * 
    * @param decl
    * @param context
-   * @return
    */
   private CAstEntity visit(EnumConstantDeclaration decl, WalkContext context) {
     return new FieldEntity(decl.getName().getIdentifier(), decl.resolveVariable().getType(), enumQuals, makePosition(decl

--- a/com.ibm.wala.cast.js.nodejs.test/src/com/ibm/wala/cast/js/nodejs/test/NodejsRequireJsonTest.java
+++ b/com.ibm.wala.cast.js.nodejs.test/src/com/ibm/wala/cast/js/nodejs/test/NodejsRequireJsonTest.java
@@ -22,7 +22,7 @@ import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 
 /**
- * @author Brian Pfretzschner <brian.pfretzschner@gmail.com>
+ * @author Brian Pfretzschner &lt;brian.pfretzschner@gmail.com&gt;
  */
 public class NodejsRequireJsonTest {
 

--- a/com.ibm.wala.cast.js.nodejs.test/src/com/ibm/wala/cast/js/nodejs/test/NodejsRequireTargetSelectorResolveTest.java
+++ b/com.ibm.wala.cast.js.nodejs.test/src/com/ibm/wala/cast/js/nodejs/test/NodejsRequireTargetSelectorResolveTest.java
@@ -22,7 +22,7 @@ import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 
 /**
- * @author Brian Pfretzschner <brian.pfretzschner@gmail.com>
+ * @author Brian Pfretzschner &lt;brian.pfretzschner@gmail.com&gt;
  */
 public class NodejsRequireTargetSelectorResolveTest {
 

--- a/com.ibm.wala.cast.js.nodejs/src/com/ibm/wala/cast/js/nodejs/NodejsCallGraphBuilderUtil.java
+++ b/com.ibm.wala.cast.js.nodejs/src/com/ibm/wala/cast/js/nodejs/NodejsCallGraphBuilderUtil.java
@@ -46,7 +46,7 @@ import com.ibm.wala.ssa.IRFactory;
 import com.ibm.wala.util.WalaException;
 
 /**
- * @author Brian Pfretzschner <brian.pfretzschner@gmail.com>
+ * @author Brian Pfretzschner &lt;brian.pfretzschner@gmail.com&gt;
  */
 public class NodejsCallGraphBuilderUtil extends JSCallGraphUtil {
 

--- a/com.ibm.wala.cast.js.nodejs/src/com/ibm/wala/cast/js/nodejs/NodejsRequireTargetSelector.java
+++ b/com.ibm.wala.cast.js.nodejs/src/com/ibm/wala/cast/js/nodejs/NodejsRequireTargetSelector.java
@@ -185,7 +185,6 @@ public class NodejsRequireTargetSelector implements MethodTargetSelector {
 	 * 
 	 * @param dir Y in the pseudo algorithm
 	 * @param target X in the pseudo algorithm
-	 * @return
 	 * @throws IOException
 	 */
 	public static SourceFileModule resolve(File rootDir, File dir, String target) throws IOException {
@@ -214,8 +213,7 @@ public class NodejsRequireTargetSelector implements MethodTargetSelector {
 	 * 4. If X.node is a file, load X.node as binary addon.  STOP
 	 * 
 	 * @param f
-	 * @return
-	 * @throws IOException 
+	 * @throws IOException
 	 */
 	private static SourceFileModule loadAsFile(File rootDir, File f) throws IOException {
 		// 1.
@@ -248,7 +246,6 @@ public class NodejsRequireTargetSelector implements MethodTargetSelector {
 	 * 4. If X/index.node is a file, load X/index.node as binary addon.  STOP
 	 * 
 	 * @param d
-	 * @return
 	 * @throws IOException
 	 */
 	private static SourceFileModule loadAsDirectory(File rootDir, File d) throws IOException {
@@ -293,8 +290,7 @@ public class NodejsRequireTargetSelector implements MethodTargetSelector {
 	 * 
 	 * @param dir
 	 * @param target
-	 * @return
-	 * @throws IOException 
+	 * @throws IOException
 	 */
 	private static SourceFileModule loadNodeModules(File rootDir, File d, String target) throws IOException {
 		List<File> dirs = nodeModulePaths(rootDir, d);
@@ -322,8 +318,7 @@ public class NodejsRequireTargetSelector implements MethodTargetSelector {
 	 * 5. return DIRS
 	 * 
 	 * @param d
-	 * @return
-	 * @throws IOException 
+	 * @throws IOException
 	 */
 	private static List<File> nodeModulePaths(File rootDir, File d) throws IOException {
 		LinkedList<File> dirs = new LinkedList<>();

--- a/com.ibm.wala.cast.js.nodejs/src/com/ibm/wala/cast/js/nodejs/NodejsRequireTargetSelector.java
+++ b/com.ibm.wala.cast.js.nodejs/src/com/ibm/wala/cast/js/nodejs/NodejsRequireTargetSelector.java
@@ -51,7 +51,7 @@ import com.ibm.wala.util.ssa.ClassLookupException;
  * This class is used by WALA internals to resolve to what functions a call
  * could potentially invoke.
  * 
- * @author Brian Pfretzschner <brian.pfretzschner@gmail.com>
+ * @author Brian Pfretzschner &lt;brian.pfretzschner@gmail.com&gt;
  */
 public class NodejsRequireTargetSelector implements MethodTargetSelector {
 
@@ -314,7 +314,7 @@ public class NodejsRequireTargetSelector implements MethodTargetSelector {
 	 * 1. let PARTS = path split(START)
 	 * 2. let I = count of PARTS - 1
 	 * 3. let DIRS = []
-	 * 4. while I >= 0,
+	 * 4. while I &gt;= 0,
 	 *    a. if PARTS[I] = "node_modules" CONTINUE
 	 *    b. DIR = path join(PARTS[0 .. I] + "node_modules")
 	 *    c. DIRS = DIRS + DIR

--- a/com.ibm.wala.cast.js.nodejs/src/com/ibm/wala/cast/js/nodejs/NodejsRequiredCoreModule.java
+++ b/com.ibm.wala.cast.js.nodejs/src/com/ibm/wala/cast/js/nodejs/NodejsRequiredCoreModule.java
@@ -24,7 +24,7 @@ import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.io.TemporaryFile;
 
 /**
- * @author Brian Pfretzschner <brian.pfretzschner@gmail.com>
+ * @author Brian Pfretzschner &lt;brian.pfretzschner@gmail.com&gt;
  */
 public class NodejsRequiredCoreModule extends NodejsRequiredSourceModule {
 

--- a/com.ibm.wala.cast.js.nodejs/src/com/ibm/wala/cast/js/nodejs/NodejsRequiredSourceModule.java
+++ b/com.ibm.wala.cast.js.nodejs/src/com/ibm/wala/cast/js/nodejs/NodejsRequiredSourceModule.java
@@ -47,8 +47,6 @@ public class NodejsRequiredSourceModule extends SourceFileModule {
 	private final String className;
 
 	/**
-	 * @param workingDir
-	 *            Must be a direct or indirect parent folder of file f.
 	 * @param f
 	 *            Must be a file located below folder workingDir.
 	 * @param clonedFrom

--- a/com.ibm.wala.cast.js.nodejs/src/com/ibm/wala/cast/js/nodejs/NodejsRequiredSourceModule.java
+++ b/com.ibm.wala.cast.js.nodejs/src/com/ibm/wala/cast/js/nodejs/NodejsRequiredSourceModule.java
@@ -30,7 +30,7 @@ import com.ibm.wala.util.io.Streams;
  * environment. The resulting function will be named GLOBAL_PREFIX + relative
  * file-name. To retrieve the final function name, use getFunctioName().
  * 
- * @author Brian Pfretzschner <brian.pfretzschner@gmail.com>
+ * @author Brian Pfretzschner &lt;brian.pfretzschner@gmail.com&gt;
  */
 public class NodejsRequiredSourceModule extends SourceFileModule {
 

--- a/com.ibm.wala.cast.js.nodejs/src/com/ibm/wala/cast/js/nodejs/NodejsRequiredSourceModule.java
+++ b/com.ibm.wala.cast.js.nodejs/src/com/ibm/wala/cast/js/nodejs/NodejsRequiredSourceModule.java
@@ -125,7 +125,6 @@ public class NodejsRequiredSourceModule extends SourceFileModule {
 	 * 
 	 * @param rootDir
 	 * @param file
-	 * @return
 	 */
 	public static String convertFileToClassName(File rootDir, File file) {
 		URI normalizedWorkingDirURI = rootDir.getAbsoluteFile().toURI().normalize();

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/html/IUrlResolver.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/html/IUrlResolver.java
@@ -22,14 +22,12 @@ public interface IUrlResolver {
   /**
    * From Internet to local
    * @param input
-   * @return
    */
   public URL resolve(URL input);
   
   /**
    * From local to Internet
    * @param input
-   * @return
    */
   public URL deResolve(URL input);
   

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/html/UrlManipulator.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/html/UrlManipulator.java
@@ -19,7 +19,6 @@ public class UrlManipulator {
   /**
    * @param urlFound the link as appear
    * @param context the URL in which the link appeared
-   * @return
    * @throws MalformedURLException
    */
   public static URL relativeToAbsoluteUrl(String urlFound, URL context) throws MalformedURLException {

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JSCallGraphUtil.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JSCallGraphUtil.java
@@ -107,7 +107,6 @@ public class JSCallGraphUtil extends com.ibm.wala.cast.ipa.callgraph.CAstCallGra
 
   /**
    * @param preprocessor CAst rewriter to use for preprocessing JavaScript source files; may be null
-   * @return
    */
   public static JavaScriptLoaderFactory makeLoaders(CAstRewriterFactory<?, ?> preprocessor) {
     if (translatorFactory == null) {

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionApplyContextInterpreter.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionApplyContextInterpreter.java
@@ -30,9 +30,7 @@ import com.ibm.wala.types.TypeName;
 /**
  * TODO cache generated IRs
  * 
- * @see <a
- *      href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Function/Apply">MDN
- *      Function.apply() docs</a> *
+ * @see <a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Function/Apply">MDN Function.apply() docs</a>
  */
 public class JavaScriptFunctionApplyContextInterpreter extends AstContextInsensitiveSSAContextInterpreter {
 

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionDotCallTargetSelector.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionDotCallTargetSelector.java
@@ -124,7 +124,6 @@ public class JavaScriptFunctionDotCallTargetSelector implements MethodTargetSele
    * @param caller
    * @param site
    * @param receiver
-   * @return
    */
   private IMethod getFunctionCallTarget(CGNode caller, CallSiteReference site, IClass receiver) {
     int nargs = getNumberOfArgsPassed(caller, site);

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/RecursionCheckContextSelector.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/RecursionCheckContextSelector.java
@@ -130,7 +130,6 @@ public class RecursionCheckContextSelector implements ContextSelector {
   /**
    * is it possible for m to be involved in a recursive cycle?
    * @param m
-   * @return
    */
   private static boolean recursionPossible(IMethod m) {
     // object or array constructors cannot be involved

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/translator/PropertyReadExpander.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/translator/PropertyReadExpander.java
@@ -145,7 +145,6 @@ public class PropertyReadExpander extends CAstRewriter<PropertyReadExpander.Rewr
    * @param element
    * @param context
    * @param nodeMap
-   * @return
    */
   private CAstNode makeConstRead(CAstNode root, CAstNode receiver, CAstNode element, RewriteContext context,
       Map<Pair<CAstNode, ExpanderKey>, CAstNode> nodeMap) {

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/callgraph/DelegatingAstPointerKeys.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/callgraph/DelegatingAstPointerKeys.java
@@ -94,7 +94,6 @@ public class DelegatingAstPointerKeys implements AstPointerKeyFactory {
    * get type for F appropriate for use in a field name.
    * 
    * @param F
-   * @return
    */
   protected IClass getFieldNameType(InstanceKey F) {
     return F.getConcreteType();
@@ -103,7 +102,6 @@ public class DelegatingAstPointerKeys implements AstPointerKeyFactory {
   /**
    * if F is a supported constant representing a field, return the corresponding {@link InstanceFieldKey} for I.  Otherwise, return <code>null</code>.
    * @param F
-   * @return
    */
   protected PointerKey getInstanceFieldPointerKeyForConstant(InstanceKey I, ConstantKey<?> F) {
     Object v = F.getValue();

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/callgraph/ScopeMappingInstanceKeys.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/callgraph/ScopeMappingInstanceKeys.java
@@ -88,7 +88,6 @@ abstract public class ScopeMappingInstanceKeys implements InstanceKeyFactory {
      * get the CGNode representing the lexical parent of {@link #creator} with
      * name definer
      * 
-     * @return
      */
     public Iterator<CGNode> getFunargNodes(Pair<String, String> name) {
       Collection<CGNode> constructorCallers = getConstructorCallers(this, name);

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/AssignInstruction.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/AssignInstruction.java
@@ -62,9 +62,6 @@ public class AssignInstruction extends SSAUnaryOpInstruction {
     ((AstPreInstructionVisitor) v).visitAssign(this);
   }
 
-  /**
-   * @return
-   */
   public int getVal() {
     return getUse(0);
   }

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
@@ -323,7 +323,6 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
    *          the AST node representing the read
    * @param context
    * @param name
-   * @return
    */
   protected int doLexicallyScopedRead(CAstNode node, WalkContext context, final String name, TypeReference type) {
     return doLexReadHelper(context, name, type);

--- a/com.ibm.wala.core.testdata/src/arraybounds/NotDetectable.java
+++ b/com.ibm.wala.core.testdata/src/arraybounds/NotDetectable.java
@@ -45,12 +45,12 @@ public class NotDetectable {
   }
 
   /**
-   * This example does not work: We know 5 > 3 and sometimes length > 5 > 3. In
+   * This example does not work: We know 5 &gt; 3 and sometimes length &gt; 5 &gt; 3. In
    * case of variables this conditional relation is resolved by introducing pi
    * nodes. For constants pi nodes can be generated, but the pi variables will
    * not be used (maybe due to constant propagation?). Additionally 5 != 3, so
    * even if we would use pi-variables for 5, there would be no relation to 3: 0
-   * -(5)-> 5, 5 -(-5)-> 0, {5,length} -(0)-> 5', 0 -(3)-> 3, 3 -(-3)-> 0 Given
+   * -(5)-&gt; 5, 5 -(-5)-&gt; 0, {5,length} -(0)-&gt; 5', 0 -(3)-&gt; 3, 3 -(-3)-&gt; 0 Given
    * the inequality graph above, we know that 5,5',3 are larger than 0 and 5
    * larger 3 and length is larger than 5', but not 5' larger than 3. Which is
    * not always the case in general anyway.

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/demandpa/AbstractPtrTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/demandpa/AbstractPtrTest.java
@@ -249,7 +249,6 @@ public abstract class AbstractPtrTest {
 
   /**
    * @param scope
-   * @return
    * @throws ClassHierarchyException
    */
   private static IClassHierarchy findOrCreateCHA(AnalysisScope scope) throws ClassHierarchyException {
@@ -261,7 +260,6 @@ public abstract class AbstractPtrTest {
 
   /**
    * @param scopeFile
-   * @return
    * @throws IOException
    */
   private AnalysisScope findOrCreateAnalysisScope() throws IOException {

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/slicer/SlicerTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/slicer/SlicerTest.java
@@ -1068,7 +1068,6 @@ public class SlicerTest {
    * @param cg
    * @param d
    * @param name
-   * @return
    */
   private static CGNode findMethod(CallGraph cg, Descriptor d, Atom name) {
     for (CGNode n : Iterator2Iterable.make(cg.getSuccNodes(cg.getFakeRootNode()))) {

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/examples/analysis/dataflow/ContextSensitiveReachingDefs.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/examples/analysis/dataflow/ContextSensitiveReachingDefs.java
@@ -195,7 +195,7 @@ public class ContextSensitiveReachingDefs {
    * balanced since a definition in a callee used as a seed for the analysis may then reach a caller, yielding a "return" without a
    * corresponding "call." An alternative to this approach, used in the Reps-Horwitz-Sagiv POPL95 paper, would be to "lift" the
    * domain of putstatic instructions with a 0 (bottom) element, have a 0->0 transition in all transfer functions, and then seed the
-   * analysis with the path edge (main_entry, 0) -> (main_entry, 0). We choose the partially-balanced approach to avoid pollution of
+   * analysis with the path edge (main_entry, 0) -&gt; (main_entry, 0). We choose the partially-balanced approach to avoid pollution of
    * the flow functions.
    * 
    */

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/arraybounds/ArrayBoundsGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/arraybounds/ArrayBoundsGraph.java
@@ -156,8 +156,8 @@ public class ArrayBoundsGraph extends DirectedHyperGraph<Integer> {
 	/**
 	 * Add variable as constant with value value.
 	 *
-	 * This will create the following construct: [zero] -(value)-> [h1] -0- >
-	 * [variable] -(-value)-> [h2] -0-> [zero].
+	 * This will create the following construct: [zero] -(value)-&gt; [h1] -0- &gt;
+	 * [variable] -(-value)-&gt; [h2] -0-&gt; [zero].
 	 *
 	 * The bidirectional linking, allows things like
 	 *
@@ -214,8 +214,8 @@ public class ArrayBoundsGraph extends DirectedHyperGraph<Integer> {
 	 * Adds var as source var. A source var is a variable, which can be used as
 	 * source for shortest path computation.
 	 *
-	 * This will create the following construct: [unlimited] -> [var] -> [var]
-	 * -(unlimited)-> [unlimited]
+	 * This will create the following construct: [unlimited] -&gt; [var] -&gt; [var]
+	 * -(unlimited)-&gt; [unlimited]
 	 *
 	 * This is a trap door construct: if [var] is not set to 0 it will get the
 	 * value unlimited, if [var] is set to 0 it will stay 0.

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/arraybounds/ArrayBoundsGraphBuilder.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/arraybounds/ArrayBoundsGraphBuilder.java
@@ -112,16 +112,16 @@ public class ArrayBoundsGraphBuilder {
 	/**
 	 * Case 1: piRestrictor restricts the pi variable for upper/ lower bounds graph
 	 * Given this code below, we want to create a hyper edge
-	 * {piParent, piRestrictor} --> {piVar}.
+	 * {piParent, piRestrictor} --&gt; {piVar}.
 	 *
-	 * If is op in {<, >} we now, that the distance from piRestrictor to piVar
-	 * is +-1 as ( a < b ) <==> ( a <= b - 1), same with "<".
+	 * If is op in {&lt;, &gt;} we now, that the distance from piRestrictor to piVar
+	 * is +-1 as ( a &lt; b ) &lt;==&gt; ( a &lt;= b - 1), same with "&lt;".
 	 * To be more precise we introduce a helper node and add
-	 * {piRestrictor} -- (-)1 --> {helper}
-	 * {piParent, helper} --> {piVar}
+	 * {piRestrictor} -- (-)1 --&gt; {helper}
+	 * {piParent, helper} --&gt; {piVar}
 	 *
 	 * Case 2: no restriction is given by the branch (i.e. the operator is not equal)
-	 * {piParent} --> {piVar}
+	 * {piParent} --&gt; {piVar}
 	 *
 	 * <code>if (piParent op piRestrictor) {piVar = piParent}</code>
 	 *

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/arraybounds/ConditionNormalizer.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/arraybounds/ConditionNormalizer.java
@@ -22,7 +22,7 @@ public class ConditionNormalizer {
 	 * hand side of the comparison, also if the branch is not taken, the
 	 * operation needs to be negated.
 	 *
-	 * p.a. the condition is !(rhs >= lhs), it will be normalized to lhs > rhs
+	 * p.a. the condition is !(rhs &gt;= lhs), it will be normalized to lhs &gt; rhs
 	 *
 	 * @param cnd
 	 *            condition to normalize

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/arraybounds/hypergraph/DirectedHyperEdge.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/arraybounds/hypergraph/DirectedHyperEdge.java
@@ -11,7 +11,7 @@ import com.ibm.wala.analysis.arraybounds.hypergraph.weight.edgeweights.EdgeWeigh
  * @author Stephan Gocht {@code <stephan@gobro.de>}
  *
  * @param <T>
- *            Type used in HyperNodes (HyperNode<T>)
+ *            Type used in HyperNodes (HyperNode&lt;T&gt;)
  */
 public class DirectedHyperEdge<T> {
 	/** Contains all destinations of this HyperEdge */

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/arraybounds/hypergraph/algorithms/ShortestPath.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/arraybounds/hypergraph/algorithms/ShortestPath.java
@@ -172,8 +172,8 @@ public class ShortestPath<T> {
    *
    * <pre>
    * (n1, n2)->(n3)
-   * Round 1: n1 = unset, n2 = -3 -> n3 = max(unset,-3) = -3
-   * Round 2: n1 = 1, n2 = -3 -> n3 = max(1,-3) = 1
+   * Round 1: n1 = unset, n2 = -3 -&gt; n3 = max(unset,-3) = -3
+   * Round 2: n1 = 1, n2 = -3 -&gt; n3 = max(1,-3) = 1
    * </pre>
    *
    * Would we compute the minimum of n3 over all rounds, it would be -3, but 1

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/arraybounds/hypergraph/weight/NormalOrder.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/arraybounds/hypergraph/weight/NormalOrder.java
@@ -5,7 +5,7 @@ import java.util.Comparator;
 import com.ibm.wala.analysis.arraybounds.hypergraph.weight.Weight.Type;
 
 /**
- * Defines a normal Order on Weight: unlimited < ... < -1 < 0 < 1 < ... not_set
+ * Defines a normal Order on Weight: unlimited &lt; ... &lt; -1 &lt; 0 &lt; 1 &lt; ... not_set
  * is not comparable
  *
  * @author Stephan Gocht {@code <stephan@gobro.de>}

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/arraybounds/hypergraph/weight/ReverseOrder.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/arraybounds/hypergraph/weight/ReverseOrder.java
@@ -5,7 +5,7 @@ import java.util.Comparator;
 import com.ibm.wala.analysis.arraybounds.hypergraph.weight.Weight.Type;
 
 /**
- * Defines a reverse Order on Weight: ... > 1 > 0 > -1 > ... > unlimited not_set
+ * Defines a reverse Order on Weight: ... &gt; 1 &gt; 0 &gt; -1 &gt; ... &gt; unlimited not_set
  * is not comparable
  *
  * @author Stephan Gocht {@code <stephan@gobro.de>}

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/CloneInterpreter.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/CloneInterpreter.java
@@ -94,7 +94,7 @@ public class CloneInterpreter implements SSAContextInterpreter {
   private final static int NEW_PC = 0;
 
   /**
-   * Mapping from TypeReference -> IR TODO: Soft references?
+   * Mapping from TypeReference -&gt; IR TODO: Soft references?
    */
   final private Map<TypeReference, IR> IRCache = HashMapFactory.make();
 

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/FactoryBypassInterpreter.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/FactoryBypassInterpreter.java
@@ -67,7 +67,7 @@ import com.ibm.wala.util.warnings.Warnings;
 public class FactoryBypassInterpreter extends AbstractReflectionInterpreter {
 
   /**
-   * A Map from CallerSiteContext -> Set <TypeReference>represents the types a factory method might create in a particular context
+   * A Map from CallerSiteContext -&gt; Set &lt;TypeReference&gt;represents the types a factory method might create in a particular context
    */
   private final Map<Context, Set<TypeReference>> map = HashMapFactory.make();
 

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/JavaTypeContext.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/JavaTypeContext.java
@@ -19,7 +19,6 @@ import com.ibm.wala.ipa.callgraph.ContextKey;
 import com.ibm.wala.ipa.callgraph.propagation.FilteredPointerKey;
 
 /**
- * @brief
  *  Implements a Context which corresponds to a given type abstraction.
  *  Thus, this maps the name "TYPE" to a JavaTypeAbstraction.
  * TODO

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/IBasicBlock.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/IBasicBlock.java
@@ -24,7 +24,7 @@ public interface IBasicBlock<InstType> extends INodeWithNumber, Iterable<InstTyp
    * is an index into the instruction array that contains all the instructions
    * for the method.
    * 
-   * If the result is < 0, the block has no instructions
+   * If the result is &lt; 0, the block has no instructions
    * 
    * @return the instruction index for the first instruction in the basic block.
    */
@@ -35,7 +35,7 @@ public interface IBasicBlock<InstType> extends INodeWithNumber, Iterable<InstTyp
    * is an index into the instruction array that contains all the instructions
    * for the method.
    * 
-   * If the result is < 0, the block has no instructions
+   * If the result is &lt; 0, the block has no instructions
    * 
    * @return the instruction index for the last instruction in the basic block
    */

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/InducedCFG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/InducedCFG.java
@@ -53,7 +53,7 @@ public class InducedCFG extends AbstractCFG<SSAInstruction, InducedCFG.BasicBloc
   private static final boolean DEBUG = false;
 
   /**
-   * A partial map from Instruction -> BasicBlock
+   * A partial map from Instruction -&gt; BasicBlock
    */
   private final BasicBlock[] i2block;
 

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/Util.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/Util.java
@@ -153,7 +153,7 @@ public class Util {
    * constants c1 and c2, respectively.
    * 
    * Callers must resolve the constant values from the {@link SymbolTable}
-   * before calling this method. These integers are <bf>not</bf> value numbers;
+   * before calling this method. These integers are <b>not</b> value numbers;
    */
   public static <I, T extends IBasicBlock<I>> T resolveBranch(ControlFlowGraph<I, T> G, T bb, int c1, int c2) {
     SSAConditionalBranchInstruction c = (SSAConditionalBranchInstruction) getLastInstruction(G, bb);

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/ExceptionPruningAnalysis.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/ExceptionPruningAnalysis.java
@@ -23,7 +23,7 @@ import com.ibm.wala.util.graph.GraphIntegrity.UnsoundGraphException;
  * control flow from a CFG. This is done by detecting exceptions that may always
  * (or never) appear.
  * 
- * @author Juergen Graf <graf@kit.edu>
+ * @author Juergen Graf &lt;graf@kit.edu&gt;
  * 
  */
 public interface ExceptionPruningAnalysis<I, T extends IBasicBlock<I>> {

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/InterprocAnalysisResult.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/InterprocAnalysisResult.java
@@ -17,7 +17,7 @@ import com.ibm.wala.ipa.callgraph.CGNode;
 /**
  * Interface to retrieve the result of the interprocedural analysis.
  * 
- * @author Juergen Graf <graf@kit.edu>
+ * @author Juergen Graf &lt;graf@kit.edu&gt;
  */
 public interface InterprocAnalysisResult<I, T extends IBasicBlock<I>> {
 

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/NullPointerAnalysis.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/NullPointerAnalysis.java
@@ -31,7 +31,7 @@ import com.ibm.wala.util.graph.GraphIntegrity.UnsoundGraphException;
  * Tries to detect impossible (or always appearing) NullPointerExceptions and removes impossible
  * control flow from the CFG.
  * 
- * @author Juergen Graf <graf@kit.edu>
+ * @author Juergen Graf &lt;graf@kit.edu&gt;
  *
  */
 public final class NullPointerAnalysis { 

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/inter/AnalysisUtil.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/inter/AnalysisUtil.java
@@ -27,8 +27,8 @@ import com.ibm.wala.ssa.analysis.IExplodedBasicBlock;
  * This class has been developed as part of a student project "Studienarbeit" by Markus Herhoffer.
  * It has been adapted and integrated into the WALA project by Juergen Graf.
  *
- * @author Markus Herhoffer <markus.herhoffer@student.kit.edu>
- * @author Juergen Graf <graf@kit.edu>
+ * @author Markus Herhoffer &lt;markus.herhoffer@student.kit.edu&gt;
+ * @author Juergen Graf &lt;graf@kit.edu&gt;
  */
 public final class AnalysisUtil {
 

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/inter/DelegatingMethodState.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/inter/DelegatingMethodState.java
@@ -19,7 +19,7 @@ import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
  * This class combines two MethodState objects. A MethodState decides if a given method call may throw an exception.
  * If the primary MethodState thinks that the call may throw an exception, the fallback MethodState is asked.
  * 
- * @author Juergen Graf <graf@kit.edu>
+ * @author Juergen Graf &lt;graf@kit.edu&gt;
  * 
  */
 class DelegatingMethodState extends MethodState {

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/inter/InterprocAnalysisResultWrapper.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/inter/InterprocAnalysisResultWrapper.java
@@ -23,7 +23,7 @@ import com.ibm.wala.ssa.analysis.IExplodedBasicBlock;
 /**
  * A wrapper for the interprocedural analysis result.
  * 
- * @author Juergen Graf <graf@kit.edu>
+ * @author Juergen Graf &lt;graf@kit.edu&gt;
  *
  */
 class InterprocAnalysisResultWrapper implements InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> {

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/inter/InterprocMethodState.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/inter/InterprocMethodState.java
@@ -24,8 +24,8 @@ import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
  * This class has been developed as part of a student project "Studienarbeit" by Markus Herhoffer.
  * It has been adapted and integrated into the WALA project by Juergen Graf.
  * 
- * @author Markus Herhoffer <markus.herhoffer@student.kit.edu>
- * @author Juergen Graf <graf@kit.edu>
+ * @author Markus Herhoffer &lt;markus.herhoffer@student.kit.edu&gt;
+ * @author Juergen Graf &lt;graf@kit.edu&gt;
  * 
  */
 class InterprocMethodState extends MethodState {

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/inter/InterprocNullPointerAnalysis.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/inter/InterprocNullPointerAnalysis.java
@@ -54,8 +54,8 @@ import com.ibm.wala.util.strings.Atom;
  * This class has been developed as part of a student project "Studienarbeit" by Markus Herhoffer.
  * It has been adapted and integrated into the WALA project by Juergen Graf.
  * 
- * @author Markus Herhoffer <markus.herhoffer@student.kit.edu>
- * @author Juergen Graf <graf@kit.edu>
+ * @author Markus Herhoffer &lt;markus.herhoffer@student.kit.edu&gt;
+ * @author Juergen Graf &lt;graf@kit.edu&gt;
  * 
  */
 public final class InterprocNullPointerAnalysis {
@@ -230,7 +230,7 @@ public final class InterprocNullPointerAnalysis {
   /**
    * Filter for CallGraphs
    * 
-   * @author Markus Herhoffer <markus.herhoffer@student.kit.edu>
+   * @author Markus Herhoffer &lt;markus.herhoffer@student.kit.edu&gt;
    * 
    */
   private static class CallGraphFilter {

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/inter/IntraprocAnalysisState.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/inter/IntraprocAnalysisState.java
@@ -31,8 +31,8 @@ import com.ibm.wala.util.graph.GraphIntegrity.UnsoundGraphException;
  * This class has been developed as part of a student project "Studienarbeit" by Markus Herhoffer.
  * It has been adapted and integrated into the WALA project by Juergen Graf.
  * 
- * @author Markus Herhoffer <markus.herhoffer@student.kit.edu>
- * @author Juergen Graf <graf@kit.edu>
+ * @author Markus Herhoffer &lt;markus.herhoffer@student.kit.edu&gt;
+ * @author Juergen Graf &lt;graf@kit.edu&gt;
  * 
  */
 final class IntraprocAnalysisState implements ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> {

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/ExplodedCFGNullPointerAnalysis.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/ExplodedCFGNullPointerAnalysis.java
@@ -27,7 +27,7 @@ import com.ibm.wala.util.graph.GraphIntegrity.UnsoundGraphException;
 /**
  * Intraprocedural null pointer analysis for the exploded control flow graph.
  * 
- * @author Juergen Graf <graf@kit.edu>
+ * @author Juergen Graf &lt;graf@kit.edu&gt;
  *
  */
 public class ExplodedCFGNullPointerAnalysis implements ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> {

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/IntraprocNullPointerAnalysis.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/IntraprocNullPointerAnalysis.java
@@ -57,7 +57,7 @@ import com.ibm.wala.util.graph.impl.SparseNumberedGraph;
 /**
  * Intraprocedural dataflow analysis to detect impossible NullPointerExceptions.
  * 
- * @author Juergen Graf <graf@kit.edu>
+ * @author Juergen Graf &lt;graf@kit.edu&gt;
  *
  */
 public class IntraprocNullPointerAnalysis<T extends ISSABasicBlock> {

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/MethodState.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/MethodState.java
@@ -17,7 +17,7 @@ import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
  * Provides a way for the nullpointer analysis to decide whether or not a called method
  * may throw an exception.
  * 
- * @author Juergen Graf <graf@kit.edu>
+ * @author Juergen Graf &lt;graf@kit.edu&gt;
  *
  */
 public abstract class MethodState {

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/MutableCFG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/MutableCFG.java
@@ -26,7 +26,7 @@ import com.ibm.wala.util.intset.IntSet;
 /**
  * A modifiable control flow graph.
  * 
- * @author Juergen Graf <graf@kit.edu>
+ * @author Juergen Graf &lt;graf@kit.edu&gt;
  *
  */
 public class MutableCFG<X, T extends IBasicBlock<X>> extends SparseNumberedGraph<T> implements ControlFlowGraph<X, T> {

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/NegativeGraphFilter.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/NegativeGraphFilter.java
@@ -19,7 +19,7 @@ import com.ibm.wala.util.graph.Graph;
  * An EdgeFilter that ignores all edges contained in a given graph. This ca be used
  * to subtract a subgraph from its main graph.
  * 
- * @author Juergen Graf <graf@kit.edu>
+ * @author Juergen Graf &lt;graf@kit.edu&gt;
  *
  */
 public class NegativeGraphFilter<T extends IBasicBlock<?>> implements EdgeFilter<T> {

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/NullPointerFrameWork.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/NullPointerFrameWork.java
@@ -26,7 +26,7 @@ import com.ibm.wala.util.intset.IntPair;
  * functions are not distribute (similar to constant propagation). Therefore we remove 
  * back edges in the flow graph.
  * 
- * @author Juergen Graf <graf@kit.edu>
+ * @author Juergen Graf &lt;graf@kit.edu&gt;
  *
  */
 public class NullPointerFrameWork<T extends ISSABasicBlock> implements IKilldallFramework<T, NullPointerState> {

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/NullPointerSolver.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/NullPointerSolver.java
@@ -18,7 +18,7 @@ import com.ibm.wala.ssa.ISSABasicBlock;
 /**
  * Intraprocedural dataflow analysis to detect impossible NullPointerExceptions.
  * 
- * @author Juergen Graf <graf@kit.edu>
+ * @author Juergen Graf &lt;graf@kit.edu&gt;
  *
  */
 public class NullPointerSolver<B extends ISSABasicBlock> extends DataflowSolver<B, NullPointerState> {

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/NullPointerState.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/NullPointerState.java
@@ -22,7 +22,7 @@ import com.ibm.wala.ssa.SymbolTable;
 /**
  * States for the ssa variables.
  * 
- * @author Juergen Graf <graf@kit.edu>
+ * @author Juergen Graf &lt;graf@kit.edu&gt;
  *
  */
 public class NullPointerState extends AbstractVariable<NullPointerState> {
@@ -76,7 +76,7 @@ public class NullPointerState extends AbstractVariable<NullPointerState> {
    * <pre>
    * v3 = phi v1, v2
    * ^ := Meet-operator
-   * f := phiValueMeetFunction(3, {1, 2}) = v1,v2,v3 -> v1,v2,[v1 ^ v2]
+   * f := phiValueMeetFunction(3, {1, 2}) = v1,v2,v3 -&gt; v1,v2,[v1 ^ v2]
    * 
    * f(1,?,?) ^ f(?,1,?) = 1,?,? ^ ?,1,? = 1,1,?
    * 
@@ -134,7 +134,7 @@ public class NullPointerState extends AbstractVariable<NullPointerState> {
    * <pre>
    * ? == unknown, 1 == not null, 0 == null, * == both
    * 
-   * meet | ? | 0 | 1 | * |  <- rhs
+   * meet | ? | 0 | 1 | * |  &lt;- rhs
    * -----|---|---|---|---|
    *    ? | ? | 0 | 1 | * |
    * -----|---|---|---|---|

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/NullPointerTransferFunctionProvider.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/NullPointerTransferFunctionProvider.java
@@ -51,7 +51,7 @@ import com.ibm.wala.ssa.analysis.IExplodedBasicBlock;
 import com.ibm.wala.util.collections.Iterator2Iterable;
 
 /**
- * @author Juergen Graf <graf@kit.edu>
+ * @author Juergen Graf &lt;graf@kit.edu&gt;
  *
  */
 class NullPointerTransferFunctionProvider<T extends ISSABasicBlock> implements ITransferFunctionProvider<T, NullPointerState> {

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/ArrayClassLoader.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/ArrayClassLoader.java
@@ -26,7 +26,7 @@ public class ArrayClassLoader {
   private final static boolean DEBUG = false;
 
   /**
-   * map: TypeReference -> ArrayClass
+   * map: TypeReference -&gt; ArrayClass
    */
   final private HashMap<TypeReference, ArrayClass> arrayClasses = HashMapFactory.make();
 

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/IClassLoader.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/IClassLoader.java
@@ -122,7 +122,7 @@ public interface IClassLoader {
   /**
    * blow away references to any classes in the set
    * 
-   * @param toRemove Collection<IClass>
+   * @param toRemove Collection&lt;IClass&gt;
    */
   public abstract void removeAll(Collection<IClass> toRemove);
 }

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/JarStreamModule.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/JarStreamModule.java
@@ -29,7 +29,7 @@ import com.ibm.wala.util.warnings.Warnings;
 /**
  * Read in a jar file from an input stream. Most parts are copied from the NestedJarFileModule class
  * and adapted to work with an input stream. 
- * @author Juergen Graf <juergen.graf@gmail.com>
+ * @author Juergen Graf &lt;juergen.graf@gmail.com&gt;
  */
 public class JarStreamModule extends JarInputStream implements Module {
 

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/ShrikeBTMethod.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/ShrikeBTMethod.java
@@ -165,7 +165,7 @@ public abstract class ShrikeBTMethod implements IMethod, BytecodeConstants {
    * 
    * This ShrikeBTMethod must not be native.
    * 
-   * @throws InvalidClassFileException, {@link UnsupportedOperationException}
+   * @throws InvalidClassFileException {@link UnsupportedOperationException}
    */
   public int getInstructionIndex(int bcIndex) throws InvalidClassFileException {
     if (isNative()) {

--- a/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/CallFlowEdges.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/CallFlowEdges.java
@@ -25,11 +25,11 @@ import com.ibm.wala.util.intset.SparseIntSet;
 public class CallFlowEdges {
 
   /**
-   * A map from integer -> (IBinaryNonNegativeIntRelation)
+   * A map from integer -&gt; (IBinaryNonNegativeIntRelation)
    * 
-   * For a fact d2, edges[d2] gives a relation R=(c,d1) s.t. (<c, d1> -> <s_p,d2>) was recorded as a call flow edge.
+   * For a fact d2, edges[d2] gives a relation R=(c,d1) s.t. (&lt;c, d1&gt; -&gt; &lt;s_p,d2&gt;) was recorded as a call flow edge.
    * 
-   * Note that we handle paths of the form <c, d1> -> <s_p,d1> specially, below.
+   * Note that we handle paths of the form &lt;c, d1&gt; -&gt; &lt;s_p,d1&gt; specially, below.
    * 
    * TODO: more representation optimization. A special representation for triples? sparse representations for CFG? exploit shorts
    * for ints?
@@ -37,9 +37,9 @@ public class CallFlowEdges {
   private final SparseVector<IBinaryNaturalRelation> edges = new SparseVector<>(1, 1.1f);
 
   /**
-   * a map from integer d1 -> int set.
+   * a map from integer d1 -&gt; int set.
    * 
-   * for fact d1, identityPaths[d1] gives the set of block numbers C s.t. for c \in C, <c, d1> -> <s_p, d1> is an edge.
+   * for fact d1, identityPaths[d1] gives the set of block numbers C s.t. for c \in C, &lt;c, d1&gt; -&gt; &lt;s_p, d1&gt; is an edge.
    */
   private final SparseVector<IntSet> identityEdges = new SparseVector<>(1, 1.1f);
 
@@ -47,7 +47,7 @@ public class CallFlowEdges {
   }
 
   /**
-   * Record that we've discovered a call edge <c,d1> -> <s_p, d2>
+   * Record that we've discovered a call edge &lt;c,d1&gt; -&gt; &lt;s_p, d2&gt;
    * 
    * @param c global number identifying the call site node
    * @param d1 source fact at the call edge

--- a/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/ISupergraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/ISupergraph.java
@@ -68,7 +68,7 @@ public interface ISupergraph<T, P> extends NumberedGraph<T> {
   Iterator<? extends T> getReturnSites(T call, P callee);
 
   /**
-   * @param r a "return" node in the supergraph
+   * @param ret a "return" node in the supergraph
    * @param callee a "called" "procedure" in the supergraph. if callee is null, answer return sites for which no callee was found.
    * @return the corresponding call nodes. There may be many.
    */

--- a/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/LocalPathEdges.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/LocalPathEdges.java
@@ -33,11 +33,11 @@ public class LocalPathEdges {
   private final static boolean PARANOID = false;
 
   /**
-   * A map from integer (d2) -> (IBinaryNonNegativeIntRelation)
+   * A map from integer (d2) -&gt; (IBinaryNonNegativeIntRelation)
    * 
-   * For fact d2, paths[d2] gives a relation R=(n,d1) s.t. (<s_p, d1> -> <n,d2>) is a path edge.
+   * For fact d2, paths[d2] gives a relation R=(n,d1) s.t. (&lt;s_p, d1&gt; -&gt; &lt;n,d2&gt;) is a path edge.
    * 
-   * Note that we handle paths of the form <s_p, d1> -> <n,d1> specially, below. We also handle paths of the form <s_p, 0> -> <n,
+   * Note that we handle paths of the form &lt;s_p, d1&gt; -&gt; &lt;n,d1&gt; specially, below. We also handle paths of the form &lt;s_p, 0&gt; -&gt; &lt;n,
    * d1> specially below.
    * 
    * We choose this somewhat convoluted representation for the following reasons: 1) of the (n, d1, d2) tuple-space, we expect the
@@ -58,9 +58,9 @@ public class LocalPathEdges {
    * space or time of the non-merging IFDS solver, for which the original paths representation works well. Is there a better data
    * structure tradeoff?
    * 
-   * A map from integer (d1) -> (IBinaryNonNegativeIntRelation)
+   * A map from integer (d1) -&gt; (IBinaryNonNegativeIntRelation)
    * 
-   * For fact d1, paths[d1] gives a relation R=(n,d2) s.t. (<s_p, d1> -> <n,d2>) is a path edge.
+   * For fact d1, paths[d1] gives a relation R=(n,d2) s.t. (&lt;s_p, d1&gt; -&gt; &lt;n,d2&gt;) is a path edge.
    * 
    * 
    * We choose this somewhat convoluted representation for the following reasons: 1) of the (n, d1, d2) tuple-space, we expect the
@@ -71,16 +71,16 @@ public class LocalPathEdges {
   private final SparseVector<IBinaryNaturalRelation> altPaths;
 
   /**
-   * a map from integer d1 -> int set.
+   * a map from integer d1 -&gt; int set.
    * 
-   * for fact d1, identityPaths[d1] gives the set of block numbers N s.t. for n \in N, <s_p, d1> -> <n, d1> is a path edge.
+   * for fact d1, identityPaths[d1] gives the set of block numbers N s.t. for n \in N, &lt;s_p, d1&gt; -&gt; &lt;n, d1&gt; is a path edge.
    */
   private final SparseVector<IntSet> identityPaths = new SparseVector<>(1, 1.1f);
 
   /**
-   * a map from integer d2 -> int set
+   * a map from integer d2 -&gt; int set
    * 
-   * for fact d2, zeroPaths[d2] gives the set of block numbers N s.t. for n \in N, <s_p, 0> -> <n, d2> is a path edge.
+   * for fact d2, zeroPaths[d2] gives the set of block numbers N s.t. for n \in N, &lt;s_p, 0&gt; -&gt; &lt;n, d2&gt; is a path edge.
    */
   private final SparseVector<IntSet> zeroPaths = new SparseVector<>(1, 1.1f);
 
@@ -193,8 +193,8 @@ public class LocalPathEdges {
   }
 
   /**
-   * N.B: If we're using the ZERO_PATH_SHORT_CIRCUIT, then we may have <s_p, d1> -> <n, d2> implicitly represented since we also
-   * have <s_p, 0> -> <n,d2>. However, getInverse() <b> will NOT </b> return these implicit d1 bits in the result. This translates
+   * N.B: If we're using the ZERO_PATH_SHORT_CIRCUIT, then we may have &lt;s_p, d1&gt; -&gt; &lt;n, d2&gt; implicitly represented since we also
+   * have &lt;s_p, 0&gt; -&gt; &lt;n,d2&gt;. However, getInverse() &lt;b&gt; will NOT &lt;/b&gt; return these implicit d1 bits in the result. This translates
    * to saying that the caller had better not care about any other d1 other than d1==0 if d1==0 is present. This happens to be true
    * in the single use of getInverse() in the tabulation solver, which uses getInverse() to propagate flow from an exit node back to
    * the caller's return site(s). Since we know that we will see flow from fact 0 to the return sites(s), we don't care about other

--- a/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/LocalSummaryEdges.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/LocalSummaryEdges.java
@@ -25,10 +25,10 @@ import com.ibm.wala.util.math.LongUtil;
 public class LocalSummaryEdges {
 
   /**
-   * A map from integer n -> (IBinaryNonNegativeIntRelation)
+   * A map from integer n -&gt; (IBinaryNonNegativeIntRelation)
    * 
    * Let s_p be an entry to this procedure, and x be an exit. n is a integer which uniquely identifies an (s_p,x) relation. For any
-   * such n, summaries[n] gives a relation R=(d1,d2) s.t. (<s_p, d1> -> <x,d2>) is a summary edge.
+   * such n, summaries[n] gives a relation R=(d1,d2) s.t. (&lt;s_p, d1&gt; -&gt; &lt;x,d2&gt;) is a summary edge.
    * 
    * Note that this representation is a little different from the representation described in the PoPL 95 paper. We cache summary
    * edges at the CALLEE, not at the CALLER!!! This allows us to avoid eagerly installing summary edges at all call sites to a
@@ -61,7 +61,7 @@ public class LocalSummaryEdges {
   }
 
   /**
-   * Record a summary edge for the flow d1 -> d2 from an entry s_p to an exit x.
+   * Record a summary edge for the flow d1 -&gt; d2 from an entry s_p to an exit x.
    * 
    * @param s_p local block number an entry
    * @param x local block number of an exit block

--- a/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/PartiallyBalancedTabulationSolver.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/PartiallyBalancedTabulationSolver.java
@@ -89,7 +89,7 @@ public class PartiallyBalancedTabulationSolver<T, P, F> extends TabulationSolver
   }
 
   /**
-   * A path edge <s_p, i> -> <n, j> was propagated, and <s_p, i> was an unbalanced seed.
+   * A path edge &lt;s_p, i&gt; -&gt; &lt;n, j&gt; was propagated, and &lt;s_p, i&gt; was an unbalanced seed.
    * So, we added a new seed callerSeed (to some return site) in the caller.  To be overridden
    * in subclasses.
    */

--- a/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/PathEdge.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/PathEdge.java
@@ -12,7 +12,7 @@ package com.ibm.wala.dataflow.IFDS;
 
 
 /**
- * an individual edge <entry, d1> -> <target, d2>
+ * an individual edge &lt;entry, d1&gt; -&gt; &lt;target, d2&gt;
  * 
  * @param <T> node type in the supergraph
  */

--- a/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/SingletonFlowFunction.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/SingletonFlowFunction.java
@@ -13,7 +13,7 @@ package com.ibm.wala.dataflow.IFDS;
 import com.ibm.wala.util.intset.SparseIntSet;
 
 /**
- * A flow function which has only the edge 0 -> dest
+ * A flow function which has only the edge 0 -&gt; dest
  */
 public class SingletonFlowFunction implements IReversibleFlowFunction {
 

--- a/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/TabulationResult.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/TabulationResult.java
@@ -15,7 +15,7 @@ import java.util.Collection;
 import com.ibm.wala.util.intset.IntSet;
 
 /**
- * The solution of a tabulation problem: a mapping from supergraph node -> bit vector representing the dataflow facts that hold at
+ * The solution of a tabulation problem: a mapping from supergraph node -&gt; bit vector representing the dataflow facts that hold at
  * the entry to the supergraph node.
  * 
  * @param <T> type of node in the supergraph

--- a/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/TabulationSolver.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/TabulationSolver.java
@@ -110,23 +110,23 @@ public class TabulationSolver<T, P, F> {
   private final TabulationProblem<T, P, F> problem;
 
   /**
-   * A map from Object (entry node in supergraph) -> LocalPathEdges.
+   * A map from Object (entry node in supergraph) -&gt; LocalPathEdges.
    *
-   * Logically, this represents a set of edges (s_p,d_i) -> (n, d_j). The data structure is chosen to attempt to save space over
+   * Logically, this represents a set of edges (s_p,d_i) -&gt; (n, d_j). The data structure is chosen to attempt to save space over
    * representing each edge explicitly.
    */
   final private Map<T, LocalPathEdges> pathEdges = HashMapFactory.make();
 
   /**
-   * A map from Object (entry node in supergraph) -> CallFlowEdges.
+   * A map from Object (entry node in supergraph) -&gt; CallFlowEdges.
    *
-   * Logically, this represents a set of edges (c,d_i) -> (s_p, d_j). The data structure is chosen to attempt to save space over
+   * Logically, this represents a set of edges (c,d_i) -&gt; (s_p, d_j). The data structure is chosen to attempt to save space over
    * representing each edge explicitly.
    */
   final private Map<T, CallFlowEdges> callFlowEdges = HashMapFactory.make();
 
   /**
-   * A map from Object (procedure) -> LocalSummaryEdges.
+   * A map from Object (procedure) -&gt; LocalSummaryEdges.
    *
    */
   final protected Map<P, LocalSummaryEdges> summaryEdges = HashMapFactory.make();
@@ -754,7 +754,7 @@ public class TabulationSolver<T, P, F> {
   }
 
   /**
-   * Propagate the fact <s_p,i> -> <n, j> has arisen as a path edge. Returns <code>true</code> iff the path edge was not previously
+   * Propagate the fact &lt;s_p,i&gt; -&gt; &lt;n, j&gt; has arisen as a path edge. Returns &lt;code&gt;true&lt;/code&gt; iff the path edge was not previously
    * observed.
    *
    * @param s_p entry block
@@ -791,10 +791,10 @@ public class TabulationSolver<T, P, F> {
   }
 
   /**
-   * Merging: suppose we're doing propagate <s_p,i> -> <n,j> but we already have path edges <s_p,i> -> <n, x>, <s_p,i> -> <n,y>, and
-   * <s_p,i> -><n, z>.
+   * Merging: suppose we're doing propagate &lt;s_p,i&gt; -&gt; &lt;n,j&gt; but we already have path edges &lt;s_p,i&gt; -&gt; &lt;n, x&gt;, &lt;s_p,i&gt; -&gt; &lt;n,y&gt;, and
+   * &lt;s_p,i&gt; -&gt;&lt;n, z&gt;.
    *
-   * let \alpha be the merge function. then instead of <s_p,i> -> <n,j>, we propagate <s_p,i> -> <n, \alpha(j,x,y,z) > !!!
+   * let \alpha be the merge function. then instead of &lt;s_p,i&gt; -&gt; &lt;n,j&gt;, we propagate &lt;s_p,i&gt; -&gt; &lt;n, \alpha(j,x,y,z) &gt; !!!
    *
    * return -1 if no fact should be propagated
    */
@@ -1042,9 +1042,9 @@ public class TabulationSolver<T, P, F> {
   }
 
   /**
-   * Indicates that due to a path edge <s_p, d1> -> <n, d2> (the 'edge'
-   * parameter) and a normal flow function application, a new path edge <s_p,
-   * d1> -> <m, d3> was created. To be overridden in subclasses. We also use
+   * Indicates that due to a path edge &lt;s_p, d1&gt; -&gt; &lt;n, d2&gt; (the 'edge'
+   * parameter) and a normal flow function application, a new path edge &lt;s_p,
+   * d1&gt; -&gt; &lt;m, d3&gt; was created. To be overridden in subclasses. We also use
    * this function to record call-to-return flow.
    *
    */
@@ -1054,9 +1054,9 @@ public class TabulationSolver<T, P, F> {
   }
 
   /**
-   * Indicates that due to a path edge 'edge' <s_p, d1> -> <n, d2> and
-   * application of a call flow function, a new path edge <calleeEntry, d3> ->
-   * <calleeEntry, d3> was created. To be overridden in subclasses.
+   * Indicates that due to a path edge 'edge' &lt;s_p, d1&gt; -&gt; &lt;n, d2&gt; and
+   * application of a call flow function, a new path edge &lt;calleeEntry, d3&gt; -&gt;
+   * &lt;calleeEntry, d3&gt; was created. To be overridden in subclasses.
    *
    */
   @SuppressWarnings("unused")
@@ -1066,10 +1066,10 @@ public class TabulationSolver<T, P, F> {
 
   /**
    * Combines [25] and [26-28]. In the caller we have a path edge
-   * 'edgeToCallSite' <s_c, d3> -> <c, d4>, where c is the call site. In the
-   * callee, we have path edge 'calleeSummaryEdge' <s_p, d1> -> <e_p, d2>. Of
-   * course, there is a call edge <c, d4> -> <s_p, d1>. Finally, we have a
-   * return edge <e_p, d2> -> <returnSite, d5>.
+   * 'edgeToCallSite' &lt;s_c, d3&gt; -&gt; &lt;c, d4&gt;, where c is the call site. In the
+   * callee, we have path edge 'calleeSummaryEdge' &lt;s_p, d1&gt; -&gt; &lt;e_p, d2&gt;. Of
+   * course, there is a call edge &lt;c, d4&gt; -&gt; &lt;s_p, d1&gt;. Finally, we have a
+   * return edge &lt;e_p, d2&gt; -&gt; &lt;returnSite, d5&gt;.
    */
   @SuppressWarnings("unused")
   protected void newSummaryEdge(PathEdge<T> edgeToCallSite, PathEdge<T> calleeSummaryEdge, T returnSite, int d5) {

--- a/com.ibm.wala.core/src/com/ibm/wala/demandpa/alg/DemandRefinementPointsTo.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/demandpa/alg/DemandRefinementPointsTo.java
@@ -259,7 +259,6 @@ public class DemandRefinementPointsTo extends AbstractDemandPointsTo {
   /**
    * @param pk
    * @param ikeyPred
-   * @return
    */
   private Pair<PointsToResult, Collection<InstanceKeyAndState>> getPointsToWithStates(PointerKey pk, Predicate<InstanceKey> ikeyPred) {
     if (!(pk instanceof com.ibm.wala.ipa.callgraph.propagation.LocalPointerKey)) {
@@ -539,7 +538,6 @@ public class DemandRefinementPointsTo extends AbstractDemandPointsTo {
 
   /**
    * @param ik
-   * @return
    */
   private Pair<PointsToResult, Collection<PointerKey>> getFlowsToInternal(InstanceKeyAndState ikAndState) {
     InstanceKey ik = ikAndState.getInstanceKey();
@@ -1666,7 +1664,6 @@ public class DemandRefinementPointsTo extends AbstractDemandPointsTo {
      * @param addGraphs whether graphs should always be added
      * @param callee
      * @param pkAndState
-     * @return
      */
     protected boolean calleeSubGraphMissingAndShouldNotBeAdded(boolean addGraphs, CGNode callee, PointerKeyAndState pkAndState) {
       return !addGraphs && !g.hasSubgraphForNode(callee);

--- a/com.ibm.wala.core/src/com/ibm/wala/demandpa/flowgraph/AbstractFlowGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/demandpa/flowgraph/AbstractFlowGraph.java
@@ -114,7 +114,7 @@ public abstract class AbstractFlowGraph extends SlowSparseNumberedLabeledGraph<O
   };
 
   /**
-   * Map: LocalPointerKey -> SSAInvokeInstruction. If we have (x, foo()), that means that x was def'fed by the return value from the
+   * Map: LocalPointerKey -&gt; SSAInvokeInstruction. If we have (x, foo()), that means that x was def'fed by the return value from the
    * call to foo()
    */
   protected final Map<PointerKey, SSAAbstractInvokeInstruction> callDefs = HashMapFactory.make();
@@ -127,7 +127,7 @@ public abstract class AbstractFlowGraph extends SlowSparseNumberedLabeledGraph<O
   protected final Map<PointerKey, Set<SSAAbstractInvokeInstruction>> callParams = HashMapFactory.make();
 
   /**
-   * Map: LocalPointerKey -> CGNode. If we have (x, foo), then x is a parameter of method foo. For now, we have to re-discover the
+   * Map: LocalPointerKey -&gt; CGNode. If we have (x, foo), then x is a parameter of method foo. For now, we have to re-discover the
    * parameter position. TODO this should just be a set; we can get the CGNode from the {@link LocalPointerKey}
    */
   protected final Map<PointerKey, CGNode> params = HashMapFactory.make();

--- a/com.ibm.wala.core/src/com/ibm/wala/demandpa/flowgraph/SimpleDemandPointerFlowGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/demandpa/flowgraph/SimpleDemandPointerFlowGraph.java
@@ -81,13 +81,13 @@ import com.ibm.wala.util.ref.ReferenceCleanser;
  * 
  * The edges represent
  * <ul>
- * <li>flow from local -> local representing assignment (i.e. phi,pi)
- * <li>flow from instancekey -> local for news
- * <li>flow from formal -> actual parameter
- * <li>flow from return value -> local
+ * <li>flow from local -&gt; local representing assignment (i.e. phi,pi)
+ * <li>flow from instancekey -&gt; local for news
+ * <li>flow from formal -&gt; actual parameter
+ * <li>flow from return value -&gt; local
  * <li>match edges
- * <li>local -> local edges representing loads/stores (e.g. x = y.f will have a edge x->y, labelled with f) for a getstatic x = Y.f,
- * we have an edge from x -> Y.f.
+ * <li>local -&gt; local edges representing loads/stores (e.g. x = y.f will have a edge x-&gt;y, labelled with f) for a getstatic x = Y.f,
+ * we have an edge from x -&gt; Y.f.
  * </ul>
  * 
  * N.B: Edges go OPPOSITE the flow of values.
@@ -119,20 +119,20 @@ public class SimpleDemandPointerFlowGraph extends SlowSparseNumberedGraph<Object
   final BitVectorIntSet cgNodesVisited = new BitVectorIntSet();
 
   /**
-   * Map: LocalPointerKey -> IField. if we have (x,f), that means x was def'fed by a getfield on f.
+   * Map: LocalPointerKey -&gt; IField. if we have (x,f), that means x was def'fed by a getfield on f.
    */
   final Map<PointerKey, IField> getFieldDefs = HashMapFactory.make();
 
   final Collection<PointerKey> arrayDefs = HashSetFactory.make();
 
   /**
-   * Map: LocalPointerKey -> SSAInvokeInstruction. If we have (x, foo()), that means that x was def'fed by the return value from a
+   * Map: LocalPointerKey -&gt; SSAInvokeInstruction. If we have (x, foo()), that means that x was def'fed by the return value from a
    * call to foo()
    */
   final Map<PointerKey, SSAInvokeInstruction> callDefs = HashMapFactory.make();
 
   /**
-   * Map: LocalPointerKey -> CGNode. If we have (x, foo), then x is a parameter of method foo. For now, we have to re-discover the
+   * Map: LocalPointerKey -&gt; CGNode. If we have (x, foo), then x is a parameter of method foo. For now, we have to re-discover the
    * parameter position.
    */
   final Map<PointerKey, CGNode> params = HashMapFactory.make();

--- a/com.ibm.wala.core/src/com/ibm/wala/demandpa/util/SimpleMemoryAccessMap.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/demandpa/util/SimpleMemoryAccessMap.java
@@ -63,12 +63,12 @@ public class SimpleMemoryAccessMap implements MemoryAccessMap {
   private static final boolean ALWAYS_BUILD_IR = true;
 
   /**
-   * Map: IField -> Set<MemoryAccess>
+   * Map: IField -&gt; Set&lt;MemoryAccess&gt;
    */
   final private Map<IField, Set<MemoryAccess>> readMap = HashMapFactory.make();
 
   /**
-   * Map: IField -> Set<MemoryAccess>
+   * Map: IField -&gt; Set&lt;MemoryAccess&gt;
    */
   final private Map<IField, Set<MemoryAccess>> writeMap = HashMapFactory.make();
 

--- a/com.ibm.wala.core/src/com/ibm/wala/escape/FILiveObjectAnalysis.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/escape/FILiveObjectAnalysis.java
@@ -51,7 +51,7 @@ public class FILiveObjectAnalysis implements ILiveObjectAnalysis {
   private final HeapGraph<?> heapGraph;
 
   /**
-   * Cached map from InstanceKey -> Set<CGNode>
+   * Cached map from InstanceKey -&gt; Set&lt;CGNode&gt;
    */
   final private Map<InstanceKey, Set<CGNode>> liveNodes = HashMapFactory.make();
 

--- a/com.ibm.wala.core/src/com/ibm/wala/escape/ILiveObjectAnalysis.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/escape/ILiveObjectAnalysis.java
@@ -26,8 +26,8 @@ public interface ILiveObjectAnalysis {
    * @param m method in question
    * @param instructionIndex index of an instruction in SSA IR. in m. if -1, it is interpreted as a wildcard meaning "any statement"
    * @throws WalaException
-   * @returns true if an object allocated at the allocation site &lt;allocMethod,allocPC> may be live immediately after the
-   *          statement <m,instructionIndex>
+   * @returns true if an object allocated at the allocation site &lt;allocMethod,allocPC&gt; may be live immediately after the
+   *          statement &lt;m,instructionIndex&gt;
    */
   public boolean mayBeLive(CGNode allocMethod, int allocPC, CGNode m, int instructionIndex) throws WalaException;
 
@@ -36,8 +36,8 @@ public interface ILiveObjectAnalysis {
    * @param m method in question
    * @param instructionIndex index of an instruction in SSA IR. in m. if -1, it is interpreted as a wildcard meaning "any statement"
    * @throws WalaException
-   * @returns true if an object allocated at the allocation site &lt;allocMethod,allocPC> may be live immediately after the
-   *          statement <m,instructionIndex>
+   * @returns true if an object allocated at the allocation site &lt;allocMethod,allocPC&gt; may be live immediately after the
+   *          statement &lt;m,instructionIndex&gt;
    */
   public boolean mayBeLive(InstanceKey ik, CGNode m, int instructionIndex) throws WalaException;
 
@@ -45,8 +45,8 @@ public interface ILiveObjectAnalysis {
    * @param ik an instance key
    * @param m method in question
    * @param instructionIndices indices of instructions in SSA IR.
-   * @returns true if an object allocated at the allocation site &lt;allocMethod,allocPC> may be live immediately after the
-   *          statement <m,instructionIndex> for any instructionIndex in the set
+   * @returns true if an object allocated at the allocation site &lt;allocMethod,allocPC&gt; may be live immediately after the
+   *          statement &lt;m,instructionIndex&gt; for any instructionIndex in the set
    */
   public boolean mayBeLive(InstanceKey ik, CGNode m, IntSet instructionIndices);
 

--- a/com.ibm.wala.core/src/com/ibm/wala/escape/ILiveObjectAnalysis.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/escape/ILiveObjectAnalysis.java
@@ -26,7 +26,7 @@ public interface ILiveObjectAnalysis {
    * @param m method in question
    * @param instructionIndex index of an instruction in SSA IR. in m. if -1, it is interpreted as a wildcard meaning "any statement"
    * @throws WalaException
-   * @returns true if an object allocated at the allocation site &lt;allocMethod,allocPC&gt; may be live immediately after the
+   * @return true if an object allocated at the allocation site &lt;allocMethod,allocPC&gt; may be live immediately after the
    *          statement &lt;m,instructionIndex&gt;
    */
   public boolean mayBeLive(CGNode allocMethod, int allocPC, CGNode m, int instructionIndex) throws WalaException;
@@ -36,7 +36,7 @@ public interface ILiveObjectAnalysis {
    * @param m method in question
    * @param instructionIndex index of an instruction in SSA IR. in m. if -1, it is interpreted as a wildcard meaning "any statement"
    * @throws WalaException
-   * @returns true if an object allocated at the allocation site &lt;allocMethod,allocPC&gt; may be live immediately after the
+   * @return true if an object allocated at the allocation site &lt;allocMethod,allocPC&gt; may be live immediately after the
    *          statement &lt;m,instructionIndex&gt;
    */
   public boolean mayBeLive(InstanceKey ik, CGNode m, int instructionIndex) throws WalaException;
@@ -45,7 +45,7 @@ public interface ILiveObjectAnalysis {
    * @param ik an instance key
    * @param m method in question
    * @param instructionIndices indices of instructions in SSA IR.
-   * @returns true if an object allocated at the allocation site &lt;allocMethod,allocPC&gt; may be live immediately after the
+   * @return true if an object allocated at the allocation site &lt;allocMethod,allocPC&gt; may be live immediately after the
    *          statement &lt;m,instructionIndex&gt; for any instructionIndex in the set
    */
   public boolean mayBeLive(InstanceKey ik, CGNode m, IntSet instructionIndices);

--- a/com.ibm.wala.core/src/com/ibm/wala/escape/IMethodEscapeAnalysis.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/escape/IMethodEscapeAnalysis.java
@@ -22,7 +22,7 @@ public interface IMethodEscapeAnalysis {
    * @param allocMethod a method which holds an allocation site
    * @param allocPC bytecode index of allocation site
    * @param m method in question
-   * @returns true if an object allocated at the allocation site &lt;allocMethod,allocPC&gt; may escape from an activation of method m,
+   * @return true if an object allocated at the allocation site &lt;allocMethod,allocPC&gt; may escape from an activation of method m,
    *          false otherwise
    */
   public boolean mayEscape(MethodReference allocMethod, int allocPC, MethodReference m) throws WalaException;

--- a/com.ibm.wala.core/src/com/ibm/wala/escape/IMethodEscapeAnalysis.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/escape/IMethodEscapeAnalysis.java
@@ -22,7 +22,7 @@ public interface IMethodEscapeAnalysis {
    * @param allocMethod a method which holds an allocation site
    * @param allocPC bytecode index of allocation site
    * @param m method in question
-   * @returns true if an object allocated at the allocation site &lt;allocMethod,allocPC> may escape from an activation of method m,
+   * @returns true if an object allocated at the allocation site &lt;allocMethod,allocPC&gt; may escape from an activation of method m,
    *          false otherwise
    */
   public boolean mayEscape(MethodReference allocMethod, int allocPC, MethodReference m) throws WalaException;

--- a/com.ibm.wala.core/src/com/ibm/wala/escape/INodeEscapeAnalysis.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/escape/INodeEscapeAnalysis.java
@@ -23,7 +23,7 @@ public interface INodeEscapeAnalysis extends IMethodEscapeAnalysis {
    * @param allocPC bytecode index of allocation site
    * @param node method in question
    * @throws WalaException
-   * @returns true if an object allocated at the allocation site &lt;allocMethod,allocPC&gt; may escape from an activation of node m,
+   * @return true if an object allocated at the allocation site &lt;allocMethod,allocPC&gt; may escape from an activation of node m,
    *          false otherwise
    */
   public boolean mayEscape(CGNode allocNode, int allocPC, CGNode node) throws WalaException;

--- a/com.ibm.wala.core/src/com/ibm/wala/escape/INodeEscapeAnalysis.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/escape/INodeEscapeAnalysis.java
@@ -23,7 +23,7 @@ public interface INodeEscapeAnalysis extends IMethodEscapeAnalysis {
    * @param allocPC bytecode index of allocation site
    * @param node method in question
    * @throws WalaException
-   * @returns true if an object allocated at the allocation site &lt;allocMethod,allocPC> may escape from an activation of node m,
+   * @returns true if an object allocated at the allocation site &lt;allocMethod,allocPC&gt; may escape from an activation of node m,
    *          false otherwise
    */
   public boolean mayEscape(CGNode allocNode, int allocPC, CGNode node) throws WalaException;

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/Context.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/Context.java
@@ -16,7 +16,7 @@ package com.ibm.wala.ipa.callgraph;
  * For example, for CFA-1, there is only one name ("caller"); and the context maps "caller" to an IMethod
  * 
  * As another example, for CPA, there would be name for each parameter slot ("zero","one","two"), and the Context provides a mapping
- * from this name to a set of types. eg. "one" -> {java.lang.String, java.lang.Date}
+ * from this name to a set of types. eg. "one" -&gt; {java.lang.String, java.lang.Date}
  */
 public interface Context {
   /**

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/ExplicitCallGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/ExplicitCallGraph.java
@@ -134,7 +134,7 @@ public class ExplicitCallGraph extends BasicCallGraph<SSAContextInterpreter> imp
   public class ExplicitNode extends NodeImpl {
 
     /**
-     * A Mapping from call site program counter (int) -> Object, where Object is a CGNode if we've discovered exactly one target for
+     * A Mapping from call site program counter (int) -&gt; Object, where Object is a CGNode if we've discovered exactly one target for
      * the site, or an IntSet of node numbers if we've discovered more than one target for the site.
      */
     protected final SparseVector<Object> targets = new SparseVector<>();

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/UnionContextSelector.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/UnionContextSelector.java
@@ -31,7 +31,7 @@ import com.ibm.wala.util.intset.IntSet;
  *
  *  @see com.ibm.wala.ipa.callgraph.impl.DelegatingContextSelector
  *
- *  @author  Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author  Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 public class UnionContextSelector implements ContextSelector {
     private final ContextSelector A;

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/Util.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/Util.java
@@ -188,7 +188,7 @@ public class Util {
   /**
    * @return Entrypoints for a set of J2SE Main classes
    * @throws IllegalArgumentException if classNames == null
-   * @throws IllegalArgumentException if (classNames != null) and (0 < classNames.length) and (classNames[0] == null)
+   * @throws IllegalArgumentException if (classNames != null) and (0 &lt; classNames.length) and (classNames[0] == null)
    * @throws IllegalArgumentException if classNames.length == 0
    */
   public static Iterable<Entrypoint> makeMainEntrypoints(final ClassLoaderReference loaderRef, final IClassHierarchy cha,

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/InstanceKey.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/InstanceKey.java
@@ -23,10 +23,10 @@ import com.ibm.wala.util.collections.Pair;
  * An InstanceKey serves as the representative for an equivalence class of
  * objects in the heap, that can be pointed to.
  * 
- * For example, for 0-CFA, an InstanceKey would embody an <IClass>... we model
+ * For example, for 0-CFA, an InstanceKey would embody an &lt;IClass&gt;... we model
  * all instances of a particular class
  * 
- * For 0-1-CFA, an InstanceKey could be <IMethod,statement #>, representing a
+ * For 0-1-CFA, an InstanceKey could be &lt;IMethod,statement #&gt;, representing a
  * particular allocation statement in a particular method.
  */
 public interface InstanceKey extends ContextItem {

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PointerKey.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PointerKey.java
@@ -14,15 +14,15 @@ package com.ibm.wala.ipa.callgraph.propagation;
  * A PointerKey instance serves as the representative for an equivalence class
  * of pointers. (or more generally ...locations, if we allow primitives).
  * 
- * For example, a PointerKey for 0-CFA might be - a <CGNode,int> pair, where the
+ * For example, a PointerKey for 0-CFA might be - a &lt;CGNode,int&gt; pair, where the
  * int represents an SSA value number. This PointerKey would represent all
- * values of the pointer of a particular local variable. - a <FieldReference>,
+ * values of the pointer of a particular local variable. - a &lt;FieldReference&gt;,
  * representing the set of instances of a given field in the heap, or of a
  * particular static field.
  * 
  * A PointerKey for 0-1-CFA, with 1-level of InstanceVar context in the Grove et
- * al. terminology, would instead of FieldReference, use a - <InstanceKey,
- * FieldReference> pair
+ * al. terminology, would instead of FieldReference, use a - &lt;InstanceKey,
+ * FieldReference&gt; pair
  */
 public interface PointerKey {
 

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PropagationCallGraphBuilder.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PropagationCallGraphBuilder.java
@@ -589,7 +589,7 @@ public abstract class PropagationCallGraphBuilder implements CallGraphBuilder<In
    * LHS U= (RHS n k)
    * 
    * 
-   * Unary op: <lhs>:= Cast_k( <rhs>)
+   * Unary op: &lt;lhs&gt;:= Cast_k( &lt;rhs&gt;)
    * 
    * (Again, technically a binary op -- see note for Assign)
    * 
@@ -803,7 +803,7 @@ public abstract class PropagationCallGraphBuilder implements CallGraphBuilder<In
   }
 
   /**
-   * Binary op: <dummy>:= ArrayLoad( &lt;arrayref>) Side effect: Creates new equations.
+   * Binary op: &lt;dummy&gt;:= ArrayLoad( &lt;arrayref&gt;) Side effect: Creates new equations.
    */
   public final class ArrayLoadOperator extends UnarySideEffect implements IPointerOperator {
     protected final MutableIntSet priorInstances = rememberGetPutHistory ? IntSetUtil.make() : null;
@@ -892,7 +892,7 @@ public abstract class PropagationCallGraphBuilder implements CallGraphBuilder<In
   }
 
   /**
-   * Binary op: <dummy>:= ArrayStore( &lt;arrayref>) Side effect: Creates new equations.
+   * Binary op: &lt;dummy&gt;:= ArrayStore( &lt;arrayref&gt;) Side effect: Creates new equations.
    */
   public final class ArrayStoreOperator extends UnarySideEffect implements IPointerOperator {
     @Override
@@ -976,7 +976,7 @@ public abstract class PropagationCallGraphBuilder implements CallGraphBuilder<In
   }
 
   /**
-   * Binary op: <dummy>:= GetField( <ref>) Side effect: Creates new equations.
+   * Binary op: &lt;dummy&gt;:= GetField( &lt;ref&gt;) Side effect: Creates new equations.
    */
   public class GetFieldOperator extends UnarySideEffect implements IPointerOperator {
     private final IField field;

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PropagationGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PropagationGraph.java
@@ -442,7 +442,7 @@ public class PropagationGraph implements IFixedPointSystem<PointsToSetVariable> 
   }
 
   /**
-   * A graph of just the variables in the system. v1 -> v2 iff there exists equation e s.t. e uses v1 and e defs v2.
+   * A graph of just the variables in the system. v1 -&gt; v2 iff there exists equation e s.t. e uses v1 and e defs v2.
    * 
    * Note that this graph trickily and fragilely reuses the nodeManager from the delegateGraph, above. This will work ok as long as
    * every variable is inserted in the delegateGraph.
@@ -834,7 +834,7 @@ public class PropagationGraph implements IFixedPointSystem<PointsToSetVariable> 
   }
 
   /**
-   * A graph of just the variables in the system. v1 -> v2 iff there exists an assignment equation e s.t. e uses v1 and e defs v2.
+   * A graph of just the variables in the system. v1 -&gt; v2 iff there exists an assignment equation e s.t. e uses v1 and e defs v2.
    * 
    */
   public NumberedGraph<PointsToSetVariable> getAssignmentGraph() {
@@ -848,7 +848,7 @@ public class PropagationGraph implements IFixedPointSystem<PointsToSetVariable> 
   }
 
   /**
-   * A graph of just the variables in the system. v1 -> v2 iff there exists an Assingnment or Filter equation e s.t. e uses v1 and e
+   * A graph of just the variables in the system. v1 -&gt; v2 iff there exists an Assingnment or Filter equation e s.t. e uses v1 and e
    * defs v2.
    * 
    */
@@ -871,7 +871,7 @@ public class PropagationGraph implements IFixedPointSystem<PointsToSetVariable> 
   }
 
   /**
-   * A graph of just the variables in the system. v1 -> v2 that are related by def-use with "interesting" operators
+   * A graph of just the variables in the system. v1 -&gt; v2 that are related by def-use with "interesting" operators
    * 
    */
   private abstract class FilteredConstraintGraphView extends AbstractNumberedGraph<PointsToSetVariable> {

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PropagationSystem.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PropagationSystem.java
@@ -81,7 +81,7 @@ public class PropagationSystem extends DefaultFixedPointSolver<PointsToSetVariab
   protected final MutableMapping<InstanceKey> instanceKeys = MutableMapping.make();
 
   /**
-   * A mapping from IClass -> MutableSharedBitVectorIntSet The range represents the instance keys that correspond to a given class.
+   * A mapping from IClass -&gt; MutableSharedBitVectorIntSet The range represents the instance keys that correspond to a given class.
    * This mapping is used to filter sets based on declared types; e.g., in cast constraints
    */
   final private Map<IClass, MutableIntSet> class2InstanceKey = HashMapFactory.make();
@@ -104,7 +104,7 @@ public class PropagationSystem extends DefaultFixedPointSolver<PointsToSetVariab
   /**
    * When doing unification, we must also updated the fixed sets in unary side effects.
    * 
-   * This maintains a map from PointsToSetVariable -> Set<UnarySideEffect>
+   * This maintains a map from PointsToSetVariable -&gt; Set&lt;UnarySideEffect&gt;
    */
   final private Map<PointsToSetVariable, Set<UnarySideEffect>> fixedSetMap = HashMapFactory.make();
 

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/cfa/CallerContextPair.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/cfa/CallerContextPair.java
@@ -17,7 +17,7 @@ import com.ibm.wala.ipa.callgraph.ContextItem;
 import com.ibm.wala.ipa.callgraph.ContextKey;
 
 /**
- * This is a {@link Context} which is defined by a pair consisting of <caller node, base context>.
+ * This is a {@link Context} which is defined by a pair consisting of &lt;caller node, base context&gt;.
  * 
  * The base context is typically some special case; e.g., a JavaTypeContext used for reflection.
  */

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/cfa/CallerSiteContext.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/cfa/CallerSiteContext.java
@@ -16,7 +16,7 @@ import com.ibm.wala.ipa.callgraph.ContextItem;
 import com.ibm.wala.ipa.callgraph.ContextKey;
 
 /**
- * A context which is a <CGNode, CallSiteReference> pair.
+ * A context which is a &lt;CGNode, CallSiteReference&gt; pair.
  */
 public class CallerSiteContext extends CallerContext {
 

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/cfa/CallerSiteContextPair.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/cfa/CallerSiteContextPair.java
@@ -17,7 +17,7 @@ import com.ibm.wala.ipa.callgraph.ContextItem;
 import com.ibm.wala.ipa.callgraph.ContextKey;
 
 /**
- * This is a context which is defined by a pair consisting of <caller node, base context>.
+ * This is a context which is defined by a pair consisting of &lt;caller node, base context&gt;.
  * 
  * The base context is typically some special case; e.g., a JavaTypeContext used for reflection.
  */

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/cfa/ContainerContextSelector.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/cfa/ContainerContextSelector.java
@@ -36,8 +36,8 @@ import com.ibm.wala.util.strings.Atom;
  * This context selector returns a context customized for the {@link InstanceKey} of the receiver if
  * <ul>
  * <li>receiver is a container, or</li>
- * was allocated in a node whose context was a {@link ReceiverInstanceContext}, and the type is interesting according to a delegate
- * {@link ZeroXInstanceKeys}
+ * <li>was allocated in a node whose context was a {@link ReceiverInstanceContext}, and the type is interesting according to a delegate
+ * {@link ZeroXInstanceKeys}</li>
  * </ul>
  * 
  * Additionally, we add one level of call string context to a few well-known static factory methods from the standard libraries.

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/cfa/ZeroXInstanceKeys.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/cfa/ZeroXInstanceKeys.java
@@ -86,8 +86,8 @@ public class ZeroXInstanceKeys implements InstanceKeyFactory {
   public static final int SMUSH_PRIMITIVE_HOLDERS = 8;
 
   /**
-   * This variant counts the N, number of allocation sites of a particular type T in each method. If N > SMUSH_LIMIT, then these N
-   * allocation sites are NOT distinguished ... instead there is a single abstract allocation site for <N,T>
+   * This variant counts the N, number of allocation sites of a particular type T in each method. If N &gt; SMUSH_LIMIT, then these N
+   * allocation sites are NOT distinguished ... instead there is a single abstract allocation site for &lt;N,T&gt;
    * 
    * Probably the best choice in many cases.
    */
@@ -134,7 +134,7 @@ public class ZeroXInstanceKeys implements InstanceKeyFactory {
   final private RTAContextInterpreter contextInterpreter;
 
   /**
-   * a Map from CGNode->Set<IClass> that should be smushed.
+   * a Map from CGNode-&gt;Set&lt;IClass&gt; that should be smushed.
    */
   protected final Map<CGNode, Set<IClass>> smushMap = HashMapFactory.make();
 

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/DelegatingExplicitCallGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/DelegatingExplicitCallGraph.java
@@ -53,7 +53,6 @@ public class DelegatingExplicitCallGraph extends ExplicitCallGraph {
    * In this implementation, super.targets is a mapping from call site -&gt;
    * Object, where Object is a
    * <ul>
-   * A Mapping from call site -&gt; Object, where Object is a
    * <li>CGNode if we've discovered exactly one target for the site
    * <li> or an IntSet of node numbers if we've discovered more than one target
    * for the site.

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/DelegatingExplicitCallGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/DelegatingExplicitCallGraph.java
@@ -50,10 +50,10 @@ public class DelegatingExplicitCallGraph extends ExplicitCallGraph {
   }
 
   /**
-   * In this implementation, super.targets is a mapping from call site ->
+   * In this implementation, super.targets is a mapping from call site -&gt;
    * Object, where Object is a
    * <ul>
-   * A Mapping from call site -> Object, where Object is a
+   * A Mapping from call site -&gt; Object, where Object is a
    * <li>CGNode if we've discovered exactly one target for the site
    * <li> or an IntSet of node numbers if we've discovered more than one target
    * for the site.

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/TypeBasedHeapModel.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/TypeBasedHeapModel.java
@@ -63,14 +63,14 @@ public class TypeBasedHeapModel implements HeapModel {
   private final Collection<CGNode> nodesHandled = HashSetFactory.make();
 
   /**
-   * Map: <PointerKey> -> thing, where thing is a FilteredPointerKey or an InstanceKey representing a constant.
+   * Map: &lt;PointerKey&gt; -&gt; thing, where thing is a FilteredPointerKey or an InstanceKey representing a constant.
    * 
    * computed lazily
    */
   private Map<PointerKey, Object> pKeys;
 
   /**
-   * @param klasses Collection<IClass>
+   * @param klasses Collection&lt;IClass&gt;
    * @throws IllegalArgumentException if cg is null
    */
   public TypeBasedHeapModel(AnalysisOptions options, Collection<IClass> klasses, CallGraph cg) {

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/TypeBasedPointerAnalysis.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/TypeBasedPointerAnalysis.java
@@ -48,7 +48,7 @@ public class TypeBasedPointerAnalysis extends AbstractPointerAnalysis {
   private final TypeBasedHeapModel heapModel;
 
   /**
-   * Map: IClass -> OrdinalSet
+   * Map: IClass -&gt; OrdinalSet
    */
   private final Map<IClass, OrdinalSet<InstanceKey>> pointsTo = HashMapFactory.make();
 

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/cha/ClassHierarchy.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/cha/ClassHierarchy.java
@@ -98,7 +98,7 @@ public class ClassHierarchy implements IClassHierarchy {
   final private IClassLoader[] loaders;
 
   /**
-   * A mapping from IClass -> Selector -> Set of IMethod
+   * A mapping from IClass -&gt; Selector -&gt; Set of IMethod
    */
   final private HashMap<IClass, Object> targetCache = HashMapFactory.make();
 
@@ -108,7 +108,7 @@ public class ClassHierarchy implements IClassHierarchy {
   private final AnalysisScope scope;
 
   /**
-   * A mapping from IClass (representing an interface) -> Set of IClass that implement that interface
+   * A mapping from IClass (representing an interface) -&gt; Set of IClass that implement that interface
    */
   private final Map<IClass, Set<IClass>> implementors = HashMapFactory.make();
 
@@ -645,7 +645,7 @@ public class ClassHierarchy implements IClassHierarchy {
 
   /**
    * Number the class hierarchy tree to support efficient subclass tests. After numbering the tree, n1 is a child of n2 iff n2.left
-   * <= n1.left ^ n1.left <= n2.right. Described as "relative numbering" by Vitek, Horspool, and Krall, OOPSLA 97
+   * &lt;= n1.left ^ n1.left &lt;= n2.right. Described as "relative numbering" by Vitek, Horspool, and Krall, OOPSLA 97
    * 
    * TODO: this implementation is recursive; un-recursify if needed
    */
@@ -999,7 +999,7 @@ public class ClassHierarchy implements IClassHierarchy {
   }
 
   /**
-   * Solely for optimization; return a Collection<TypeReference> representing the subclasses of Error
+   * Solely for optimization; return a Collection&lt;TypeReference&gt; representing the subclasses of Error
    * 
    * kind of ugly. a better scheme?
    */
@@ -1016,7 +1016,7 @@ public class ClassHierarchy implements IClassHierarchy {
   }
 
   /**
-   * Solely for optimization; return a Collection<TypeReference> representing the subclasses of RuntimeException
+   * Solely for optimization; return a Collection&lt;TypeReference&gt; representing the subclasses of RuntimeException
    * 
    * kind of ugly. a better scheme?
    */

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/cha/IClassHierarchy.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/cha/IClassHierarchy.java
@@ -144,14 +144,14 @@ public interface IClassHierarchy extends Iterable<IClass> {
   public Collection<IClass> computeSubClasses(TypeReference type);
 
   /**
-   * Solely for optimization; return a Collection<TypeReference> representing the subclasses of Error
+   * Solely for optimization; return a Collection&lt;TypeReference&gt; representing the subclasses of Error
    * 
    * kind of ugly. a better scheme?
    */
   public Collection<TypeReference> getJavaLangErrorTypes();
 
   /**
-   * Solely for optimization; return a Collection<TypeReference> representing the subclasses of {@link RuntimeException}
+   * Solely for optimization; return a Collection&lt;TypeReference&gt; representing the subclasses of {@link RuntimeException}
    * 
    * kind of ugly. a better scheme?
    */

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/modref/ModRef.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/modref/ModRef.java
@@ -95,7 +95,7 @@ public class ModRef<T extends InstanceKey> {
   }
 
   /**
-   * For each call graph node, what heap locations (as determined by a heap model) may it write, <bf> NOT </bf> including its
+   * For each call graph node, what heap locations (as determined by a heap model) may it write, <b> NOT </b> including its
    * callees transitively
    * 
    * @param heapExclude
@@ -106,7 +106,7 @@ public class ModRef<T extends InstanceKey> {
   }
 
   /**
-   * For each call graph node, what heap locations (as determined by a heap model) may it read, <bf> NOT </bf> including its callees
+   * For each call graph node, what heap locations (as determined by a heap model) may it read, <b> NOT </b> including its callees
    * transitively
    * 
    * @param heapExclude
@@ -119,7 +119,7 @@ public class ModRef<T extends InstanceKey> {
     return new DelegatingExtendedHeapModel(pa.getHeapModel());
   }
   /**
-   * For a call graph node, what heap locations (as determined by a heap model) may it write, <bf> NOT </bf> including it's callees
+   * For a call graph node, what heap locations (as determined by a heap model) may it write, <b> NOT </b> including it's callees
    * transitively
    * 
    * @param heapExclude
@@ -142,7 +142,7 @@ public class ModRef<T extends InstanceKey> {
   }
 
   /**
-   * For a call graph node, what heap locations (as determined by a heap model) may it read, <bf> NOT </bf> including it's callees
+   * For a call graph node, what heap locations (as determined by a heap model) may it read, <b> NOT </b> including it's callees
    * transitively
    */
   private Collection<PointerKey> scanNodeForRef(final CGNode n, final PointerAnalysis<T> pa, HeapExclusions heapExclude) {

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/modref/ModRefFieldAccess.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/modref/ModRefFieldAccess.java
@@ -33,7 +33,7 @@ import com.ibm.wala.util.collections.Iterator2Iterable;
  * Computes interprocedural field accesses for a given method.
  * 
  * @author Martin Seidel
- * @author Juergen Graf <juergen.graf@gmail.com>
+ * @author Juergen Graf &lt;juergen.graf@gmail.com&gt;
  *
  */
 public final class ModRefFieldAccess {

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/PDG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/PDG.java
@@ -161,7 +161,7 @@ public class PDG<T extends InstanceKey> implements NumberedGraph<Statement> {
 
   /**
    * WARNING: Since we're using a {@link HashMap} of {@link SSAInstruction}s, and equals() of {@link SSAInstruction} assumes a
-   * canonical representative for each instruction, we <bf>must</bf> ensure that we use the same IR object throughout
+   * canonical representative for each instruction, we <b>must</b> ensure that we use the same IR object throughout
    * initialization!!
    */
   private void populate() {
@@ -786,7 +786,7 @@ public class PDG<T extends InstanceKey> implements NumberedGraph<Statement> {
 
   /**
    * Wrap an {@link SSAInstruction} in a {@link Statement}. WARNING: Since we're using a {@link HashMap} of {@link SSAInstruction}s,
-   * and equals() of {@link SSAInstruction} assumes a canonical representative for each instruction, we <bf>must</bf> ensure that we
+   * and equals() of {@link SSAInstruction} assumes a canonical representative for each instruction, we <b>must</b> ensure that we
    * use the same IR object throughout initialization!!
    */
   private Statement ssaInstruction2Statement(SSAInstruction s, IR ir, Map<SSAInstruction, Integer> instructionIndices) {

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/SDG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/SDG.java
@@ -197,7 +197,7 @@ public class SDG<T extends InstanceKey> extends AbstractNumberedGraph<Statement>
   }
 
   /**
-   * iterate over the nodes <bf>without</bf> constructing any new ones. Use with extreme care. May break graph traversals that
+   * iterate over the nodes <b>without</b> constructing any new ones. Use with extreme care. May break graph traversals that
    * lazily add more nodes.
    */
   @Override
@@ -260,7 +260,7 @@ public class SDG<T extends InstanceKey> extends AbstractNumberedGraph<Statement>
     }
 
     /**
-     * iterate over the nodes <bf>without</bf> constructing any new ones. Use with extreme care. May break graph traversals that
+     * iterate over the nodes <b>without</b> constructing any new ones. Use with extreme care. May break graph traversals that
      * lazily add more nodes.
      */
     Iterator<? extends Statement> iterateLazyNodes() {

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/BypassMethodTargetSelector.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/BypassMethodTargetSelector.java
@@ -45,7 +45,7 @@ public class BypassMethodTargetSelector implements MethodTargetSelector {
   static final boolean DEBUG = false;
 
   /**
-   * Method summaries collected for methods. Mapping Object -> MethodSummary where Object is either a
+   * Method summaries collected for methods. Mapping Object -&gt; MethodSummary where Object is either a
    * <ul>
    * <li>MethodReference
    * <li>TypeReference
@@ -75,7 +75,7 @@ public class BypassMethodTargetSelector implements MethodTargetSelector {
   private final ClassHierarchyMethodTargetSelector chaMethodTargetSelector;
 
   /**
-   * Mapping from MethodReference -> SyntheticMethod We may call syntheticMethod.put(m,null) .. in which case we use containsKey()
+   * Mapping from MethodReference -&gt; SyntheticMethod We may call syntheticMethod.put(m,null) .. in which case we use containsKey()
    * to check for having already considered m.
    */
   final private HashMap<MethodReference, SummarizedMethod> syntheticMethods = HashMapFactory.make();

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/MethodBypass.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/MethodBypass.java
@@ -37,7 +37,7 @@ public class MethodBypass {
   static final boolean DEBUG = false;
 
   /**
-   * Method summaries collected for methods. Mapping Object -> MethodSummary where Object is either a
+   * Method summaries collected for methods. Mapping Object -&gt; MethodSummary where Object is either a
    * <ul>
    * <li>MethodReference
    * <li>TypeReference
@@ -57,7 +57,7 @@ public class MethodBypass {
   private final IClassHierarchy cha;
 
   /**
-   * Mapping from MethodReference -> SyntheticMethod
+   * Mapping from MethodReference -&gt; SyntheticMethod
    */
   final private HashMap<MethodReference, SummarizedMethod> syntheticMethods = HashMapFactory.make();
 

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/MethodSummary.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/MethodSummary.java
@@ -40,7 +40,7 @@ public class MethodSummary {
   private ArrayList<SSAInstruction> statements;
 
   /**
-   * Map: value number -> constant
+   * Map: value number -&gt; constant
    */
   private Map<Integer, ConstantValue> constantValues;
 

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/SummarizedMethodWithNames.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/SummarizedMethodWithNames.java
@@ -63,7 +63,7 @@ import com.ibm.wala.util.strings.Atom;
  *  names in synthetic methods. This should not change th analysis-result but may come in handy when
  *  debugging.
  *
- *  @author     Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author     Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since      2013-11-25
  */
 public class SummarizedMethodWithNames extends SummarizedMethod {

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/VolatileMethodSummary.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/VolatileMethodSummary.java
@@ -246,7 +246,7 @@ public class VolatileMethodSummary {
     }
 
     /**
-     *  Like {@link addStatement(SSAInstructionWithPC <? extends SSAInstruction>) but may replace an existing one.
+     *  Like {@link addStatement(SSAInstructionWithPC <? extends SSAInstruction>)} but may replace an existing one.
      *
      *  @param  statement    The statement to add without care of overwriting
      *  @return true if a statement has actually been overwritten 

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/VolatileMethodSummary.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/VolatileMethodSummary.java
@@ -409,7 +409,7 @@ public class VolatileMethodSummary {
     /**
     *   Retrieves a mapping from SSA-Number to a constant.
     *
-    *   You can add Constants using the function {@link addConstant(java.lang.Integer, ConstantValue)}.
+    *   You can add Constants using the function {@link #addConstant(java.lang.Integer, ConstantValue)}.
     *   A call to this function gets passed directly to the internal MethodSummary.
     *
     *   @return a mapping from SSA-Number to assigned ConstantValue

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/VolatileMethodSummary.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/VolatileMethodSummary.java
@@ -246,7 +246,7 @@ public class VolatileMethodSummary {
     }
 
     /**
-     *  Like {@link addStatement(SSAInstructionWithPC <? extends SSAInstruction>)} but may replace an existing one.
+     *  Like {@link #addStatement(SSAInstructionWithPC)} but may replace an existing one.
      *
      *  @param  statement    The statement to add without care of overwriting
      *  @return true if a statement has actually been overwritten 

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/VolatileMethodSummary.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/VolatileMethodSummary.java
@@ -79,7 +79,7 @@ import com.ibm.wala.util.strings.Atom;
  *  @see com.ibm.wala.dalvik.ipa.callgraph.impl.DexFakeRootMethod
  *  @see com.ibm.wala.ipa.summaries.MethodSummary
  *
- *  @author     Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author     Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since      2013-09-08
  */
 @SuppressWarnings("javadoc")

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/XMLMethodSummaryReader.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/XMLMethodSummaryReader.java
@@ -269,7 +269,7 @@ public class XMLMethodSummaryReader implements BytecodeConstants {
     private int nextLocal = -1;
 
     /**
-     * A mapping from String (variable name) -> Integer (local number)
+     * A mapping from String (variable name) -&gt; Integer (local number)
      */
     private Map<String, Integer> symbolTable = null;
 

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/AuxiliaryCache.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/AuxiliaryCache.java
@@ -26,19 +26,19 @@ import com.ibm.wala.util.ref.CacheReference;
 /**
  * A cache for auxiliary information based on an SSA representation
  * 
- * A mapping from (IMethod,Context) -> SSAOptions -> SoftReference -> something
+ * A mapping from (IMethod,Context) -&gt; SSAOptions -&gt; SoftReference -&gt; something
  * 
  * This doesn't work very well ... GCs don't do such a great job with SoftReferences ... revamp it.
  */
 public class AuxiliaryCache implements IAuxiliaryCache {
 
   /**
-   * A mapping from IMethod -> SSAOptions -> SoftReference -> IR
+   * A mapping from IMethod -&gt; SSAOptions -&gt; SoftReference -&gt; IR
    */
   private HashMap<Pair<IMethod, Context>, Map<SSAOptions, Object>> dictionary = HashMapFactory.make();
 
   /**
-   * Help out the garbage collector: clear this cache when the number of items is > RESET_THRESHOLD
+   * Help out the garbage collector: clear this cache when the number of items is &gt; RESET_THRESHOLD
    */
   final private static int RESET_THRESHOLD = 2000;
 

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/DefUse.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/DefUse.java
@@ -28,17 +28,17 @@ public class DefUse {
   static final boolean DEBUG = false;
 
   /**
-   * A mapping from integer (value number) -> {@link SSAInstruction} that defines the value
+   * A mapping from integer (value number) -&gt; {@link SSAInstruction} that defines the value
    */
   final private SSAInstruction[] defs;
 
   /**
-   * A mapping from integer (value number) -> bit vector holding integers representing instructions that use the value number
+   * A mapping from integer (value number) -&gt; bit vector holding integers representing instructions that use the value number
    */
   final private MutableIntSet[] uses;
 
   /**
-   * A Mapping from integer -> Instruction
+   * A Mapping from integer -&gt; Instruction
    */
   final protected ArrayList<SSAInstruction> allInstructions = new ArrayList<>();
 

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/IAuxiliaryCache.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/IAuxiliaryCache.java
@@ -28,7 +28,7 @@ interface IAuxiliaryCache {
   Object find(IMethod m, Context c, SSAOptions options);
 
   /**
-   * cache new auxiliary information for an <m,options> pair
+   * cache new auxiliary information for an &lt;m,options&gt; pair
    * 
    * @param m a method
    * @param options options governing ssa construction

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/InstanceOfPiPolicy.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/InstanceOfPiPolicy.java
@@ -19,12 +19,12 @@ import com.ibm.wala.util.collections.Pair;
  * A pi node policy with the following rule:
  * 
  * If we have the following code:
- * <p>
- * <verbatim> S1: c = v1 instanceof T S2: if (c == 0) { ... } </verbatim>
+ *
+ * <pre> S1: c = v1 instanceof T S2: if (c == 0) { ... } </pre>
  * 
  * replace it with:
- * <p>
- * <verbatim> S1: c = v1 instanceof T S2: if (c == 0) { v2 = PI(v1, S1) .... } </verbatim>
+ *
+ * <pre> S1: c = v1 instanceof T S2: if (c == 0) { v2 = PI(v1, S1) .... } </pre>
  * 
  * The same pattern holds if the test is c == 1. This renaming allows SSA-based analysis to reason about the type of v2 depending on
  * the outcome of the branch.

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/NullTestPiPolicy.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/NullTestPiPolicy.java
@@ -18,9 +18,9 @@ import com.ibm.wala.util.collections.Pair;
 /**
  * A pi node policy with the following rule:
  * 
- * If we have the following code: <verbatim> S1: if (c op null) { ... } </verbatim>
+ * If we have the following code: <pre> S1: if (c op null) { ... } </pre>
  * 
- * replace it with: <verbatim> S1: if (c op null) { v2 = PI(c, S1) .... } </verbatim>
+ * replace it with: <pre> S1: if (c op null) { v2 = PI(c, S1) .... } </pre>
  * 
  * This renaming allows SSA-based analysis to reason about the nullness of v2 depending on the outcome of the branch.
  */

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/SSABuilder.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/SSABuilder.java
@@ -87,7 +87,7 @@ public class SSABuilder extends AbstractIntStackMachine {
   final private SymbolTable symbolTable;
 
   /**
-   * A logical mapping from <bcIndex, valueNumber> -> local number if null, don't build it.
+   * A logical mapping from &lt;bcIndex, valueNumber&gt; -&gt; local number if null, don't build it.
    */
   private final SSA2LocalMap localMap;
 
@@ -923,7 +923,7 @@ public class SSABuilder extends AbstractIntStackMachine {
   }
   
   /**
-   * A logical mapping from <pc, valueNumber> -> local number Note: make sure this class remains static: this persists as part of
+   * A logical mapping from &lt;pc, valueNumber&gt; -&gt; local number Note: make sure this class remains static: this persists as part of
    * the IR!!
    */
   private static class SSA2LocalMap implements com.ibm.wala.ssa.IR.SSA2LocalMap {
@@ -931,7 +931,7 @@ public class SSABuilder extends AbstractIntStackMachine {
     private final ShrikeCFG shrikeCFG;
 
     /**
-     * Mapping Integer -> IntPair where p maps to (vn,L) iff we've started a range at pc p where value number vn corresponds to
+     * Mapping Integer -&gt; IntPair where p maps to (vn,L) iff we've started a range at pc p where value number vn corresponds to
      * local L
      */
     private final IntPair[] localStoreMap;

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/SSACFG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/SSACFG.java
@@ -1041,7 +1041,7 @@ public class SSACFG implements ControlFlowGraph<SSAInstruction, ISSABasicBlock>,
   }
 
   /**
-   * has exceptional edge src -> dest
+   * has exceptional edge src -&gt; dest
    * 
    * @throws IllegalArgumentException if dest is null
    */
@@ -1057,7 +1057,7 @@ public class SSACFG implements ControlFlowGraph<SSAInstruction, ISSABasicBlock>,
   }
 
   /**
-   * has normal edge src -> dest
+   * has normal edge src -&gt; dest
    * 
    * @throws IllegalArgumentException if dest is null
    */

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/SSACache.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/SSACache.java
@@ -15,7 +15,7 @@ import com.ibm.wala.ipa.callgraph.Context;
 import com.ibm.wala.ipa.callgraph.impl.Everywhere;
 
 /**
- * A mapping from IMethod -> SSAOptions -> SoftReference -> Something
+ * A mapping from IMethod -&gt; SSAOptions -&gt; SoftReference -&gt; Something
  * 
  * This doesn't work very well ... GCs don't do such a great job with SoftReferences ... revamp it.
  */
@@ -132,21 +132,21 @@ public class SSACache {
   }
 
   /**
-   * Invalidate the cached IR for a <method,context> pair
+   * Invalidate the cached IR for a &lt;method,context&gt; pair
    */
   public void invalidateIR(IMethod method, Context c) {
     irCache.invalidate(method, c);
   }
 
   /**
-   * Invalidate the cached {@link DefUse} for a <method,context> pair
+   * Invalidate the cached {@link DefUse} for a &lt;method,context&gt; pair
    */
   public void invalidateDU(IMethod method, Context c) {
     duCache.invalidate(method, c);
   }
 
   /**
-   * Invalidate all cached information for a <method,context> pair
+   * Invalidate all cached information for a &lt;method,context&gt; pair
    */
   public void invalidate(IMethod method, Context c) {
     invalidateIR(method, c);

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/SSACheckCastInstruction.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/SSACheckCastInstruction.java
@@ -46,7 +46,7 @@ public abstract class SSACheckCastInstruction extends SSAInstruction {
   /**
    * @param result A new value number def'fed by this instruction when the type check succeeds.
    * @param val The value being checked by this instruction
-   * @param type The type which this instruction checks
+   * @param types The types which this instruction checks
    */
   protected SSACheckCastInstruction(int iindex, int result, int val, TypeReference[] types, boolean isPEI) {
     super(iindex);

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/SSAIndirectionData.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/SSAIndirectionData.java
@@ -21,11 +21,11 @@ import java.util.Collection;
  * So if we have
  * 
  * Example A:
- * <tt>
+ * <pre>
  * v2 = SSAAddressOf v1;
  * v7 = #1;
  * v3 = SSALoadIndirect v2; (1)
- * <\tt>
+ * </pre>
  * 
  * Then this map will tell us that instruction (1) indirectly uses whichever source-level entity (in the source or bytecode) v1 represents.
  * 

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/SSAPiInstruction.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/SSAPiInstruction.java
@@ -20,18 +20,18 @@ package com.ibm.wala.ssa;
  * 
  * for example, the following pseudo-code
  * <p>
- * <verbatim>
+ * <pre>
  *     boolean condition = (x instanceof Integer);
  *     if (condition) {
  *        S1;
  *     else {
  *        S2;
  *     }
- * </verbatim>
+ * </pre>
  * 
  * could be translated roughly as follows:
  * 
- * <verbatim>
+ * <pre>
  *     boolean condition = (x instanceof Integer);
  *     LABEL1: if (condition) {
  *        x_1 = pi(x, LABEL1);
@@ -40,7 +40,7 @@ package com.ibm.wala.ssa;
  *        x_2 = pi(x, LABEL2);
  *        S2;
  *     }
- * </verbatim>
+ * </pre>
  */
 public class SSAPiInstruction extends SSAUnaryOpInstruction {
   private final SSAInstruction cause;

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/SymbolTable.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/SymbolTable.java
@@ -32,7 +32,7 @@ public class SymbolTable implements Cloneable {
   final private int[] parameters;
 
   /**
-   * Mapping from Constant -> value number
+   * Mapping from Constant -&gt; value number
    */
   private HashMap<ConstantValue, Integer> constants = HashMapFactory.make(10);
 
@@ -52,7 +52,7 @@ public class SymbolTable implements Cloneable {
   }
 
   /**
-   * Values. Note: this class must maintain the following invariant: values.length > nextFreeValueNumber.
+   * Values. Note: this class must maintain the following invariant: values.length &gt; nextFreeValueNumber.
    */
   private Value[] values = new Value[5];
 

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/analysis/DeadAssignmentElimination.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/analysis/DeadAssignmentElimination.java
@@ -87,7 +87,7 @@ public class DeadAssignmentElimination {
   private static class DeadValueSystem extends DefaultFixedPointSolver<BooleanVariable> {
 
     /**
-     * Map: value number -> BooleanVariable isLive
+     * Map: value number -&gt; BooleanVariable isLive
      */
     final private Map<Integer, BooleanVariable> vars = HashMapFactory.make();
 

--- a/com.ibm.wala.core/src/com/ibm/wala/types/Descriptor.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/types/Descriptor.java
@@ -26,7 +26,7 @@ import com.ibm.wala.util.strings.UTF8Convert;
 public final class Descriptor {
 
   /**
-   * A mapping from Key -> Descriptor
+   * A mapping from Key -&gt; Descriptor
    */
   private static final Map<Key, Descriptor> map = HashMapFactory.make();
 

--- a/com.ibm.wala.core/src/com/ibm/wala/types/FieldReference.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/types/FieldReference.java
@@ -25,7 +25,7 @@ public final class FieldReference extends MemberReference {
   private final static boolean DEBUG = false;
 
   /**
-   * Used to canonicalize MemberReferences a mapping from Key -> MemberReference
+   * Used to canonicalize MemberReferences a mapping from Key -&gt; MemberReference
    */
   final private static HashMap<Key, FieldReference> dictionary = HashMapFactory.make();
 

--- a/com.ibm.wala.core/src/com/ibm/wala/types/MethodReference.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/types/MethodReference.java
@@ -22,7 +22,7 @@ import com.ibm.wala.util.strings.Atom;
  */
 public final class MethodReference extends MemberReference {
   /**
-   * Used to canonicalize MethodReferences a mapping from Key -> MethodReference
+   * Used to canonicalize MethodReferences a mapping from Key -&gt; MethodReference
    */
   final private static HashMap<Key, MethodReference> dictionary = HashMapFactory.make();
 

--- a/com.ibm.wala.core/src/com/ibm/wala/types/TypeName.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/types/TypeName.java
@@ -39,7 +39,7 @@ public final class TypeName implements Serializable {
   private static final long serialVersionUID = -3256390509887654326L;
 
   /**
-   * canonical mapping from TypeNameKey -> TypeName
+   * canonical mapping from TypeNameKey -&gt; TypeName
    */
   private final static Map<TypeNameKey, TypeName> map = HashMapFactory.make();
 
@@ -253,7 +253,7 @@ public final class TypeName implements Serializable {
      *                  0 => class 
      *                  >0 => mask of levels of array, reference, pointer
      *                  
-     *  When the mask is > 0, it represents levels of type qualifiers (in C 
+     *  When the mask is &gt; 0, it represents levels of type qualifiers (in C
      *  terminology) for array, reference and pointer types.  There is also a
      *  special mask for when the innermost type is a primitive.  The mask is
      *  a bitfield laid out in inverse dimension order. 

--- a/com.ibm.wala.core/src/com/ibm/wala/types/TypeReference.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/types/TypeReference.java
@@ -579,8 +579,8 @@ public final class TypeReference implements Serializable {
    * TypeReferences are canonical. However, note that two TypeReferences can be non-equal, yet still represent the same
    * IClass.
    * 
-   * These two TypeReference are <bf>NOT</bf> equal(), but they both represent the IClass which is named
    * For example, the there can be two TypeReferences &lt;Application,java.lang.Object&gt; and &lt;Primordial,java.lang.Object&gt;.
+   * These two TypeReference are <b>NOT</b> equal(), but they both represent the IClass which is named
    * &lt;Primordial,java.lang.Object&gt;
    */
   @Override

--- a/com.ibm.wala.core/src/com/ibm/wala/types/TypeReference.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/types/TypeReference.java
@@ -579,9 +579,9 @@ public final class TypeReference implements Serializable {
    * TypeReferences are canonical. However, note that two TypeReferences can be non-equal, yet still represent the same
    * IClass.
    * 
-   * For example, the there can be two TypeReferences <Application,java.lang.Object> and <Primordial,java.lang.Object>.
    * These two TypeReference are <bf>NOT</bf> equal(), but they both represent the IClass which is named
-   * <Primordial,java.lang.Object>
+   * For example, the there can be two TypeReferences &lt;Application,java.lang.Object&gt; and &lt;Primordial,java.lang.Object&gt;.
+   * &lt;Primordial,java.lang.Object&gt;
    */
   @Override
   public final boolean equals(Object other) {

--- a/com.ibm.wala.core/src/com/ibm/wala/types/generics/ClassSignature.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/types/generics/ClassSignature.java
@@ -20,7 +20,7 @@ import com.ibm.wala.shrikeCT.InvalidClassFileException;
  * Under construction.
  * 
  * ClassSignature: 
- *    (<FormalTypeParameter+>)? SuperclassSignature SuperinterfaceSignature*
+ *    (&lt;FormalTypeParameter+&gt;)? SuperclassSignature SuperinterfaceSignature*
  * 
  * SuperclassSignature:
  *    ClassTypeSignature

--- a/com.ibm.wala.core/src/com/ibm/wala/types/generics/ClassTypeSignature.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/types/generics/ClassTypeSignature.java
@@ -28,7 +28,7 @@ import com.ibm.wala.types.TypeReference;
  *   Identifier TypeArguments?
  *   
  * TypeArguments:
- *   <TypeArguments+>
+ *   &lt;TypeArguments+&gt;
  * 
  * @author sjfink
  * 

--- a/com.ibm.wala.core/src/com/ibm/wala/types/generics/TypeArgument.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/types/generics/TypeArgument.java
@@ -18,12 +18,12 @@ import com.ibm.wala.types.TypeReference;
 /**
  * UNDER CONSTRUCTION
  * 
- * <verbatim> TypeArgument: WildcardIndicator? FieldTypeSignature *
+ * <pre> TypeArgument: WildcardIndicator? FieldTypeSignature *
  * 
  * WildcardIndicator: + -
  * 
  * 
- * </verbatim>
+ * </pre>
  * 
  * @author sjfink
  * 

--- a/com.ibm.wala.core/src/com/ibm/wala/types/generics/TypeSignature.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/types/generics/TypeSignature.java
@@ -19,13 +19,13 @@ import com.ibm.wala.util.debug.Assertions;
 /**
  * UNDER CONSTRUCTION.
  * 
- * <verbatim> TypeSignature: FieldTypeSignature BaseType (code for a primitive)
+ * <pre> TypeSignature: FieldTypeSignature BaseType (code for a primitive)
  * 
  * FieldTypeSignature: ClassTypeSignature ArrayTypeSignature TypeVariableSignature
  * 
  * TypeVariableSignature: T identifier ;
  * 
- * </verbatim>
+ * </pre>
  * 
  * @author sjfink
  * 

--- a/com.ibm.wala.core/src/com/ibm/wala/util/PrimitiveAssignability.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/PrimitiveAssignability.java
@@ -54,7 +54,7 @@ import com.ibm.wala.types.TypeReference;
  *
  *  This Class does not consider Boxing / Unboxing 
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since  2013-11-21
  */
 public class PrimitiveAssignability {

--- a/com.ibm.wala.core/src/com/ibm/wala/util/bytecode/BytecodeStream.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/bytecode/BytecodeStream.java
@@ -243,7 +243,7 @@ public class BytecodeStream implements BytecodeConstants {
   }
 
   /**
-   * Returns the offset of the branch (as a signed short) Used for if<cond>, ificmp<cond>, ifacmp<cond>, goto, jsr
+   * Returns the offset of the branch (as a signed short) Used for if&lt;cond&gt;, ificmp&lt;cond&gt;, ifacmp&lt;cond&gt;, goto, jsr
    * 
    * @return branch offset
    * @see #getWideBranchOffset()

--- a/com.ibm.wala.core/src/com/ibm/wala/util/shrike/ShrikeClassReaderHandle.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/shrike/ShrikeClassReaderHandle.java
@@ -51,7 +51,7 @@ public class ShrikeClassReaderHandle {
 
   /**
    * @return an instance of the class reader ... create one if necessary
-   * @throw InvalidClassFileException iff Shrike fails to read the class file
+   * @throws InvalidClassFileException iff Shrike fails to read the class file
    *        correctly.
    */
   public ClassReader get() throws InvalidClassFileException {

--- a/com.ibm.wala.core/src/com/ibm/wala/util/ssa/ClassLookupException.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/ssa/ClassLookupException.java
@@ -51,7 +51,7 @@ package com.ibm.wala.util.ssa;
  *  In typical cases this should not be propergated out from the utility
  *  classes.
  *
- *  @author     Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author     Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 public class ClassLookupException extends RuntimeException {
     private static final long serialVersionUID = 7551139209041666026L;

--- a/com.ibm.wala.core/src/com/ibm/wala/util/ssa/IInstantiator.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/ssa/IInstantiator.java
@@ -52,7 +52,7 @@ import com.ibm.wala.types.TypeReference;
  *
  * This mainly applies to the connectThrough-Function.
  *
- * @author Tobias Blaschke <code@tobiasblaschke.de>
+ * @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 public interface IInstantiator {
     /**

--- a/com.ibm.wala.core/src/com/ibm/wala/util/ssa/ParameterAccessor.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/ssa/ParameterAccessor.java
@@ -77,7 +77,7 @@ import com.ibm.wala.util.ssa.SSAValue.WeaklyNamedKey;
  *  If you want to alter the values of the incoming parameters you may also want to use the ParameterManager
  *  which tracks the changes.
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since  2013-10-19
  */
 public class ParameterAccessor {
@@ -142,7 +142,7 @@ public class ParameterAccessor {
      *
      *  Use .getNumber() to access the associated SSA-Value.
      *
-     *  @author Tobias Blaschke <code@tobiasblaschke.de>
+     *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
      *  @since  2013-10-19
      */
     public static class Parameter extends SSAValue {
@@ -1582,7 +1582,7 @@ public class ParameterAccessor {
     }
 
     /**
-     *  Shorthand for forInvokeStatic(final List<? extends Parameter> args, final ParameterAccessor target, final IClassHierarchy cha).
+     *  Shorthand for forInvokeStatic(final List&lt;? extends Parameter&gt; args, final ParameterAccessor target, final IClassHierarchy cha).
      *
      *  Generates a new ParameterAccessor for target and hands the call through.
      */
@@ -1591,7 +1591,7 @@ public class ParameterAccessor {
     }
 
     /**
-     *  Shorthand for forInvokeVirtual(final int self, final List<? extends Parameter> args, final ParameterAccessor target, final IClassHierarchy cha).
+     *  Shorthand for forInvokeVirtual(final int self, final List&lt;? extends Parameter&gt; args, final ParameterAccessor target, final IClassHierarchy cha).
      *
      *  Generates a new ParameterAccessor for target and hands the call through.
      */

--- a/com.ibm.wala.core/src/com/ibm/wala/util/ssa/SSAValue.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/ssa/SSAValue.java
@@ -57,7 +57,7 @@ import com.ibm.wala.types.TypeReference;
  *  @see    com.ibm.wala.util.ssa.TypeSafeInstructionFactory
  *  @see    com.ibm.wala.util.ssa.ParameterAccessor
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since  2013-10-20
  */
 public class SSAValue {

--- a/com.ibm.wala.core/src/com/ibm/wala/util/ssa/SSAValueManager.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/ssa/SSAValueManager.java
@@ -57,7 +57,7 @@ import com.ibm.wala.util.strings.Atom;
 /**
  *  Manage SSA-Variables in synthetic methods.
  *
- *  @author  Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author  Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since   2013-09-19
  */
 public class SSAValueManager {

--- a/com.ibm.wala.core/src/com/ibm/wala/util/ssa/TypeSafeInstructionFactory.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/ssa/TypeSafeInstructionFactory.java
@@ -77,7 +77,7 @@ import com.ibm.wala.types.TypeReference;
  *
  *  @see    com.ibm.wala.classLoader.JavaLanguage.JavaInstructionFactory
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since  2013-10-20
  */
 public class TypeSafeInstructionFactory {

--- a/com.ibm.wala.core/src/com/ibm/wala/util/ssa/package-info.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/ssa/package-info.java
@@ -51,6 +51,6 @@
  *  the regular one.
  *
  *  @since  2013-10-25
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 package com.ibm.wala.util.ssa;

--- a/com.ibm.wala.core/src/com/ibm/wala/util/strings/Atom.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/strings/Atom.java
@@ -468,8 +468,6 @@ public final class Atom implements Serializable {
   /**
    * Special method that is called by Java deserialization process. Any HashCons'ed object should implement it, in order to make
    * sure that all equal objects are consolidated.
-   * 
-   * @return
    */
   private Object readResolve() {
     return findOrCreate(this.val);

--- a/com.ibm.wala.core/src/com/ibm/wala/util/strings/Atom.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/strings/Atom.java
@@ -28,7 +28,7 @@ public final class Atom implements Serializable {
   private static final long serialVersionUID = -3256390509887654329L;
 
   /**
-   * Used to canonicalize Atoms, a mapping from AtomKey -> Atom. AtomKeys are not canonical, but Atoms are.
+   * Used to canonicalize Atoms, a mapping from AtomKey -&gt; Atom. AtomKeys are not canonical, but Atoms are.
    */
   final private static HashMap<AtomKey, Atom> dictionary = HashMapFactory.make();
 
@@ -196,8 +196,8 @@ public final class Atom implements Serializable {
   }
 
 /**
-   * Is "this" atom a reserved member name? Note: Sun has reserved all member names starting with '<' for future use. At present,
-   * only <init> and <clinit> are used.
+   * Is "this" atom a reserved member name? Note: Sun has reserved all member names starting with '&lt;' for future use. At present,
+   * only &lt;init&gt; and &lt;clinit&gt; are used.
    */
   public final boolean isReservedMemberName() {
     if (length() == 0) {

--- a/com.ibm.wala.core/src/com/ibm/wala/util/strings/UTF8Convert.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/strings/UTF8Convert.java
@@ -51,7 +51,7 @@ public abstract class UTF8Convert {
    * 
    * @param utf8 (pseudo-)utf8 byte array
    * @throws UTFDataFormatException if the (pseudo-)utf8 byte array is not valid (pseudo-)utf8
-   * @returns unicode string
+   * @return unicode string
    * @throws IllegalArgumentException if utf8 is null
    */
   @SuppressWarnings("unused")
@@ -112,7 +112,7 @@ public abstract class UTF8Convert {
    * The output format is controlled by the WRITE_PSEUDO_UTF8 flag.
    * 
    * @param s String to convert
-   * @returns array containing sequence of (pseudo-)utf8 formatted bytes
+   * @return array containing sequence of (pseudo-)utf8 formatted bytes
    * @throws IllegalArgumentException if s is null
    */
   public static byte[] toUTF8(String s) {
@@ -165,7 +165,7 @@ public abstract class UTF8Convert {
    * Check whether the given sequence of bytes is valid (pseudo-)utf8.
    * 
    * @param bytes byte array to check
-   * @returns true iff the given sequence is valid (pseudo-)utf8.
+   * @return true iff the given sequence is valid (pseudo-)utf8.
    * @throws IllegalArgumentException if bytes is null
    */
   public static boolean check(byte[] bytes) {

--- a/com.ibm.wala.core/src/com/ibm/wala/viz/viewer/PaPanel.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/viz/viewer/PaPanel.java
@@ -194,7 +194,6 @@ public class PaPanel extends JSplitPane {
 
   /**
    * Override if you want different roots for your heap tree.
-   * @return
    */
   protected List<Object> getRootNodes(){
     List<Object> ret = new ArrayList<>();
@@ -230,7 +229,6 @@ public class PaPanel extends JSplitPane {
   /**
    * Used for filling the tree dynamically. Override and handle your own nodes / different links.
    * @param node
-   * @return
    */
   protected List<Object> getChildrenFor(Object node) {
     List<Object> ret = new ArrayList<>();
@@ -255,7 +253,6 @@ public class PaPanel extends JSplitPane {
    * pointer keys (not just for fields)
    * 
    * @param ik
-   * @return
    */
   protected List<? extends PointerKey> getPointerKeysUnderInstanceKey(InstanceKey ik) {
     int ikIndex = pa.getInstanceKeyMapping().getMappedIndex(ik);

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/DexIMethod.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/DexIMethod.java
@@ -3275,7 +3275,7 @@ public class DexIMethod implements IBytecodeMethod<Instruction> {
      *
      * @throws UnsupportedOperationException
      *
-     * @todo    Review this implementation - it may be horribly wrong!
+     * TODO: Review this implementation - it may be horribly wrong!
      */
 	@Override
 	public Collection<CallSiteReference> getCallSites() {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModel.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModel.java
@@ -120,7 +120,7 @@ import com.ibm.wala.util.strings.Atom;
  *
  *  All these Models are added to a synthetic AndroidModelClass.
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 public class AndroidModel /* makes SummarizedMethod */ 
         implements IClassHierarchyDweller {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModelClass.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModelClass.java
@@ -87,7 +87,7 @@ import com.ibm.wala.util.strings.Atom;
  *  @see    com.ibm.wala.ipa.callgraph.impl.FakeRootClass
  *
  *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
- *  @todo   Move this class into an other loader? Currently: Primordial
+ *  TODO: Move this class into an other loader? Currently: Primordial
  */
 public final /* singleton */ class AndroidModelClass extends SyntheticClass {
     private static Logger logger = LoggerFactory.getLogger(AndroidModelClass.class);

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModelClass.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModelClass.java
@@ -86,7 +86,7 @@ import com.ibm.wala.util.strings.Atom;
  *
  *  @see    com.ibm.wala.ipa.callgraph.impl.FakeRootClass
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @todo   Move this class into an other loader? Currently: Primordial
  */
 public final /* singleton */ class AndroidModelClass extends SyntheticClass {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/IntentModel.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/IntentModel.java
@@ -51,7 +51,7 @@ import com.ibm.wala.util.strings.Atom;
 /**
  *  Like MicroModel but includes CallBacks.
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since  2014-02-12
  */
 public class IntentModel extends AndroidModel {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/MicroModel.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/MicroModel.java
@@ -52,7 +52,7 @@ import com.ibm.wala.util.strings.Atom;
  *
  *  Is used by the IntentContextInterpreter if a Intent can be resolved internally.
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since  2013-10-12
  */
 public class MicroModel extends AndroidModel {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/MiniModel.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/MiniModel.java
@@ -66,7 +66,7 @@ import com.ibm.wala.util.strings.Atom;
  *  the Context at the call site is insufficient to determine the actual target. In this case an 
  *  UnknownTargetModel which uses an MiniModel and an ExternalModel is placed there.
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since  2013-10-29
  */
 public class MiniModel extends AndroidModel {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/package-info.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/package-info.java
@@ -93,6 +93,6 @@
  *  should have been read or overrides been placed manually (or both).
  *
  *  @since  2013-10-25
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 package com.ibm.wala.dalvik.ipa.callgraph.androidModel;

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/AndroidModelParameterManager.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/AndroidModelParameterManager.java
@@ -66,9 +66,10 @@ import com.ibm.wala.util.ssa.SSAValue;
  *  @since   2013-09-19
  *
  *  TODO:
- *  @todo   Track if a variable has been refered to to be able to prune unused Phi-Instructions later
- *  @todo   Trim Memory consumption? The whole class should not be in memory for long time so this
- *      might be not neccessary.
+ *  <ul>
+ *    <li>Track if a variable has been refered to to be able to prune unused Phi-Instructions later</li>
+ *    <li>Trim Memory consumption? The whole class should not be in *  memory for long time so this might be not neccessary.</li>
+ *  </ul>
  */
 public class AndroidModelParameterManager {
  

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/AndroidModelParameterManager.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/AndroidModelParameterManager.java
@@ -62,7 +62,7 @@ import com.ibm.wala.util.ssa.SSAValue;
  *
  *  @see com.ibm.wala.dalvik.ipa.callgraph.androidModel.structure.AbstractAndroidModel
  *
- *  @author  Tobias Blaschke <code@toiasblaschke.de>
+ *  @author  Tobias Blaschke &lt;code@toiasblaschke.de&gt;
  *  @since   2013-09-19
  *
  *  TODO:

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/DefaultInstantiationBehavior.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/DefaultInstantiationBehavior.java
@@ -57,7 +57,7 @@ import com.ibm.wala.util.strings.Atom;
 /**
  *  Contains some predefined behaviors.
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since  2013-10-25
  */
 public class DefaultInstantiationBehavior extends IInstantiationBehavior {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/FlatInstantiator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/FlatInstantiator.java
@@ -137,7 +137,7 @@ public class FlatInstantiator implements IInstantiator {
      *
      *  If T is an array-type a new array of length 1 is generated.
      *
-     *  @todo   Do we want to mix in REUSE-Parameters?
+     *  TODO: Do we want to mix in REUSE-Parameters?
      */
     public SSAValue createInstance(final TypeReference T, final boolean asManaged, VariableKey key, Set<? extends SSAValue> seen) {
         return createInstance(T, asManaged, key, seen, 0);

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/FlatInstantiator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/FlatInstantiator.java
@@ -80,7 +80,7 @@ import com.ibm.wala.util.ssa.TypeSafeInstructionFactory;
  *
  *  This variant limits recursion depth.
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 public class FlatInstantiator implements IInstantiator {
     private static final Logger logger = LoggerFactory.getLogger(FlatInstantiator.class);

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/IInstantiationBehavior.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/IInstantiationBehavior.java
@@ -48,7 +48,7 @@ import com.ibm.wala.types.TypeName;
 
 /**
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 public abstract class IInstantiationBehavior implements Serializable {
 	private static final long serialVersionUID = -3698760758700891479L;

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/Instantiator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/Instantiator.java
@@ -84,7 +84,7 @@ import com.ibm.wala.util.strings.Atom;
  *
  *  Creates an instance of (hopefully) anything.
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 public class Instantiator implements IInstantiator {
     private static final Logger logger = LoggerFactory.getLogger(Instantiator.class);

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/Instantiator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/Instantiator.java
@@ -126,7 +126,7 @@ public class Instantiator implements IInstantiator {
      *
      *  If T is an array-type a new array of length 1 is generated.
      *
-     *  @todo   Do we want to mix in REUSE-Parameters?
+     *  TODO: Do we want to mix in REUSE-Parameters?
      */
     public SSAValue createInstance(final TypeReference T, final boolean asManaged, VariableKey key, Set<? extends SSAValue> seen) {
         if (T == null) {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/LoadedInstantiationBehavior.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/LoadedInstantiationBehavior.java
@@ -57,7 +57,7 @@ import com.ibm.wala.util.strings.Atom;
  *
  *  This class generates an empty mutable IInstantiationBehavior.
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since  2013-10-25
  */
 public class LoadedInstantiationBehavior extends IInstantiationBehavior {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/ReuseParameters.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/ReuseParameters.java
@@ -75,7 +75,7 @@ import com.ibm.wala.util.strings.Atom;
  *  @see    com.ibm.wala.dalvik.ipa.callgraph.androidModel.parameters.IInstantiationBehavior
  *  @see    com.ibm.wala.util.ssa.ParameterAccessor 
  *  
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since  2013-11-02
  */
 public class ReuseParameters {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/SpecializedInstantiator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/SpecializedInstantiator.java
@@ -72,7 +72,7 @@ import com.ibm.wala.util.ssa.TypeSafeInstructionFactory;
  *  For example instantiating an android.content.Context would pull in all Android-components in
  *  scope resulting in a massivly overapproximated model.
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 public class SpecializedInstantiator extends FlatInstantiator {
 

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/SpecializedInstantiator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/SpecializedInstantiator.java
@@ -96,7 +96,7 @@ public class SpecializedInstantiator extends FlatInstantiator {
      *
      *  If T is an array-type a new array of length 1 is generated.
      *
-     *  @todo   Do we want to mix in REUSE-Parameters?
+     *  TODO: Do we want to mix in REUSE-Parameters?
      */
     @Override
     public SSAValue createInstance(final TypeReference T, final boolean asManaged, VariableKey key, Set<? extends SSAValue> seen) {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/package-info.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/package-info.java
@@ -47,6 +47,6 @@
  *  @see    com.ibm.wala.dalvik.ipa.callgraph.androidModel.parameters.IInstantiationBehavior
  *
  *  @since  2013-10-25
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 package com.ibm.wala.dalvik.ipa.callgraph.androidModel.parameters;

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/AbstractAndroidModel.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/AbstractAndroidModel.java
@@ -71,7 +71,7 @@ import com.ibm.wala.util.ssa.TypeSafeInstructionFactory;
  *  @see        com.ibm.wala.dalvik.ipa.callgraph.impl.AndroidEntryPoint.ExecutionOrder
  *  @see        com.ibm.wala.dalvik.ipa.callgraph.androidModel.parameters.AndroidModelParameterManager
  *
- *  @author     Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author     Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since      2013-09-07
  */
 public abstract class AbstractAndroidModel  {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/LoopAndroidModel.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/LoopAndroidModel.java
@@ -74,7 +74,7 @@ import com.ibm.wala.util.ssa.TypeSafeInstructionFactory;
  *  restart of the Application (instance-state) or when the potential restart of the App
  *  shall be ignored.
  *
- *  @author     Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author     Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 public class LoopAndroidModel extends SingleStartAndroidModel {
     private static final Logger logger = LoggerFactory.getLogger(LoopAndroidModel.class);

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/LoopKillAndroidModel.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/LoopKillAndroidModel.java
@@ -72,7 +72,7 @@ import com.ibm.wala.util.ssa.TypeSafeInstructionFactory;
  *  needed again they get started using that savedIstanceState.
  *
  *  @see        com.ibm.wala.dalvik.ipa.callgraph.androidModel.structure.LoopAndroidModel
- *  @author     Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author     Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 public class LoopKillAndroidModel extends LoopAndroidModel {
     private static final Logger logger = LoggerFactory.getLogger(LoopKillAndroidModel.class);

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/SequentialAndroidModel.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/SequentialAndroidModel.java
@@ -53,7 +53,7 @@ import com.ibm.wala.util.ssa.TypeSafeInstructionFactory;
  *  This model should not be particular useful in practice. However it might come in
  *  handy for debugging purposes or as a skeleton for an other Model.
  *
- *  @author     Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author     Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since      2013-09-18
  */
 public final class SequentialAndroidModel extends AbstractAndroidModel {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/SingleStartAndroidModel.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/SingleStartAndroidModel.java
@@ -73,7 +73,7 @@ import com.ibm.wala.util.ssa.TypeSafeInstructionFactory;
  *
  *  @see        com.ibm.wala.dalvik.ipa.callgraph.androidModel.structure.LoopAndroidModel
  *  @see        com.ibm.wala.dalvik.ipa.callgraph.androidModel.structure.LoopKillAndroidModel
- *  @author     Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author     Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 public class SingleStartAndroidModel extends AbstractAndroidModel {
     private static final Logger logger = LoggerFactory.getLogger(SingleStartAndroidModel.class);

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/package-info.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/package-info.java
@@ -48,6 +48,6 @@
  *  @see    com.ibm.wala.dalvik.ipa.callgraph.androidModel.structure.AbstractAndroidModel
  *
  *  @since  2013-10-25
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 package com.ibm.wala.dalvik.ipa.callgraph.androidModel.structure;

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/AndroidBoot.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/AndroidBoot.java
@@ -70,7 +70,7 @@ import com.ibm.wala.util.strings.Atom;
  *  @see    com.ibm.wala.dalvik.ipa.callgraph.androidModel.AndroidModel
  *  @see    com.ibm.wala.dalvik.util.AndroidEntryPointManager
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since  2013-10-23
  */
 public class AndroidBoot {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/AndroidStartComponentTool.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/AndroidStartComponentTool.java
@@ -76,7 +76,7 @@ import com.ibm.wala.util.strings.Atom;
  *
  *  This class is only used by AndroidModel.getMethodAs() as it got a bit lengthy.
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since  2013-10-22
  */
 public class AndroidStartComponentTool {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/ExternalModel.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/ExternalModel.java
@@ -78,7 +78,7 @@ import com.ibm.wala.util.strings.Atom;
  *
  *  @see    com.ibm.wala.dalvik.ipa.callgraph.propagation.cfa.IntentContextInterpreter
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since  2013-10-15
  */
 public class ExternalModel extends AndroidModel {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/Overrides.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/Overrides.java
@@ -73,7 +73,7 @@ import com.ibm.wala.util.collections.HashMapFactory;
  *  @see    com.ibm.wala.dalvik.ipa.callgraph.propagation.cfa
  *  @see    com.ibm.wala.dalvik.ipa.callgraph.propagation.cfa.IntentStarters
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since  2013-10-28
  */
 public class Overrides {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/Overrides.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/Overrides.java
@@ -194,7 +194,7 @@ public class Overrides {
      *  the MethodTargetSelector returned.
      *
      *  @return a MethodTargetSelector that overrides all startComponent-calls.
-     *  @todo   Use delayed computation?
+     *  TODO: Use delayed computation?
      */
     public MethodTargetSelector overrideAll() throws CancelException {
         final HashMap<MethodReference, SummarizedMethod> overrides = HashMapFactory.make();

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/SystemServiceModel.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/SystemServiceModel.java
@@ -182,7 +182,7 @@ public class SystemServiceModel extends AndroidModel {
     /**
      *  Fill the model with instructions.
      *
-     *  @todo use "global" instances
+     *  TODO: use "global" instances
      */
     //@Override
     private void populate(Iterable<? extends AndroidEntryPoint> entrypoints) {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/SystemServiceModel.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/SystemServiceModel.java
@@ -77,7 +77,7 @@ import com.ibm.wala.util.strings.Atom;
  *
  *  @see    com.ibm.wala.dalvik.ipa.callgraph.propagation.cfa.IntentContextInterpreter
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since  2013-10-15
  */
 public class SystemServiceModel extends AndroidModel {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/UnknownTargetModel.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/UnknownTargetModel.java
@@ -83,7 +83,7 @@ import com.ibm.wala.util.strings.Atom;
  *
  *  @see    com.ibm.wala.dalvik.ipa.callgraph.propagation.cfa.IntentContextInterpreter
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since  2013-10-18
  */
 public class UnknownTargetModel  extends AndroidModel {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/package-info.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/package-info.java
@@ -51,6 +51,6 @@
  *  @see    com.ibm.wala.dalvik.ipa.callgraph.propagation.cfa 
  *
  *  @since  2013-10-25
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 package com.ibm.wala.dalvik.ipa.callgraph.androidModel.stubs;

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/impl/AndroidEntryPoint.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/impl/AndroidEntryPoint.java
@@ -59,7 +59,7 @@ import com.ibm.wala.util.strings.Atom;
  *
  *  @see    com.ibm.wala.dalvik.util.AndroidEntryPointLocator
  *
- *  @author  Tobias Blaschke <code@toiasblaschke.de>
+ *  @author  Tobias Blaschke &lt;code@toiasblaschke.de&gt;
  *  @since   2013-09-01
  */
 public class AndroidEntryPoint extends DexEntryPoint {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/AndroidContext.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/AndroidContext.java
@@ -48,7 +48,7 @@ import com.ibm.wala.ipa.callgraph.ContextKey;
 /**
  *  Fetches an android/content/Context.
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since  2013-10-14
  */
 public class AndroidContext implements Context {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/Intent.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/Intent.java
@@ -68,7 +68,7 @@ import com.ibm.wala.util.strings.Atom;
  * @see     com.ibm.wala.dalvik.ipa.callgraph.propagation.cfa.IntentContextSelector
  * @see     com.ibm.wala.dalvik.ipa.callgraph.propagation.cfa.IntentContextInterpreter
  *
- * @author  Tobias Blaschke <code@tobiasblaschke.de>
+ * @author  Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  * @since   2013-10-12
  */
 public class Intent implements ContextItem, Comparable<Intent> {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/Intent.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/Intent.java
@@ -253,7 +253,7 @@ public class Intent implements ContextItem, Comparable<Intent> {
      *  IntentStarters.StartInfo to determine the Target. However it is nicer to set the Component
      *  here.
      *
-     *  @todo   Set the Component somewhere
+     *  TODO: Set the Component somewhere
      */
     public AndroidComponent getComponent() {
         return this.targetCompontent;
@@ -272,9 +272,9 @@ public class Intent implements ContextItem, Comparable<Intent> {
      *  Recomputes if the Intent is internal.
      *  TODO: 
      *  @param intent 
-     *  @todo   Implement it ;)
-     *  @todo   What to return if it does not, but Summary-Information is available?
-     *  @todo   We should read in the Manifest.xml rather than relying on the packet name!
+     *  TODO: Implement it ;)
+     *  TODO: What to return if it does not, but Summary-Information is available?
+     *  TODO: We should read in the Manifest.xml rather than relying on the packet name!
      */
     private static boolean isInternal(Intent intent) {  // XXX: This may loop forever!
         /*final Intent override = AndroidEntryPointManager.MANAGER.getIntent(intent);

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentContext.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentContext.java
@@ -49,7 +49,7 @@ import com.ibm.wala.ipa.callgraph.ContextKey;
  *
  *  This class takes a parent so we don't loose information by overwriting.
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since  2013-10-14
  */
 public class IntentContext implements Context {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentContextInterpreter.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentContextInterpreter.java
@@ -91,7 +91,7 @@ import com.ibm.wala.util.CancelException;
  *  @see    com.ibm.wala.dalvik.ipa.callgraph.androidModel.MicroModel
  *  @see    com.ibm.wala.dalvik.ipa.callgraph.androidModel.stubs.ExternalModel
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since  2013-10-14
  */
 public class IntentContextInterpreter implements SSAContextInterpreter {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentContextSelector.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentContextSelector.java
@@ -70,7 +70,7 @@ import com.ibm.wala.util.intset.IntSetUtil;
  *  @see    com.ibm.wala.dalvik.ipa.callgraph.propagation.cfa.IntentContextInterpreter
  *  @see    com.ibm.wala.dalvik.ipa.callgraph.propagation.cfa.IntentStarters
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since  2013-10-14
  */
 public class IntentContextSelector implements ContextSelector {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentMap.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentMap.java
@@ -54,7 +54,7 @@ import com.ibm.wala.util.strings.StringStuff;
  *
  *  This class is only of use in conjunction with the IntentContextSelector
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 /*package*/ class IntentMap {
     private final Map<InstanceKey, Intent> seen = new HashMap<>();

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentStarters.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentStarters.java
@@ -61,8 +61,8 @@ import com.ibm.wala.util.collections.HashMapFactory;
  * This is used by the IntentContextSelector to add an IntentContext to this Methods.
  *
  * TODO:
- * @todo    Fill in better values for targetAccuracy and componentType
- * @todo    Add declaring class
+ * TODO: Fill in better values for targetAccuracy and componentType
+ * TODO: Add declaring class
  * @author  Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  * @since   1013-10-16
  */

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentStarters.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentStarters.java
@@ -63,7 +63,7 @@ import com.ibm.wala.util.collections.HashMapFactory;
  * TODO:
  * @todo    Fill in better values for targetAccuracy and componentType
  * @todo    Add declaring class
- * @author  Tobias Blaschke <code@tobiasblaschke.de>
+ * @author  Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  * @since   1013-10-16
  */
 public class IntentStarters {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/package-info.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/package-info.java
@@ -64,6 +64,6 @@
  * @see     com.ibm.wala.dalvik.ipa.callgraph.androidModel.MicroModel 
  * @see     com.ibm.wala.dalvik.ipa.callgraph.androidModel.stubs.UnknownTargetModel
  * @see     com.ibm.wala.dalvik.ipa.callgraph.androidModel.stubs.ExternalModel
- * @author  Tobias Blaschke <code@tobiasblaschke.de>
+ * @author  Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 package com.ibm.wala.dalvik.ipa.callgraph.propagation.cfa;

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/DexSSABuilder.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/DexSSABuilder.java
@@ -113,7 +113,7 @@ public class DexSSABuilder extends AbstractIntRegisterMachine {
     final private SymbolTable symbolTable;
 
     /**
-     * A logical mapping from <bcIndex, valueNumber> -> local number if null, don't build it.
+     * A logical mapping from &lt;bcIndex, valueNumber&gt; -&gt; local number if null, don't build it.
      */
     private final SSA2LocalMap localMap;
 
@@ -1378,7 +1378,7 @@ public class DexSSABuilder extends AbstractIntRegisterMachine {
     }
 
     /**
-     * A logical mapping from <pc, valueNumber> -> local number Note: make sure this class remains static: this persists as part of
+     * A logical mapping from &lt;pc, valueNumber&gt; -&gt; local number Note: make sure this class remains static: this persists as part of
      * the IR!!
      */
     private static class SSA2LocalMap implements com.ibm.wala.ssa.IR.SSA2LocalMap {
@@ -1386,7 +1386,7 @@ public class DexSSABuilder extends AbstractIntRegisterMachine {
         private final DexCFG dexCFG;
 
         /**
-         * Mapping Integer -> IntPair where p maps to (vn,L) iff we've started a range at pc p where value number vn corresponds to
+         * Mapping Integer -&gt; IntPair where p maps to (vn,L) iff we've started a range at pc p where value number vn corresponds to
          * local L
          */
         private final IntPair[] localStoreMap;

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidComponent.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidComponent.java
@@ -50,7 +50,7 @@ import com.ibm.wala.util.strings.StringStuff;
 /**
  *  Android Components like Activity, Service, ...
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since  2013-10-16
  */
 public enum AndroidComponent {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidEntryPointLocator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidEntryPointLocator.java
@@ -201,7 +201,7 @@ nextMethod:
                     // Restrict the set
                     bases.add(AndroidTypes.Application);
                     bases.add(AndroidTypes.Activity);
-                    /** @todo TODO: add Fragments in getEntryPoints */
+                    /** TODO: TODO: add Fragments in getEntryPoints */
                     //bases.add(AndroidTypes.Fragment);
                     bases.add(AndroidTypes.Service);
                     bases.add(AndroidTypes.ContentProvider);

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidEntryPointLocator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidEntryPointLocator.java
@@ -78,7 +78,7 @@ import com.ibm.wala.util.config.SetOfClasses;
  *  Iterates the ClassHierarchy matching its elements to a set of hardcoded entrypoint-specifications.
  *  Then optionally uses heuristics to select further entrypoints.
  *
- *  @author     Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author     Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 public final class AndroidEntryPointLocator {
     private static final Logger logger = LoggerFactory.getLogger(AndroidEntryPointLocator.class);

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidEntryPointManager.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidEntryPointManager.java
@@ -583,7 +583,7 @@ public final /* singleton */ class AndroidEntryPointManager implements Serializa
      *  @param  intent  The intent to resolve
      *  @return where to resolve it to or the given intent if no information is available
      *
-     *  @todo TODO: Malicious Intent-Table could cause endless loops
+     *  TODO: TODO: Malicious Intent-Table could cause endless loops
      */
     public Intent getIntent(Intent intent) {
         if (overrideIntents.containsKey(intent)) {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidEntryPointManager.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidEntryPointManager.java
@@ -76,7 +76,7 @@ import com.ibm.wala.util.strings.StringStuff;
  *
  *  See the single settings for further description.
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 public final /* singleton */ class AndroidEntryPointManager implements Serializable {
     private static final Logger logger = LoggerFactory.getLogger(AndroidEntryPointManager.class);

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
@@ -83,7 +83,7 @@ import com.ibm.wala.dalvik.ipa.callgraph.propagation.cfa.Intent;
  *      You will be able to access it using attributesHistory.get(Attr).peek()
  *
  * TODO:
- * @todo    Handle Info in the DATA-Tag correctly!
+ * TODO: Handle Info in the DATA-Tag correctly!
  * @since   2013-10-13
  * @author  Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
@@ -520,7 +520,7 @@ public class AndroidManifestXMLReader {
     /**
      *  Read the specification of an Intent from AndroidManifest.
      *
-     *  @todo   Handle the URI
+     *  TODO: Handle the URI
      */
     private static class IntentItem extends ParserItem {
         @Override

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
@@ -85,7 +85,7 @@ import com.ibm.wala.dalvik.ipa.callgraph.propagation.cfa.Intent;
  * TODO:
  * @todo    Handle Info in the DATA-Tag correctly!
  * @since   2013-10-13
- * @author  Tobias Blaschke <code@tobiasblaschke.de>
+ * @author  Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 public class AndroidManifestXMLReader {
     /**

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidPreFlightChecks.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidPreFlightChecks.java
@@ -128,7 +128,7 @@ public class AndroidPreFlightChecks {
      *  @see    com.ibm.wala.dalvik.ipa.callgraph.androidModel.stubs.Overrides.StartComponentMethodTargetSelector
      *
      *  @return if check passed
-     *  @todo this doesn't check anything yet
+     *  TODO: this doesn't check anything yet
      */
     public boolean checkOverridesInPlace() {
         boolean pass = true;

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidPreFlightChecks.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidPreFlightChecks.java
@@ -59,7 +59,7 @@ import com.ibm.wala.types.TypeReference;
  *
  *  These checks may be run before building the CallGraph to verify everything is in place.
  *
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since  2013-11-01
  */
 public class AndroidPreFlightChecks {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidSettingFactory.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidSettingFactory.java
@@ -50,7 +50,7 @@ import com.ibm.wala.util.strings.StringStuff;
  *  This is for use by a parser to generate the Objects to place in the AndroidEntryPointManager.
  *
  *  @see    AndroidManifestXMLReader
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  *  @since  2013-10-14
  */
 public class AndroidSettingFactory {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidSettingFactory.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidSettingFactory.java
@@ -137,7 +137,7 @@ public class AndroidSettingFactory {
      *  @param  name    The Action this intent represents
      *  @param  uri     The URI to match may be null
      *  @throws IllegalArgumentException If name was null or starts with a dot and pack is null
-     *  @todo   Check Target-Types
+     *  TODO: Check Target-Types
      */
     public static Intent intent(String pack, String name, String uri) {
         if ((name == null) || (name.isEmpty())) {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidTypes.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidTypes.java
@@ -47,7 +47,7 @@ import com.ibm.wala.types.TypeReference;
 /**
  *  Constants for types used by the AndroidModel
  *
- *  @author     Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author     Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 public final class AndroidTypes {
 

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/ActivityEP.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/ActivityEP.java
@@ -52,7 +52,7 @@ import com.ibm.wala.dalvik.util.AndroidEntryPointLocator.AndroidPossibleEntryPoi
  *  The specifications are read and handled by AndroidEntryPointLocator.
  *
  *  @see    com.ibm.wala.dalvik.util.AndroidEntryPointLocator
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 public final class ActivityEP {
 	// see: http://developer.android.com/reference/android/app/Activity.html

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/ApplicationEP.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/ApplicationEP.java
@@ -53,7 +53,7 @@ import com.ibm.wala.dalvik.util.AndroidEntryPointLocator.AndroidPossibleEntryPoi
  *  see: http://developer.android.com/reference/android/app/Application.html
  *
  *  @see    com.ibm.wala.dalvik.util.AndroidEntryPointLocator
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 public final class ApplicationEP {
 

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/FragmentEP.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/FragmentEP.java
@@ -53,7 +53,7 @@ import com.ibm.wala.dalvik.util.AndroidEntryPointLocator.AndroidPossibleEntryPoi
  *  https://developer.android.com/reference/android/app/Fragment.html
  *
  *  @see    com.ibm.wala.dalvik.util.AndroidEntryPointLocator
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 public final class FragmentEP {
 

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/LoaderCB.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/LoaderCB.java
@@ -52,7 +52,7 @@ import com.ibm.wala.dalvik.util.AndroidEntryPointLocator.AndroidPossibleEntryPoi
  *  AndroidEntryPointLocator are set to include call-backs.
  *
  *  @see    com.ibm.wala.dalvik.util.AndroidEntryPointLocator
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 public final class LoaderCB {
     

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/LocationEP.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/LocationEP.java
@@ -52,7 +52,7 @@ import com.ibm.wala.dalvik.util.AndroidEntryPointLocator.AndroidPossibleEntryPoi
  *  AndroidEntryPointLocator are set to include call-backs.
  *  
  *  @see    com.ibm.wala.dalvik.util.AndroidEntryPointLocator
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 public final class LocationEP {
 	public static final AndroidPossibleEntryPoint onLocationChanged = new AndroidPossibleEntryPoint("onLocationChanged", ExecutionOrder.MIDDLE_OF_LOOP);

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/ProviderEP.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/ProviderEP.java
@@ -52,7 +52,7 @@ import com.ibm.wala.dalvik.util.AndroidEntryPointLocator.AndroidPossibleEntryPoi
  *  The specifications are read and handled by AndroidEntryPointLocator.
  *
  *  @see    com.ibm.wala.dalvik.util.AndroidEntryPointLocator
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 public final class ProviderEP {
 	public static final AndroidPossibleEntryPoint onCreate = new AndroidPossibleEntryPoint("onCreate", ExecutionOrder.AT_FIRST);

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/ServiceEP.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/ServiceEP.java
@@ -52,7 +52,7 @@ import com.ibm.wala.dalvik.util.AndroidEntryPointLocator.AndroidPossibleEntryPoi
  *  The specifications are read and handled by AndroidEntryPointLocator.
  *
  *  @see    com.ibm.wala.dalvik.util.AndroidEntryPointLocator
- *  @author Tobias Blaschke <code@tobiasblaschke.de>
+ *  @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 public final class ServiceEP {
     /**

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/package-info.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/package-info.java
@@ -52,6 +52,6 @@
  * adapted to load the specifications.
  *
  * @see    com.ibm.wala.dalvik.util.AndroidEntryPointLocator
- * @author Tobias Blaschke <code@tobiasblaschke.de>
+ * @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 package com.ibm.wala.dalvik.util.androidEntryPoints;

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/package-info.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/package-info.java
@@ -44,6 +44,6 @@
  * These include mainly locationg and managing EntryPoints. The model howver is
  * built in the androidModel-Package.
  *
- * @author Tobias Blaschke <code@tobiasblaschke.de>
+ * @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  */
 package com.ibm.wala.dalvik.util;

--- a/com.ibm.wala.ide.jdt.test/source/com/ibm/wala/demandpa/driver/DemandCastChecker.java
+++ b/com.ibm.wala.ide.jdt.test/source/com/ibm/wala/demandpa/driver/DemandCastChecker.java
@@ -177,7 +177,6 @@ public class DemandCastChecker {
    * @param scope
    * @param cha
    * @param options
-   * @return
    * @throws CancelException
    * @throws IllegalArgumentException
    */

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/types/FlowType.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/types/FlowType.java
@@ -124,7 +124,6 @@ public abstract class FlowType<E extends ISSABasicBlock> {
      * 
      * @param a
      * @param b
-     * @return
      */
     @SuppressWarnings("unused")
 	private boolean compareBlocks(BasicBlockInContext<E> a,

--- a/com.ibm.wala.scandroid/source/org/scandroid/model/AppModelMethod.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/model/AppModelMethod.java
@@ -89,7 +89,7 @@ public class AppModelMethod {
 	
 	int nextLocal;
     /**
-     * A mapping from String (variable name) -> Integer (local number)
+     * A mapping from String (variable name) -&gt; Integer (local number)
      */
     private Map<String, Integer> symbolTable = null;
     

--- a/com.ibm.wala.scandroid/source/org/scandroid/spec/MethodNamePattern.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/spec/MethodNamePattern.java
@@ -98,7 +98,6 @@ public class MethodNamePattern {
 	 * Returns a Collection of IMethods which are found in the following 
 	 * ClassLoaders: Application, Primordial, Extension
 	 * @param cha
-	 * @return
 	 */
 	public Collection<IMethod> getPossibleTargets(IClassHierarchy cha) {
 		Collection<IMethod> matching = new LinkedList<>();

--- a/com.ibm.wala.scandroid/source/org/scandroid/spec/SpecUtils.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/spec/SpecUtils.java
@@ -58,7 +58,6 @@ public class SpecUtils {
 	 * 
 	 * @param s1
 	 * @param s2
-	 * @return
 	 */
 	public static ISpecs combine(final ISpecs s1, final ISpecs s2) {
 		return new ISpecs() {

--- a/com.ibm.wala.scandroid/source/org/scandroid/spec/StaticSpecs.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/spec/StaticSpecs.java
@@ -99,9 +99,6 @@ public class StaticSpecs implements ISpecs {
 		return new SourceSpec[] {};
 	}
 
-	/**
-	 * @return
-	 */
 	private List<IField> collectFields() {
 		List<IField> fields = new ArrayList<>();
 		Iterator<IClass> itr = cha.iterator();

--- a/com.ibm.wala.scandroid/source/org/scandroid/synthmethod/SSAtoXMLVisitor.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/synthmethod/SSAtoXMLVisitor.java
@@ -465,7 +465,6 @@ public class SSAtoXMLVisitor implements SSAInstruction.IVisitor {
      *
      * @param defNum
      *
-     * @return
      * @throws IllegalStateException
      */
     private String getLocalName(int defNum) throws IllegalStateException {

--- a/com.ibm.wala.scandroid/source/org/scandroid/synthmethod/SSAtoXMLVisitor.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/synthmethod/SSAtoXMLVisitor.java
@@ -461,7 +461,7 @@ public class SSAtoXMLVisitor implements SSAInstruction.IVisitor {
      * local name associated with it) then this will throw an illegal state
      * exception.
      *
-     * TODO needs to return 'arg0' -> 'argN' for those value numbers...
+     * TODO needs to return 'arg0' -&gt; 'argN' for those value numbers...
      *
      * @param defNum
      *

--- a/com.ibm.wala.scandroid/source/org/scandroid/synthmethod/XMLSummaryWriter.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/synthmethod/XMLSummaryWriter.java
@@ -267,7 +267,6 @@ public class XMLSummaryWriter {
      * (I[Ljava/lang/String;)[Ljava/lang/String;
      * 
      * @param summary
-     * @return
      */
     private static String getMethodDescriptor(MethodSummary summary) {
         StringBuilder typeSigs = new StringBuilder("(");

--- a/com.ibm.wala.scandroid/source/org/scandroid/util/AndroidAnalysisContext.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/util/AndroidAnalysisContext.java
@@ -299,7 +299,6 @@ public class AndroidAnalysisContext {
 	/**
 	 * Returns all concrete classes implementing the given interface or any subinterfaces
 	 * @param iRoot
-	 * @return
 	 */
 	public Collection<IClass> concreteClassesForInterface(IClass iRoot) {
 		Set<IClass> clazzes = HashSetFactory.make();

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/DupInstruction.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/DupInstruction.java
@@ -13,7 +13,7 @@ package com.ibm.wala.shrikeBT;
 /**
  * This class represents dup instructions. There are two kinds of dup instructions, dup and dup_x1:
  * 
- * dup: a::rest => a::a::rest dup_x1: a::b::rest => a::b::a::rest
+ * dup: a::rest =&gt; a::a::rest dup_x1: a::b::rest =&gt; a::b::a::rest
  */
 public final class DupInstruction extends Instruction {
   final private int size;

--- a/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/CRTData.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/CRTData.java
@@ -25,7 +25,7 @@ import com.ibm.wala.sourcepos.InvalidRangeException.Cause;
  * @see CRTFlags
  * @see CRTable
  * @author Siegfried Weber
- * @author Juergen Graf <juergen.graf@gmail.com>
+ * @author Juergen Graf &lt;juergen.graf@gmail.com&gt;
  */
 public final class CRTData {
 

--- a/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/CRTFlags.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/CRTFlags.java
@@ -26,7 +26,7 @@ import java.util.LinkedList;
  * @see CRTData
  * @see CRTable
  * @author Siegfried Weber
- * @author Juergen Graf <juergen.graf@gmail.com>
+ * @author Juergen Graf &lt;juergen.graf@gmail.com&gt;
  */
 public final class CRTFlags {
 

--- a/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/CRTable.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/CRTable.java
@@ -27,7 +27,7 @@ import java.util.LinkedList;
  * @see CRTData
  * @see CRTFlags
  * @author Siegfried Weber
- * @author Juergen Graf <juergen.graf@gmail.com>
+ * @author Juergen Graf &lt;juergen.graf@gmail.com&gt;
  */
 public final class CRTable extends PositionsAttribute {
 

--- a/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/Debug.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/Debug.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * @author Juergen Graf <juergen.graf@gmail.com>
+ * @author Juergen Graf &lt;juergen.graf@gmail.com&gt;
  * 
  */
 public final class Debug {

--- a/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/InvalidCRTDataException.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/InvalidCRTDataException.java
@@ -26,7 +26,7 @@ import java.util.LinkedList;
  * @see CRTData
  * @see CRTFlags
  * @author Siegfried Weber
- * @author Juergen Graf <juergen.graf@gmail.com>
+ * @author Juergen Graf &lt;juergen.graf@gmail.com&gt;
  */
 class InvalidCRTDataException extends Exception {
 

--- a/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/InvalidPositionException.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/InvalidPositionException.java
@@ -21,7 +21,7 @@ package com.ibm.wala.sourcepos;
  * An exception for invalid positions.
  * 
  * @author Siegfried Weber
- * @author Juergen Graf <juergen.graf@gmail.com>
+ * @author Juergen Graf &lt;juergen.graf@gmail.com&gt;
  */
 class InvalidPositionException extends Exception {
 

--- a/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/InvalidRangeException.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/InvalidRangeException.java
@@ -21,7 +21,7 @@ package com.ibm.wala.sourcepos;
  * An exception for invalid ranges.
  * 
  * @author Siegfried Weber
- * @author Juergen Graf <juergen.graf@gmail.com>
+ * @author Juergen Graf &lt;juergen.graf@gmail.com&gt;
  */
 class InvalidRangeException extends Exception {
 

--- a/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/InvalidSourceInfoException.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/InvalidSourceInfoException.java
@@ -23,7 +23,7 @@ package com.ibm.wala.sourcepos;
  * CharacterRangeTable.
  * 
  * @author Siegfried Weber
- * @author Juergen Graf <juergen.graf@gmail.com>
+ * @author Juergen Graf &lt;juergen.graf@gmail.com&gt;
  */
 public class InvalidSourceInfoException extends Exception {
 

--- a/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/MethodPositions.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/MethodPositions.java
@@ -26,7 +26,7 @@ import com.ibm.wala.sourcepos.InvalidRangeException.Cause;
  * This class represents the MethodPositions attribute.
  * 
  * @author Siegfried Weber
- * @author Juergen Graf <juergen.graf@gmail.com>
+ * @author Juergen Graf &lt;juergen.graf@gmail.com&gt;
  */
 public final class MethodPositions extends PositionsAttribute {
 

--- a/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/Position.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/Position.java
@@ -22,7 +22,7 @@ package com.ibm.wala.sourcepos;
  * format: {@code line-number << LINESHIFT + column-number}
  * 
  * @author Siegfried Weber
- * @author Juergen Graf <juergen.graf@gmail.com>
+ * @author Juergen Graf &lt;juergen.graf@gmail.com&gt;
  */
 public final class Position {
 

--- a/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/PositionsAttribute.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/PositionsAttribute.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * This is the super class of all position attributes.
  * 
  * @author Siegfried Weber
- * @author Juergen Graf <juergen.graf@gmail.com>
+ * @author Juergen Graf &lt;juergen.graf@gmail.com&gt;
  */
 abstract class PositionsAttribute {
 

--- a/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/Range.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/sourcepos/Range.java
@@ -21,7 +21,7 @@ package com.ibm.wala.sourcepos;
  * This class represents a range in the source file.
  * 
  * @author Siegfried Weber
- * @author Juergen Graf <juergen.graf@gmail.com>
+ * @author Juergen Graf &lt;juergen.graf@gmail.com&gt;
  */
 public class Range {
 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/graph/dominators/Dominators.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/graph/dominators/Dominators.java
@@ -352,7 +352,7 @@ public abstract class Dominators<T> {
   /**
    * This method inspects the passed node and returns the following: node, if node is a root of a tree in the forest
    * 
-   * any vertex, u != r such that otherwise r is the root of the tree containing node and * semi(u) is minimum on the path r -> v
+   * any vertex, u != r such that otherwise r is the root of the tree containing node and * semi(u) is minimum on the path r -&gt; v
    * 
    * See TOPLAS 1(1), July 1979, p 128 for details.
    * 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/graph/traverse/BoundedBFSIterator.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/graph/traverse/BoundedBFSIterator.java
@@ -55,7 +55,7 @@ public class BoundedBFSIterator<T> implements Iterator<T> {
   private final int k;
 
   /**
-   * boundary[i] is the first index which represents a child that is > i hops away.
+   * boundary[i] is the first index which represents a child that is &gt; i hops away.
    */
   private final int[] boundary;
 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/heapTrace/HeapTracer.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/heapTrace/HeapTracer.java
@@ -69,7 +69,7 @@ public class HeapTracer {
     private final boolean traceStatics;
 
     /**
-     * Map: Class -> Integer, the size of each class
+     * Map: Class -&gt; Integer, the size of each class
      */
     private final HashMap<Class<?>, Integer> sizeMap = HashMapFactory.make();
 
@@ -627,13 +627,13 @@ public class HeapTracer {
      */
     class Demographics {
 	/**
-	 * mapping: Object (key) -> Integer (number of instances in a partition)
+	 * mapping: Object (key) -&gt; Integer (number of instances in a partition)
 	 */
 	private final HashMap<Object, Integer> instanceCount = HashMapFactory
 		.make();
 
 	/**
-	 * mapping: Object (key) -> Integer (bytes)
+	 * mapping: Object (key) -&gt; Integer (bytes)
 	 */
 	private final HashMap<Object, Integer> sizeCount = HashMapFactory
 		.make();
@@ -725,7 +725,7 @@ public class HeapTracer {
     public class Result {
 
 	/**
-	 * a mapping from Field (static field roots) -> Demographics object
+	 * a mapping from Field (static field roots) -&gt; Demographics object
 	 */
 	private final HashMap<Field, Demographics> roots = HashMapFactory
 		.make();

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/IntegerUnionFind.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/IntegerUnionFind.java
@@ -23,8 +23,8 @@ public class IntegerUnionFind {
    * 
    * parent[i+1] =
    * <ul>
-   * <li>j > 0 if i is in the same equiv class as j
-   * <li>j <= 0 if i is the representative of a class of size -(j)+1
+   * &lt;li&gt;j &gt; 0 if i is in the same equiv class as j
+   * <li>j &lt;= 0 if i is the representative of a class of size -(j)+1
    * </ul>
    * 
    * we initialize parent[j] = 0, so each element is a class of size 1


### PR DESCRIPTION
This pull request includes a large number of fixes to various Javadoc errors: unescaped `<` and `>`, invalid HTM tags, invalid Javadoc tags, etc. See the individual commit descriptions for more details.

These problems were all revealed when using Gradle to build Javadoc documentation. I have no idea why neither Maven nor Eclipse report any of these problems during their Javadoc processing.