### PR TITLE
Added a CAstNode and a CAstOperator to support some wanted python features.

### DIFF
--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/CAstNode.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/CAstNode.java
@@ -113,6 +113,7 @@ public interface CAstNode {
   public static final int ECHO = 25;
   public static final int YIELD_STMT = 26;
   public static final int FORIN_LOOP = 27;
+  public static final int GLOBAL_DECL = 28;
 
   // expression kinds
   public static final int FUNCTION_EXPR = 100;

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/impl/CAstOperator.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/impl/CAstOperator.java
@@ -88,6 +88,7 @@ public class CAstOperator implements CAstNode {
   public final static CAstOperator OP_BIT_XOR = new CAstOperator("^");
   public final static CAstOperator OP_REL_XOR = new CAstOperator("^^");
   public final static CAstOperator OP_IN = new CAstOperator("in");
+  public final static CAstOperator OP_NOT_IN = new CAstOperator("not in");
 
 }
 


### PR DESCRIPTION
I'm in the process of attempting to support more python features.
I added the GLOBAL_DECL CAstNode to model the python global statement.
I also added the OP_NOT_IN CAstOperator to support the "not in" operation, as WALA would crash for any script including this operation.