### PR TITLE
Add API to add an InputStream for a jar to an AnalysisScope

### DIFF
--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cha/AnalysisScopeTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cha/AnalysisScopeTest.java
@@ -1,0 +1,42 @@
+package com.ibm.wala.core.tests.cha;
+
+import com.ibm.wala.core.tests.util.TestConstants;
+import com.ibm.wala.ipa.callgraph.AnalysisScope;
+import com.ibm.wala.ipa.cha.ClassHierarchy;
+import com.ibm.wala.ipa.cha.ClassHierarchyException;
+import com.ibm.wala.ipa.cha.ClassHierarchyFactory;
+import com.ibm.wala.types.ClassLoaderReference;
+import com.ibm.wala.types.TypeReference;
+import com.ibm.wala.util.config.AnalysisScopeReader;
+import com.ibm.wala.util.io.FileProvider;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class AnalysisScopeTest {
+
+  @Test
+  public void testJarInputStream() throws IOException, ClassHierarchyException {
+    AnalysisScope scope = AnalysisScopeReader.readJavaScope(TestConstants.WALA_TESTDATA,
+        (new FileProvider()).getFile("J2SEClassHierarchyExclusions.txt"),
+        AnalysisScopeTest.class.getClassLoader());
+    // assumes com.ibm.wala.core.tests is the current working directory
+    Path bcelJarPath = Paths.get(
+        System.getProperty("user.dir"),
+        "..",
+        "com.ibm.wala.core.testdata",
+        "bcel-5.2.jar"
+    );
+    scope.addInputStreamForJarToScope(ClassLoaderReference.Application, new FileInputStream
+        (bcelJarPath.toString()));
+    ClassHierarchy cha = ClassHierarchyFactory.make(scope);
+    Assert.assertNotNull("couldn't find expected class", cha.lookupClass(
+        TypeReference.findOrCreate(ClassLoaderReference.Application,
+            "Lorg/apache/bcel/verifier/Verifier")));
+  }
+}

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cha/MissingSuperTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cha/MissingSuperTest.java
@@ -43,7 +43,8 @@ public class MissingSuperTest extends WalaTestCase {
   @Test
   public void testMissingSuper() throws IOException, ClassHierarchyException {
     AnalysisScope scope = AnalysisScopeReader.readJavaScope(TestConstants.WALA_TESTDATA,
-        (new FileProvider()).getFile("J2SEClassHierarchyExclusions.txt"), DupFieldsTest.class.getClassLoader());
+        (new FileProvider()).getFile("J2SEClassHierarchyExclusions.txt"),
+        MissingSuperTest.class.getClassLoader());
     TypeReference ref = TypeReference.findOrCreate(ClassLoaderReference.Application,
         "Lmissingsuper/MissingSuper");
     // without phantom classes, won't be able to resolve

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/AnalysisScope.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/AnalysisScope.java
@@ -214,6 +214,12 @@ public class AnalysisScope {
     s.add(new ClassFileModule(file, null));
   }
 
+  /**
+   * Add a jar file to the scope via an {@link InputStream}.  NOTE: The InputStream should *not*
+   * be a {@link java.util.jar.JarInputStream}; it should be a regular {@link InputStream} for
+   * the raw bytes of the jar file.
+   *
+   */
   public void addInputStreamForJarToScope(ClassLoaderReference loader, InputStream stream) throws
       IOException {
     MapUtil.findOrCreateList(moduleMap, loader).add(new JarStreamModule(stream));

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/AnalysisScope.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/AnalysisScope.java
@@ -11,6 +11,8 @@
 package com.ibm.wala.ipa.callgraph;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.NotSerializableException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -29,6 +31,7 @@ import com.ibm.wala.classLoader.BinaryDirectoryTreeModule;
 import com.ibm.wala.classLoader.ClassFileModule;
 import com.ibm.wala.classLoader.IClassLoader;
 import com.ibm.wala.classLoader.JarFileModule;
+import com.ibm.wala.classLoader.JarStreamModule;
 import com.ibm.wala.classLoader.Language;
 import com.ibm.wala.classLoader.Module;
 import com.ibm.wala.classLoader.SourceDirectoryTreeModule;
@@ -210,6 +213,12 @@ public class AnalysisScope {
     List<Module> s = MapUtil.findOrCreateList(moduleMap, loader);
     s.add(new ClassFileModule(file, null));
   }
+
+  public void addInputStreamForJarToScope(ClassLoaderReference loader, InputStream stream) throws
+      IOException {
+    MapUtil.findOrCreateList(moduleMap, loader).add(new JarStreamModule(stream));
+  }
+
 
   /**
    * Add a jar file to the scope for a loader


### PR DESCRIPTION
This is useful, e.g., if you have the bytes of a jar file in memory and want to load it into an AnalysisScope.