### PR TITLE
Tweaks and instructions for WALA as an IntelliJ IDEA project

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,6 @@
-/gradle.xml
-/modules
+*.iml
+/libraries/*.xml
+/modules.xml
+/tasks.xml
+/usage.statistics.xml
 /workspace.xml

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,0 @@
-com.ibm.wala

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$" />
+            <option value="$PROJECT_DIR$/buildSrc" />
+            <option value="$PROJECT_DIR$/com.ibm.wala-repository" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.cast" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.cast.java" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.cast.java.ecj" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.cast.java.test" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.cast.java.test.data" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.cast.js" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.cast.js.html.nu_validator" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.cast.js.nodejs" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.cast.js.nodejs.test" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.cast.js.rhino" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.cast.js.rhino.test" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.cast.js.test" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.cast.js.test.data" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.cast.test" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.core" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.core.testdata" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.core.tests" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.dalvik" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.dalvik.test" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.ide" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.ide.jdt" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.ide.jdt.test" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.ide.jsdt" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.ide.jsdt.tests" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.ide.tests" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.ide_feature" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.scandroid" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.shrike" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.tests.ide_feature" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.tests_feature" />
+            <option value="$PROJECT_DIR$/com.ibm.wala.util" />
+            <option value="$PROJECT_DIR$/com.ibm.wala_feature" />
+          </set>
+        </option>
+        <option name="useAutoImport" value="true" />
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/.idea/runConfigurations/After_Opening_Pristine_Project.xml
+++ b/.idea/runConfigurations/After_Opening_Pristine_Project.xml
@@ -1,0 +1,20 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="After Opening Pristine Project" type="GradleRunConfiguration" factoryName="Gradle" singleton="true">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="prepareIntelliJIDEA" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <method />
+  </configuration>
+</component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="" vcs="Git" />
   </component>
 </project>

--- a/README-Gradle.md
+++ b/README-Gradle.md
@@ -141,6 +141,63 @@ plugin](https://docs.gradle.org/current/userguide/eclipse_plugin.html).
 A few WALA sub-projects already use this:  look for `eclipse.project`
 in `*/build.gradle` for examples.
 
+## IntelliJ IDEA
+
+### Opening WALA in IntelliJ IDEA
+
+WALA comes preconfigured as an openable IntelliJ IDEA project.  Open
+the top-level WALA directory as a project; it should have a
+distinctive badge on its folder icon marking it as a directory
+containing a recognized IntelliJ IDEA project.  Do *not* open the
+top-level WALA `build.gradle` in that directory as a project:  this
+will begin an “Import Project from Gradle” process that is *not* the
+recommended way to bring WALA up in IntelliJ IDEA.
+
+The first time you open the WALA project, IntelliJ IDEA will
+synchronize its project model with the Gradle build configuration,
+including downloading some large supporting libraries.  After the
+lengthy import process completes, **use “Run → Run… → After Opening
+Pristine Project” to perform some post-import configuration.** This
+also can take tens of minutes, but is only necessary in a clean,
+never-previously-built tree.  Immediately after importing, you may see
+some Java compilation errors in the IntelliJ IDEA “Messages” view.
+These should all go away after running the “After Opening Pristine
+Project” step.  [Be
+patient](#external-dependencies-patience-is-a-virtue) during the
+initial project open and also during the “After Opening Pristine
+Project” step, especially if you have a slow network connection.
+
+If you prefer a non-interactive approach, instead of using “After
+Opening Pristine Project” you can run `./gradlew prepareIntelliJIDEA`
+either before or after opening WALA in IntelliJ IDEA.
+
+### Benign Warning About Non-Managed Maven Project
+
+Each time you open the WALA project, IntelliJ IDEA may report
+“Non-managed pom.xml file found” in its event log.  This arises
+because WALA supports both Gradle and Maven, but WALA in IntelliJ IDEA
+needs only the Gradle configuration.  You can safely ignore this
+notification, permanently disable it using the offered “Disable
+notification” link, or even disable the IntelliJ IDEA Maven plugin
+entirely if you have no other need for it.
+
+### Project Configuration as Derived Model
+
+IntelliJ IDEA automatically derives its project models from the Gradle
+build configuration, including all information about both internal and
+external build dependencies.  However, this synchronization only goes
+in one direction: from Gradle to IntelliJ IDEA, not from IntelliJ IDEA
+back into Gradle.  If you manipulate the project structure using the
+IntelliJ IDEA’s user interface, your changes will likely be
+overwritten the next time IntelliJ IDEA scans the Gradle build
+configuration.
+
+This particularly applies to settings found in the “Modules” and
+“Libraries” sections of the “Project Structure” dialog.  The right way
+to change module and library settings is to change the Gradle
+configuration such that the *derived* IntelliJ IDEA model is what you
+want it to be.
+
 ## Gradle Command Line
 
 You do not need to install Gradle separately.  **WALA includes its own

--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ subprojects { subproject ->
 	jar.manifest.from('META-INF/MANIFEST.MF')
 
 	task afterEclipseBuildshipImport(dependsOn: processTestResources)
-	task afterIntelliJIDEAOpen
+	task prepareIntelliJIDEA
 
 	test {
 		include '**/*Test.class'

--- a/com.ibm.wala.cast.test/build.gradle
+++ b/com.ibm.wala.cast.test/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 eclipse.project.natures 'org.eclipse.pde.PluginNature'
-afterIntelliJIDEAOpen.dependsOn jarTest
+prepareIntelliJIDEA.dependsOn jarTest
 
 sourceSets.test.java.srcDirs = ['harness-src/java']
 

--- a/com.ibm.wala.dalvik.test/build.gradle
+++ b/com.ibm.wala.dalvik.test/build.gradle
@@ -93,7 +93,7 @@ clean.dependsOn cleanCopyDxJar
 
 compileTestJava.dependsOn copyDxJar
 afterEclipseBuildshipImport.dependsOn copyDxJar
-afterIntelliJIDEAOpen.dependsOn copyDxJar
+prepareIntelliJIDEA.dependsOn copyDxJar
 
 task copyAndroidJar(type: Sync, dependsOn: installAndroidSdk) {
 	from "${installAndroidSdk.destinationDir}/platforms/${installAndroidSdk.components['platforms']}/android.jar"


### PR DESCRIPTION
We already had some IntelliJ IDEA project metadata files in `.idea`. I've revisited and updated those now that I have more experience with Gradle + IntelliJ IDEA + Git.  I think this now represents a better set of decisions regarding what does and does not belong in version control.

This commit also extends `README-Gradle.md` with [clear instructions on how to bring up WALA as a top-level IntelliJ IDEA project](https://github.com/liblit/WALA/blob/WALA-as-IntelliJ-IDEA-project/README-Gradle.md#intellij-idea).  The instructions are of a similar flavor to the Eclipse instructions that were already present, though the details vary.  Most notably, with IntelliJ IDEA you should *open* WALA as an existing project, not *import* it as a new Gradle project derived from `build.gradle`. This is exactly the reverse of what one should and shouldn't do for WALA in Eclipse.