### PR TITLE
Expose AST node children as overt List rather than covert array

### DIFF
--- a/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/CAstDumper.java
+++ b/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/CAstDumper.java
@@ -129,8 +129,8 @@ public class CAstDumper {
 	
 	private int getNonTrivialChildCount(CAstNode node) {
 	  int cnt = 0;
-	  for(int i=0;i<node.getChildCount();++i)
-	    if(!isTrivial(node.getChild(i)))
+	  for (CAstNode child : node.getChildren())
+	    if (!isTrivial(child))
 	      ++cnt;
 	  return cnt;
 	}
@@ -141,9 +141,9 @@ public class CAstDumper {
 	    return;
 		// normalise away single-child block expressions
 		if(NORMALISE && node.getKind() == CAstNode.BLOCK_EXPR && getNonTrivialChildCount(node) == 1) {
-		  for(int i=0;i<node.getChildCount();++i)
-		    if(!isTrivial(node.getChild(i)))
-		      dump(node.getChild(i), indent, buf, cfg);
+		  for (CAstNode child : node.getChildren())
+		    if (!isTrivial(child))
+		      dump(child, indent, buf, cfg);
 		} else {
 			buf.append(indent(indent)).append(labeller.addNode(node)).append(": ");
 			if(node.getKind() == CAstNode.CONSTANT) {
@@ -178,8 +178,7 @@ public class CAstDumper {
 				buf.append(']');
 			}
 			buf.append('\n');
-			for(int i=0;i<node.getChildCount();++i) {
-				CAstNode child = node.getChild(i);
+			for (CAstNode child : node.getChildren()) {
 				// omit empty statements in a block
 				if(NORMALISE && node.getKind() == CAstNode.BLOCK_STMT && child != null && child.getKind() == CAstNode.EMPTY)
 					continue;

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/ArgumentSpecialization.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/ArgumentSpecialization.java
@@ -249,7 +249,7 @@ public class ArgumentSpecialization {
               } 
               
               if (result == null) {
-                CAstNode[] children = copyChildrenArrayAndTargets(root, cfg, context, nodeMap);
+                final List<CAstNode> children = copyChildrenArrayAndTargets(root, cfg, context, nodeMap);
                 CAstNode copy = Ast.makeNode(root.getKind(), children);
                 result = copy;
               }

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/ArgumentSpecialization.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/ArgumentSpecialization.java
@@ -237,7 +237,7 @@ public class ArgumentSpecialization {
                    for (CAstNode c : s.getMultiple("args")) {
                      x.add(copyNodes(c, cfg, context, nodeMap));
                    }
-                   result = Ast.makeNode(CAstNode.CALL, x.toArray(new CAstNode[0]));
+                   result = Ast.makeNode(CAstNode.CALL, x);
                  }
                 }
                

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/CorrelatedPairExtractionPolicy.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/CorrelatedPairExtractionPolicy.java
@@ -226,8 +226,9 @@ public class CorrelatedPairExtractionPolicy extends ExtractionPolicy {
     
     // special hack to handle "var p = ..., x = y[p];", where startNode = "y[p]"
     if(block.getChild(0).getKind() == CAstNode.BLOCK_STMT && start == 0) {
+      final Iterator<CAstNode> blockChild = block.getChild(0).getChildren().iterator();
       for(start_inner=0;start_inner<block.getChild(0).getChildCount();++start_inner)
-        if(NodePos.inSubtree(startNode.getChild(), block.getChild(0).getChild(start_inner)))
+        if(NodePos.inSubtree(startNode.getChild(), blockChild.next()))
           return Pair.make(block, new TwoLevelExtractionRegion(start, end, start_inner, end_inner, Collections.singletonList(parmName), locals));
     }
     // special hack to handle the case where we're extracting the body of a local scope

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/NodePos.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/NodePos.java
@@ -43,8 +43,8 @@ public abstract class NodePos implements CAstRewriter.RewriteContext<CAstBasicRe
 			return true;
 		if(tree == null)
 			return false;
-		for(int i=0;i<tree.getChildCount();++i)
-			if(inSubtree(node, tree.getChild(i)))
+		for(CAstNode child : tree.getChildren())
+			if(inSubtree(node, child))
 				return true;
 		return false;
 	}

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/translator/JavaScriptTranslatorToCAst.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/translator/JavaScriptTranslatorToCAst.java
@@ -10,8 +10,8 @@
  *******************************************************************************/
 package com.ibm.wala.cast.js.translator;
 
-import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.Vector;
 
@@ -41,7 +41,7 @@ public interface JavaScriptTranslatorToCAst extends TranslatorToCAst {
       getParent().addNameDecl(n);
     }
 
-    default Collection<CAstNode> getNameDecls() {
+    default List<CAstNode> getNameDecls() {
       return getParent().getNameDecls();
     }
 
@@ -81,7 +81,7 @@ public interface JavaScriptTranslatorToCAst extends TranslatorToCAst {
     }
 
     @Override
-    public Collection<CAstNode> getNameDecls() {
+    public List<CAstNode> getNameDecls() {
       Assertions.UNREACHABLE();
       return null;
     }
@@ -127,7 +127,7 @@ public interface JavaScriptTranslatorToCAst extends TranslatorToCAst {
     public void addNameDecl(CAstNode v) { initializers.add(v); }
 
     @Override
-    public Collection<CAstNode> getNameDecls() { return initializers; }
+    public List<CAstNode> getNameDecls() { return initializers; }
 
     @Override
     public String script() {

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/translator/PropertyReadExpander.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/translator/PropertyReadExpander.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.wala.cast.js.translator;
 
+import java.util.List;
 import java.util.Map;
 
 import com.ibm.wala.cast.ir.translator.AstTranslator.InternalCAstSymbol;
@@ -300,7 +301,7 @@ public class PropertyReadExpander extends CAstRewriter<PropertyReadExpander.Rewr
       return root;
 
     } else {
-      CAstNode[] children = copyChildrenArrayAndTargets(root, cfg, READ, nodeMap);
+      final List<CAstNode> children = copyChildrenArrayAndTargets(root, cfg, READ, nodeMap);
       CAstNode copy = Ast.makeNode(kind, children);
       nodeMap.put(Pair.make(root, context.key()), copy);
       return copy;

--- a/com.ibm.wala.cast.test/harness-src/java/com/ibm/wala/cast/test/TestCAstPattern.java
+++ b/com.ibm.wala.cast.test/harness-src/java/com/ibm/wala/cast/test/TestCAstPattern.java
@@ -12,6 +12,7 @@ package com.ibm.wala.cast.test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -34,16 +35,16 @@ public class TestCAstPattern extends WalaTestCase {
     private final Map<String, Object> testNameMap = new HashMap<>();
 
     @Override
-    public CAstNode makeNode(int kind, CAstNode... children) {
+    public CAstNode makeNode(int kind, List<CAstNode> children) {
       if (kind == NAME_ASSERTION_SINGLE || kind == NAME_ASSERTION_MULTI) {
-        assert children.length == 2;
-        final Object child0Value = children[0].getValue();
+        assert children.size() == 2;
+        final Object child0Value = children.get(0).getValue();
         assert child0Value instanceof String;
         final String name = (String) child0Value;
         @SuppressWarnings("unused")
-        CAstNode result = children[1];
+        CAstNode result = children.get(1);
         if (kind == NAME_ASSERTION_SINGLE) {
-          testNameMap.put(name, children[1]);
+          testNameMap.put(name, children.get(1));
         } else {
           @SuppressWarnings("unchecked")
           ArrayList<CAstNode> nodeList = (ArrayList<CAstNode>) testNameMap.get(name);
@@ -51,9 +52,9 @@ public class TestCAstPattern extends WalaTestCase {
             nodeList = new ArrayList<>();
             testNameMap.put(name, nodeList);
           }
-          nodeList.add(children[1]);
+          nodeList.add(children.get(1));
         }
-        return children[1];
+        return children.get(1);
       } else {
         return super.makeNode(kind, children);
       }

--- a/com.ibm.wala.cast.test/harness-src/java/com/ibm/wala/cast/test/TestCAstPattern.java
+++ b/com.ibm.wala.cast.test/harness-src/java/com/ibm/wala/cast/test/TestCAstPattern.java
@@ -34,7 +34,7 @@ public class TestCAstPattern extends WalaTestCase {
     private final Map<String, Object> testNameMap = new HashMap<>();
 
     @Override
-    public CAstNode makeNode(int kind, CAstNode children[]) {
+    public CAstNode makeNode(int kind, CAstNode... children) {
       if (kind == NAME_ASSERTION_SINGLE || kind == NAME_ASSERTION_MULTI) {
         assert children.length == 2;
         final Object child0Value = children[0].getValue();

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/ConstantFoldingRewriter.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/ConstantFoldingRewriter.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.ibm.wala.cast.ir.translator;
 
+import java.util.List;
 import java.util.Map;
 
 import com.ibm.wala.cast.tree.CAst;
@@ -67,7 +68,7 @@ public abstract class ConstantFoldingRewriter extends CAstBasicRewriter<NonCopyi
       result = root;
       
     } else {
-      CAstNode[] children = copyChildrenArrayAndTargets(root, cfg, context, nodeMap);
+      List<CAstNode> children = copyChildrenArrayAndTargets(root, cfg, context, nodeMap);
       CAstNode copy = Ast.makeNode(root.getKind(), children);
       result = copy;
     }

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/TranslatorToCAst.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/TranslatorToCAst.java
@@ -328,8 +328,8 @@ public interface TranslatorToCAst {
   default <X extends WalkContext<X,Y>, Y> void pushSourcePosition(WalkContext<X, Y> context, CAstNode n, Position p) {
     if (context.pos().getPosition(n) == null && !(n.getKind()==CAstNode.FUNCTION_EXPR || n.getKind()==CAstNode.FUNCTION_STMT)) {
         context.pos().setPosition(n, p);
-        for(int i = 0; i < n.getChildCount(); i++) {
-          pushSourcePosition(context, n.getChild(i), p);
+        for(CAstNode child : n.getChildren()) {
+          pushSourcePosition(context, child, p);
         }
     }
   }

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/CAst.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/CAst.java
@@ -10,6 +10,8 @@
  *****************************************************************************/
 package com.ibm.wala.cast.tree;
 
+import java.util.List;
+
 /**
  *  The main interface for creating CAPA Abstract Syntax Trees.  This
  * interface provides essentially a factory for creating AST nodes in
@@ -46,10 +48,13 @@ public interface CAst {
   CAstNode makeNode(int kind, CAstNode c1, CAstNode c2, CAstNode c3, CAstNode c4, CAstNode c5, CAstNode c6);
 
   /** Make a node of type kind specifying an array of children. */
-  CAstNode makeNode(int kind, CAstNode[] cs);
+  CAstNode makeNode(int kind, CAstNode... cs);
 
   /** Make a node of type kind giving a first child and array of the rest. */
   CAstNode makeNode(int kind, CAstNode firstChild, CAstNode[] otherChildren);
+
+  /** Make a node of type kind specifying a list of children. */
+  CAstNode makeNode(int kind, List<CAstNode> cs);
 
   /** Make a boolean constant node. */
   CAstNode makeConstant(boolean value);

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/CAstControlFlowMap.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/CAstControlFlowMap.java
@@ -12,8 +12,6 @@ package com.ibm.wala.cast.tree;
 
 import java.util.Collection;
 
-import com.ibm.wala.util.debug.Assertions;
-
 /**
  * The control flow information for the CAPA AST of a particular entity. An ast
  * may contain various nodes that pertain to control flow---such as gotos,
@@ -38,7 +36,7 @@ public interface CAstControlFlowMap {
    * A distinguished target that means this control flow is the target of an
    * uncaught exception.
    */
-  public static final CAstNode EXCEPTION_TO_EXIT = new CAstNode() {
+  public static final CAstNode EXCEPTION_TO_EXIT = new CAstLeafNode() {
     @Override
     public int getKind() {
       return CAstNode.CONSTANT;
@@ -47,17 +45,6 @@ public interface CAstControlFlowMap {
     @Override
     public Object getValue() {
       return this;
-    }
-
-    @Override
-    public CAstNode getChild(int n) {
-      Assertions.UNREACHABLE();
-      return null;
-    }
-
-    @Override
-    public int getChildCount() {
-      return 0;
     }
 
     @Override

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/CAstLeafNode.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/CAstLeafNode.java
@@ -1,0 +1,20 @@
+package com.ibm.wala.cast.tree;
+
+import java.util.NoSuchElementException;
+
+/**
+ * Convenience interface for implementing an AST node with no children
+ */
+public interface CAstLeafNode extends CAstNode {
+
+    @Override
+    default CAstNode getChild(int n) {
+        throw new NoSuchElementException("leaf AST node has no children");
+    }
+
+    @Override
+    default int getChildCount() {
+        return 0;
+    }
+
+}

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/CAstLeafNode.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/CAstLeafNode.java
@@ -1,6 +1,7 @@
 package com.ibm.wala.cast.tree;
 
-import java.util.NoSuchElementException;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Convenience interface for implementing an AST node with no children
@@ -8,13 +9,8 @@ import java.util.NoSuchElementException;
 public interface CAstLeafNode extends CAstNode {
 
     @Override
-    default CAstNode getChild(int n) {
-        throw new NoSuchElementException("leaf AST node has no children");
-    }
-
-    @Override
-    default int getChildCount() {
-        return 0;
+    default List<CAstNode> getChildren() {
+        return Collections.emptyList();
     }
 
 }

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/CAstNode.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/CAstNode.java
@@ -10,6 +10,9 @@
  *****************************************************************************/
 package com.ibm.wala.cast.tree;
 
+import java.util.List;
+import java.util.NoSuchElementException;
+
 /**
  *  This interface represents nodes of CAPA Abstract Syntax Trees.  It
  * is a deliberately minimal interface, simply assuming that the nodes
@@ -196,11 +199,21 @@ public interface CAstNode {
    *  Return the nth child of this node.  If there is no such child,
    * this method should throw a NoSuchElementException.
    */
-  CAstNode getChild(int n);
+  default CAstNode getChild(int n) {
+    try {
+      return getChildren().get(n);
+    } catch (IndexOutOfBoundsException e) {
+      throw new NoSuchElementException(e.getMessage());
+    }
+  }
 
   /**
    * How many children does this node have?
    */
-  int getChildCount();
+  default int getChildCount() {
+    return getChildren().size();
+  }
+
+  List<CAstNode> getChildren();
 
 }

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/CAstNode.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/CAstNode.java
@@ -11,7 +11,6 @@
 package com.ibm.wala.cast.tree;
 
 import java.util.List;
-import java.util.NoSuchElementException;
 
 /**
  *  This interface represents nodes of CAPA Abstract Syntax Trees.  It
@@ -197,14 +196,10 @@ public interface CAstNode {
 
   /**
    *  Return the nth child of this node.  If there is no such child,
-   * this method should throw a NoSuchElementException.
+   * this method should throw an IndexOutOfBoundsException.
    */
   default CAstNode getChild(int n) {
-    try {
-      return getChildren().get(n);
-    } catch (IndexOutOfBoundsException e) {
-      throw new NoSuchElementException(e.getMessage());
-    }
+    return getChildren().get(n);
   }
 
   /**

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/impl/CAstImpl.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/impl/CAstImpl.java
@@ -10,7 +10,9 @@
  *****************************************************************************/
 package com.ibm.wala.cast.tree.impl;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import com.ibm.wala.cast.tree.CAst;
@@ -88,45 +90,45 @@ public class CAstImpl implements CAst {
 
   @Override
   public CAstNode makeNode(int kind, CAstNode c1, CAstNode[] cs) {
-    CAstNode[] children = new CAstNode[cs.length + 1];
-    children[0] = c1;
-    System.arraycopy(cs, 0, children, 1, cs.length);
+    List<CAstNode> children = new ArrayList<>(cs.length + 1);
+    children.add(c1);
+    children.addAll(Arrays.asList(cs));
     return makeNode(kind, children);
   }
 
   @Override
   public CAstNode makeNode(int kind) {
-    return makeNode(kind, new CAstNode[0]);
+    return makeNode(kind, Collections.emptyList());
   }
 
   @Override
   public CAstNode makeNode(int kind, CAstNode c1) {
-    return makeNode(kind, new CAstNode[] { c1 });
+    return makeNode(kind, Collections.singletonList(c1));
   }
 
   @Override
   public CAstNode makeNode(int kind, CAstNode c1, CAstNode c2) {
-    return makeNode(kind, new CAstNode[] { c1, c2 });
+    return makeNode(kind, Arrays.asList(c1, c2));
   }
 
   @Override
   public CAstNode makeNode(int kind, CAstNode c1, CAstNode c2, CAstNode c3) {
-    return makeNode(kind, new CAstNode[] { c1, c2, c3 });
+    return makeNode(kind, Arrays.asList(c1, c2, c3));
   }
 
   @Override
   public CAstNode makeNode(int kind, CAstNode c1, CAstNode c2, CAstNode c3, CAstNode c4) {
-    return makeNode(kind, new CAstNode[] { c1, c2, c3, c4 });
+    return makeNode(kind, Arrays.asList(c1, c2, c3, c4));
   }
 
   @Override
   public CAstNode makeNode(int kind, CAstNode c1, CAstNode c2, CAstNode c3, CAstNode c4, CAstNode c5) {
-    return makeNode(kind, new CAstNode[] { c1, c2, c3, c4, c5 });
+    return makeNode(kind, Arrays.asList(c1, c2, c3, c4, c5));
   }
 
   @Override
   public CAstNode makeNode(int kind, CAstNode c1, CAstNode c2, CAstNode c3, CAstNode c4, CAstNode c5, CAstNode c6) {
-    return makeNode(kind, new CAstNode[] { c1, c2, c3, c4, c5, c6 });
+    return makeNode(kind, Arrays.asList(c1, c2, c3, c4, c5, c6));
   }
 
   @Override

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/impl/CAstImpl.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/impl/CAstImpl.java
@@ -13,6 +13,7 @@ package com.ibm.wala.cast.tree.impl;
 import java.util.NoSuchElementException;
 
 import com.ibm.wala.cast.tree.CAst;
+import com.ibm.wala.cast.tree.CAstLeafNode;
 import com.ibm.wala.cast.tree.CAstNode;
 import com.ibm.wala.cast.util.CAstPrinter;
 
@@ -136,7 +137,7 @@ public class CAstImpl implements CAst {
     return makeNode(kind, new CAstNode[] { c1, c2, c3, c4, c5, c6 });
   }
 
-  protected static class CAstValueImpl implements CAstNode {
+  protected static class CAstValueImpl implements CAstLeafNode {
     protected final Object value;
 
     protected CAstValueImpl(Object value) {
@@ -151,16 +152,6 @@ public class CAstImpl implements CAst {
     @Override
     public Object getValue() {
       return value;
-    }
-
-    @Override
-    public CAstNode getChild(int n) {
-      throw new NoSuchElementException();
-    }
-
-    @Override
-    public int getChildCount() {
-      return 0;
     }
 
     @Override

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/impl/CAstImpl.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/impl/CAstImpl.java
@@ -10,7 +10,8 @@
  *****************************************************************************/
 package com.ibm.wala.cast.tree.impl;
 
-import java.util.NoSuchElementException;
+import java.util.Arrays;
+import java.util.List;
 
 import com.ibm.wala.cast.tree.CAst;
 import com.ibm.wala.cast.tree.CAstLeafNode;
@@ -34,16 +35,16 @@ public class CAstImpl implements CAst {
   }
 
   protected static class CAstNodeImpl implements CAstNode {
-    protected final CAstNode[] cs;
+    protected final List<CAstNode> cs;
 
     protected final int kind;
 
-    protected CAstNodeImpl(int kind, CAstNode[] cs) {
+    protected CAstNodeImpl(int kind, List<CAstNode> cs) {
       this.kind = kind;
       this.cs = cs;
 
-      for (int i = 0; i < cs.length; i++)
-        assert cs[i] != null : "argument " + i + " is null for node kind " + kind + " [" + CAstPrinter.entityKindAsString(kind)
+      for (int i = 0; i < cs.size(); i++)
+        assert cs.get(i) != null : "argument " + i + " is null for node kind " + kind + " [" + CAstPrinter.entityKindAsString(kind)
             + ']';
     }
 
@@ -58,17 +59,8 @@ public class CAstImpl implements CAst {
     }
 
     @Override
-    public CAstNode getChild(int n) {
-      try {
-        return cs[n];
-      } catch (ArrayIndexOutOfBoundsException e) {
-        throw new NoSuchElementException(n + " of " + CAstPrinter.print(this));
-      }
-    }
-
-    @Override
-    public int getChildCount() {
-      return cs.length;
+    public List<CAstNode> getChildren() {
+      return cs;
     }
 
     @Override
@@ -90,7 +82,7 @@ public class CAstImpl implements CAst {
   }
 
   @Override
-  public CAstNode makeNode(final int kind, final CAstNode[] cs) {
+  public CAstNode makeNode(final int kind, final List<CAstNode> cs) {
     return new CAstNodeImpl(kind, cs);
   }
 
@@ -135,6 +127,11 @@ public class CAstImpl implements CAst {
   @Override
   public CAstNode makeNode(int kind, CAstNode c1, CAstNode c2, CAstNode c3, CAstNode c4, CAstNode c5, CAstNode c6) {
     return makeNode(kind, new CAstNode[] { c1, c2, c3, c4, c5, c6 });
+  }
+
+  @Override
+  public CAstNode makeNode(int kind, CAstNode... cs) {
+    return makeNode(kind, Arrays.asList(cs));
   }
 
   protected static class CAstValueImpl implements CAstLeafNode {

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/impl/CAstOperator.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/impl/CAstOperator.java
@@ -10,8 +10,7 @@
  *****************************************************************************/
 package com.ibm.wala.cast.tree.impl;
 
-import java.util.NoSuchElementException;
-
+import com.ibm.wala.cast.tree.CAstLeafNode;
 import com.ibm.wala.cast.tree.CAstNode;
 
 /**
@@ -22,7 +21,7 @@ import com.ibm.wala.cast.tree.CAstNode;
  *
  * @author Julian Dolby (dolby@us.ibm.com)
  */
-public class CAstOperator implements CAstNode {
+public class CAstOperator implements CAstLeafNode {
   private final String op;
   
   protected CAstOperator(String op) { 
@@ -42,16 +41,6 @@ public class CAstOperator implements CAstNode {
   @Override
   public Object getValue() { 
     return op;
-  }
-  
-  @Override
-  public CAstNode getChild(int n) {
-    throw new NoSuchElementException(); 
-  }
-    
-  @Override
-  public int getChildCount() { 
-    return 0; 
   }
 
   /*

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/impl/CAstValueImpl.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/impl/CAstValueImpl.java
@@ -44,12 +44,9 @@ public class CAstValueImpl extends CAstImpl {
     @Override
     public boolean equals(Object o) {
       if (! (o instanceof CAstNode)) return false;
-      if (kind != ((CAstNode)o).getKind()) return false;
-      if (((CAstNode)o).getChildCount() != cs.size()) return false;
-      for(int i = 0; i < cs.size(); i++)
-	if (! cs.get(i).equals(((CAstNode)o).getChild(i)))
-	  return false;
-
+      final CAstNode otherNode = (CAstNode) o;
+      if (kind != otherNode.getKind()) return false;
+      if (!getChildren().equals(otherNode.getChildren())) return false;
       return true;
     }
   }

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/impl/CAstValueImpl.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/impl/CAstValueImpl.java
@@ -12,6 +12,8 @@ package com.ibm.wala.cast.tree.impl;
 
 import com.ibm.wala.cast.tree.CAstNode;
 
+import java.util.List;
+
 /**
  * An implementation of CAst, i.e. a simple factory for creating capa
  * ast nodes.  This class simply creates generic nodes with a kind
@@ -26,7 +28,7 @@ public class CAstValueImpl extends CAstImpl {
 
   protected static class CAstNodeValueImpl extends CAstNodeImpl {
       
-    protected CAstNodeValueImpl(int kind, CAstNode cs[]) {
+    protected CAstNodeValueImpl(int kind, List<CAstNode> cs) {
       super(kind, cs);
     }
 
@@ -43,9 +45,9 @@ public class CAstValueImpl extends CAstImpl {
     public boolean equals(Object o) {
       if (! (o instanceof CAstNode)) return false;
       if (kind != ((CAstNode)o).getKind()) return false;
-      if (((CAstNode)o).getChildCount() != cs.length) return false;
-      for(int i = 0; i < cs.length; i++)
-	if (! cs[i].equals(((CAstNode)o).getChild(i)))
+      if (((CAstNode)o).getChildCount() != cs.size()) return false;
+      for(int i = 0; i < cs.size(); i++)
+	if (! cs.get(i).equals(((CAstNode)o).getChild(i)))
 	  return false;
 
       return true;
@@ -53,7 +55,7 @@ public class CAstValueImpl extends CAstImpl {
   }
   
   @Override
-  public CAstNode makeNode(final int kind, final CAstNode[] cs) {
+  public CAstNode makeNode(final int kind, final List<CAstNode> cs) {
     return new CAstNodeValueImpl(kind, cs);
   }
 

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/rewrite/CAstRewriter.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/rewrite/CAstRewriter.java
@@ -15,9 +15,11 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.ibm.wala.cast.tree.CAst;
 import com.ibm.wala.cast.tree.CAstControlFlowMap;
@@ -132,22 +134,19 @@ public abstract class CAstRewriter<C extends CAstRewriter.RewriteContext<K>, K e
   }
 
   protected CAstNode copySubtreesIntoNewNode(CAstNode n, CAstControlFlowMap cfg, C c, Map<Pair<CAstNode, K>, CAstNode> nodeMap, Pair<CAstNode, K> pairKey) {
-    CAstNode[] newChildren = copyChildrenArray(n, cfg, c, nodeMap);
+    final List<CAstNode> newChildren = copyChildrenArray(n, cfg, c, nodeMap);
     CAstNode newN = Ast.makeNode(n.getKind(), newChildren);
     assert !nodeMap.containsKey(pairKey);
     nodeMap.put(pairKey, newN);
     return newN;
   }
 
-  protected CAstNode[] copyChildrenArray(CAstNode n, CAstControlFlowMap cfg, C context, Map<Pair<CAstNode, K>, CAstNode> nodeMap) {
-    CAstNode[] newChildren = new CAstNode[n.getChildCount()];
-    for (int i = 0; i < newChildren.length; i++)
-      newChildren[i] = copyNodes(n.getChild(i), cfg, context, nodeMap);
-    return newChildren;
+  protected List<CAstNode> copyChildrenArray(CAstNode n, CAstControlFlowMap cfg, C context, Map<Pair<CAstNode, K>, CAstNode> nodeMap) {
+    return n.getChildren().stream().map(child -> copyNodes(child, cfg, context, nodeMap)).collect(Collectors.toList());
   }
 
-  protected CAstNode[] copyChildrenArrayAndTargets(CAstNode n, CAstControlFlowMap cfg, C context, Map<Pair<CAstNode, K>, CAstNode> nodeMap) {
-    CAstNode[] children = copyChildrenArray(n, cfg, context, nodeMap);
+  protected List<CAstNode> copyChildrenArrayAndTargets(CAstNode n, CAstControlFlowMap cfg, C context, Map<Pair<CAstNode, K>, CAstNode> nodeMap) {
+    final List<CAstNode> children = copyChildrenArray(n, cfg, context, nodeMap);
     if (cfg != null) {
       final Collection<Object> targetLabels = cfg.getTargetLabels(n);
       if (targetLabels != null)

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/visit/CAstVisitor.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/visit/CAstVisitor.java
@@ -662,9 +662,7 @@ public abstract class CAstVisitor<C extends CAstVisitor.Context> {
       if (visitor.visitNew(n, context, visitor))
         break;
 
-      for(int i = 1; i < n.getChildCount(); i++) {
-	visitor.visit(n.getChild(i), context, visitor);
-      }	  
+      visitChildren(n, 1, context, visitor);
 
       visitor.leaveNew(n, context, visitor);
       break;
@@ -868,9 +866,7 @@ public abstract class CAstVisitor<C extends CAstVisitor.Context> {
       if (visitor.visitEcho(n, context, visitor)) {
 	break;
       }
-      for(int i = 0; i < n.getChildCount(); i++) {
-	visitor.visit(n.getChild(i), context, visitor);
-      }
+      visitAllChildren(n, context, visitor);
       visitor.leaveEcho(n, context, visitor);
       break;
     }
@@ -879,9 +875,7 @@ public abstract class CAstVisitor<C extends CAstVisitor.Context> {
       if (visitor.visitYield(n, context, visitor)) {
   break;
       }
-      for(int i = 0; i < n.getChildCount(); i++) {
-  visitor.visit(n.getChild(i), context, visitor);
-      }
+      visitAllChildren(n, context, visitor);
       visitor.leaveYield(n, context, visitor);
       break;
     }

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/util/CAstFunctions.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/util/CAstFunctions.java
@@ -25,8 +25,8 @@ public class CAstFunctions {
     if (f.test(tree)) {
       return tree;
     } else {
-      for (int i = 0; i < tree.getChildCount(); i++) {
-        CAstNode result = findIf(tree.getChild(i), f);
+      for (final CAstNode child : tree.getChildren()) {
+        CAstNode result = findIf(child, f);
         if (result != null) {
           return result;
         }

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/util/CAstPrinter.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/util/CAstPrinter.java
@@ -250,8 +250,8 @@ public class CAstPrinter {
 	    w.write( " at " + p );
 	if (uglyBrackets) w.write(">");
 	w.write("\n");
-	for(int i = 0; i < top.getChildCount(); i++) {
-	  doPrintTo( top.getChild(i), pos, w, depth+1, uglyBrackets );
+	for(CAstNode child : top.getChildren()) {
+	  doPrintTo( child, pos, w, depth+1, uglyBrackets );
 	}
 	if (uglyBrackets) {
 	  for(int i = 0; i < depth; i++) w.write("  ");

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/util/CAstToDOM.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/util/CAstToDOM.java
@@ -52,8 +52,8 @@ public class CAstToDOM extends CAstPrinter {
     Element nodeElt = doc.createElement(kindAsString(astNode.getKind()));
 
     if (astNode.getValue() == null) {
-      for(int i = 0; i < astNode.getChildCount(); i++) {
-	nodeToDOM(doc, nodeElt, astNode.getChild(i));
+      for(CAstNode child : astNode.getChildren()) {
+	nodeToDOM(doc, nodeElt, child);
       }
 
     } else {


### PR DESCRIPTION
Previously access to AST children was provided via `getChildCount()` and `getChild(int)` methods.  These effectively treated the children as some sort of array-like sequence, but with none of the API conveniences that a proper Java array or `Collection` offers.  Exposing a node’s children as a standard `List` makes it easy for us to write loops over children, create `Iterator`s over children, use bulk operations like `Collections.addAll`, etc.

Most such `List`s of children will actually still be arrays, wrapped up as `ArrayList`. One might fear that this extra level of encapsulation would harm performance. However, I found no consistent performance change across 20 trials of the `com.ibm.wala.core.tests.callGraph*` tests.