### PR TITLE
Don’t copy an entire array just to iterate over its elements

### DIFF
--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/SSACFG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/SSACFG.java
@@ -11,6 +11,7 @@
 package com.ibm.wala.ssa;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -838,11 +839,7 @@ public class SSACFG implements ControlFlowGraph<SSAInstruction, ISSABasicBlock>,
    */
   @Override
   public Iterator<ISSABasicBlock> iterator() {
-    ArrayList<ISSABasicBlock> list = new ArrayList<>();
-    for (BasicBlock b : basicBlocks) {
-      list.add(b);
-    }
-    return list.iterator();
+    return Arrays.<ISSABasicBlock>asList(basicBlocks).iterator();
   }
 
   /*


### PR DESCRIPTION
Don’t copy an entire array just to iterate over its elements. Instead, use `ArrayList::asList` to create a `List` backed by the existing array. Strictly speaking, these are not equivalent: the array-backed list is read-only, whereas the list copied from an array is modifiable.  But I strongly suspect that nobody is modifying the list used here anyway, so we may as well avoid the O(_n_) copy operation.