### PR TITLE
Duplicate code cleanup related to CAstRewriter.copynodes

### DIFF
--- a/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/examples/ast/SynchronizedBlockDuplicator.java
+++ b/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/examples/ast/SynchronizedBlockDuplicator.java
@@ -229,15 +229,7 @@ public class SynchronizedBlockDuplicator extends
     } else {
       // invoke copyNodes() on the children with context c, ensuring, e.g., that
       // the body of a synchronized block gets cloned
-      CAstNode[] newChildren = new CAstNode[n.getChildCount()];
-      for (int i = 0; i < newChildren.length; i++)
-        newChildren[i] = copyNodes(n.getChild(i), cfg, c, nodeMap);
-
-      CAstNode newN = Ast.makeNode(n.getKind(), newChildren);
-
-      nodeMap.put(Pair.make(n, c.key()), newN);
-
-      return newN;
+      return copySubtreesIntoNewNode(n, cfg, c, nodeMap);
     }
   }
 }

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/ArgumentSpecialization.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/ArgumentSpecialization.java
@@ -249,15 +249,7 @@ public class ArgumentSpecialization {
               } 
               
               if (result == null) {
-                CAstNode children[] = new CAstNode[root.getChildCount()];
-                for (int i = 0; i < children.length; i++) {
-                  children[i] = copyNodes(root.getChild(i), cfg, context, nodeMap);
-                }
-                for(Object label: cfg.getTargetLabels(root)) {
-                  if (label instanceof CAstNode) {
-                    copyNodes((CAstNode)label, cfg, context, nodeMap);
-                  }
-                }
+                CAstNode[] children = copyChildrenArrayAndTargets(root, cfg, context, nodeMap);
                 CAstNode copy = Ast.makeNode(root.getKind(), children);
                 result = copy;
               }

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/translator/PropertyReadExpander.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/translator/PropertyReadExpander.java
@@ -300,15 +300,7 @@ public class PropertyReadExpander extends CAstRewriter<PropertyReadExpander.Rewr
       return root;
 
     } else {
-      CAstNode children[] = new CAstNode[root.getChildCount()];
-      for (int i = 0; i < children.length; i++) {
-        children[i] = copyNodes(root.getChild(i), cfg, READ, nodeMap);
-      }
-      for(Object label: cfg.getTargetLabels(root)) {
-        if (label instanceof CAstNode) {
-          copyNodes((CAstNode)label, cfg, READ, nodeMap);
-        }
-      }
+      CAstNode[] children = copyChildrenArrayAndTargets(root, cfg, READ, nodeMap);
       CAstNode copy = Ast.makeNode(kind, children);
       nodeMap.put(Pair.make(root, context.key()), copy);
       return copy;

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/ConstantFoldingRewriter.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/ConstantFoldingRewriter.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package com.ibm.wala.cast.ir.translator;
 
-import java.util.Collection;
 import java.util.Map;
 
 import com.ibm.wala.cast.tree.CAst;
@@ -68,21 +67,7 @@ public abstract class ConstantFoldingRewriter extends CAstBasicRewriter<NonCopyi
       result = root;
       
     } else {
-      CAstNode children[] = new CAstNode[root.getChildCount()];
-      for (int i = 0; i < children.length; i++) {
-        children[i] = copyNodes(root.getChild(i), cfg, context, nodeMap);
-      }
-      if (cfg != null) {
-        Collection<Object> labels = cfg.getTargetLabels(root);
-        if (labels != null) {
-          for(Object label: labels) {
-            if (label instanceof CAstNode) {
-              copyNodes((CAstNode)label, cfg, context, nodeMap);
-            } 
-          }
-        }
-      }
-      
+      CAstNode[] children = copyChildrenArrayAndTargets(root, cfg, context, nodeMap);
       CAstNode copy = Ast.makeNode(root.getKind(), children);
       result = copy;
     }

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/rewrite/AstLoopUnwinder.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/rewrite/AstLoopUnwinder.java
@@ -138,15 +138,7 @@ public class AstLoopUnwinder
 			  
       return code;
     } else {
-	CAstNode[] newChildren = new CAstNode[ n.getChildCount() ];
-	for(int i = 0; i < newChildren.length; i++) 
-	  newChildren[i] = copyNodes(n.getChild(i), cfg, c, nodeMap);
-			  
-	CAstNode newN = Ast.makeNode(n.getKind(), newChildren);
-			  			
-	nodeMap.put(Pair.make(n, c.key()), newN);
-	
-	return newN; 
+        return copySubtreesIntoNewNode(n, cfg, c, nodeMap);
     }
   }	  
 }

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/rewrite/CAstCloner.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/rewrite/CAstCloner.java
@@ -37,8 +37,12 @@ public class CAstCloner extends CAstBasicRewriter<CAstBasicRewriter.NonCopyingCo
   }
 
   @Override
-  protected CAstNode copyNodes(CAstNode root, final CAstControlFlowMap cfg, NonCopyingContext c, Map<Pair<CAstNode,NoKey>, CAstNode> nodeMap) {
-    final Pair<CAstNode, NoKey> pairKey = Pair.make(root, c.key());
+  protected CAstNode copyNodes(CAstNode root, final CAstControlFlowMap cfg, NonCopyingContext context, Map<Pair<CAstNode,NoKey>, CAstNode> nodeMap) {
+    final Pair<CAstNode, NoKey> pairKey = Pair.make(root, context.key());
+    return copyNodes(root, cfg, context, nodeMap, pairKey);
+  }
+
+  protected CAstNode copyNodes(CAstNode root, CAstControlFlowMap cfg, NonCopyingContext context, Map<Pair<CAstNode, NoKey>, CAstNode> nodeMap, Pair<CAstNode, NoKey> pairKey) {
     if (root instanceof CAstOperator) {
       nodeMap.put(pairKey, root);
       return root;
@@ -48,16 +52,7 @@ public class CAstCloner extends CAstBasicRewriter<CAstBasicRewriter.NonCopyingCo
       nodeMap.put(pairKey, copy);
       return copy;
     } else {
-      CAstNode newChildren[] = new CAstNode[root.getChildCount()];
-
-      for (int i = 0; i < root.getChildCount(); i++) {
-        newChildren[i] = copyNodes(root.getChild(i), cfg, c, nodeMap);
-      }
-
-      CAstNode copy = Ast.makeNode(root.getKind(), newChildren);
-      assert !nodeMap.containsKey(pairKey);
-      nodeMap.put(pairKey, copy);
-      return copy;
+      return copySubtreesIntoNewNode(root, cfg, context, nodeMap, pairKey);
     }
   }
 


### PR DESCRIPTION
Found using a mix of IntelliJ IDEA duplicate-code-finding tools and manual inspection.  Refactored using a mix of IntelliJ IDEA refactoring tools and manual edits.