### PR TITLE
Fix bug with method lookup

### DIFF
--- a/com.ibm.wala.core.testdata/src/methodLookup/MethodLookupStuff.java
+++ b/com.ibm.wala.core.testdata/src/methodLookup/MethodLookupStuff.java
@@ -1,0 +1,15 @@
+package methodLookup;
+
+public class MethodLookupStuff {
+
+  static class A {
+    A(int foo) {      
+    }
+    
+    A() {}
+  }
+  
+  static class B extends A {
+    
+  }
+}

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cha/GetTargetsTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cha/GetTargetsTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 
 import com.ibm.wala.classLoader.ClassLoaderFactory;
 import com.ibm.wala.classLoader.ClassLoaderFactoryImpl;
+import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.core.tests.util.TestConstants;
 import com.ibm.wala.core.tests.util.WalaTestCase;
@@ -28,6 +29,7 @@ import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.ipa.cha.ClassHierarchyFactory;
 import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.MethodReference;
+import com.ibm.wala.types.Selector;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.config.AnalysisScopeReader;
 import com.ibm.wala.util.io.FileProvider;
@@ -95,5 +97,13 @@ public class GetTargetsTest extends WalaTestCase {
       System.err.println(method);
     }
     Assert.assertEquals(1, c.size());
+  }
+  
+  @Test
+  public void testConstructorLookup() {
+    IClass testKlass = cha.lookupClass(TypeReference.findOrCreate(ClassLoaderReference.Application, 
+        "LmethodLookup/MethodLookupStuff$B"));
+    IMethod m = testKlass.getMethod(Selector.make("<init>(I)V"));
+    Assert.assertNull(m);
   }
 }

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/BytecodeClass.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/BytecodeClass.java
@@ -453,7 +453,8 @@ public abstract class BytecodeClass<T extends IClassLoader> implements IClass {
     }
 
     // check parent, caching if found
-    if (!selector.equals(MethodReference.clinitSelector) && !selector.equals(MethodReference.initSelector)) {
+    if (!selector.equals(MethodReference.clinitSelector) 
+        && !selector.getName().equals(MethodReference.initAtom)) {
       IClass superclass = getSuperclass();
       if (superclass != null) {
         IMethod inherit = superclass.getMethod(selector);


### PR DESCRIPTION
The previous lookup logic would erroneously look in superclasses for a constructor with parameters.

Bug reported on [the mailing list](https://groups.google.com/forum/#!msg/wala-sourceforge-net/6m_VmDF-lZ0/erZIYQ68BwAJ;context-place=topic/wala-sourceforge-net/TjRzdDyljjY)