### PR TITLE
Use the proper JUnit mechanism for conditionally skipping tests

### DIFF
--- a/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/AbstractFieldBasedTest.java
+++ b/com.ibm.wala.cast.js.rhino.test/harness-src/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/AbstractFieldBasedTest.java
@@ -4,6 +4,8 @@ import java.net.URL;
 import java.util.Map;
 import java.util.Set;
 
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assume.*;
 import org.junit.Before;
 
 import com.ibm.wala.cast.ir.translator.TranslatorToCAst.Error;
@@ -55,12 +57,9 @@ public abstract class AbstractFieldBasedTest extends TestJSCallGraphShape {
   /**
    * for long-running tests that tend to time out on Travis
    */
-  protected JSCallGraph runTestExceptOnTravis(URL url, Object[][] assertions, BuilderType... builderTypes) throws WalaException, Error, CancelException {
-    if (System.getenv("TRAVIS") == null) {
-      return runTest(url, assertions, builderTypes);
-    } else {
-      return null;
-    }
+  protected void runTestExceptOnTravis(URL url, Object[][] assertions, BuilderType... builderTypes) throws WalaException, Error, CancelException {
+    assumeThat("not running on Travis CI", System.getenv("TRAVIS"), nullValue());
+    runTest(url, assertions, builderTypes);
   }
 
   protected void dumpCG(JSCallGraph cg) {


### PR DESCRIPTION
These are slow tests that we were already effectively turning into no-ops when running on Travis CI.  By skipping them using the proper JUnit mechanism, these tests will show up as ignored or skipped in test outcome reports.  That's better than having them show up as passing, when we really don't know whether they would have passed or failed.