### PR TITLE
Have Travis CI periodically try to build each Gradle subproject separately

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,255 @@ matrix:
     - os: osx
       env: BUILD_SYSTEM=gradle
       language: java
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.java
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.java.ecj
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.java.test
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.java.test.data
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.js
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.js.html.nu_validator
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.js.nodejs
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.js.nodejs.test
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.js.rhino
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.js.rhino.test
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.js.test
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.js.test.data
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.test
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.core
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.core.testdata
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.core.tests
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.dalvik
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.dalvik.test
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.ide
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.ide.jdt
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.ide.jdt.test
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.ide.jsdt
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.ide.jsdt.tests
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.ide.tests
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.scandroid
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.shrike
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: linux
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.util
+      language: java
+      jdk: oraclejdk8
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast
+      language: java
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.java
+      language: java
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.java.ecj
+      language: java
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.java.test
+      language: java
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.java.test.data
+      language: java
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.js
+      language: java
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.js.html.nu_validator
+      language: java
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.js.nodejs
+      language: java
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.js.nodejs.test
+      language: java
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.js.rhino
+      language: java
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.js.rhino.test
+      language: java
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.js.test
+      language: java
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.js.test.data
+      language: java
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.test
+      language: java
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.core
+      language: java
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.core.testdata
+      language: java
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.core.tests
+      language: java
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.dalvik
+      language: java
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.dalvik.test
+      language: java
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.ide
+      language: java
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.ide.jdt
+      language: java
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.ide.jdt.test
+      language: java
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.ide.jsdt
+      language: java
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.ide.jsdt.tests
+      language: java
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.ide.tests
+      language: java
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.scandroid
+      language: java
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.shrike
+      language: java
+      if: type = cron
+    - os: osx
+      env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.util
+      language: java
+      if: type = cron


### PR DESCRIPTION
In theory, if Gradle dependencies are set up correctly, then it should be possible to build any subproject starting with a pristine tree. If subproject *X* depends on subproject *Y*, then Gradle should know that building *X* requires building *Y* first. The way to test this is to systematically build each subproject starting from a pristine WALA tree. Unfortunately, with 29 subprojects on 2 supported platforms, that can take a while. Travis CI runs up to five jobs at a time, and running this entire set of tests takes nearly 7 hours. So that’s not something we want to do on every push or on every pull request. However, this would be reasonable to do less frequently, such as once per week.

Fortunately, Travis CI has support for running periodic (e.g., weekly) tests: [cron jobs](https://docs.travis-ci.com/user/cron-jobs/). This pull request adds a 29 × 2 single-subproject build tests that will only be enabled when run from a Travis CI cron job. If you think this is a good idea, then you should **do two things:**

1. Accept this pull request.
2. Follow the [Travis CI cron job instructions](https://docs.travis-ci.com/user/cron-jobs/) to add a weekly cron job using the following configuration:
    * Branch: master
    * Interval: weekly
    * Options: Always run