### PR TITLE
Load Gradle plugins using “plugins” closure rather than “apply plugin”

### DIFF
--- a/com.ibm.wala.cast.java.test.data/build.gradle
+++ b/com.ibm.wala.cast.java.test.data/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'eclipse'
+plugins {
+	id 'eclipse'
+}
 
 sourceSets.test.java.srcDirs = ['src']
 

--- a/com.ibm.wala.cast.java.test/build.gradle
+++ b/com.ibm.wala.cast.java.test/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'com.github.hauner.jarTest'
-apply plugin: 'eclipse'
+plugins {
+	id 'com.github.hauner.jarTest'
+	id 'eclipse'
+}
 
 eclipse.project.natures 'org.eclipse.pde.PluginNature'
 

--- a/com.ibm.wala.cast.java/build.gradle
+++ b/com.ibm.wala.cast.java/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'eclipse'
+plugins {
+	id 'eclipse'
+}
 
 eclipse.project.natures 'org.eclipse.pde.PluginNature'
 

--- a/com.ibm.wala.cast.js.rhino.test/build.gradle
+++ b/com.ibm.wala.cast.js.rhino.test/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'com.github.hauner.jarTest'
+plugins {
+	id 'com.github.hauner.jarTest'
+}
 
 sourceSets.test {
 	java.srcDirs = ['harness-src']

--- a/com.ibm.wala.cast.js.test.data/build.gradle
+++ b/com.ibm.wala.cast.js.test.data/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'base'
+plugins {
+	id 'base'
+}
 
 task downloadAjaxslt(type: VerifiedDownload) {
 	def version = '0.8.1'

--- a/com.ibm.wala.cast.js.test/build.gradle
+++ b/com.ibm.wala.cast.js.test/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'com.github.hauner.jarTest'
+plugins {
+	id 'com.github.hauner.jarTest'
+}
 
 sourceSets.test {
 	java.srcDirs = ['harness-src']

--- a/com.ibm.wala.cast.test/build.gradle
+++ b/com.ibm.wala.cast.test/build.gradle
@@ -1,6 +1,8 @@
-apply plugin: 'com.github.hauner.jarTest'
-apply plugin: 'cpp'
-apply plugin: 'eclipse'
+plugins {
+	id 'com.github.hauner.jarTest'
+	id 'cpp'
+	id 'eclipse'
+}
 
 eclipse.project.natures 'org.eclipse.pde.PluginNature'
 

--- a/com.ibm.wala.cast/build.gradle
+++ b/com.ibm.wala.cast/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'cpp'
-apply plugin: 'eclipse'
+plugins {
+	id 'cpp'
+	id 'eclipse'
+}
 
 eclipse.project.natures 'org.eclipse.pde.PluginNature'
 

--- a/com.ibm.wala.core.testdata/build.gradle
+++ b/com.ibm.wala.core.testdata/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'eclipse'
+plugins {
+	id 'eclipse'
+}
 
 eclipse.project.natures 'org.eclipse.pde.PluginNature'
 

--- a/com.ibm.wala.core.tests/build.gradle
+++ b/com.ibm.wala.core.tests/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'com.github.hauner.jarTest'
-apply plugin: 'eclipse'
+plugins {
+	id 'com.github.hauner.jarTest'
+	id 'eclipse'
+}
 
 eclipse.project.natures 'org.eclipse.pde.PluginNature'
 

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'eclipse'
+plugins {
+	id 'eclipse'
+}
 
 eclipse.project.natures 'org.eclipse.pde.PluginNature'
 

--- a/com.ibm.wala.ide.tests/build.gradle
+++ b/com.ibm.wala.ide.tests/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'com.github.hauner.jarTest'
-apply plugin: 'eclipse'
+plugins {
+	id 'com.github.hauner.jarTest'
+	id 'eclipse'
+}
 
 eclipse.project.natures 'org.eclipse.pde.PluginNature'
 

--- a/com.ibm.wala.ide/build.gradle
+++ b/com.ibm.wala.ide/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'eclipse'
+plugins {
+	id 'eclipse'
+}
 
 eclipse.project.natures 'org.eclipse.pde.PluginNature'
 

--- a/com.ibm.wala.shrike/build.gradle
+++ b/com.ibm.wala.shrike/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'eclipse'
+plugins {
+	id 'eclipse'
+}
 
 eclipse.project.natures 'org.eclipse.pde.PluginNature'
 

--- a/com.ibm.wala.util/build.gradle
+++ b/com.ibm.wala.util/build.gradle
@@ -1,4 +1,6 @@
-apply plugin: 'eclipse'
+plugins {
+	id 'eclipse'
+}
 
 eclipse.project.natures 'org.eclipse.pde.PluginNature'
 


### PR DESCRIPTION
Apparently the latter is considered a “[legacy method](https://docs.gradle.org/current/userguide/plugins.html#sec:old_plugin_application).” Thanks for [pointing this out](https://github.com/wpilibsuite/gradle-jni/issues/5#issuecomment-391498975), @ThadHouse!