### PR TITLE
Use an overload to configure tasks more tersely

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ subprojects { subproject ->
 
 	tasks.register('prepareIntelliJIDEA')
 
-	tasks.named('test').configure {
+	tasks.named('test') {
 		include '**/*Test.class'
 		include '**/*TestCase.class'
 		include '**/*Tests.class'
@@ -203,7 +203,7 @@ allprojects {
 final def addCastLibrary(project, recipient) {
 	recipient.binaries.whenElementFinalized { binary ->
 		binary.linkTask.get().configure { linkTask ->
-			project.project(':com.ibm.wala.cast:cast').tasks.named(linkTask.name).configure { castTask ->
+			project.project(':com.ibm.wala.cast:cast').tasks.named(linkTask.name) { castTask ->
 				addRpath(linkTask, getNativeLibraryOutput(castTask))
 			}
 		}

--- a/com.ibm.wala.cast.java.test.data/build.gradle
+++ b/com.ibm.wala.cast.java.test.data/build.gradle
@@ -20,11 +20,11 @@ tasks.register('cleanDownloadJLex', Delete) {
 	delete downloadJLex.get().dest.parent
 }
 
-tasks.named('compileTestJava').configure {
+tasks.named('compileTestJava') {
 	dependsOn 'downloadJLex'
 }
 
-tasks.named('clean').configure {
+tasks.named('clean') {
 	dependsOn 'cleanDownloadJLex'
 }
 

--- a/com.ibm.wala.cast.java.test/build.gradle
+++ b/com.ibm.wala.cast.java.test/build.gradle
@@ -29,6 +29,6 @@ dependencies {
 		)
 }
 
-tasks.named('test').configure {
+tasks.named('test') {
 	maxHeapSize = '800M'
 }

--- a/com.ibm.wala.cast.js.html.nu_validator/build.gradle
+++ b/com.ibm.wala.cast.js.html.nu_validator/build.gradle
@@ -18,12 +18,12 @@ dependencies {
 		)
 }
 
-tasks.named('processTestResources').configure {
+tasks.named('processTestResources') {
 	def data = project(':com.ibm.wala.cast.js.test.data')
 	dependsOn data.tasks.named('processTestResources')
 	from data.sourceSets.test.resources
 }
 
-tasks.named('test').configure {
+tasks.named('test') {
 	maxHeapSize = '800M'
 }

--- a/com.ibm.wala.cast.js.nodejs.test/build.gradle
+++ b/com.ibm.wala.cast.js.nodejs.test/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 		)
 }
 
-tasks.named('test').configure {
+tasks.named('test') {
 	maxHeapSize = '800M'
 
 	// fails with java.lang.OutOfMemoryError for unknown reasons

--- a/com.ibm.wala.cast.js.nodejs/build.gradle
+++ b/com.ibm.wala.cast.js.nodejs/build.gradle
@@ -33,11 +33,11 @@ tasks.register('cleanUnpackNodeJSLib', Delete) {
 	delete fileTree(dir: 'dat/core-modules', include: '*.js')
 }
 
-tasks.named('processResources').configure {
+tasks.named('processResources') {
 	dependsOn 'unpackNodeJSLib'
 }
 
-tasks.named('clean').configure {
+tasks.named('clean') {
 	dependsOn 'cleanUnpackNodeJSLib'
 }
 

--- a/com.ibm.wala.cast.js.rhino.test/build.gradle
+++ b/com.ibm.wala.cast.js.rhino.test/build.gradle
@@ -25,13 +25,13 @@ dependencies {
 		)
 }
 
-tasks.named('processTestResources').configure {
+tasks.named('processTestResources') {
 	def data = project(':com.ibm.wala.cast.js.test.data')
 	dependsOn data.tasks.named('processTestResources')
 	from data.sourceSets.test.resources
 }
 
-tasks.named('test').configure {
+tasks.named('test') {
 	environment 'TRAVIS', 1
 	maxHeapSize = '800M'
 
@@ -44,6 +44,6 @@ tasks.register('cleanTestExtras', Delete) {
 	delete 'expected.dump'
 }
 
-tasks.named('cleanTest').configure {
+tasks.named('cleanTest') {
 	dependsOn 'cleanTestExtras'
 }

--- a/com.ibm.wala.cast.js.test.data/build.gradle
+++ b/com.ibm.wala.cast.js.test.data/build.gradle
@@ -19,10 +19,10 @@ tasks.register('unpackAjaxslt', Sync) {
 	into 'examples-src/ajaxslt'
 }
 
-tasks.named('clean').configure {
+tasks.named('clean') {
 	dependsOn 'cleanUnpackAjaxslt'
 }
 
-tasks.named('processTestResources').configure {
+tasks.named('processTestResources') {
 	dependsOn 'unpackAjaxslt'
 }

--- a/com.ibm.wala.cast.js.test/build.gradle
+++ b/com.ibm.wala.cast.js.test/build.gradle
@@ -24,12 +24,12 @@ dependencies {
 		)
 }
 
-tasks.named('processTestResources').configure {
+tasks.named('processTestResources') {
 	def data = project(':com.ibm.wala.cast.js.test.data')
 	dependsOn data.tasks.named('processTestResources')
 	from data.sourceSets.test.resources
 }
 
-tasks.named('test').configure {
+tasks.named('test') {
 	maxHeapSize = '800M'
 }

--- a/com.ibm.wala.cast.js/build.gradle
+++ b/com.ibm.wala.cast.js/build.gradle
@@ -18,7 +18,7 @@ tasks.register('createPackageList', CreatePackageList) {
 	sourceSet sourceSets.main.java
 }
 
-tasks.named('javadoc').configure {
+tasks.named('javadoc') {
 	def rhinoName = ':com.ibm.wala.cast.js.rhino'
 	dependsOn "$rhinoName:compileJava"
 

--- a/com.ibm.wala.cast.test/build.gradle
+++ b/com.ibm.wala.cast.test/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 eclipse.project.natures 'org.eclipse.pde.PluginNature'
 
-tasks.named('prepareIntelliJIDEA').configure {
+tasks.named('prepareIntelliJIDEA') {
 	dependsOn 'jarTest'
 }
 
@@ -29,7 +29,7 @@ dependencies {
 		)
 }
 
-tasks.named('test').configure {
+tasks.named('test') {
 	final def xlator_project_name = 'xlator_test'
 	final def xlator_link_name = 'linkDebug'
 	dependsOn "$xlator_project_name:$xlator_link_name"

--- a/com.ibm.wala.cast/build.gradle
+++ b/com.ibm.wala.cast/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 		)
 }
 
-tasks.named('javadoc').configure {
+tasks.named('javadoc') {
 	def jsName = ':com.ibm.wala.cast.js'
 	dependsOn "$jsName:compileJava"
 	dependsOn "$jsName:createPackageList"
@@ -38,10 +38,10 @@ tasks.register('copyJarsIntoLib', Sync) {
 	into 'lib'
 }
 
-tasks.named('assemble').configure {
+tasks.named('assemble') {
 	dependsOn 'copyJarsIntoLib'
 }
 
-tasks.named('clean').configure {
+tasks.named('clean') {
 	dependsOn 'cleanCopyJarsIntoLib'
 }

--- a/com.ibm.wala.core.testdata/build.gradle
+++ b/com.ibm.wala.core.testdata/build.gradle
@@ -145,7 +145,7 @@ tasks.register('cleanExtractBcel', Delete) {
 	delete files(extractBcel)[0]
 }
 
-tasks.named('clean').configure {
+tasks.named('clean') {
 	dependsOn 'cleanExtractBcel'
 }
 
@@ -167,7 +167,7 @@ tasks.register('cleanDownloadJavaCup', Delete) {
 	delete downloadJavaCup
 }
 
-tasks.named('clean').configure {
+tasks.named('clean') {
 	dependsOn 'cleanDownloadJavaCup'
 }
 
@@ -188,7 +188,7 @@ tasks.register('cleanCollectJLex', Delete) {
 	delete collectJLex
 }
 
-tasks.named('clean').configure {
+tasks.named('clean') {
 	dependsOn 'cleanCollectJLex'
 }
 
@@ -238,7 +238,7 @@ tasks.register('cleanGenerateHelloHashJar', Delete) {
 	}
 }
 
-tasks.named('clean').configure {
+tasks.named('clean') {
 	dependsOn 'cleanGenerateHelloHashJar'
 }
 
@@ -260,7 +260,7 @@ tasks.register('cleanCollectTestData', Delete) {
 	delete collectTestData
 }
 
-tasks.named('clean').configure {
+tasks.named('clean') {
 	dependsOn 'cleanCollectTestData'
 }
 
@@ -287,6 +287,6 @@ tasks.register('cleanColllectTestDataA', Delete) {
 	delete collectTestDataA
 }
 
-tasks.named('clean').configure {
+tasks.named('clean') {
 	dependsOn 'cleanCollectTestDataA'
 }

--- a/com.ibm.wala.core.tests/build.gradle
+++ b/com.ibm.wala.core.tests/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 		)
 }
 
-tasks.named('processTestResources').configure {
+tasks.named('processTestResources') {
 	def testdata = project(':com.ibm.wala.core.testdata')
 	dependsOn testdata.tasks.named('compileTestJava')
 	dependsOn testdata.tasks.named('extractBcel')
@@ -44,7 +44,7 @@ tasks.named('processTestResources').configure {
 	from testdata.buildKawaTestJar
 }
 
-tasks.named('test').configure {
+tasks.named('test') {
 	maxHeapSize = '1500M'
 	systemProperty 'com.ibm.wala.junit.analyzingJar', 'true'
 	systemProperty 'com.ibm.wala.junit.profile', 'short'
@@ -55,6 +55,6 @@ tasks.register('cleanTestExtras', Delete) {
 	delete 'report'
 }
 
-tasks.named('cleanTest').configure {
+tasks.named('cleanTest') {
 	dependsOn 'cleanTestExtras'
 }

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 		)
 }
 
-tasks.named('javadoc').configure {
+tasks.named('javadoc') {
 	def dalvik = ':com.ibm.wala.dalvik'
 	dependsOn "$dalvik:compileJava"
 

--- a/com.ibm.wala.dalvik.test/build.gradle
+++ b/com.ibm.wala.dalvik.test/build.gradle
@@ -98,19 +98,19 @@ final def copyDxJar = tasks.register('copyDxJar', Sync) {
 	into 'lib'
 }
 
-tasks.named('clean').configure {
+tasks.named('clean') {
 	dependsOn 'cleanCopyDxJar'
 }
 
-tasks.named('compileTestJava').configure {
+tasks.named('compileTestJava') {
 	dependsOn 'copyDxJar'
 }
 
-tasks.named('afterEclipseBuildshipImport').configure {
+tasks.named('afterEclipseBuildshipImport') {
 	dependsOn 'copyDxJar'
 }
 
-tasks.named('prepareIntelliJIDEA').configure {
+tasks.named('prepareIntelliJIDEA') {
 	dependsOn 'copyDxJar'
 }
 
@@ -126,7 +126,7 @@ tasks.register('downloadSampleCup', VerifiedDownload) {
 	checksum '76b549e7c6e802b811a374248175ecf4'
 }
 
-tasks.named('clean').configure {
+tasks.named('clean') {
 	dependsOn 'cleanDownloadSampleCup'
 }
 
@@ -136,7 +136,7 @@ tasks.register('downloadSampleLex', VerifiedDownload) {
 	checksum 'ae887758b2657981d023a72a165da830'
 }
 
-tasks.named('clean').configure {
+tasks.named('clean') {
 	dependsOn 'cleanDownloadSampleLex'
 }
 
@@ -160,7 +160,7 @@ dependencies {
 	testRuntime files("${copyAndroidJar.destinationDir}/android.jar")
 }
 
-tasks.named('processTestResources').configure {
+tasks.named('processTestResources') {
 	from copyAndroidJar
 	from downloadSampleCup
 	from downloadSampleLex
@@ -168,15 +168,15 @@ tasks.named('processTestResources').configure {
 }
 
 if (isWindows)
-	tasks.named('test').configure {
+	tasks.named('test') {
 		exclude '**/droidbench/**'
 	}
 else
-	tasks.named('processTestResources').configure {
+	tasks.named('processTestResources') {
 		dependsOn 'unpackDroidBench'
 	}
 
-tasks.named('test').configure {
+tasks.named('test') {
 	maxHeapSize = '800M'
 }
 
@@ -188,6 +188,6 @@ tasks.register('cleanTestExtras', Delete) {
 	)
 }
 
-tasks.named('cleanTest').configure {
+tasks.named('cleanTest') {
 	dependsOn 'cleanTestExtras'
 }

--- a/com.ibm.wala.dalvik/build.gradle
+++ b/com.ibm.wala.dalvik/build.gradle
@@ -14,7 +14,7 @@ tasks.register('createPackageList', CreatePackageList) {
 	sourceSet sourceSets.main.java
 }
 
-tasks.named('javadoc').configure {
+tasks.named('javadoc') {
 	dependsOn 'createPackageList'
 	doFirst {
 		options.linksOffline outputDirectory.path, createPackageList.packageList.parent

--- a/com.ibm.wala.ide.jdt.test/build.gradle
+++ b/com.ibm.wala.ide.jdt.test/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 		)
 }
 
-tasks.named('test').configure {
+tasks.named('test') {
 	maxHeapSize = '1200M'
 
 	// https://github.com/liblit/WALA/issues/5

--- a/com.ibm.wala.ide.jsdt.tests/build.gradle
+++ b/com.ibm.wala.ide.jsdt.tests/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 		)
 }
 
-tasks.named('test').configure {
+tasks.named('test') {
 	// https://github.com/liblit/WALA/issues/5
 	exclude '**/JSProjectScopeTest.class'
 }

--- a/com.ibm.wala.util/build.gradle
+++ b/com.ibm.wala.util/build.gradle
@@ -6,7 +6,7 @@ eclipse.project.natures 'org.eclipse.pde.PluginNature'
 
 sourceSets.main.java.srcDirs = ['src']
 
-tasks.named('javadoc').configure {
+tasks.named('javadoc') {
 	def coreName = ':com.ibm.wala.core'
 	dependsOn "$coreName:compileJava"
 


### PR DESCRIPTION
The main [Gradle task configuration avoidance page](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html) recommends using `tasks.named('foo').configure { ... }` to add lazy configuration logic to an existing task named `foo`. That was indeed the best option when the task configuration avoidance APIs first appeared.

However, [additional `named(...)` overloads were added later](https://github.com/gradle/gradle/pull/6688) that take the configuration closure as a final argument. Thus, `tasks.named('foo').configure { ... }` can now be simplified to `tasks.named('foo') { ... }`.

This change does not introduce any deep shifts in how the build happens. It is merely a syntactic-sugar-level refactoring to replace a chained sequence of two method calls with a single call that does the same thing.