### PR TITLE
New IntelliJ IDEA project metadata file for file encoding settings

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with NO BOM" />
+</project>


### PR DESCRIPTION
IntelliJ IDEA 2018.3 added this automatically.  The encoding it represents is to _not_ add a byte-order mark (BOM) to new UTF-8 files. That’s what the existing files use, and is presumably what we want in the future.