### PR TITLE
Publish all generated Java bytecode jar archives

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,12 @@ subprojects { subproject ->
 
 	jar.manifest.from('META-INF/MANIFEST.MF')
 
+	publishing.publications {
+		mavenJava(MavenPublication) {
+			from components.java
+		}
+	}
+
 	task afterEclipseBuildshipImport(dependsOn: processTestResources)
 	task prepareIntelliJIDEA
 


### PR DESCRIPTION
These changes allow one to use `./gradlew publishToMavenLocal` to put WALA jar archives in a local Maven repository for subsequent use by other Maven-based projects. We do not have any remote Maven repositories configured, though presumably that would work too if someone cared to set it up. I doubted whether this work work properly on the first try to fix #326. Apparently it does, at least to @msridhar’s satisfaction. Cool!

Note for future work: this change does nothing special in support of the Eclipse Provisioning Platform (p2). If p2 repositories are still considered important, then more work would be needed before Gradle could replace Maven entirely. liblit/WALA#6 has some discussion on this.