### PR TITLE
Protected visibility for JavaSourceLoaderImpl's internal methods and classes

### DIFF
--- a/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/loader/JavaSourceLoaderImpl.java
+++ b/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/loader/JavaSourceLoaderImpl.java
@@ -91,7 +91,7 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
 
   /**
    * WALA representation of a Java class residing in a source file
-   * 
+   *
    * @author rfuhrer
    */
   public class JavaClass extends AstClass {
@@ -100,7 +100,7 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
     protected final Collection<TypeName> superTypeNames;
 
     private final Collection<Annotation> annotations;
-    
+
     public JavaClass(String typeName, Collection<TypeName> superTypeNames, CAstSourcePositionMap.Position position, Collection<CAstQualifier> qualifiers,
         JavaSourceLoaderImpl loader, IClass enclosingClass, Collection<Annotation> annotations) {
       super(position, TypeName.string2TypeName(typeName), loader, (short) mapToInt(qualifiers), new HashMap<Atom, IField>(), new HashMap<Selector, IMethod>());
@@ -141,11 +141,11 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
 /** END Custom change: Common superclass is optional */
         Assertions.UNREACHABLE("Cannot find super class for " + this + " in " + superTypeNames);
       }
-      
+
       if (excludedSupertype){
         System.err.println("Not tracking calls through excluded superclass of " + getName() + " extends " + superTypeNames);
       }
-      
+
       return null;
     }
 
@@ -165,17 +165,17 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
       return result;
     }
 
-    private void addMethod(CAstEntity methodEntity, IClass owner, AbstractCFG<?, ?> cfg, SymbolTable symtab, boolean hasCatchBlock,
+    protected void addMethod(CAstEntity methodEntity, IClass owner, AbstractCFG<?, ?> cfg, SymbolTable symtab, boolean hasCatchBlock,
         Map<IBasicBlock<SSAInstruction>, TypeReference[]> caughtTypes, boolean hasMonitorOp, AstLexicalInformation lexicalInfo, DebuggingInformation debugInfo) {
       declaredMethods.put(Util.methodEntityToSelector(methodEntity), new ConcreteJavaMethod(methodEntity, owner, cfg, symtab,
           hasCatchBlock, caughtTypes, hasMonitorOp, lexicalInfo, debugInfo));
     }
 
-    private void addMethod(CAstEntity methodEntity, IClass owner) {
+    protected void addMethod(CAstEntity methodEntity, IClass owner) {
       declaredMethods.put(Util.methodEntityToSelector(methodEntity), new AbstractJavaMethod(methodEntity, owner));
     }
 
-    private void addField(CAstEntity fieldEntity) {
+    protected void addField(CAstEntity fieldEntity) {
       declaredFields.put(Util.fieldEntityToAtom(fieldEntity), new JavaField(fieldEntity, JavaSourceLoaderImpl.this, this, JavaSourceLoaderImpl.this.getAnnotations(fieldEntity)));
     }
 
@@ -199,7 +199,7 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
     }
   }
 
-  private Collection<Annotation> getAnnotations(CAstEntity e) {
+  protected Collection<Annotation> getAnnotations(CAstEntity e) {
     Collection<CAstAnnotation> annotations = e.getAnnotations();
     if (annotations == null || annotations.isEmpty()) {
       return null;
@@ -221,14 +221,14 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
       return result;
     }
   }
-  
+
   /**
    * WALA representation of a field on a Java type that resides in a source file
-   * 
+   *
    * @author rfuhrer
    */
-  private class JavaField extends AstField {
-    private JavaField(CAstEntity fieldEntity, IClassLoader loader, IClass declaringClass, Collection<Annotation> annotations) {
+  protected class JavaField extends AstField {
+    protected JavaField(CAstEntity fieldEntity, IClassLoader loader, IClass declaringClass, Collection<Annotation> annotations) {
       super(FieldReference.findOrCreate(declaringClass.getReference(), Atom.findOrCreateUnicodeAtom(fieldEntity.getName()),
           TypeReference.findOrCreate(loader.getReference(), TypeName.string2TypeName(fieldEntity.getType().getName()))),
           fieldEntity.getQualifiers(), declaringClass, declaringClass.getClassHierarchy(), annotations);
@@ -238,10 +238,10 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
   /**
    * Generic DOMO representation of a method on a Java type that resides in a
    * source file
-   * 
+   *
    * @author rfuhrer
    */
-  private abstract class JavaEntityMethod extends AstMethod {
+  protected abstract class JavaEntityMethod extends AstMethod {
     private final TypeReference[] parameterTypes;
 
     private final TypeReference[] exceptionTypes;
@@ -276,7 +276,7 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
       return parameterTypes[i];
     }
 
-    private TypeReference[] computeParameterTypes(CAstEntity methodEntity) {
+    protected TypeReference[] computeParameterTypes(CAstEntity methodEntity) {
       TypeReference[] types;
       CAstType.Function type = (Function) methodEntity.getType();
       int argCount = type.getArgumentTypes().size();
@@ -303,7 +303,7 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
       return exceptionTypes;
     }
 
-    private TypeReference[] computeExceptionTypes(CAstEntity methodEntity) {
+    protected TypeReference[] computeExceptionTypes(CAstEntity methodEntity) {
       CAstType.Function fType = (Function) methodEntity.getType();
       Collection<CAstType> exceptionTypes = fType.getExceptionTypes();
 
@@ -326,10 +326,10 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
   /**
    * DOMO representation of an abstract (body-less) method on a Java type that
    * resides in a source file
-   * 
+   *
    * @author rfuhrer
    */
-  private class AbstractJavaMethod extends JavaEntityMethod {
+  protected class AbstractJavaMethod extends JavaEntityMethod {
     public AbstractJavaMethod(CAstEntity methodEntity, IClass owner) {
       super(methodEntity, owner);
     }
@@ -360,7 +360,7 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
   /**
    * DOMO representation of a concrete method (which has a body) on a Java type
    * that resides in a source file
-   * 
+   *
    * @author rfuhrer
    */
   public class ConcreteJavaMethod extends JavaEntityMethod {
@@ -483,7 +483,7 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
     super(loaderRef, cha.getScope().getArrayClassLoader(), parent, cha.getScope().getExclusions(), cha);
     this.existsCommonSuperclass = existsCommonSuperClass;
   }
-  
+
   public JavaSourceLoaderImpl(ClassLoaderReference loaderRef, IClassLoader parent, IClassHierarchy cha) {
     // standard case: we have a common super class
     this(true, loaderRef, parent, cha);
@@ -503,7 +503,7 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
 /** BEGIN Custom change: Optional deletion of fTypeMap */
   public static volatile boolean deleteTypeMapAfterInit = true;
 /** END Custom change: Optional deletion of fTypeMap */
-  
+
 
   @Override
   public void init(List<Module> modules) throws IOException {
@@ -528,10 +528,10 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
     ((JavaClass) owner).addField(n);
   }
 
-  private static TypeName toWALATypeName(CAstType type) {
+  protected static TypeName toWALATypeName(CAstType type) {
     return TypeName.string2TypeName(type.getName());
   }
-  
+
   public IClass defineType(CAstEntity type, String typeName, CAstEntity owner) {
     Collection<TypeName> superTypeNames = new ArrayList<>();
     for (CAstType superType : type.getType().getSupertypes()) {
@@ -544,7 +544,7 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
     if (getParent().lookupClass(javaClass.getName()) != null) {
       return null;
     }
-    
+
     fTypeMap.put(type, javaClass);
     loadedClasses.put(javaClass.getName(), javaClass);
     return javaClass;
@@ -554,7 +554,7 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
   public String toString() {
     return "Java Source Loader (classes " + loadedClasses.values() + ")";
   }
-  
+
   public static class InstructionFactory extends JavaInstructionFactory implements AstJavaInstructionFactory {
 
     @Override
@@ -658,9 +658,9 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
        return new AstLexicalWrite(iindex, definer, globalName, type, rhs);
     }
   }
-  
-  private static final InstructionFactory insts = new InstructionFactory();
-  
+
+  protected static final InstructionFactory insts = new InstructionFactory();
+
   @Override
   public InstructionFactory getInstructionFactory() {
     return insts;


### PR DESCRIPTION
Since JavaSourceLoaderImpl is an abstract class, I would recommend to give visibility of internal fields at least to all the implementing classes in order to allow user modifications.