### PR TITLE
Require JUnit 4.12 instead of 4.11

### DIFF
--- a/com.ibm.wala.cast.java.test/build.gradle
+++ b/com.ibm.wala.cast.java.test/build.gradle
@@ -7,7 +7,7 @@ sourceSets.test.java.srcDirs = ['src']
 
 dependencies {
 	testCompile(
-		'junit:junit:4.11',
+		'junit:junit:4.12',
 		'org.osgi:org.osgi.core:4.2.0',
 		project(':com.ibm.wala.cast'),
 		project(':com.ibm.wala.cast.java'),

--- a/com.ibm.wala.cast.java.test/pom.xml
+++ b/com.ibm.wala.cast.java.test/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies> 

--- a/com.ibm.wala.cast.js.html.nu_validator/pom.xml
+++ b/com.ibm.wala.cast.js.html.nu_validator/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies> 

--- a/com.ibm.wala.cast.js.nodejs.test/build.gradle
+++ b/com.ibm.wala.cast.js.nodejs.test/build.gradle
@@ -5,7 +5,7 @@ sourceSets.test {
 
 dependencies {
 	testCompile(
-		'junit:junit:4.11',
+		'junit:junit:4.12',
 		project(':com.ibm.wala.cast.js.nodejs'),
 		project(':com.ibm.wala.core'),
 		)

--- a/com.ibm.wala.cast.js.nodejs.test/pom.xml
+++ b/com.ibm.wala.cast.js.nodejs.test/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies> 

--- a/com.ibm.wala.cast.js.rhino.test/build.gradle
+++ b/com.ibm.wala.cast.js.rhino.test/build.gradle
@@ -7,7 +7,7 @@ sourceSets.test {
 
 dependencies {
 	testCompile(
-		'junit:junit:4.11',
+		'junit:junit:4.12',
 		project(':com.ibm.wala.cast'),
 		project(':com.ibm.wala.cast.js'),
 		project(':com.ibm.wala.cast.js.rhino'),

--- a/com.ibm.wala.cast.js.rhino.test/pom.xml
+++ b/com.ibm.wala.cast.js.rhino.test/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies> 

--- a/com.ibm.wala.cast.js.test/build.gradle
+++ b/com.ibm.wala.cast.js.test/build.gradle
@@ -7,7 +7,7 @@ sourceSets.test {
 
 dependencies {
 	testCompile(
-		'junit:junit:4.11',
+		'junit:junit:4.12',
 		project(':com.ibm.wala.cast'),
 		project(':com.ibm.wala.cast.js'),
 		project(':com.ibm.wala.cast.js.rhino'),

--- a/com.ibm.wala.cast.js.test/pom.xml
+++ b/com.ibm.wala.cast.js.test/pom.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies> 

--- a/com.ibm.wala.cast.test/build.gradle
+++ b/com.ibm.wala.cast.test/build.gradle
@@ -8,7 +8,7 @@ sourceSets.test.java.srcDirs = ['harness-src/java']
 
 dependencies {
 	testCompile(
-		'junit:junit:4.11',
+		'junit:junit:4.12',
 		project(':com.ibm.wala.cast'),
 		project(':com.ibm.wala.core'),
 		project(':com.ibm.wala.util'),

--- a/com.ibm.wala.cast.test/pom.xml
+++ b/com.ibm.wala.cast.test/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/com.ibm.wala.core.tests/build.gradle
+++ b/com.ibm.wala.core.tests/build.gradle
@@ -11,7 +11,7 @@ sourceSets.test {
 dependencies {
 	testCompile(
 		'eclipse-deps:org.eclipse.core.runtime:+',
-		'junit:junit:4.11',
+		'junit:junit:4.12',
 		'org.apache.ant:ant:1.8.2',
 		'org.hamcrest:hamcrest-core:1.3',
 		'org.osgi:org.osgi.core:4.2.0',

--- a/com.ibm.wala.core.tests/pom.xml
+++ b/com.ibm.wala.core.tests/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies> 

--- a/com.ibm.wala.dalvik.test/META-INF/MANIFEST.MF
+++ b/com.ibm.wala.dalvik.test/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Require-Bundle: org.eclipse.core.runtime,
  com.ibm.wala.dalvik;bundle-version="1.0.0",
  com.ibm.wala.core;bundle-version="1.3.4",
  com.ibm.wala.shrike;bundle-version="1.3.4",
- org.junit;bundle-version="4.11.0"
+ org.junit;bundle-version="4.12.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ClassPath: .,

--- a/com.ibm.wala.dalvik.test/build.gradle
+++ b/com.ibm.wala.dalvik.test/build.gradle
@@ -117,7 +117,7 @@ clean.dependsOn cleanDownloadSampleLex
 
 dependencies {
 	testCompile(
-		'junit:junit:4.11',
+		'junit:junit:4.12',
 		'org.osgi:org.osgi.core:4.2.0',
 		files("${copyDxJar.destinationDir}/dx.jar"),
 		project(':com.ibm.wala.core'),

--- a/com.ibm.wala.dalvik.test/pom.xml
+++ b/com.ibm.wala.dalvik.test/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/com.ibm.wala.ide.jdt.test/build.gradle
+++ b/com.ibm.wala.ide.jdt.test/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 		'eclipse-deps:org.eclipse.core.runtime:+',
 		'eclipse-deps:org.eclipse.jdt.core:+',
 		'eclipse-deps:org.eclipse.osgi:+',
-		'junit:junit:4.11',
+		'junit:junit:4.12',
 		'org.osgi:org.osgi.core:4.2.0',
 		project(':com.ibm.wala.cast'),
 		project(':com.ibm.wala.cast.java'),

--- a/com.ibm.wala.ide.jsdt.tests/build.gradle
+++ b/com.ibm.wala.ide.jsdt.tests/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 		'eclipse-deps:org.eclipse.core.runtime:+',
 		'eclipse-deps:org.eclipse.equinox.common:+',
 		'eclipse-deps:org.eclipse.osgi:+',
-		'junit:junit:4.11',
+		'junit:junit:4.12',
 		'org.osgi:org.osgi.core:4.2.0',
 		'wst-deps:org.eclipse.wst.jsdt.core:+',
 		project(':com.ibm.wala.cast'),


### PR DESCRIPTION
WALA itself does not use any JUnit 4.12 features.  However, I am working on a WALA-based project that does require JUnit 4.12.  Mixing jar versions is a path to madness.  So if the WALA maintainers don’t mind, it would make my life easier if WALA itself required JUnit 4.12. Otherwise, I need to maintain that 4.11/4.12 difference indefinitely as a divergence between official WALA and my WALA variant.

I suppose an alternative could be to let the JUnit version be specified externally somehow. I have not explored this option in depth, but could look into it if simply moving to JUnit 4.12 is undesirable.