### PR TITLE
Allow the build cache to work for verified downloads

### DIFF
--- a/buildSrc/src/main/groovy/verified-download.groovy
+++ b/buildSrc/src/main/groovy/verified-download.groovy
@@ -28,12 +28,6 @@ class VerifiedDownload extends org.gradle.api.DefaultTask {
 		return project.file(dest)
 	}
 
-	VerifiedDownload() {
-		outputs.upToDateWhen {
-			getDest().exists()
-		}
-	}
-
 	@TaskAction
 	downloadAndVerify() {
 		def destFile = getDest()


### PR DESCRIPTION
The build cache would have worked here on its own. Unfortunately I was accidentally disabling it due to an ill-conceived `upToDateWhen` call. See [Gradle issue #8564](https://github.com/gradle/gradle/issues/8584) for more discussion of [why I thought that call was useful](https://github.com/gradle/gradle/issues/8584#issuecomment-466451327), but [why it turned out to be harmful instead](https://github.com/gradle/gradle/issues/8584#issuecomment-466299895).

This should give second and subsequent rebuilds a nice performance boost. It might even speed up our Travis CI builds and make them less flaky, since we ask Travis CI to cache (snapshot and restore) the Gradle build cache across jobs.

That being said, the original `upToDateWhen` call was added to work around a specific problem, whereby Gradle would become convinced that the correct outcome of some download task is to have nothing downloaded at all. Once Gradle gets into this state, there seems to be no way to convince it to reattempt the download short of removing the project’s `.gradle` subdirectory and rebuilding everything from scratch. (Using `./gradlew --rerun-tasks` might work too; I have not tried it yet.) I am still seeing this problem crop up occasionally, as noted [here](https://github.com/gradle/gradle/issues/8584#issuecomment-466458821) and [here](https://github.com/gradle/gradle/issues/8584#issuecomment-466469525). I haven’t been able to reproduce the problem on demand, though. Until I do, **it’s hard to say whether we are better off with or without this change. I am torn, to be honest.**