### PR TITLE
Fix the comparison method for ConstantKey

### DIFF
--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/ConstantKey.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/ConstantKey.java
@@ -37,7 +37,7 @@ public final class ConstantKey<T> implements InstanceKey {
   public boolean equals(Object obj) {
     if (obj instanceof ConstantKey) {
       ConstantKey other = (ConstantKey) obj;
-      return value == null ? other.value == null : value.equals(other.value);
+      return valueClass.equals(other.valueClass) ? (value == null ? other.value == null : value.equals(other.value)) : false;
     } else {
       return false;
     }


### PR DESCRIPTION
For cross language analysis using WALA, ``ConstantKey`` should be compared using both of the type and value to distinguish same constant values having different types due to the languages.