### PR TITLE
Add NodeManager stream API

### DIFF
--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/CallGraphTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/CallGraphTest.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -463,6 +464,11 @@ public class CallGraphTest extends WalaTestCase {
       @Override
       public Iterator<MethodReference> iterator() {
         return nodes.iterator();
+      }
+
+      @Override
+      public Stream<MethodReference> stream() {
+        return nodes.stream();
       }
 
       /*

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/pointers/BasicHeapGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/pointers/BasicHeapGraph.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.function.IntFunction;
+import java.util.stream.Stream;
 
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IField;
@@ -80,6 +81,11 @@ public class BasicHeapGraph<T extends InstanceKey> extends HeapGraphImpl<T> {
       @Override
       public Iterator<Object> iterator() {
         return new CompoundIterator<>(pointerKeys.iterator(), P.getInstanceKeyMapping().iterator());
+      }
+
+      @Override
+      public Stream<Object> stream() {
+        return Stream.concat(pointerKeys.stream(), P.getInstanceKeyMapping().stream());
       }
 
       @Override
@@ -405,6 +411,14 @@ public class BasicHeapGraph<T extends InstanceKey> extends HeapGraphImpl<T> {
   @Override
   public Iterator<Object> iterator() {
     return G.iterator();
+  }
+
+  /*
+   * @see com.ibm.wala.util.graph.NodeManager#iterateNodes()
+   */
+  @Override
+  public Stream<Object> stream() {
+    return G.stream();
   }
 
   /*

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/AbstractCFG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/AbstractCFG.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Stream;
 
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.shrikeBT.Constants;
@@ -415,6 +416,11 @@ public abstract class AbstractCFG<I, T extends IBasicBlock<I>> implements Contro
   @Override
   public Iterator<T> iterator() {
     return nodeManager.iterator();
+  }
+
+  @Override
+  public Stream<T> stream() {
+    return nodeManager.stream();
   }
 
   @Override

--- a/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/BackwardsSupergraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/BackwardsSupergraph.java
@@ -12,6 +12,7 @@ package com.ibm.wala.dataflow.IFDS;
 
 import java.util.Iterator;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import com.ibm.wala.util.collections.FilterIterator;
 import com.ibm.wala.util.collections.Iterator2Collection;
@@ -150,6 +151,11 @@ public class BackwardsSupergraph<T, P> implements ISupergraph<T, P> {
   @Override
   public Iterator<T> iterator() {
     return delegate.iterator();
+  }
+
+  @Override
+  public Stream<T> stream() {
+    return delegate.stream();
   }
 
   /*

--- a/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/ICFGSupergraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/ICFGSupergraph.java
@@ -23,6 +23,7 @@ package com.ibm.wala.dataflow.IFDS;
 
 import java.util.Iterator;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import com.ibm.wala.cfg.ControlFlowGraph;
 import com.ibm.wala.ipa.callgraph.CGNode;
@@ -196,6 +197,11 @@ public class ICFGSupergraph implements ISupergraph<BasicBlockInContext<IExploded
   @Override
   public Iterator<BasicBlockInContext<IExplodedBasicBlock>> iterator() {
     return icfg.iterator();
+  }
+
+  @Override
+  public Stream<BasicBlockInContext<IExplodedBasicBlock>> stream() {
+    return icfg.stream();
   }
 
   @Override

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/pruned/PrunedCallGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/pruned/PrunedCallGraph.java
@@ -18,6 +18,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import com.ibm.wala.classLoader.CallSiteReference;
 import com.ibm.wala.classLoader.IMethod;
@@ -64,6 +65,12 @@ public class PrunedCallGraph implements CallGraph {
 		}
 		
 		return col.iterator();
+	}
+
+	@Override
+	public Stream<CGNode> stream() {
+		assert keep.stream().allMatch(cg::containsNode);
+		return keep.stream();
 	}
 
 	@Override

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/cfg/AbstractInterproceduralCFG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/cfg/AbstractInterproceduralCFG.java
@@ -402,13 +402,7 @@ public abstract class AbstractInterproceduralCFG<T extends ISSABasicBlock> imple
    */
   @Override
   public Iterator<BasicBlockInContext<T>> iterator() {
-    if (WARN_ON_EAGER_CONSTRUCTION) {
-      System.err.println("WARNING: forcing full ICFG construction by calling iterator()");
-    }
-    if (FAIL_ON_EAGER_CONSTRUCTION) {
-      throw new UnimplementedError();
-    }
-    constructFullGraph();
+    constructFullGraph("iterator");
     return g.iterator();
   }
 
@@ -417,13 +411,7 @@ public abstract class AbstractInterproceduralCFG<T extends ISSABasicBlock> imple
    */
   @Override
   public Stream<BasicBlockInContext<T>> stream() {
-    if (WARN_ON_EAGER_CONSTRUCTION) {
-      System.err.println("WARNING: forcing full ICFG construction by calling stream()");
-    }
-    if (FAIL_ON_EAGER_CONSTRUCTION) {
-      throw new UnimplementedError();
-    }
-    constructFullGraph();
+    constructFullGraph("stream");
     return g.stream();
   }
 
@@ -432,19 +420,20 @@ public abstract class AbstractInterproceduralCFG<T extends ISSABasicBlock> imple
    */
   @Override
   public int getNumberOfNodes() {
-    if (WARN_ON_EAGER_CONSTRUCTION) {
-      System.err.println("WARNING: forcing full ICFG construction by calling getNumberOfNodes()");
-    }
-    if (FAIL_ON_EAGER_CONSTRUCTION) {
-      throw new UnimplementedError();
-    }
-    constructFullGraph();
+    constructFullGraph("getNumberOfNodes");
     return g.getNumberOfNodes();
   }
 
   private boolean constructedFullGraph = false;
 
-  private void constructFullGraph() {
+  private void constructFullGraph(String onBehalfOf) {
+    if (WARN_ON_EAGER_CONSTRUCTION) {
+      System.err.format("WARNING: forcing full ICFG construction by calling %s()\n", onBehalfOf);
+    }
+    if (FAIL_ON_EAGER_CONSTRUCTION) {
+      throw new UnimplementedError();
+    }
+
     if (!constructedFullGraph) {
       for (CGNode n : cg) {
         addIntraproceduralNodesAndEdgesForCGNodeIfNeeded(n);
@@ -787,13 +776,7 @@ public abstract class AbstractInterproceduralCFG<T extends ISSABasicBlock> imple
 
   @Override
   public int getMaxNumber() {
-    if (WARN_ON_EAGER_CONSTRUCTION) {
-      System.err.println("WARNING: forcing full ICFG construction by calling getMaxNumber()");
-    }
-    if (FAIL_ON_EAGER_CONSTRUCTION) {
-      throw new UnimplementedError();
-    }
-    constructFullGraph();
+    constructFullGraph("getMaxNumber");
     return g.getMaxNumber();
   }
 

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/cfg/AbstractInterproceduralCFG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/cfg/AbstractInterproceduralCFG.java
@@ -14,6 +14,7 @@ import java.util.Iterator;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import com.ibm.wala.cfg.ControlFlowGraph;
 import com.ibm.wala.cfg.IBasicBlock;
@@ -409,6 +410,21 @@ public abstract class AbstractInterproceduralCFG<T extends ISSABasicBlock> imple
     }
     constructFullGraph();
     return g.iterator();
+  }
+
+  /*
+   * @see com.ibm.wala.util.graph.NodeManager#iterateNodes()
+   */
+  @Override
+  public Stream<BasicBlockInContext<T>> stream() {
+    if (WARN_ON_EAGER_CONSTRUCTION) {
+      System.err.println("WARNING: forcing full ICFG construction by calling stream()");
+    }
+    if (FAIL_ON_EAGER_CONSTRUCTION) {
+      throw new UnimplementedError();
+    }
+    constructFullGraph();
+    return g.stream();
   }
 
   /*

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/cfg/PrunedCFG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/cfg/PrunedCFG.java
@@ -17,6 +17,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import com.ibm.wala.cfg.ControlFlowGraph;
 import com.ibm.wala.cfg.IBasicBlock;
@@ -212,6 +213,11 @@ public class PrunedCFG<I, T extends IBasicBlock<I>> extends AbstractNumberedGrap
     @Override
     public Iterator<T> iterator() {
       return filterNodes(nodes.iterator());
+    }
+
+    @Override
+    public Stream<T> stream() {
+      return nodes.stream().filter(subset::contains);
     }
 
     @Override

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/PDG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/PDG.java
@@ -18,6 +18,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import com.ibm.wala.analysis.stackMachine.AbstractIntStackMachine;
 import com.ibm.wala.cfg.ControlFlowGraph;
@@ -1178,6 +1179,12 @@ public class PDG<T extends InstanceKey> implements NumberedGraph<Statement> {
   public Iterator<Statement> iterator() {
     populate();
     return delegate.iterator();
+  }
+
+  @Override
+  public Stream<Statement> stream() {
+    populate();
+    return delegate.stream();
   }
 
   @Override

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/SDGSupergraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/SDGSupergraph.java
@@ -11,6 +11,7 @@
 package com.ibm.wala.ipa.slicer;
 
 import java.util.Iterator;
+import java.util.stream.Stream;
 
 import com.ibm.wala.dataflow.IFDS.ISupergraph;
 import com.ibm.wala.ipa.callgraph.CGNode;
@@ -353,6 +354,11 @@ class SDGSupergraph implements ISupergraph<Statement, PDG<? extends InstanceKey>
   @Override
   public Iterator<Statement> iterator() {
     return sdg.iterator();
+  }
+
+  @Override
+  public Stream<Statement> stream() {
+    return sdg.stream();
   }
 
   @Override

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/thin/CISDG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/thin/CISDG.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
@@ -210,6 +211,11 @@ public class CISDG implements ISDG {
   @Override
   public Iterator<Statement> iterator() {
     return noHeap.iterator();
+  }
+
+  @Override
+  public Stream<Statement> stream() {
+    return noHeap.stream();
   }
 
   @Override

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/SSACFG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/SSACFG.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import com.ibm.wala.cfg.AbstractCFG;
 import com.ibm.wala.cfg.BytecodeCFG;
@@ -827,6 +828,11 @@ public class SSACFG implements ControlFlowGraph<SSAInstruction, ISSABasicBlock>,
   @Override
   public Iterator<ISSABasicBlock> iterator() {
     return Arrays.<ISSABasicBlock>asList(basicBlocks).iterator();
+  }
+
+  @Override
+  public Stream<ISSABasicBlock> stream() {
+    return Arrays.stream(basicBlocks);
   }
 
   /*

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/analysis/ExplodedControlFlowGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/analysis/ExplodedControlFlowGraph.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Stream;
 
 import com.ibm.wala.cfg.ControlFlowGraph;
 import com.ibm.wala.classLoader.IMethod;
@@ -264,6 +265,11 @@ public class ExplodedControlFlowGraph implements ControlFlowGraph<SSAInstruction
   @Override
   public Iterator<IExplodedBasicBlock> iterator() {
     return allNodes.iterator();
+  }
+
+  @Override
+  public Stream<IExplodedBasicBlock> stream() {
+    return allNodes.stream();
   }
 
   @Override

--- a/com.ibm.wala.scandroid/source/org/scandroid/domain/IFDSTaintDomain.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/domain/IFDSTaintDomain.java
@@ -53,6 +53,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import com.ibm.wala.dataflow.IFDS.PathEdge;
 import com.ibm.wala.dataflow.IFDS.TabulationDomain;
@@ -148,6 +149,11 @@ public class IFDSTaintDomain <E extends ISSABasicBlock>
         return table.keySet().iterator();
     }
     
+    @Override
+    public Stream<DomainElement> stream() {
+        return objects.stream();
+    }
+
     public Set<CodeElement> codeElements () {
     	return elementIndex.keySet();
     }

--- a/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/PrefixTransferGraph.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/PrefixTransferGraph.java
@@ -56,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.scandroid.prefixtransfer.StringBuilderUseAnalysis.StringBuilderToStringInstanceKeySite;
 import org.scandroid.prefixtransfer.modeledAllocations.ConstantString;
@@ -225,6 +226,11 @@ public class PrefixTransferGraph implements Graph<InstanceKeySite> {
     @Override
     public Iterator<InstanceKeySite> iterator() {
         return nodes.iterator();
+    }
+
+    @Override
+    public Stream<InstanceKeySite> stream() {
+        return nodes.stream();
     }
 
     @Override

--- a/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/UriPrefixTransferGraph.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/UriPrefixTransferGraph.java
@@ -58,6 +58,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.scandroid.prefixtransfer.StringBuilderUseAnalysis.StringBuilderToStringInstanceKeySite;
 import org.scandroid.prefixtransfer.modeledAllocations.ConstantString;
@@ -344,6 +345,11 @@ public class UriPrefixTransferGraph implements Graph<InstanceKeySite> {
     @Override
     public Iterator<InstanceKeySite> iterator() {
         return nodes.iterator();
+    }
+
+    @Override
+    public Stream<InstanceKeySite> stream() {
+        return nodes.stream();
     }
 
     @Override

--- a/com.ibm.wala.util/src/com/ibm/wala/util/collections/ObjectArrayMapping.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/collections/ObjectArrayMapping.java
@@ -13,6 +13,7 @@ package com.ibm.wala.util.collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.stream.Stream;
 
 import com.ibm.wala.util.debug.Assertions;
 import com.ibm.wala.util.debug.UnimplementedError;
@@ -65,6 +66,11 @@ public class ObjectArrayMapping<T> implements OrdinalSetMapping<T> {
   @Override
   public Iterator<T> iterator() {
     return map.keySet().iterator();
+  }
+
+  @Override
+  public Stream<T> stream() {
+    return map.keySet().stream();
   }
 
   @Override

--- a/com.ibm.wala.util/src/com/ibm/wala/util/graph/AbstractGraph.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/graph/AbstractGraph.java
@@ -11,6 +11,7 @@
 package com.ibm.wala.util.graph;
 
 import java.util.Iterator;
+import java.util.stream.Stream;
 
 import com.ibm.wala.util.collections.Iterator2Iterable;
 
@@ -28,6 +29,11 @@ public abstract class AbstractGraph<T> implements Graph<T> {
    * @return the object which manages edges in the graph
    */
   protected abstract EdgeManager<T> getEdgeManager();
+
+  @Override
+  public Stream<T> stream() {
+    return getNodeManager().stream();
+  }
 
   /*
    * @see com.ibm.wala.util.graph.Graph#iterateNodes()

--- a/com.ibm.wala.util/src/com/ibm/wala/util/graph/GraphSlicer.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/graph/GraphSlicer.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import com.ibm.wala.util.collections.FilterIterator;
 import com.ibm.wala.util.collections.HashSetFactory;
@@ -70,6 +71,11 @@ public class GraphSlicer {
       @Override
       public Iterator<T> iterator() {
         return new FilterIterator<>(g.iterator(), p);
+      }
+
+      @Override
+      public Stream<T> stream() {
+        return g.stream().filter(p);
       }
 
       @Override
@@ -191,6 +197,11 @@ public class GraphSlicer {
       @Override
       public Iterator<E> iterator() {
         return new FilterIterator<>(G.iterator(), fmember);
+      }
+
+      @Override
+      public Stream<E> stream() {
+        return G.stream().filter(fmember);
       }
 
       @Override

--- a/com.ibm.wala.util/src/com/ibm/wala/util/graph/NodeManager.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/graph/NodeManager.java
@@ -12,6 +12,7 @@ package com.ibm.wala.util.graph;
 
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.stream.Stream;
 
 /**
  * An object which tracks graph nodes.
@@ -27,7 +28,14 @@ public interface NodeManager<T> extends Iterable<T> {
    * @return an {@link Iterator} of the nodes in this graph
    */
   @Override
-  public Iterator<T> iterator();
+  default Iterator<T> iterator() {
+    return stream().iterator();
+  }
+
+  /**
+   * @return a {@link Stream} of the nodes in this graph
+   */
+  Stream<T> stream();
 
   /**
    * @return the number of nodes in this graph

--- a/com.ibm.wala.util/src/com/ibm/wala/util/graph/impl/BasicNodeManager.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/graph/impl/BasicNodeManager.java
@@ -13,6 +13,7 @@ package com.ibm.wala.util.graph.impl;
 
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.stream.Stream;
 
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.graph.NodeManager;
@@ -23,6 +24,11 @@ import com.ibm.wala.util.graph.NodeManager;
 public class BasicNodeManager<T> implements NodeManager<T> {
 
   final private HashSet<T> nodes = HashSetFactory.make();
+
+  @Override
+  public Stream<T> stream() {
+    return nodes.stream();
+  }
 
   @Override
   public Iterator<T> iterator() {

--- a/com.ibm.wala.util/src/com/ibm/wala/util/graph/impl/BasicOrderedMultiGraph.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/graph/impl/BasicOrderedMultiGraph.java
@@ -12,6 +12,7 @@ package com.ibm.wala.util.graph.impl;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.collections.SimpleVector;
@@ -108,6 +109,11 @@ public class BasicOrderedMultiGraph<T> implements OrderedMultiGraph<T> {
   @Override
   public Iterator<T> iterator() {
     return delegate.iterator();
+  }
+
+  @Override
+  public Stream<T> stream() {
+    return delegate.stream();
   }
 
   @Override

--- a/com.ibm.wala.util/src/com/ibm/wala/util/graph/impl/DelegatingGraph.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/graph/impl/DelegatingGraph.java
@@ -11,6 +11,7 @@
 package com.ibm.wala.util.graph.impl;
 
 import java.util.Iterator;
+import java.util.stream.Stream;
 
 import com.ibm.wala.util.graph.Graph;
 
@@ -81,6 +82,11 @@ public class DelegatingGraph<T> implements Graph<T> {
   @Override
   public Iterator<T> iterator() {
     return delegate.iterator();
+  }
+
+  @Override
+  public Stream<T> stream() {
+    return delegate.stream();
   }
 
   @Override

--- a/com.ibm.wala.util/src/com/ibm/wala/util/graph/impl/DelegatingNumberedNodeManager.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/graph/impl/DelegatingNumberedNodeManager.java
@@ -12,6 +12,8 @@ package com.ibm.wala.util.graph.impl;
 
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 import com.ibm.wala.util.debug.Assertions;
 import com.ibm.wala.util.graph.INodeWithNumber;
@@ -107,6 +109,12 @@ public class DelegatingNumberedNodeManager<T extends INodeWithNumber> implements
         Assertions.UNREACHABLE();
       }
     };
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public Stream<T> stream() {
+    return Arrays.stream(nodes).filter(Objects::nonNull).map(node -> (T) node);
   }
 
   /*

--- a/com.ibm.wala.util/src/com/ibm/wala/util/graph/impl/ExtensionGraph.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/graph/impl/ExtensionGraph.java
@@ -13,6 +13,7 @@ package com.ibm.wala.util.graph.impl;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import com.ibm.wala.util.collections.CompoundIterator;
 import com.ibm.wala.util.collections.EmptyIterator;
@@ -173,6 +174,11 @@ public class ExtensionGraph<T> implements NumberedGraph<T> {
   @Override
   public Iterator<T> iterator() {
     return new CompoundIterator<>(original.iterator(), additionalNodes.iterator());
+  }
+
+  @Override
+  public Stream<T> stream() {
+    return Stream.concat(original.stream(), additionalNodes.stream());
   }
 
   @Override

--- a/com.ibm.wala.util/src/com/ibm/wala/util/graph/impl/SlowNumberedNodeManager.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/graph/impl/SlowNumberedNodeManager.java
@@ -12,6 +12,7 @@ package com.ibm.wala.util.graph.impl;
 
 import java.io.Serializable;
 import java.util.Iterator;
+import java.util.stream.Stream;
 
 import com.ibm.wala.util.graph.NumberedNodeManager;
 import com.ibm.wala.util.intset.IntSet;
@@ -58,6 +59,10 @@ public class SlowNumberedNodeManager<T> implements NumberedNodeManager<T>, Seria
     return map.iterator();
   }
 
+  @Override
+  public Stream<T> stream() {
+    return map.stream();
+  }
 
   @Override
   public int getNumberOfNodes() {

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/MutableMapping.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/MutableMapping.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.stream.Stream;
 
 import com.ibm.wala.util.collections.HashMapFactory;
 
@@ -125,6 +126,11 @@ public class MutableMapping<T> implements OrdinalSetMapping<T>, Serializable {
   @Override
   public Iterator<T> iterator() {
     return map.keySet().iterator();
+  }
+
+  @Override
+  public Stream<T> stream() {
+    return map.keySet().stream();
   }
 
   /*

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/OffsetOrdinalSetMapping.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/OffsetOrdinalSetMapping.java
@@ -12,6 +12,7 @@ package com.ibm.wala.util.intset;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.stream.Stream;
 
 /**
  * An ordinal set mapping, backed a delegate, but adding an offset to each index.
@@ -75,6 +76,11 @@ public class OffsetOrdinalSetMapping<T> implements OrdinalSetMapping<T> {
   @Override
   public Iterator<T> iterator() {
     return delegate.iterator();
+  }
+
+  @Override
+  public Stream<T> stream() {
+    return delegate.stream();
   }
 
 }

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/OrdinalSetMapping.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/OrdinalSetMapping.java
@@ -11,6 +11,7 @@
 package com.ibm.wala.util.intset;
 
 import java.util.NoSuchElementException;
+import java.util.stream.Stream;
 
 /**
  * An object that implements a bijection between whole numbers and objects.
@@ -47,4 +48,11 @@ public interface OrdinalSetMapping<T> extends Iterable<T> {
    * @return the integer to which the object is mapped.
    */
   public int add(T o);
+
+  /**
+   * Stream over mapped objects.
+   *
+   * @return a stream over the mapped objects
+   */
+  Stream<T> stream();
 }


### PR DESCRIPTION
This allows expressing some graph operations more succinctly by using the Java stream APIs.  However, be cautious: performance implications of Java streams are nontrivial.

For some folks, Java streams have a reputation for poor performance. The reality is more nuanced.  Yes, they can encourage needless abstraction, adding layers of indirect objects, making simple tasks unnecessarily slow.  But they can also speed things up by encouraging use of higher-level bulk operations.  Processing stream elements in parallel can also either boost or harm performance, depending on how many items are being manipulated and much potential concurrency is available.  So … it’s complicated.