### PR TITLE
Fixes #360  Exception in AndroidAnalysisScope 

### DIFF
--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidAnalysisScope.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidAnalysisScope.java
@@ -33,16 +33,19 @@ public class AndroidAnalysisScope {
 
 	public static AnalysisScope setUpAndroidAnalysisScope(URI classpath, String exclusions, ClassLoader loader, URI... androidLib) throws IOException {
 		AnalysisScope scope;
+		File exclusionsFile = exclusions != null? new File(exclusions) : null;
+
 		if (androidLib == null || androidLib.length == 0) {
-			scope = AnalysisScopeReader.readJavaScope(BASIC_FILE, new File(exclusions), loader);
+			scope = AnalysisScopeReader.readJavaScope(BASIC_FILE, exclusionsFile, loader);
 		} else {
 			scope = AnalysisScope.createJavaAnalysisScope();
 
-			File exclusionsFile = new File(exclusions);
-	        try (final InputStream fs = exclusionsFile.exists()? new FileInputStream(exclusionsFile): FileProvider.class.getClassLoader().getResourceAsStream(exclusionsFile.getName())) {
-	        	scope.setExclusions(new FileOfClasses(fs));
-	        }
-	        
+			if (exclusionsFile != null) {
+				try (final InputStream fs = exclusionsFile.exists() ? new FileInputStream(exclusionsFile) : FileProvider.class.getClassLoader().getResourceAsStream(exclusionsFile.getName())) {
+					scope.setExclusions(new FileOfClasses(fs));
+				}
+			}
+
 			scope.setLoaderImpl(ClassLoaderReference.Primordial,
 					"com.ibm.wala.dalvik.classLoader.WDexClassLoaderImpl");
 


### PR DESCRIPTION
Fixes inconsistent behavior of the exclusions argument.
Depending on the androidLib argument, setting exclusions to null
is either fine or raises an exception.

This patch makes exclusions truely optional for any case
when null is passed.