### PR TITLE
Categorize Eclipse sources as main vs. test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -164,3 +164,21 @@ allprojects {
 		options.addStringOption('Xdoclint:none', '-quiet')
 	}
 }
+
+
+////////////////////////////////////////////////////////////////////////
+//
+//  Eclipse IDE integration
+//
+
+// workaround for <https://github.com/gradle/gradle/issues/4802>
+allprojects {
+	apply plugin: 'eclipse'
+
+	eclipse.classpath.file.whenMerged {
+		entries.each {
+			if (it in org.gradle.plugins.ide.eclipse.model.AbstractClasspathEntry && it.entryAttributes['gradle_used_by_scope'] == 'test')
+				it.entryAttributes['test'] = true
+		}
+	}
+}


### PR DESCRIPTION
This leverages [new Eclipse 4.8 (Photon) features that distinguish main code from test code](https://www.eclipse.org/photon/noteworthy/index.php#test-sources). An eventual fix to an [open feature request](https://github.com/gradle/gradle/issues/4802) might mean that Buildship starts doing this automatically, but for now we can do it ourselves.

If using an older Eclipse release, this change does nothing useful, but neither does it cause any harm.