### PR TITLE
Turn off a Gradle warning about Gradle 5.0 incompatibility

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -35,3 +35,5 @@ include(
 	'com.ibm.wala.util',
 	'com.ibm.wala_feature',
 )
+
+enableFeaturePreview('STABLE_PUBLISHING')


### PR DESCRIPTION
The issue here is a planned change to how `publishing` blocks work. Per [the Gradle documentation](https://docs.gradle.org/4.9/userguide/publishing_maven.html#publishing_maven:deferred_configuration), the right way to prepare for this change is to enable it and check for unexpected changes in what gets published to a local repository. I have done this, and find no unexpected changes.

So we are actually ready for Gradle 5.0; the warning is a false positive for us.  Leaving the future change enabled means we won’t keep seeing this warning.  It also means that any further changes to our use of `publishing` will be tested under that future change, which is a good way to avoid surprises later.