### PR TITLE
Avoid Exceptions with Phantom Superclasses

### DIFF
--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/BytecodeClass.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/BytecodeClass.java
@@ -296,7 +296,8 @@ public abstract class BytecodeClass<T extends IClassLoader> implements IClass {
       computeSuperclass();
     }
     if (superClass == null && !getReference().equals(TypeReference.JavaLangObject)) {
-      throw new NoSuperclassFoundException("No superclass found for " + this + " Superclass name " + superName);
+      //throw new NoSuperclassFoundException("No superclass found for " + this + " Superclass name " + superName);
+      return null;
     }
     return superClass;
   }

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/PhantomClass.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/PhantomClass.java
@@ -53,7 +53,8 @@ public class PhantomClass extends SyntheticClass {
 
   @Override
   public IMethod getMethod(Selector selector) {
-    throw new UnsupportedOperationException();
+    //throw new UnsupportedOperationException();
+    return null;
   }
 
   @Override


### PR DESCRIPTION
@msridhar /cc @lazaroclapp
Building the CFG fails with `NoSuperclassFoundException` when a callee method has a _phantom_ superclass.
Continue by returning `null` instead.