### PR TITLE
Improvements for Kawa- and JNI-related Gradle build tasks

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -3,5 +3,5 @@ repositories {
 }
 
 dependencies {
-	compile 'de.undercouch:gradle-download-task:3.4.1'
+	compile 'de.undercouch:gradle-download-task:3.4.3'
 }

--- a/com.ibm.wala.cast.test/build.gradle
+++ b/com.ibm.wala.cast.test/build.gradle
@@ -111,6 +111,15 @@ model {
 
 			// all combined as a colon-delimited path list
 			args pathElements.join(':')
+
+			// log output to file, although we don't validate it
+			final def outFile = file("$temporaryDir/stdout-and-stderr.log")
+			outputs.file outFile
+			doFirst {
+				final def fileStream = new FileOutputStream(outFile)
+				standardOutput fileStream
+				errorOutput fileStream
+			}
 		}
 
 		check.dependsOn checkSmoke_main

--- a/com.ibm.wala.core.testdata/.gitignore
+++ b/com.ibm.wala.core.testdata/.gitignore
@@ -1,0 +1,1 @@
+/kawa-chess/

--- a/com.ibm.wala.core.testdata/build.gradle
+++ b/com.ibm.wala.core.testdata/build.gradle
@@ -270,22 +270,3 @@ task cleanColllectTestDataA(type: Delete) {
 }
 
 clean.dependsOn cleanCollectTestDataA
-
-
-////////////////////////////////////////////////////////////////////////
-//
-//  help Eclipse build these extra jars when needed
-//
-
-afterEclipseBuildshipImport {
-	dependsOn(
-		collectJLex,
-		collectTestData,
-		collectTestDataA,
-		downloadJavaCup,
-		extractBcel,
-		generateHelloHashJar,
-		buildChessJar,
-		buildKawaTestJar,
-		)
-}

--- a/com.ibm.wala.core.testdata/build.gradle
+++ b/com.ibm.wala.core.testdata/build.gradle
@@ -1,8 +1,3 @@
-buildscript {
-  repositories { mavenCentral() }
-  dependencies { classpath 'org.ajoberstar:gradle-git:0.2.3' }
-}
-
 plugins {
 	id 'eclipse'
 }
@@ -11,94 +6,90 @@ eclipse.project.natures 'org.eclipse.pde.PluginNature'
 
 sourceSets.test.java.srcDirs = ['src']
 
+
 ////////////////////////////////////////////////////////////////////////
 //
 //  download and extract kawa 3.0 "kawa.jar"
 //
 
-task downloadKawa(type: Exec) {
-     commandLine "wget", "ftp://ftp.gnu.org/pub/gnu/kawa/kawa-3.0.zip"
-     workingDir "$temporaryDir"
-     def destination = file("$temporaryDir/kawa-3.0.zip")
-     enabled = !destination.exists() //to clone only once
+task downloadKawa(type: VerifiedDownload) {
+	ext.version = '3.0'
+	final def archive = "kawa-${version}.zip"
+	src "https://ftp.gnu.org/pub/gnu/kawa/$archive"
+	dest "$temporaryDir/$archive"
+	checksum '2713e6dfb939274ba3b1d36daea68436'
 }
 
-task extractKawa(type: Copy, dependsOn: downloadKawa) {
-	from(zipTree("${downloadKawa.temporaryDir}/kawa-3.0.zip")) {
-		include "kawa-3.0/lib/kawa.jar"
+task extractKawa(type: Sync, dependsOn: downloadKawa) {
+	from(zipTree(downloadKawa.dest)) {
+		include "kawa-${downloadKawa.version}/lib/kawa.jar"
 		eachFile {
 			relativePath new RelativePath(!directory, relativePath.lastName)
 		}
 	}
-	into projectDir
+	into temporaryDir
 	includeEmptyDirs false
-	outputs.file 'kawa.jar'
-	def destination = file('kawa.jar')
-        enabled = !destination.exists() //to clone only once
+	outputs.file "$temporaryDir/kawa.jar"
 }
 
-task cleanExtractKawa(type: Delete) {
-	delete files(extractKawa)[0]
-}
-
-clean.dependsOn cleanExtractKawa
 
 ////////////////////////////////////////////////////////////////////////
 //
-//  build kawa chess
+//  specialized task for Kawa compilation into jar archive
 //
-import org.ajoberstar.gradle.git.tasks.*
 
-task getKawaChess(type: GitClone) {
-        def destination = file("kawa-chess")
-        uri = "https://github.com/ttu-fpclub/kawa-chess"
-        destinationPath = destination
-        bare = false
-        enabled = !destination.exists() //to clone only once
+@CacheableTask
+class CompileKawaJar extends Jar {
+
+	@Nested final def compile = project.task("compileKawaInto${name.capitalize()}", type: JavaExec) {
+		dependsOn(project.extractKawa)
+		final def kawaJar = project.files(project.extractKawa)[0]
+		classpath kawaJar
+		main 'kawa.repl'
+
+		args '-d', temporaryDir
+		outputs.dir temporaryDir
+
+		logging.captureStandardError LogLevel.INFO
+		args '--main', '-C'
+	}
+
+	CompileKawaJar() {
+		compile.dependsOn(dependsOn)
+		from compile
+		version null
+	}
+
+	void setArgs(Object... args) {
+		compile.args args
+	}
 }
 
-task compileChessFiles(type: JavaExec) {
-	def kawaImg = file('kawa-chess/img.scm')
-	def kawaPos = file('kawa-chess/pos.scm')
-	def kawaChess = file('kawa-chess/chess.scm')
-	def kawaGui = file('kawa-chess/gui.scm')
-	inputs.file kawaImg
-	inputs.file kawaPos
-	inputs.file kawaChess
-	inputs.file kawaGui
 
-	workingDir = file('kawa-chess')
+////////////////////////////////////////////////////////////////////////
+//
+//  download, unpack, and build kawa chess
+//
 
-	def kawaJar = new File("kawa.jar")
-	inputs.file kawaJar
-	classpath kawaJar
-
-	main 'kawa.repl'
-	args '-C', 'img.scm', 'pos.scm', 'chess.scm', 'gui.scm'
+task downloadKawaChess(type: VerifiedDownload) {
+	ext.commitHash = 'f1d2dcc707a1ef19dc159e2eaee5aecc8a41d7a8'
+	src "https://github.com/ttu-fpclub/kawa-chess/archive/${commitHash}.zip"
+	dest "$temporaryDir/kawa-chess.zip"
+	checksum 'cf29613d2be5f476a475ee28b4df9d9e'
 }
 
-compileChessFiles.dependsOn extractKawa
-compileChessFiles.dependsOn getKawaChess
-
-task compileChessMain(type: JavaExec, dependsOn: compileChessFiles) {
-	def kawaJar = new File("kawa.jar")
-	inputs.file kawaJar
-	classpath kawaJar
-
-	workingDir = file("kawa-chess")
-
-	def kawaMain = file('kawa-chess/main.scm')
-	inputs.file kawaMain
-
-	main 'kawa.repl'
-	args '--main', '-C', 'main.scm'
+task unpackKawaChess(type: Sync, dependsOn: downloadKawaChess) {
+	from zipTree(downloadKawaChess.dest)
+	into temporaryDir
+	ext.top = "$destinationDir/kawa-chess-${downloadKawaChess.commitHash}"
 }
 
-task buildChessJar(type: Jar, dependsOn: compileChessMain) {
-	from file('kawa-chess')
+task buildChessJar(type: CompileKawaJar, dependsOn: unpackKawaChess) {
+	final def schemePath = { "$unpackKawaChess.top/${it}.scm" }
+	final def schemeFiles = files(['chess', 'gui', 'img', 'main', 'pos'].collect(schemePath))
+	args schemePath('main')
+	inputs.files schemeFiles
 	baseName 'kawachess'
-	version null
-	destinationDir projectDir
 }
 
 
@@ -107,25 +98,11 @@ task buildChessJar(type: Jar, dependsOn: compileChessMain) {
 //  build the kawa test jar
 //
 
-task compileKawaTestMain(type: JavaExec, dependsOn: extractKawa) {
-	def kawaJar = new File("kawa.jar")
-	inputs.file kawaJar
-	classpath kawaJar
-
-	workingDir file('kawasrc')
-	
-        def kawaMain = file('kawasrc/test.scm')
-	inputs.file kawaMain
-
-	main 'kawa.repl'
-	args '--main', '-C', 'test.scm'
-}
-
-task buildKawaTestJar(type: Jar, dependsOn: compileKawaTestMain) {
-	from file('kawasrc')
+task buildKawaTestJar(type: CompileKawaJar) {
+	final def schemeFile = file('kawasrc/test.scm')
+	args schemeFile
+	inputs.files schemeFile
 	baseName 'kawatest'
-	version null
-	destinationDir projectDir
 }
 
 


### PR DESCRIPTION
Recent WALA changes added several new downloads and build tasks related to the [Kawa Scheme language](https://www.gnu.org/software/kawa/). This pull request [reworks the Gradle build logic for those tasks](https://github.com/wala/WALA/commit/febf20145e5fe495764c9e476b6ef0c803fe32fe) to make better use of Gradle infrastructure: incremental builds, precise dependency management, build caching, integrated download support, etc. We get all of this in 28% fewer lines of build code thanks to factoring out repeated logic and leveraging existing Gradle facilities.

I’m also sneaking in a [small tweak](https://github.com/wala/WALA/commit/a7cef8e77abc91bab47d557ac4485fe4801fa175) to add declared outputs for a JNI-related test task. Without those declared outputs, this task could not be cached and was always treated as out-of-date.