### PR TITLE
In PrunedCallGraph, require that kept nodes be subset of unpruned graph

### DIFF
--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/pruned/PrunedCallGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/pruned/PrunedCallGraph.java
@@ -36,9 +36,24 @@ public class PrunedCallGraph implements CallGraph {
 	private Set<CGNode> keep;
 	private Map<CGNode,Set<CGNode>> remove = Collections.emptyMap();
 	
+	/**
+	 * Create a pruned (filtered) view of an existing call graph.
+	 *
+	 * <p>Note: the created instance retains references to {@code cg} and {@code keep} without making private copies
+	 * thereof.  Be cautious if subsequently modifying {@code cg} or {@code keep} outside of this class's control.  In
+	 * particular, {@code keep} must always be a subset of the nodes in {@code cg} or else unexpected behavior may
+	 * arise.</p>
+	 *
+	 * @param cg   Underlying call graph to prune
+	 * @param keep Subset of {@code cg} nodes to include in the pruned graph
+	 * @throws IllegalArgumentException if any {@code keep} node is not a node in {@code cg}
+	 */
 	public PrunedCallGraph(CallGraph cg, Set<CGNode> keep) {
 		this.cg = cg;
 		this.keep = keep;
+		for (CGNode keptNode : keep)
+			if (!cg.containsNode(keptNode))
+				throw new IllegalArgumentException(String.format("%s does not contain %s", cg, keptNode));
 	}
 
   public PrunedCallGraph(CallGraph cg, Set<CGNode> keep, Map<CGNode,Set<CGNode>> remove) {
@@ -55,21 +70,11 @@ public class PrunedCallGraph implements CallGraph {
 
 	@Override
 	public Iterator<CGNode> iterator() {
-		Iterator<CGNode> tmp = cg.iterator();
-		Collection<CGNode> col = new LinkedList<>();
-		while (tmp.hasNext()) {
-			CGNode n = tmp.next();
-			if (keep.contains(n)) {
-				col.add(n);
-			}
-		}
-		
-		return col.iterator();
+		return keep.iterator();
 	}
 
 	@Override
 	public Stream<CGNode> stream() {
-		assert keep.stream().allMatch(cg::containsNode);
 		return keep.stream();
 	}
 


### PR DESCRIPTION
In `PrunedCallGraph`, require that `keep` (the set of nodes to be kept) be a subset of the nodes in the unpruned graph.  Check for this at construction time, and raise an exception if violated.

The caller could potentially change either the `keep` set or the unpruned graph after constructing the `PrunedCallGraph` instance.  If they do that, then PrunedCallGraph might break, and the caller gets to keep all the pieces.  We could be rechecking the “subset” relationship in each and every place it is assumed to hold, but that seems excessive.  So instead we just add a big warning in the constructor’s Javadoc documentation.

See <https://github.com/wala/WALA/pull/427#discussion_r259913855> for the concluding piece of the discussion that led us to enact this “subset” requirement.