### PR TITLE
Remove com.ibm.wala.dalvik dependency on CAst

### DIFF
--- a/com.ibm.wala.dalvik/META-INF/MANIFEST.MF
+++ b/com.ibm.wala.dalvik/META-INF/MANIFEST.MF
@@ -4,8 +4,7 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: com.ibm.wala.dalvik
 Bundle-Version: 1.5.1.qualifier
 Require-Bundle: com.ibm.wala.core;bundle-version="1.1.3",
- com.ibm.wala.shrike;bundle-version="1.3.1",
- com.ibm.wala.cast;bundle-version="1.0.0"
+ com.ibm.wala.shrike;bundle-version="1.3.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy 
 Export-Package: com.google.common.annotations,

--- a/com.ibm.wala.dalvik/build.gradle
+++ b/com.ibm.wala.dalvik/build.gradle
@@ -4,7 +4,6 @@ dependencies {
 	compile(
 		'org.slf4j:slf4j-api:1.7.2',
 		'org.smali:dexlib2:2.2.5',
-		project(':com.ibm.wala.cast'),
 		project(':com.ibm.wala.core'),
 		project(':com.ibm.wala.shrike'),
 		project(':com.ibm.wala.util'),

--- a/com.ibm.wala.dalvik/mvncentral.xml
+++ b/com.ibm.wala.dalvik/mvncentral.xml
@@ -54,11 +54,6 @@
     </dependency>
     <dependency>
       <groupId>com.ibm.wala</groupId>
-      <artifactId>com.ibm.wala.cast</artifactId>
-      <version>1.5.1-SNAPSHOT</version>
-    </dependency>
-    <dependency>
-      <groupId>com.ibm.wala</groupId>
       <artifactId>com.ibm.wala.shrike</artifactId>
       <version>1.5.1-SNAPSHOT</version>
     </dependency>

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/dex/instructions/BinaryLiteralOperation.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/dex/instructions/BinaryLiteralOperation.java
@@ -48,9 +48,9 @@
 
 package com.ibm.wala.dalvik.dex.instructions;
 
+import com.ibm.wala.dalvik.dex.instructions.BinaryOperation.DalvikBinaryOp;
 import org.jf.dexlib2.Opcode;
 
-import com.ibm.wala.cast.ir.ssa.CAstBinaryOp;
 import com.ibm.wala.dalvik.classLoader.DexIMethod;
 import com.ibm.wala.dalvik.classLoader.Literal;
 import com.ibm.wala.shrikeBT.IBinaryOpInstruction;
@@ -90,21 +90,21 @@ public class BinaryLiteralOperation extends Instruction {
         switch(op)
         {
         case CMPL_FLOAT:
-            return CAstBinaryOp.LT;
+            return DalvikBinaryOp.LT;
         case CMPG_FLOAT:
-            return CAstBinaryOp.GT;
+            return DalvikBinaryOp.GT;
         case CMPL_DOUBLE:
-            return CAstBinaryOp.LT;
+            return DalvikBinaryOp.LT;
         case CMPG_DOUBLE:
-            return CAstBinaryOp.GT;
+            return DalvikBinaryOp.GT;
         case CMPL_LONG:
-            return CAstBinaryOp.LT;
+            return DalvikBinaryOp.LT;
         case CMPG_LONG:
-            return CAstBinaryOp.GT;
+            return DalvikBinaryOp.GT;
         case CMPL_INT:
-            return CAstBinaryOp.LT;
+            return DalvikBinaryOp.LT;
         case CMPG_INT:
-            return CAstBinaryOp.GT;
+            return DalvikBinaryOp.GT;
         case ADD_INT:
             return IBinaryOpInstruction.Operator.ADD;
         case RSUB_INT:

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/dex/instructions/BinaryOperation.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/dex/instructions/BinaryOperation.java
@@ -50,14 +50,13 @@ package com.ibm.wala.dalvik.dex.instructions;
 
 import org.jf.dexlib2.Opcode;
 
-import com.ibm.wala.cast.ir.ssa.CAstBinaryOp;
 import com.ibm.wala.dalvik.classLoader.DexIMethod;
 import com.ibm.wala.shrikeBT.IBinaryOpInstruction;
 import com.ibm.wala.shrikeBT.IShiftInstruction;
 
 public class BinaryOperation extends Instruction {
 
-    public static enum OpID {CMPL_FLOAT,CMPG_FLOAT,
+    public enum OpID {CMPL_FLOAT,CMPG_FLOAT,
         CMPL_DOUBLE,CMPG_DOUBLE,
         CMPL_LONG,CMPG_LONG,
         CMPL_INT,CMPG_INT,
@@ -65,6 +64,18 @@ public class BinaryOperation extends Instruction {
         ADD_LONG,SUB_LONG,MUL_LONG,DIV_LONG,REM_LONG,AND_LONG,OR_LONG,XOR_LONG,SHL_LONG,SHR_LONG,USHR_LONG,
         ADD_FLOAT,SUB_FLOAT,MUL_FLOAT,DIV_FLOAT,REM_FLOAT,
         ADD_DOUBLE,SUB_DOUBLE,MUL_DOUBLE,DIV_DOUBLE,REM_DOUBLE}
+
+    /**
+     * for binary ops not defined in JVML
+     */
+    public enum DalvikBinaryOp implements IBinaryOpInstruction.IOperator {
+        LT, GT;
+
+        @Override
+        public String toString() {
+            return super.toString().toLowerCase();
+        }
+    }
 
     public final OpID op;
     public final int oper1;
@@ -87,21 +98,21 @@ public class BinaryOperation extends Instruction {
     public IBinaryOpInstruction.IOperator getOperator() {
         switch(op) {
         case CMPL_FLOAT:
-            return CAstBinaryOp.LT;
+            return DalvikBinaryOp.LT;
         case CMPG_FLOAT:
-            return CAstBinaryOp.GT;
+            return DalvikBinaryOp.GT;
         case CMPL_DOUBLE:
-            return CAstBinaryOp.LT;
+            return DalvikBinaryOp.LT;
         case CMPG_DOUBLE:
-            return CAstBinaryOp.GT;
+            return DalvikBinaryOp.GT;
         case CMPL_LONG:
-            return CAstBinaryOp.LT;
+            return DalvikBinaryOp.LT;
         case CMPG_LONG:
-            return CAstBinaryOp.GT;
+            return DalvikBinaryOp.GT;
         case CMPL_INT:
-            return CAstBinaryOp.LT;
+            return DalvikBinaryOp.LT;
         case CMPG_INT:
-            return CAstBinaryOp.GT;
+            return DalvikBinaryOp.GT;
         case ADD_INT:
             return IBinaryOpInstruction.Operator.ADD;
         case SUB_INT:

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/dex/instructions/UnaryOperation.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/dex/instructions/UnaryOperation.java
@@ -50,7 +50,6 @@ package com.ibm.wala.dalvik.dex.instructions;
 
 import org.jf.dexlib2.Opcode;
 
-import com.ibm.wala.cast.ir.ssa.CAstUnaryOp;
 import com.ibm.wala.dalvik.classLoader.DexIMethod;
 import com.ibm.wala.shrikeBT.IUnaryOpInstruction;
 import com.ibm.wala.shrikeBT.IUnaryOpInstruction.IOperator;
@@ -58,7 +57,20 @@ import com.ibm.wala.util.debug.Assertions;
 
 public class UnaryOperation extends Instruction {
 
-    public static enum OpID {MOVE, MOVE_WIDE, MOVE_EXCEPTION, NOT, NEGINT, NOTINT, NEGLONG, NOTLONG, NEGFLOAT, NEGDOUBLE, DOUBLETOLONG, DOUBLETOFLOAT, INTTOBYTE, INTTOCHAR, INTTOSHORT, DOUBLETOINT, FLOATTODOUBLE, FLOATTOLONG, FLOATTOINT, LONGTODOUBLE, LONGTOFLOAT, LONGTOINT, INTTODOUBLE, INTTOFLOAT, INTTOLONG}
+    public enum OpID {MOVE, MOVE_WIDE, MOVE_EXCEPTION, NOT, NEGINT, NOTINT, NEGLONG, NOTLONG, NEGFLOAT, NEGDOUBLE, DOUBLETOLONG, DOUBLETOFLOAT, INTTOBYTE, INTTOCHAR, INTTOSHORT, DOUBLETOINT, FLOATTODOUBLE, FLOATTOLONG, FLOATTOINT, LONGTODOUBLE, LONGTOFLOAT, LONGTOINT, INTTODOUBLE, INTTOFLOAT, INTTOLONG}
+
+    /**
+     * for unary ops not defined in JVML
+     */
+    public enum DalvikUnaryOp implements IUnaryOpInstruction.IOperator {
+        BITNOT;
+
+        @Override
+        public String toString() {
+            return super.toString().toLowerCase();
+        }
+
+    }
 
     public final OpID op;
     public final int source;
@@ -119,15 +131,15 @@ public class UnaryOperation extends Instruction {
         {
         // SSA unary ops
         case NOT:
-            return CAstUnaryOp.BITNOT;
+            return DalvikUnaryOp.BITNOT;
         case NEGINT:
             return IUnaryOpInstruction.Operator.NEG;
         case NOTINT:
-            return CAstUnaryOp.BITNOT;
+            return DalvikUnaryOp.BITNOT;
         case NEGLONG:
             return IUnaryOpInstruction.Operator.NEG;
         case NOTLONG:
-            return CAstUnaryOp.BITNOT;
+            return DalvikUnaryOp.BITNOT;
         case NEGFLOAT:
             return IUnaryOpInstruction.Operator.NEG;
         case NEGDOUBLE:


### PR DESCRIPTION
We don't want this dependency since Dalvik is not an AST-based frontend.  Removal required creating a couple of new enums in the Dalvik package.  This will break any clients that relied on the old CAst enum values, unfortunately, and I don't know a good way to make that a compile-time failure.  But we should still break this bad dependence.

/cc @reddr 

Issue pointed out in #393 