### PR TITLE
Teach Travis CI that native components have no Javadoc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - "travis/before-install-$BUILD_SYSTEM"
   - export PATH=$M2_HOME/bin:$PATH
 install:
-  - export submodule=${BUILD_ONLY_SUBMODULE:+:$BUILD_ONLY_SUBMODULE:}
+  - export SUBMODULE_PREFIX=${BUILD_ONLY_SUBMODULE:+:$BUILD_ONLY_SUBMODULE:}
   - "travis/install-$BUILD_SYSTEM"
 script:
   - export AUTH_TOKEN

--- a/travis/install-gradle
+++ b/travis/install-gradle
@@ -1,3 +1,3 @@
 #!/bin/sh -eux
 
-./gradlew --continue --no-build-cache "$submodule"assemble
+./gradlew --continue --no-build-cache "$SUBMODULE_PREFIX"assemble

--- a/travis/script-gradle
+++ b/travis/script-gradle
@@ -2,10 +2,21 @@
 
 case "$TRAVIS_OS_NAME" in
   (linux) headless=xvfb-run ;;
-  (osx) headless='' ;;
+  (osx) headless= ;;
+esac
+
+case "$SUBMODULE_PREFIX" in
+  (:*:*:)
+    # native subsubcomponent: no Java code, so no Javadoc
+    documentation=
+    ;;
+  (*)
+    # Java subcomponent
+    documentation=javadoc
+    ;;
 esac
 
 $headless ./gradlew --continue --no-build-cache --stacktrace \
-	  "$submodule"build \
-	  "$submodule"javadoc \
+	  "$SUBMODULE_PREFIX"build \
+	  ${documentation:+$SUBMODULE_PREFIX$documentation} \
 	  lintGradle


### PR DESCRIPTION
The weekly Travis CI test tries to build each subproject in isolation, to test whether we have any implicit ordering dependencies among subprojects.  Part of that per-subproject work is to build the `javadoc`
task.  For most subprojects, that does what you’d expect:  build the Javadoc documentation for the subproject’s Java code.  For subprojects that build native components, though, there is no Java code and the `javadoc` task doesn’t even exist.

Fixes #424.