### PR TITLE
Fix leak in LambdaSummaryClass

### DIFF
--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/LambdaMethodTargetSelector.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/LambdaMethodTargetSelector.java
@@ -10,9 +10,6 @@
  */
 package com.ibm.wala.ipa.summaries;
 
-import java.util.Map;
-import java.util.WeakHashMap;
-
 import com.ibm.wala.classLoader.CallSiteReference;
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IMethod;
@@ -27,6 +24,8 @@ import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.strings.Atom;
+
+import java.util.Map;
 
 public class LambdaMethodTargetSelector implements MethodTargetSelector {
 

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/LambdaMethodTargetSelector.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/LambdaMethodTargetSelector.java
@@ -89,7 +89,7 @@ public class LambdaMethodTargetSelector implements MethodTargetSelector {
     BootstrapMethod bootstrap = invoke.getBootstrap();
     LambdaSummaryClass result = classSummaries.get(bootstrap);
     if (result == null) {
-      result = LambdaSummaryClass.findOrCreate(caller, invoke);
+      result = LambdaSummaryClass.create(caller, invoke);
       classSummaries.put(bootstrap, result);
     }
     return result;

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/LambdaMethodTargetSelector.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/LambdaMethodTargetSelector.java
@@ -30,7 +30,7 @@ import com.ibm.wala.util.strings.Atom;
 
 public class LambdaMethodTargetSelector implements MethodTargetSelector {
 
-  private final Map<BootstrapMethod, SummarizedMethod> methodSummaries = new WeakHashMap<>();
+  private final Map<BootstrapMethod, SummarizedMethod> methodSummaries = HashMapFactory.make();
 
   private final Map<BootstrapMethod, LambdaSummaryClass> classSummaries = HashMapFactory.make();
 

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/LambdaMethodTargetSelector.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/LambdaMethodTargetSelector.java
@@ -10,6 +10,7 @@
  */
 package com.ibm.wala.ipa.summaries;
 
+import java.util.Map;
 import java.util.WeakHashMap;
 
 import com.ibm.wala.classLoader.CallSiteReference;
@@ -24,13 +25,14 @@ import com.ibm.wala.ssa.SSAInstructionFactory;
 import com.ibm.wala.ssa.SSAInvokeDynamicInstruction;
 import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.TypeReference;
+import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.strings.Atom;
 
 public class LambdaMethodTargetSelector implements MethodTargetSelector {
 
-  private final WeakHashMap<BootstrapMethod, SummarizedMethod> methodSummaries = new WeakHashMap<>();
+  private final Map<BootstrapMethod, SummarizedMethod> methodSummaries = new WeakHashMap<>();
 
-  private final WeakHashMap<BootstrapMethod, LambdaSummaryClass> classSummaries = new WeakHashMap<>();
+  private final Map<BootstrapMethod, LambdaSummaryClass> classSummaries = HashMapFactory.make();
 
 
   private final MethodTargetSelector base;

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/LambdaSummaryClass.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/LambdaSummaryClass.java
@@ -10,12 +10,6 @@
  */
 package com.ibm.wala.ipa.summaries;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
-import java.util.WeakHashMap;
-
 import com.ibm.wala.classLoader.CallSiteReference;
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IField;
@@ -26,7 +20,6 @@ import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.shrikeBT.Constants;
 import com.ibm.wala.shrikeBT.IInvokeInstruction.Dispatch;
-import com.ibm.wala.shrikeCT.BootstrapMethodsReader.BootstrapMethod;
 import com.ibm.wala.shrikeCT.InvalidClassFileException;
 import com.ibm.wala.ssa.SSAInstructionFactory;
 import com.ibm.wala.ssa.SSAInvokeDynamicInstruction;
@@ -40,6 +33,11 @@ import com.ibm.wala.types.annotations.Annotation;
 import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.strings.Atom;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
 
 public class LambdaSummaryClass extends SyntheticClass {
 

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/LambdaSummaryClass.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/LambdaSummaryClass.java
@@ -43,19 +43,13 @@ import com.ibm.wala.util.strings.Atom;
 
 public class LambdaSummaryClass extends SyntheticClass {
 
-  private static WeakHashMap<BootstrapMethod, LambdaSummaryClass> summaries = new WeakHashMap<>();
-  
   public static LambdaSummaryClass findOrCreate(CGNode caller, SSAInvokeDynamicInstruction inst) {
-    if (! summaries.containsKey(inst.getBootstrap())) {
-      String bootstrapCls = caller.getMethod().getDeclaringClass().getName().toString().replace("/", "$").substring(1);
-      int bootstrapIndex = inst.getBootstrap().getIndexInClassFile();
-      TypeReference ref = TypeReference.findOrCreate(ClassLoaderReference.Primordial, "Lwala/lambda" + '$' + bootstrapCls + '$' + bootstrapIndex);
-      LambdaSummaryClass cls = new LambdaSummaryClass(ref, caller.getClassHierarchy(), inst);
-      caller.getClassHierarchy().addClass(cls);
-      summaries.put(inst.getBootstrap(), cls);
-    }
-    
-    return summaries.get(inst.getBootstrap());
+    String bootstrapCls = caller.getMethod().getDeclaringClass().getName().toString().replace("/", "$").substring(1);
+    int bootstrapIndex = inst.getBootstrap().getIndexInClassFile();
+    TypeReference ref = TypeReference.findOrCreate(ClassLoaderReference.Primordial, "Lwala/lambda" + '$' + bootstrapCls + '$' + bootstrapIndex);
+    LambdaSummaryClass cls = new LambdaSummaryClass(ref, caller.getClassHierarchy(), inst);
+    caller.getClassHierarchy().addClass(cls);
+    return cls;
   }
   
   private final SSAInvokeDynamicInstruction invoke;

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/LambdaSummaryClass.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/LambdaSummaryClass.java
@@ -41,7 +41,7 @@ import java.util.Set;
 
 public class LambdaSummaryClass extends SyntheticClass {
 
-  public static LambdaSummaryClass findOrCreate(CGNode caller, SSAInvokeDynamicInstruction inst) {
+  public static LambdaSummaryClass create(CGNode caller, SSAInvokeDynamicInstruction inst) {
     String bootstrapCls = caller.getMethod().getDeclaringClass().getName().toString().replace("/", "$").substring(1);
     int bootstrapIndex = inst.getBootstrap().getIndexInClassFile();
     TypeReference ref = TypeReference.findOrCreate(ClassLoaderReference.Primordial, "Lwala/lambda" + '$' + bootstrapCls + '$' + bootstrapIndex);


### PR DESCRIPTION
Fixes #419 

Move the cache from `LambdaSummaryClass` to `LambdaMethodTargetSelector` and make it non-static.  There should be only one instance of `LambdaMethodTargetSelector` per analysis so this should remove the leak.

Also remove use of `WeakHashMap` as in these cases the keys are reachable from the values via strong references.