### PR TITLE
Fix dangling Javadoc comments

### DIFF
--- a/.idea/inspectionProfiles/Javadoc.xml
+++ b/.idea/inspectionProfiles/Javadoc.xml
@@ -25,7 +25,10 @@
     <inspection_tool class="BashDuplicateFunction" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="BashEvaluateArithmeticExpression" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="BashEvaluateExpression" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="BashFixShebang" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="BashFixShebang" enabled="false" level="WARNING" enabled_by_default="false">
+      <shebang>/bin/bash</shebang>
+      <shebang>/bin/sh</shebang>
+    </inspection_tool>
     <inspection_tool class="BashFloatArithmetic" enabled="false" level="INFO" enabled_by_default="false" />
     <inspection_tool class="BashGlobalLocalVarDef" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="BashGloballyRegisteredVariable" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
@@ -91,10 +94,15 @@
     <inspection_tool class="ConditionalCanBeOptional" enabled="false" level="INFORMATION" enabled_by_default="false" />
     <inspection_tool class="ConditionalCanBePushedInsideExpression" enabled="false" level="INFORMATION" enabled_by_default="false" />
     <inspection_tool class="ConditionalExpression" enabled="false" level="INFORMATION" enabled_by_default="false" />
-    <inspection_tool class="ConfusingElse" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="ConfusingElse" enabled="false" level="INFORMATION" enabled_by_default="false">
+      <option name="reportWhenNoStatementFollow" value="true" />
+    </inspection_tool>
     <inspection_tool class="ConstantConditionalExpression" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="ConstantConditionalExpressionJS" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="ConstantConditions" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ConstantConditions" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="SUGGEST_NULLABLE_ANNOTATIONS" value="false" />
+      <option name="DONT_REPORT_TRUE_ASSERT_STATEMENTS" value="false" />
+    </inspection_tool>
     <inspection_tool class="ConstantExpression" enabled="false" level="INFORMATION" enabled_by_default="false" />
     <inspection_tool class="ConstantIfStatementJS" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="ContinueOrBreakFromFinallyBlock" enabled="false" level="WARNING" enabled_by_default="false" />
@@ -124,7 +132,15 @@
     <inspection_tool class="CssReplaceWithShorthandSafely" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="CssReplaceWithShorthandUnsafely" enabled="false" level="INFORMATION" enabled_by_default="false" />
     <inspection_tool class="CssUnitlessNumber" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="CssUnknownProperty" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="CssUnknownProperty" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="myCustomPropertiesEnabled" value="false" />
+      <option name="myIgnoreVendorSpecificProperties" value="false" />
+      <option name="myCustomPropertiesList">
+        <value>
+          <list size="0" />
+        </value>
+      </option>
+    </inspection_tool>
     <inspection_tool class="CssUnknownTarget" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="CssUnresolvedClass" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="CssUnresolvedCustomProperty" enabled="false" level="ERROR" enabled_by_default="false" />
@@ -132,9 +148,12 @@
     <inspection_tool class="CssUnusedSymbol" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="CsvValidation" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="CythonUsageBeforeDeclarationInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="DanglingJavadoc" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="DefaultAnnotationParam" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="DefaultFileTemplate" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="DefaultFileTemplate" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="CHECK_FILE_HEADER" value="true" />
+      <option name="CHECK_TRY_CATCH_SECTION" value="true" />
+      <option name="CHECK_METHOD_BODY" value="true" />
+    </inspection_tool>
     <inspection_tool class="DelegatesTo" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="Dependency" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="DeprecatedClassUsageInspection" enabled="false" level="WARNING" enabled_by_default="false" />
@@ -158,7 +177,9 @@
     <inspection_tool class="DockerFileAssignments" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="DoubleNegation" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="DuplicateCaseLabelJS" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="DuplicateCondition" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="DuplicateCondition" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="ignoreSideEffectConditions" value="true" />
+    </inspection_tool>
     <inspection_tool class="DuplicateExpressions" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="DuplicateThrows" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="DuplicatedBlockNamesInspection" enabled="false" level="WARNING" enabled_by_default="false" />
@@ -177,12 +198,18 @@
     <inspection_tool class="ES6UnusedImports" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="EmptyFinallyBlock" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="EmptyMethod" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="EmptyStatementBody" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="EmptyStatementBodyJS" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="EmptyStatementBody" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_reportEmptyBlocks" value="true" />
+    </inspection_tool>
+    <inspection_tool class="EmptyStatementBodyJS" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_reportEmptyBlocks" value="false" />
+    </inspection_tool>
     <inspection_tool class="EmptyTryBlock" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="EndBlockNamesInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="EndlessStream" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="EnumSwitchStatementWhichMissesCases" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="EnumSwitchStatementWhichMissesCases" enabled="false" level="INFORMATION" enabled_by_default="false">
+      <option name="ignoreSwitchStatementsWithDefault" value="true" />
+    </inspection_tool>
     <inspection_tool class="EqualsBetweenInconvertibleTypes" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="EqualsOnSuspiciousObject" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="EqualsReplaceableByObjectsCall" enabled="false" level="WARNING" enabled_by_default="false" />
@@ -203,8 +230,13 @@
     <inspection_tool class="FlowJSConfig" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="FlowJSFlagCommentPlacement" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="FoldExpressionIntoStream" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="ForCanBeForeach" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="ForLoopReplaceableByWhile" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="ForCanBeForeach" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="REPORT_INDEXED_LOOP" value="true" />
+      <option name="ignoreUntypedCollections" value="false" />
+    </inspection_tool>
+    <inspection_tool class="ForLoopReplaceableByWhile" enabled="false" level="INFORMATION" enabled_by_default="false">
+      <option name="m_ignoreLoopsWithoutConditions" value="false" />
+    </inspection_tool>
     <inspection_tool class="FrequentlyUsedInheritorInspection" enabled="false" level="INFORMATION" enabled_by_default="false" />
     <inspection_tool class="FunctionalExpressionCanBeFolded" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="FuseStreamOperations" enabled="false" level="WARNING" enabled_by_default="false" />
@@ -262,23 +294,55 @@
     <inspection_tool class="HtmlMissingClosingTag" enabled="false" level="INFORMATION" enabled_by_default="false" />
     <inspection_tool class="HtmlTagCanBeJavadocTag" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="HtmlUnknownAnchorTarget" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="HtmlUnknownAttribute" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="HtmlUnknownAttribute" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="myValues">
+        <value>
+          <list size="0" />
+        </value>
+      </option>
+      <option name="myCustomValuesEnabled" value="true" />
+    </inspection_tool>
     <inspection_tool class="HtmlUnknownBooleanAttribute" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="HtmlUnknownTag" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="HtmlUnknownTag" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="myValues">
+        <value>
+          <list size="6">
+            <item index="0" class="java.lang.String" itemvalue="nobr" />
+            <item index="1" class="java.lang.String" itemvalue="noembed" />
+            <item index="2" class="java.lang.String" itemvalue="comment" />
+            <item index="3" class="java.lang.String" itemvalue="noscript" />
+            <item index="4" class="java.lang.String" itemvalue="embed" />
+            <item index="5" class="java.lang.String" itemvalue="script" />
+          </list>
+        </value>
+      </option>
+      <option name="myCustomValuesEnabled" value="true" />
+    </inspection_tool>
     <inspection_tool class="HtmlUnknownTarget" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="IdempotentLoopBody" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="IfCanBeAssertion" enabled="false" level="INFORMATION" enabled_by_default="false" />
-    <inspection_tool class="IfCanBeSwitch" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="IfCanBeSwitch" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="minimumBranches" value="3" />
+      <option name="suggestIntSwitches" value="false" />
+      <option name="suggestEnumSwitches" value="false" />
+    </inspection_tool>
     <inspection_tool class="IgnoreCoverEntry" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="IgnoreDuplicateEntry" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="IgnoreIncorrectEntry" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="IgnoreRelativeEntry" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="IgnoreResultOfCall" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="IgnoreResultOfCall" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_reportAllNonLibraryCalls" value="false" />
+      <option name="callCheckString" value="java.io.File,.*,java.io.InputStream,read|skip|available|markSupported,java.io.Reader,read|skip|ready|markSupported,java.lang.Boolean,.*,java.lang.Byte,.*,java.lang.Character,.*,java.lang.Double,.*,java.lang.Float,.*,java.lang.Integer,.*,java.lang.Long,.*,java.lang.Math,.*,java.lang.Object,equals|hashCode|toString,java.lang.Short,.*,java.lang.StrictMath,.*,java.lang.String,.*,java.lang.Thread,interrupted,java.math.BigInteger,.*,java.math.BigDecimal,.*,java.net.InetAddress,.*,java.net.URI,.*,java.util.Arrays,.*,java.util.List,of,java.util.Set,of,java.util.Map,of|ofEntries|entry,java.util.Collections,(?!addAll).*,java.util.UUID,.*,java.util.regex.Matcher,pattern|toMatchResult|start|end|group|groupCount|matches|find|lookingAt|quoteReplacement|replaceAll|replaceFirst|regionStart|regionEnd|hasTransparentBounds|hasAnchoringBounds|hitEnd|requireEnd,java.util.regex.Pattern,.*,java.util.stream.BaseStream,.*" />
+    </inspection_tool>
     <inspection_tool class="IgnoreSyntaxEntry" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="IgnoreUnusedEntry" enabled="false" level="UNUSED ENTRY" enabled_by_default="false" />
     <inspection_tool class="ImplicitArrayToString" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="ImplicitSubclassInspection" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="ImplicitTypeConversion" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="ImplicitTypeConversion" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="BITS" value="1720" />
+      <option name="FLAG_EXPLICIT_CONVERSION" value="true" />
+      <option name="IGNORE_NODESET_TO_BOOLEAN_VIA_STRING" value="true" />
+    </inspection_tool>
     <inspection_tool class="IncompatibleMask" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="IncompatibleMaskJS" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="IncompleteProperty" enabled="false" level="ERROR" enabled_by_default="false" />
@@ -313,10 +377,15 @@
     <inspection_tool class="JSLastCommaInArrayLiteral" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JSLastCommaInObjectLiteral" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JSMethodCanBeStatic" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="JSMismatchedCollectionQueryUpdate" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JSMismatchedCollectionQueryUpdate" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="queries" value="trace,write,forEach,length" />
+      <option name="updates" value="pop,push,shift,splice,unshift,add,insert,remove" />
+    </inspection_tool>
     <inspection_tool class="JSNonASCIINames" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JSObjectNullOrUndefined" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="JSPotentiallyInvalidConstructorUsage" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JSPotentiallyInvalidConstructorUsage" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="myConsiderUppercaseFunctionsToBeConstructors" value="true" />
+    </inspection_tool>
     <inspection_tool class="JSPotentiallyInvalidTargetOfIndexedPropertyAccess" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JSPotentiallyInvalidUsageOfClassThis" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JSPotentiallyInvalidUsageOfThis" enabled="false" level="WARNING" enabled_by_default="false" />
@@ -326,7 +395,11 @@
     <inspection_tool class="JSReferencingMutableVariableFromClosure" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JSRemoveUnnecessaryParentheses" enabled="false" level="INFORMATION" enabled_by_default="false" />
     <inspection_tool class="JSStringConcatenationToES6Template" enabled="false" level="INFORMATION" enabled_by_default="false" />
-    <inspection_tool class="JSSuspiciousNameCombination" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JSSuspiciousNameCombination" enabled="false" level="WARNING" enabled_by_default="false">
+      <group names="x,width,left,right" />
+      <group names="y,height,top,bottom" />
+      <exclude classes="Math" />
+    </inspection_tool>
     <inspection_tool class="JSTypeOfValues" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JSUndeclaredVariable" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="JSUndefinedPropertyAssignment" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
@@ -377,7 +450,9 @@
     <inspection_tool class="LengthOneStringsInConcatenation" enabled="false" level="INFORMATION" enabled_by_default="false" />
     <inspection_tool class="ListRemoveInLoop" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="LongLiteralsEndingWithLowercaseL" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="LoopConditionNotUpdatedInsideLoop" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="LoopConditionNotUpdatedInsideLoop" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="ignoreIterators" value="false" />
+    </inspection_tool>
     <inspection_tool class="LoopStatementThatDoesntLoopJS" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="LoopStatementsThatDontLoop" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="LossyEncoding" enabled="false" level="WARNING" enabled_by_default="false" />
@@ -395,11 +470,24 @@
     <inspection_tool class="MethodNameSameAsClassName" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="MethodRefCanBeReplacedWithLambda" enabled="false" level="INFORMATION" enabled_by_default="false" />
     <inspection_tool class="MismatchedArrayReadWrite" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="MismatchedCollectionQueryUpdate" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MismatchedCollectionQueryUpdate" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="queryNames">
+        <value />
+      </option>
+      <option name="updateNames">
+        <value />
+      </option>
+      <option name="ignoredClasses">
+        <value />
+      </option>
+    </inspection_tool>
     <inspection_tool class="MismatchedStringBuilderQueryUpdate" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="MissingDeprecatedAnnotation" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="MissingFinalNewline" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="MissingOverrideAnnotation" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="MissingOverrideAnnotation" enabled="false" level="INFORMATION" enabled_by_default="false">
+      <option name="ignoreObjectMethods" value="true" />
+      <option name="ignoreAnonymousClassMethods" value="false" />
+    </inspection_tool>
     <inspection_tool class="MisspelledHeader" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="MoveFieldAssignmentToInitializer" enabled="false" level="INFORMATION" enabled_by_default="false" />
     <inspection_tool class="MultiCatchCanBeSplit" enabled="false" level="INFORMATION" enabled_by_default="false" />
@@ -413,10 +501,23 @@
     <inspection_tool class="NonAtomicOperationOnVolatileField" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="NpmUsedModulesInstalled" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="NullArgumentToVariableArgMethod" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="NullableProblems" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="NullableProblems" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="REPORT_NULLABLE_METHOD_OVERRIDES_NOTNULL" value="true" />
+      <option name="REPORT_NOT_ANNOTATED_METHOD_OVERRIDES_NOTNULL" value="true" />
+      <option name="REPORT_NOTNULL_PARAMETER_OVERRIDES_NULLABLE" value="true" />
+      <option name="REPORT_NOT_ANNOTATED_PARAMETER_OVERRIDES_NOTNULL" value="true" />
+      <option name="REPORT_NOT_ANNOTATED_GETTER" value="true" />
+      <option name="REPORT_NOT_ANNOTATED_SETTER_PARAMETER" value="true" />
+      <option name="REPORT_ANNOTATION_NOT_PROPAGATED_TO_OVERRIDERS" value="true" />
+      <option name="REPORT_NULLS_PASSED_TO_NON_ANNOTATED_METHOD" value="true" />
+    </inspection_tool>
     <inspection_tool class="NumberEquality" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="NumericOverflow" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="ObjectEquality" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="ObjectEquality" enabled="false" level="INFORMATION" enabled_by_default="false">
+      <option name="m_ignoreEnums" value="true" />
+      <option name="m_ignoreClassObjects" value="true" />
+      <option name="m_ignorePrivateConstructors" value="false" />
+    </inspection_tool>
     <inspection_tool class="ObjectEqualsCanBeEquality" enabled="false" level="INFORMATION" enabled_by_default="false" />
     <inspection_tool class="ObjectsEqualsCanBeSimplified" enabled="false" level="INFORMATION" enabled_by_default="false" />
     <inspection_tool class="ObviousNullCheck" enabled="false" level="WARNING" enabled_by_default="false" />
@@ -430,11 +531,19 @@
     <inspection_tool class="PackageAccessibility" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="PackageJsonMismatchedDependency" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="ParameterCanBeLocal" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PointlessArithmeticExpression" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="PointlessArithmeticExpression" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_ignoreExpressionsContainingConstants" value="true" />
+    </inspection_tool>
     <inspection_tool class="PointlessArithmeticExpressionJS" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PointlessBitwiseExpression" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PointlessBitwiseExpressionJS" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PointlessBooleanExpression" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="PointlessBitwiseExpression" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_ignoreExpressionsContainingConstants" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PointlessBitwiseExpressionJS" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_ignoreExpressionsContainingConstants" value="false" />
+    </inspection_tool>
+    <inspection_tool class="PointlessBooleanExpression" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_ignoreExpressionsContainingConstants" value="true" />
+    </inspection_tool>
     <inspection_tool class="PointlessBooleanExpressionJS" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="PointlessNullCheck" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="PrimitiveArrayArgumentToVariableArgMethod" enabled="false" level="WARNING" enabled_by_default="false" />
@@ -478,7 +587,13 @@
     <inspection_tool class="PyNoneFunctionAssignmentInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="PyOldStyleClassesInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="PyOverloadsInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyPackageRequirementsInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="PyPackageRequirementsInspection" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="ignoredPackages">
+        <value>
+          <list size="0" />
+        </value>
+      </option>
+    </inspection_tool>
     <inspection_tool class="PyPep8Inspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="PyPep8NamingInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="PyPropertyAccessInspection" enabled="false" level="WARNING" enabled_by_default="false" />
@@ -509,7 +624,12 @@
     <inspection_tool class="PyUnnecessaryBackslashInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="PyUnreachableCodeInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="PyUnresolvedReferencesInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyUnusedLocalInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="PyUnusedLocalInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false">
+      <option name="ignoreTupleUnpacking" value="true" />
+      <option name="ignoreLambdaParameters" value="true" />
+      <option name="ignoreLoopIterationVariables" value="true" />
+      <option name="ignoreVariablesStartingWithUnderscore" value="true" />
+    </inspection_tool>
     <inspection_tool class="PyramidSetupInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="Query_bound_parameters" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="Query_index_required" enabled="false" level="WARNING" enabled_by_default="false" />
@@ -530,9 +650,14 @@
     <inspection_tool class="RedundantSuppression" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="RedundantThrows" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="RedundantTypeArguments" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="RedundantTypeConversion" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantTypeConversion" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="CHECK_ANY" value="false" />
+    </inspection_tool>
     <inspection_tool class="ReflectionForUnavailableAnnotation" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="RefusedBequest" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RefusedBequest" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="ignoreEmptySuperMethods" value="false" />
+      <option name="onlyReportWhenAnnotated" value="true" />
+    </inspection_tool>
     <inspection_tool class="RegExpDuplicateAlternationBranch" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="RegExpEmptyAlternationBranch" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="RegExpEscapedMetaCharacter" enabled="false" level="INFORMATION" enabled_by_default="false" />
@@ -544,7 +669,9 @@
     <inspection_tool class="ReplaceAllDot" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="ReplaceInefficientStreamCount" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="ReplaceNullCheck" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="RequiredAttributes" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RequiredAttributes" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="myAdditionalRequiredHtmlAttributes" value="" />
+    </inspection_tool>
     <inspection_tool class="ReservedWordUsedAsNameJS" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="Restricted_Python_calls" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="ReturnFromFinallyBlock" enabled="false" level="WARNING" enabled_by_default="false" />
@@ -572,7 +699,11 @@
     <inspection_tool class="SingleStatementInBlock" enabled="false" level="INFORMATION" enabled_by_default="false" />
     <inspection_tool class="SingletonConstructor" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="SortedCollectionWithNonComparableKeys" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false" />
+    <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">
+      <option name="processCode" value="true" />
+      <option name="processLiterals" value="true" />
+      <option name="processComments" value="true" />
+    </inspection_tool>
     <inspection_tool class="StaticInitializerReferencesSubClass" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="StaticPseudoFunctionalStyleMethod" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="StreamToLoop" enabled="false" level="INFORMATION" enabled_by_default="false" />
@@ -586,14 +717,27 @@
     <inspection_tool class="StringTokenizerDelimiter" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="SuspiciousArrayMethodCall" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="SuspiciousListRemoveInLoop" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="SuspiciousMethodCalls" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="SuspiciousNameCombination" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SuspiciousMethodCalls" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="REPORT_CONVERTIBLE_METHOD_CALLS" value="true" />
+    </inspection_tool>
+    <inspection_tool class="SuspiciousNameCombination" enabled="false" level="WARNING" enabled_by_default="false">
+      <group names="x,width,left,right" />
+      <group names="y,height,top,bottom" />
+      <ignored>
+        <option name="METHOD_MATCHER_CONFIG" value="java.io.PrintStream,println,java.io.PrintWriter,println,java.lang.System,identityHashCode,java.sql.PreparedStatement,set.*,java.sql.ResultSet,update.*,java.sql.SQLOutput,write.*,java.lang.Integer,compare.*,java.lang.Long,compare.*,java.lang.Short,compare,java.lang.Byte,compare,java.lang.Character,compare,java.lang.Boolean,compare,java.lang.Math,.*,java.lang.StrictMath,.*" />
+      </ignored>
+    </inspection_tool>
     <inspection_tool class="SuspiciousSystemArraycopy" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="SuspiciousToArrayCall" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="SuspiciousTypeOfGuard" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="SwitchStatementWithTooFewBranches" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SwitchStatementWithTooFewBranches" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_limit" value="2" />
+    </inspection_tool>
     <inspection_tool class="SynchronizationOnGetClass" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="SynchronizationOnLocalVariableOrMethodParameter" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="SynchronizationOnLocalVariableOrMethodParameter" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="reportLocalVariables" value="true" />
+      <option name="reportMethodParameters" value="true" />
+    </inspection_tool>
     <inspection_tool class="SynchronizeOnNonFinalField" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="SyntaxError" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="TailRecursion" enabled="false" level="INFORMATION" enabled_by_default="false" />
@@ -604,7 +748,10 @@
     <inspection_tool class="ThrowableNotThrown" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="ThrowablePrintedToSystemOut" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="ToArrayCallWithZeroLengthArrayArgument" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="TooBroadScope" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="TooBroadScope" enabled="false" level="INFORMATION" enabled_by_default="false">
+      <option name="m_allowConstructorAsInitializer" value="false" />
+      <option name="m_onlyLookAtBlocks" value="false" />
+    </inspection_tool>
     <inspection_tool class="TrailingSpacesInProperty" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="TrivialConditionalJS" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="TrivialFunctionalExpressionUsage" enabled="false" level="WARNING" enabled_by_default="false" />
@@ -633,8 +780,12 @@
     <inspection_tool class="UNCHECKED_WARNING" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UNUSED_IMPORT" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UnclearBinaryExpression" enabled="false" level="INFORMATION" enabled_by_default="false" />
-    <inspection_tool class="UnnecessarilyQualifiedInnerClassAccess" enabled="false" level="INFORMATION" enabled_by_default="false" />
-    <inspection_tool class="UnnecessaryBlockStatement" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="UnnecessarilyQualifiedInnerClassAccess" enabled="false" level="INFORMATION" enabled_by_default="false">
+      <option name="ignoreReferencesNeedingImport" value="false" />
+    </inspection_tool>
+    <inspection_tool class="UnnecessaryBlockStatement" enabled="false" level="INFORMATION" enabled_by_default="false">
+      <option name="ignoreSwitchBranches" value="false" />
+    </inspection_tool>
     <inspection_tool class="UnnecessaryBoxing" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UnnecessaryBreak" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UnnecessaryCallToStringValueOf" enabled="false" level="WARNING" enabled_by_default="false" />
@@ -655,10 +806,20 @@
     <inspection_tool class="UnnecessaryLabelOnBreakStatementJS" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UnnecessaryLabelOnContinueStatement" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UnnecessaryLabelOnContinueStatementJS" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="UnnecessaryLocalVariable" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="UnnecessaryLocalVariableJS" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryLocalVariable" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_ignoreImmediatelyReturnedVariables" value="false" />
+      <option name="m_ignoreAnnotatedVariables" value="false" />
+    </inspection_tool>
+    <inspection_tool class="UnnecessaryLocalVariableJS" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="m_ignoreImmediatelyReturnedVariables" value="false" />
+      <option name="m_ignoreAnnotatedVariables" value="false" />
+    </inspection_tool>
     <inspection_tool class="UnnecessaryModuleDependencyInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="UnnecessaryParentheses" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryParentheses" enabled="false" level="INFORMATION" enabled_by_default="false">
+      <option name="ignoreClarifyingParentheses" value="false" />
+      <option name="ignoreParenthesesOnConditionals" value="false" />
+      <option name="ignoreParenthesesOnLambdaParameter" value="false" />
+    </inspection_tool>
     <inspection_tool class="UnnecessaryQualifiedReference" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UnnecessaryReturn" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UnnecessaryReturnJS" enabled="false" level="WARNING" enabled_by_default="false" />
@@ -670,8 +831,14 @@
     <inspection_tool class="UnregisteredActivator" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="UnresolvedReference" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="UnstableApiUsage" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="UnterminatedStatementJS" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="UnusedAssignment" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnterminatedStatementJS" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="ignoreSemicolonAtEndOfBlock" value="true" />
+    </inspection_tool>
+    <inspection_tool class="UnusedAssignment" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="REPORT_PREFIX_EXPRESSIONS" value="false" />
+      <option name="REPORT_POSTFIX_EXPRESSIONS" value="true" />
+      <option name="REPORT_REDUNDANT_INITIALIZER" value="true" />
+    </inspection_tool>
     <inspection_tool class="UnusedLabel" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UnusedProperty" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UnusedReturnValue" enabled="false" level="WARNING" enabled_by_default="false" />
@@ -686,7 +853,9 @@
     </inspection_tool>
     <inspection_tool class="WebpackConfigHighlighting" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="WhileCanBeForeach" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="WhileLoopSpinsOnField" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="WhileLoopSpinsOnField" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="ignoreNonEmtpyLoops" value="true" />
+    </inspection_tool>
     <inspection_tool class="WithStatementJS" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="WrapperTypeMayBePrimitive" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="WrongImportPackage" enabled="false" level="ERROR" enabled_by_default="false" />

--- a/.idea/inspectionProfiles/No_Back_Sliding.xml
+++ b/.idea/inspectionProfiles/No_Back_Sliding.xml
@@ -143,7 +143,6 @@
     <inspection_tool class="CssUnusedSymbol" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="CsvValidation" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="CythonUsageBeforeDeclarationInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="DanglingJavadoc" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="DefaultAnnotationParam" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="DefaultFileTemplate" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="CHECK_FILE_HEADER" value="true" />

--- a/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/loader/JavaSourceLoaderImpl.java
+++ b/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/loader/JavaSourceLoaderImpl.java
@@ -84,10 +84,10 @@ import java.util.Set;
 /** A {@link ClassLoaderImpl} that processes source file entities in the compile-time classpath. */
 public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
   public Map<CAstEntity, IClass> fTypeMap = HashMapFactory.make();
-  /** BEGIN Custom change: Common superclass is optional */
+  /* BEGIN Custom change: Common superclass is optional */
   private final boolean
       existsCommonSuperclass; // extension to deal with X10 that has no common superclass
-  /** END Custom change: Common superclass is optional */
+  /* END Custom change: Common superclass is optional */
 
   /**
    * WALA representation of a Java class residing in a source file
@@ -151,12 +151,12 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
       // The following test allows the root class to reside in source; without
       // it, the assertion requires all classes represented by a JavaClass to
       // have a superclass.
-      /** BEGIN Custom change: Common superclass is optional */
+      /* BEGIN Custom change: Common superclass is optional */
       // Is no longer true in new X10 - no common object super class
       if (existsCommonSuperclass
           && !getName().equals(JavaSourceLoaderImpl.this.getLanguage().getRootType().getName())
           && !excludedSupertype) {
-        /** END Custom change: Common superclass is optional */
+        /* END Custom change: Common superclass is optional */
         Assertions.UNREACHABLE("Cannot find super class for " + this + " in " + superTypeNames);
       }
 
@@ -571,7 +571,7 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
     return result;
   }
 
-  /** BEGIN Custom change: Common superclass is optional */
+  /* BEGIN Custom change: Common superclass is optional */
   public JavaSourceLoaderImpl(
       boolean existsCommonSuperClass,
       ClassLoaderReference loaderRef,
@@ -591,7 +591,7 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
     // standard case: we have a common super class
     this(true, loaderRef, parent, cha);
   }
-  /** END Custom change: Common superclass is optional */
+  /* END Custom change: Common superclass is optional */
   public IClassHierarchy getClassHierarchy() {
     return cha;
   }
@@ -602,17 +602,17 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
   }
 
   protected abstract SourceModuleTranslator getTranslator();
-  /** BEGIN Custom change: Optional deletion of fTypeMap */
+  /* BEGIN Custom change: Optional deletion of fTypeMap */
   public static volatile boolean deleteTypeMapAfterInit = true;
-  /** END Custom change: Optional deletion of fTypeMap */
+  /* END Custom change: Optional deletion of fTypeMap */
   @Override
   public void init(List<Module> modules) throws IOException {
     super.init(modules);
-    /** BEGIN Custom change: Optional deletion of fTypeMap */
+    /* BEGIN Custom change: Optional deletion of fTypeMap */
     if (deleteTypeMapAfterInit) {
       fTypeMap = null;
     }
-    /** END Custom change: Optional deletion of fTypeMap */
+    /* END Custom change: Optional deletion of fTypeMap */
   }
 
   public void defineFunction(

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JSCFABuilder.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JSCFABuilder.java
@@ -108,9 +108,6 @@ public abstract class JSCFABuilder extends JSSSAPropagationCallGraphBuilder {
 
           /**
            * All values used as property names get implicitly converted to strings in JavaScript.
-           *
-           * @see
-           *     com.ibm.wala.cast.ipa.callgraph.DelegatingAstPointerKeys#getFieldNameType(com.ibm.wala.ipa.callgraph.propagation.InstanceKey)
            */
           @Override
           protected IClass getFieldNameType(InstanceKey F) {

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/cha/CrossLanguageClassHierarchy.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/cha/CrossLanguageClassHierarchy.java
@@ -272,10 +272,10 @@ public class CrossLanguageClassHierarchy implements IClassHierarchy {
     return new CrossLanguageClassHierarchy(scope, factory, hierarchies);
   }
 
-  /** BEGIN Custom change: unresolved classes */
+  /* BEGIN Custom change: unresolved classes */
   @Override
   public Set<TypeReference> getUnresolvedClasses() {
     return HashSetFactory.make();
   }
-  /** END Custom change: unresolved classes */
+  /* END Custom change: unresolved classes */
 }

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/analysis/LiveAnalysis.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/analysis/LiveAnalysis.java
@@ -77,7 +77,7 @@ public class LiveAnalysis {
     final BitVectorIntSet liveAtExit = new BitVectorIntSet(considerLiveAtExit);
     final SSAInstruction[] instructions = cfg.getInstructions();
 
-    /** Gen/kill operator specific to exit basic blocks */
+    /* Gen/kill operator specific to exit basic blocks */
     final class ExitBlockGenKillOperator extends UnaryOperator<BitVectorVariable> {
       @Override
       public String toString() {
@@ -108,7 +108,7 @@ public class LiveAnalysis {
       }
     }
 
-    /** Gen/kill operator for a regular basic block. */
+    /* Gen/kill operator for a regular basic block. */
     final class BlockValueGenKillOperator extends UnaryOperator<BitVectorVariable> {
       private final ISSABasicBlock block;
 

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/analysis/LiveAnalysis.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/analysis/LiveAnalysis.java
@@ -194,7 +194,7 @@ public class LiveAnalysis {
       }
     }
 
-    /** Create the solver */
+    /* Create the solver */
     final BitVectorSolver<ISSABasicBlock> S =
         new BitVectorSolver<>(
             new IKilldallFramework<ISSABasicBlock, BitVectorVariable>() {
@@ -247,14 +247,14 @@ public class LiveAnalysis {
               }
             });
 
-    /** Solve the analysis problem */
+    /* Solve the analysis problem */
     try {
       S.solve(null);
     } catch (CancelException e) {
       throw new CancelRuntimeException(e);
     }
 
-    /** Prepare the lazy result with a closure. */
+    /* Prepare the lazy result with a closure. */
     return new Result() {
 
       @Override

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AbstractClassEntity.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AbstractClassEntity.java
@@ -9,7 +9,6 @@
  *     IBM Corporation - initial API and implementation
  */
 
-/** */
 package com.ibm.wala.cast.ir.translator;
 
 import com.ibm.wala.cast.tree.CAstQualifier;

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AbstractCodeEntity.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AbstractCodeEntity.java
@@ -9,7 +9,6 @@
  *     IBM Corporation - initial API and implementation
  */
 
-/** */
 package com.ibm.wala.cast.ir.translator;
 
 import com.ibm.wala.cast.tree.CAstNode;

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AbstractDataEntity.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AbstractDataEntity.java
@@ -9,7 +9,6 @@
  *     IBM Corporation - initial API and implementation
  */
 
-/** */
 package com.ibm.wala.cast.ir.translator;
 
 import com.ibm.wala.cast.tree.CAstControlFlowMap;

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AbstractEntity.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AbstractEntity.java
@@ -9,7 +9,6 @@
  *     IBM Corporation - initial API and implementation
  */
 
-/** */
 package com.ibm.wala.cast.ir.translator;
 
 import com.ibm.wala.cast.tree.CAstAnnotation;

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AbstractFieldEntity.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AbstractFieldEntity.java
@@ -9,7 +9,6 @@
  *     IBM Corporation - initial API and implementation
  */
 
-/** */
 package com.ibm.wala.cast.ir.translator;
 
 import com.ibm.wala.cast.tree.CAstEntity;

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AbstractGlobalEntity.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AbstractGlobalEntity.java
@@ -9,7 +9,6 @@
  *     IBM Corporation - initial API and implementation
  */
 
-/** */
 package com.ibm.wala.cast.ir.translator;
 
 import com.ibm.wala.cast.tree.CAstQualifier;

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AbstractScriptEntity.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AbstractScriptEntity.java
@@ -9,7 +9,6 @@
  *     IBM Corporation - initial API and implementation
  */
 
-/** */
 package com.ibm.wala.cast.ir.translator;
 
 import com.ibm.wala.cast.tree.CAstNode;

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/loader/AstMethod.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/loader/AstMethod.java
@@ -337,7 +337,7 @@ public abstract class AstMethod implements IMethod {
   public int getNumberOfParameters() {
     return symtab.getParameterValueNumbers().length;
   }
-  /** BEGIN Custom change: precise bytecode positions */
+  /* BEGIN Custom change: precise bytecode positions */
 
   /*
    * @see com.ibm.wala.classLoader.IMethod#getParameterSourcePosition(int)
@@ -346,7 +346,7 @@ public abstract class AstMethod implements IMethod {
   public SourcePosition getParameterSourcePosition(int paramNum) throws InvalidClassFileException {
     return null;
   }
-  /** END Custom change: precise bytecode positions */
+  /* END Custom change: precise bytecode positions */
   @Override
   public int getLineNumber(int instructionIndex) {
     Position pos = debugInfo.getInstructionPosition(instructionIndex);

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/arraybounds/hypergraph/package-info.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/arraybounds/hypergraph/package-info.java
@@ -1,8 +1,7 @@
-package com.ibm.wala.analysis.arraybounds.hypergraph;
-
 /**
  * This package contains a generic implementation of directed hypergraphs. The implementation is
  * optimized for shortest path search, with {@link
  * com.ibm.wala.analysis.arraybounds.hypergraph.algorithms.ShortestPath#compute(com.ibm.wala.analysis.arraybounds.hypergraph.DirectedHyperGraph,
  * com.ibm.wala.analysis.arraybounds.hypergraph.HyperNode, java.util.Comparator) ShortestPath}
  */
+package com.ibm.wala.analysis.arraybounds.hypergraph;

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/ClassFactoryContextInterpreter.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/ClassFactoryContextInterpreter.java
@@ -50,10 +50,10 @@ public class ClassFactoryContextInterpreter implements SSAContextInterpreter {
 
   private static final boolean DEBUG = false;
 
-  /** BEGIN Custom change: caching */
+  /* BEGIN Custom change: caching */
   private final Map<String, IR> cache = HashMapFactory.make();
 
-  /** END Custom change: caching */
+  /* END Custom change: caching */
   @Override
   public IR getIR(CGNode node) {
     if (node == null) {
@@ -63,7 +63,7 @@ public class ClassFactoryContextInterpreter implements SSAContextInterpreter {
     if (DEBUG) {
       System.err.println("generating IR for " + node);
     }
-    /** BEGIN Custom change: caching */
+    /* BEGIN Custom change: caching */
     final Context context = node.getContext();
     final IMethod method = node.getMethod();
     final String hashKey = method.toString() + '@' + context.toString();
@@ -75,7 +75,7 @@ public class ClassFactoryContextInterpreter implements SSAContextInterpreter {
       cache.put(hashKey, result);
     }
 
-    /** END Custom change: caching */
+    /* END Custom change: caching */
     return result;
   }
 

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/ClassNewInstanceContextInterpreter.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/ClassNewInstanceContextInterpreter.java
@@ -66,10 +66,10 @@ public class ClassNewInstanceContextInterpreter extends AbstractReflectionInterp
 
   private final IClassHierarchy cha;
 
-  /** BEGIN Custom change: caching */
+  /* BEGIN Custom change: caching */
   private final Map<String, IR> cache = HashMapFactory.make();
 
-  /** END Custom change: caching */
+  /* END Custom change: caching */
   public ClassNewInstanceContextInterpreter(IClassHierarchy cha) {
     this.cha = cha;
   }
@@ -83,7 +83,7 @@ public class ClassNewInstanceContextInterpreter extends AbstractReflectionInterp
     if (DEBUG) {
       System.err.println("generating IR for " + node);
     }
-    /** BEGIN Custom change: caching */
+    /* BEGIN Custom change: caching */
     final Context context = node.getContext();
     final IMethod method = node.getMethod();
     final String hashKey = method.toString() + '@' + context.toString();
@@ -95,7 +95,7 @@ public class ClassNewInstanceContextInterpreter extends AbstractReflectionInterp
       cache.put(hashKey, result);
     }
 
-    /** END Custom change: caching */
+    /* END Custom change: caching */
     return result;
   }
 

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/GetClassContextInterpeter.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/GetClassContextInterpeter.java
@@ -45,10 +45,10 @@ import java.util.Map;
  */
 public class GetClassContextInterpeter implements SSAContextInterpreter {
 
-  /** BEGIN Custom change: caching */
+  /* BEGIN Custom change: caching */
   private final Map<String, IR> cache = HashMapFactory.make();
 
-  /** END Custom change: caching */
+  /* END Custom change: caching */
   private static final boolean DEBUG = false;
 
   @Override
@@ -60,7 +60,7 @@ public class GetClassContextInterpeter implements SSAContextInterpreter {
     if (DEBUG) {
       System.err.println("generating IR for " + node);
     }
-    /** BEGIN Custom change: caching */
+    /* BEGIN Custom change: caching */
     final Context context = node.getContext();
     final IMethod method = node.getMethod();
     final String hashKey = method.toString() + '@' + context.toString();
@@ -72,7 +72,7 @@ public class GetClassContextInterpeter implements SSAContextInterpreter {
       cache.put(hashKey, result);
     }
 
-    /** END Custom change: caching */
+    /* END Custom change: caching */
     return result;
   }
 

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/GetMethodContextInterpreter.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/GetMethodContextInterpreter.java
@@ -119,10 +119,6 @@ public class GetMethodContextInterpreter implements SSAContextInterpreter {
     return getIR(node).getInstructions().length;
   }
 
-  /**
-   * @see
-   *     com.ibm.wala.ipa.callgraph.propagation.rta.RTAContextInterpreter#understands(com.ibm.wala.ipa.callgraph.CGNode)
-   */
   @Override
   public boolean understands(CGNode node) {
     if (node == null) {

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/JavaLangClassContextInterpreter.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/JavaLangClassContextInterpreter.java
@@ -109,10 +109,10 @@ public class JavaLangClassContextInterpreter implements SSAContextInterpreter {
 
   private static final boolean DEBUG = false;
 
-  /** BEGIN Custom change: caching */
+  /* BEGIN Custom change: caching */
   private final Map<String, IR> cache = HashMapFactory.make();
 
-  /** END Custom change: caching */
+  /* END Custom change: caching */
   /*
    * @see com.ibm.wala.ipa.callgraph.propagation.SSAContextInterpreter#getIR(com.ibm.wala.ipa.callgraph.CGNode)
    */
@@ -125,7 +125,7 @@ public class JavaLangClassContextInterpreter implements SSAContextInterpreter {
     if (DEBUG) {
       System.err.println("generating IR for " + node);
     }
-    /** BEGIN Custom change: caching */
+    /* BEGIN Custom change: caching */
     final Context context = node.getContext();
     final IMethod method = node.getMethod();
     final String hashKey = method.toString() + '@' + context.toString();
@@ -233,7 +233,7 @@ public class JavaLangClassContextInterpreter implements SSAContextInterpreter {
     Assertions.UNREACHABLE("Unexpected method " + method);
     return null;
   }
-  /** END Custom change: caching */
+  /* END Custom change: caching */
 
   /*
    * @see com.ibm.wala.ipa.callgraph.propagation.SSAContextInterpreter#getNumberOfStatements(com.ibm.wala.ipa.callgraph.CGNode)

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/ReflectiveInvocationInterpreter.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/ReflectiveInvocationInterpreter.java
@@ -60,10 +60,10 @@ public class ReflectiveInvocationInterpreter extends AbstractReflectionInterpret
           "invoke",
           "(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;");
 
-  /** BEGIN Custom change: caching */
+  /* BEGIN Custom change: caching */
   private final Map<String, IR> cache = HashMapFactory.make();
 
-  /** END Custom change: caching */
+  /* END Custom change: caching */
   /*
    * @see com.ibm.wala.ipa.callgraph.propagation.SSAContextInterpreter#getIR(com.ibm.wala.ipa.callgraph.CGNode)
    */
@@ -80,7 +80,7 @@ public class ReflectiveInvocationInterpreter extends AbstractReflectionInterpret
     @SuppressWarnings("unchecked")
     ConstantKey<IMethod> c = (ConstantKey<IMethod>) recv.get(ContextKey.RECEIVER);
     IMethod m = c.getValue();
-    /** BEGIN Custom change: caching */
+    /* BEGIN Custom change: caching */
     final IMethod method = node.getMethod();
     final String hashKey = method.toString() + '@' + recv.toString();
 
@@ -91,7 +91,7 @@ public class ReflectiveInvocationInterpreter extends AbstractReflectionInterpret
       cache.put(hashKey, result);
     }
 
-    /** END Custom change: caching */
+    /* END Custom change: caching */
     return result;
   }
 

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/IMethod.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/IMethod.java
@@ -89,7 +89,7 @@ public interface IMethod extends IMember, ContextItem {
    *     information is not available.
    */
   int getLineNumber(int bcIndex);
-  /** BEGIN Custom change: precise positions */
+  /* BEGIN Custom change: precise positions */
   public interface SourcePosition extends Comparable<SourcePosition> {
     int getFirstLine();
 
@@ -107,7 +107,7 @@ public interface IMethod extends IMember, ContextItem {
   SourcePosition getSourcePosition(int instructionIndex) throws InvalidClassFileException;
 
   SourcePosition getParameterSourcePosition(int paramNum) throws InvalidClassFileException;
-  /** END Custom change: precise positions */
+  /* END Custom change: precise positions */
 
   /**
    * @return the (source code) name of the local variable of a given number at the specified program

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/ShrikeBTMethod.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/ShrikeBTMethod.java
@@ -85,7 +85,7 @@ public abstract class ShrikeBTMethod implements IMethod, BytecodeConstants {
 
     /** Mapping from instruction index to program counter. */
     private int[] pcMap;
-    /** BEGIN Custom change: precise positions */
+    /* BEGIN Custom change: precise positions */
 
     /** Cached map representing position information for bytecode instruction at given index */
     protected SourcePosition[] positionMap;
@@ -93,7 +93,7 @@ public abstract class ShrikeBTMethod implements IMethod, BytecodeConstants {
     /** Sourcecode positions for method parameters */
     protected SourcePosition[] paramPositionMap;
 
-    /** END Custom change: precise positions */
+    /* END Custom change: precise positions */
 
     /**
      * Cached map representing line number information in ShrikeCT format TODO: do more careful
@@ -744,7 +744,7 @@ public abstract class ShrikeBTMethod implements IMethod, BytecodeConstants {
       return null;
     }
   }
-  /** BEGIN Custom change: precise bytecode positions */
+  /* BEGIN Custom change: precise bytecode positions */
 
   /*
    * @see com.ibm.wala.classLoader.IMethod#getSourcePosition(int)
@@ -761,7 +761,7 @@ public abstract class ShrikeBTMethod implements IMethod, BytecodeConstants {
   public SourcePosition getParameterSourcePosition(int paramNum) throws InvalidClassFileException {
     return (getBCInfo().paramPositionMap == null) ? null : getBCInfo().paramPositionMap[paramNum];
   }
-  /** END Custom change: precise bytecode positions */
+  /* END Custom change: precise bytecode positions */
 
   /*
    * @see com.ibm.wala.classLoader.IMethod#getLineNumber(int)

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/ShrikeCTMethod.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/ShrikeCTMethod.java
@@ -143,7 +143,7 @@ public final class ShrikeCTMethod extends ShrikeBTMethod implements IBytecodeMet
       return reader.getClasses();
     }
   }
-  /** BEGIN Custom change: precise positions */
+  /* BEGIN Custom change: precise positions */
   private static final class SPos implements SourcePosition {
     String fileName;
     final int firstLine;
@@ -213,13 +213,13 @@ public final class ShrikeCTMethod extends ShrikeBTMethod implements IBytecodeMet
       return fileName + '(' + firstLine + ',' + firstCol + '-' + lastLine + ',' + lastCol + ')';
     }
   }
-  /** END Custom change: precise positions */
+  /* END Custom change: precise positions */
   @Override
   protected void processDebugInfo(BytecodeInfo bcInfo) throws InvalidClassFileException {
     CodeReader cr = getCodeReader();
     bcInfo.lineNumberMap = LineNumberTableReader.makeBytecodeToSourceMap(cr);
     bcInfo.localVariableMap = LocalVariableTableReader.makeVarMap(cr);
-    /** BEGIN Custom change: precise bytecode positions */
+    /* BEGIN Custom change: precise bytecode positions */
     Position param = null;
     try {
       param = SourcePositionTableReader.findParameterPosition(shrikeMethodIndex, cr);
@@ -261,7 +261,7 @@ public final class ShrikeCTMethod extends ShrikeBTMethod implements IBytecodeMet
             new SPos(sourceFile, p.firstLine, p.lastLine, p.firstCol, p.lastCol);
       }
     }
-    /** END Custom change: : precise bytecode positions */
+    /* END Custom change: : precise bytecode positions */
   }
 
   @Override

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/SyntheticMethod.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/SyntheticMethod.java
@@ -300,7 +300,7 @@ public class SyntheticMethod implements IMethod {
   public Descriptor getDescriptor() {
     return method.getSelector().getDescriptor();
   }
-  /** BEGIN Custom change: : precise bytecode positions */
+  /* BEGIN Custom change: : precise bytecode positions */
 
   /*
    * @see com.ibm.wala.classLoader.IMethod#getSourcePosition(int)
@@ -317,7 +317,7 @@ public class SyntheticMethod implements IMethod {
   public SourcePosition getParameterSourcePosition(int paramNum) throws InvalidClassFileException {
     return null;
   }
-  /** END Custom change: precise bytecode positions */
+  /* END Custom change: precise bytecode positions */
 
   /*
    * @see com.ibm.wala.classLoader.IMethod#getLineNumber(int)

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/Util.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/Util.java
@@ -57,7 +57,7 @@ public class Util {
   /** TODO: Make these properties? */
   public static String nativeSpec = "natives.xml";
 
-  /** BEGIN Custom change: change native spec */
+  /* BEGIN Custom change: change native spec */
   public static void setNativeSpec(String xmlFile) {
     nativeSpec = xmlFile;
   }
@@ -65,7 +65,7 @@ public class Util {
   public static String getNativeSpec() {
     return nativeSpec;
   }
-  /** END Custom change: change native spec */
+  /* END Custom change: change native spec */
   /**
    * Set up an AnalysisOptions object with default selectors, corresponding to class hierarchy
    * lookup

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PropagationCallGraphBuilder.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PropagationCallGraphBuilder.java
@@ -232,7 +232,7 @@ public abstract class PropagationCallGraphBuilder implements CallGraphBuilder<In
       }
     }
 
-    /**
+    /*
      * BEGIN Custom change: throw exception on empty entry points. This is a severe issue that
      * should not go undetected!
      */
@@ -240,7 +240,7 @@ public abstract class PropagationCallGraphBuilder implements CallGraphBuilder<In
       throw new IllegalStateException(
           "Could not create a entrypoint callsites: " + Warnings.asString());
     }
-    /**
+    /*
      * END Custom change: throw exception on empty entry points. This is a severe issue that should
      * not go undetected!
      */
@@ -678,12 +678,12 @@ public abstract class PropagationCallGraphBuilder implements CallGraphBuilder<In
     return pointerKeyFactory;
   }
 
-  /** BEGIN Custom change: setter for pointerkey factory */
+  /* BEGIN Custom change: setter for pointerkey factory */
   public void setPointerKeyFactory(PointerKeyFactory pkFact) {
     pointerKeyFactory = pkFact;
   }
 
-  /** END Custom change: setter for pointerkey factory */
+  /* END Custom change: setter for pointerkey factory */
   public RTAContextInterpreter getContextInterpreter() {
     return contextInterpreter;
   }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/SSAPropagationCallGraphBuilder.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/SSAPropagationCallGraphBuilder.java
@@ -111,7 +111,7 @@ public abstract class SSAPropagationCallGraphBuilder extends PropagationCallGrap
   /** Counter for wiping soft caches */
   private static int wipeCount = 0;
 
-  /** use type inference to avoid unnecessary filter constraints? */
+  // /** use type inference to avoid unnecessary filter constraints? */
   // private final static boolean OPTIMIZE_WITH_TYPE_INFERENCE = true;
   /**
    * An optimization: if we can locally determine the final solution for a points-to set, then don't

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/cfa/FallbackContextInterpreter.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/cfa/FallbackContextInterpreter.java
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  */
 
-/**
+/*
  * This file is part of the Joana IFC project. It is developed at the Programming Paradigms Group of
  * the Karlsruhe Institute of Technology.
  *

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/TypeBasedHeapModel.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/rta/TypeBasedHeapModel.java
@@ -228,10 +228,6 @@ public class TypeBasedHeapModel implements HeapModel {
   /**
    * Note that this always returns a {@link FilteredPointerKey}, since the {@link
    * TypeBasedPointerAnalysis} relies on the type filter to compute points to sets.
-   *
-   * @see
-   *     com.ibm.wala.ipa.callgraph.propagation.PointerKeyFactory#getPointerKeyForLocal(com.ibm.wala.ipa.callgraph.CGNode,
-   *     int)
    */
   @Override
   public FilteredPointerKey getPointerKeyForLocal(CGNode node, int valueNumber) {

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/cfg/exceptionpruning/interprocedural/package-info.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/cfg/exceptionpruning/interprocedural/package-info.java
@@ -1,3 +1,2 @@
-/** */
 /** @author stephan */
 package com.ibm.wala.ipa.cfg.exceptionpruning.interprocedural;

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/cha/ClassHierarchy.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/cha/ClassHierarchy.java
@@ -884,7 +884,7 @@ public class ClassHierarchy implements IClassHierarchy {
     if (a == null) {
       throw new IllegalArgumentException("a is null");
     }
-    /** BEGIN Custom change: remember unresolved classes */
+    /* BEGIN Custom change: remember unresolved classes */
     final IClass cls = lookupClassRecursive(a);
 
     if (cls == null) {
@@ -895,7 +895,7 @@ public class ClassHierarchy implements IClassHierarchy {
   }
 
   private IClass lookupClassRecursive(TypeReference a) {
-    /** END Custom change: remember unresolved classes */
+    /* END Custom change: remember unresolved classes */
     ClassLoaderReference loader = a.getClassLoader();
 
     ClassLoaderReference parent = loader.getParent();
@@ -1307,7 +1307,7 @@ public class ClassHierarchy implements IClassHierarchy {
     }
   }
 
-  /** BEGIN Custom change: remember unresolved classes */
+  /* BEGIN Custom change: remember unresolved classes */
   private final Set<TypeReference> unresolved = HashSetFactory.make();
 
   @Override
@@ -1315,7 +1315,7 @@ public class ClassHierarchy implements IClassHierarchy {
     return unresolved;
   }
 
-  /** END Custom change: remember unresolved classes */
+  /* END Custom change: remember unresolved classes */
   public MissingSuperClassHandling getSuperClassHandling() {
     return superClassHandling;
   }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/cha/IClassHierarchy.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/cha/IClassHierarchy.java
@@ -50,10 +50,10 @@ public interface IClassHierarchy extends Iterable<IClass> {
 
   public int getNumber(IClass c);
 
-  /** BEGIN Custom change: remember unresolved classes */
+  /* BEGIN Custom change: remember unresolved classes */
   public Set<TypeReference> getUnresolvedClasses();
 
-  /** END Custom change: remember unresolved classes */
+  /* END Custom change: remember unresolved classes */
   /**
    * Find the possible targets of a call to a method reference
    *

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/PDG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/PDG.java
@@ -69,7 +69,7 @@ import java.util.stream.Stream;
 /** Program dependence graph for a single call graph node */
 public class PDG<T extends InstanceKey> implements NumberedGraph<Statement> {
 
-  /** BEGIN Custom change: control deps */
+  /* BEGIN Custom change: control deps */
   public enum Dependency {
     CONTROL_DEP,
     DATA_AND_CONTROL_DEP
@@ -77,7 +77,7 @@ public class PDG<T extends InstanceKey> implements NumberedGraph<Statement> {
 
   private final SlowSparseNumberedLabeledGraph<Statement, Dependency> delegate =
       new SlowSparseNumberedLabeledGraph<>(Dependency.DATA_AND_CONTROL_DEP);
-  /** END Custom change: control deps */
+  /* END Custom change: control deps */
   private static final boolean VERBOSE = false;
 
   private final CGNode node;
@@ -313,9 +313,9 @@ public class PDG<T extends InstanceKey> implements NumberedGraph<Statement> {
               Statement dest = ssaInstruction2Statement(st, ir, instructionIndices);
               assert src != null;
               delegate.addEdge(src, dest);
-              /** BEGIN Custom change: control deps */
+              /* BEGIN Custom change: control deps */
               delegate.addEdge(src, dest, Dependency.CONTROL_DEP);
-              /** END Custom change: control deps */
+              /* END Custom change: control deps */
             }
           }
         }
@@ -332,9 +332,9 @@ public class PDG<T extends InstanceKey> implements NumberedGraph<Statement> {
       for (SSAInstruction st : exitDom) {
         Statement dest = ssaInstruction2Statement(st, ir, instructionIndices);
         delegate.addEdge(methodEntry, dest);
-        /** BEGIN Custom change: control deps */
+        /* BEGIN Custom change: control deps */
         delegate.addEdge(methodEntry, dest, Dependency.CONTROL_DEP);
-        /** END Custom change: control deps */
+        /* END Custom change: control deps */
       }
     }
     // add CD from method entry to all callee parameter assignments
@@ -345,7 +345,7 @@ public class PDG<T extends InstanceKey> implements NumberedGraph<Statement> {
     // addEdge(methodEntry, paramCalleeStatements[i]);
     // }
 
-    /**
+    /*
      * JTD: While phi nodes live in a particular basic block, they represent a meet of values from
      * multiple blocks. Hence, they are really like multiple statements that are control dependent
      * in the manner of the predecessor blocks. When the slicer is following both data and control
@@ -374,16 +374,16 @@ public class PDG<T extends InstanceKey> implements NumberedGraph<Statement> {
               assert pss != null;
               Statement pst = ssaInstruction2Statement(pss, ir, instructionIndices);
               delegate.addEdge(pst, phiSt);
-              /** BEGIN Custom change: control deps */
+              /* BEGIN Custom change: control deps */
               delegate.addEdge(pst, phiSt, Dependency.CONTROL_DEP);
-              /** END Custom change: control deps */
+              /* END Custom change: control deps */
             } else {
               for (ISSABasicBlock cpb : Iterator2Iterable.make(cdg.getPredNodes(pb))) {
-                /** BEGIN Custom change: control deps */
+                /* BEGIN Custom change: control deps */
                 if (cpb.getLastInstructionIndex() < 0) {
                   continue;
                 }
-                /** END Custom change: control deps */
+                /* END Custom change: control deps */
                 SSAInstruction cps = ir.getInstructions()[cpb.getLastInstructionIndex()];
                 assert cps != null
                     : "unexpected null final instruction for CDG predecessor "
@@ -392,9 +392,9 @@ public class PDG<T extends InstanceKey> implements NumberedGraph<Statement> {
                         + node;
                 Statement cpst = ssaInstruction2Statement(cps, ir, instructionIndices);
                 delegate.addEdge(cpst, phiSt);
-                /** BEGIN Custom change: control deps */
+                /* BEGIN Custom change: control deps */
                 delegate.addEdge(cpst, phiSt, Dependency.CONTROL_DEP);
-                /** END Custom change: control deps */
+                /* END Custom change: control deps */
               }
             }
             phiUseIndex++;
@@ -1288,9 +1288,9 @@ public class PDG<T extends InstanceKey> implements NumberedGraph<Statement> {
     Assertions.UNREACHABLE();
     return null;
   }
-  /** BEGIN Custom change: control deps */
+  /* BEGIN Custom change: control deps */
   public boolean isControlDependend(Statement from, Statement to) {
     return delegate.hasEdge(from, to, Dependency.CONTROL_DEP);
   }
-  /** END Custom change: control deps */
+  /* END Custom change: control deps */
 }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/SyntheticIR.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/SyntheticIR.java
@@ -96,7 +96,7 @@ public class SyntheticIR extends IR {
       }
     }
 
-    /**
+    /*
      * In InducedCFGs, we have nulled out phi instructions from the instruction array ... so go back
      * and retrieve them now.
      */

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/XMLMethodSummaryReader.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/XMLMethodSummaryReader.java
@@ -723,7 +723,7 @@ public class XMLMethodSummaryReader implements BytecodeConstants {
       if (V == null) {
         Assertions.UNREACHABLE("Must specify value for aastore " + governingMethod);
       }
-      /** BEGIN Custom change: expect type information in array-store instructions */
+      /* BEGIN Custom change: expect type information in array-store instructions */
       String strType = atts.getValue(A_TYPE);
       TypeReference type;
       if (strType == null) {
@@ -731,12 +731,12 @@ public class XMLMethodSummaryReader implements BytecodeConstants {
       } else {
         type = TypeReference.findOrCreate(governingLoader, strType);
       }
-      /** END Custom change: get type information in array-store instructions */
+      /* END Custom change: get type information in array-store instructions */
       Integer valueNumber = symbolTable.get(V);
       if (valueNumber == null) {
         Assertions.UNREACHABLE("Cannot lookup value: " + V);
       }
-      /** BEGIN Custom change: expect type information in array-store instructions */
+      /* BEGIN Custom change: expect type information in array-store instructions */
       SSAArrayStoreInstruction S =
           insts.ArrayStoreInstruction(
               governingMethod.getNumberOfStatements(),
@@ -744,7 +744,7 @@ public class XMLMethodSummaryReader implements BytecodeConstants {
               0,
               valueNumber.intValue(),
               type);
-      /** END Custom change: get type information in array-store instructions */
+      /* END Custom change: get type information in array-store instructions */
       governingMethod.addStatement(S);
     }
 

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/SSABuilder.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/SSABuilder.java
@@ -475,10 +475,6 @@ public class SSABuilder extends AbstractIntStackMachine {
                 getCurrentInstructionIndex(), instruction.getOperator(), result, val1, val2));
       }
 
-      /**
-       * @see
-       *     com.ibm.wala.shrikeBT.IInstruction.Visitor#visitConditionalBranch(IConditionalBranchInstruction)
-       */
       @Override
       public void visitConditionalBranch(IConditionalBranchInstruction instruction) {
         int val2 = workingState.pop();

--- a/com.ibm.wala.core/src/com/ibm/wala/types/TypeReference.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/types/TypeReference.java
@@ -35,7 +35,7 @@ public final class TypeReference implements Serializable {
   /* Serial version */
   private static final long serialVersionUID = -3256390509887654327L;
 
-  /**
+  /*
    * NOTE: initialisation order is important!
    *
    * <p>TypeReferences are canonical.

--- a/com.ibm.wala.core/src/com/ibm/wala/util/ProgressMaster.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/ProgressMaster.java
@@ -114,7 +114,7 @@ public class ProgressMaster implements IProgressMonitor {
     killNanny();
   }
 
-  /** BEGIN Custom change: subtasks and canceling */
+  /* BEGIN Custom change: subtasks and canceling */
   @Override
   public void subTask(String subTask) {
     delegate.subTask(subTask);
@@ -124,7 +124,7 @@ public class ProgressMaster implements IProgressMonitor {
   public void cancel() {
     setCanceled();
   }
-  /** END Custom change: subtasks and canceling */
+  /* END Custom change: subtasks and canceling */
   @Override
   public synchronized void worked(int work) {
     killNanny();

--- a/com.ibm.wala.core/src/com/ibm/wala/util/ssa/SSAValueManager.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/ssa/SSAValueManager.java
@@ -66,22 +66,22 @@ public class SSAValueManager {
   private final boolean AUTOMAKE_NAMES = true;
 
   private enum ValueStatus {
-    UNUSED,
     /** Value has never been mentioned before */
-    UNALLOCATED,
+    UNUSED,
     /** Awaiting to be set using setAllocation */
-    ALLOCATED,
+    UNALLOCATED,
     /** Set and ready to use */
-    FREE,
+    ALLOCATED,
     /** Has to be assigned using a Phi-Instruction */
-    INVALIDATED,
+    FREE,
     /** Should only be used as argument to a Phi Instruction */
-    CLOSED,
+    INVALIDATED,
     /** Should not be referenced any more */
-    FREE_INVALIDATED,
+    CLOSED,
     /** Well FREE and INVALIDATED */
-    FREE_CLOSED
+    FREE_INVALIDATED,
     /** Well FREE and CLOSED */
+    FREE_CLOSED
   }
 
   // TODO: nextLocal may be 0 on getUnamanged!

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/analysis/typeInference/DalvikTypeInference.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/analysis/typeInference/DalvikTypeInference.java
@@ -65,7 +65,7 @@ public class DalvikTypeInference extends TypeInference {
 
     @Override
     public byte evaluate(TypeVariable _lhs, TypeVariable[] _rhs) {
-      /**
+      /*
        * TODO: Find a better solution than downcasting. Downcasting is really ugly, although I can
        * be sure here that it succeeds because I control what type the parameters have. There must
        * be a cleaner solution which does not cause tons of changes in WALA's code, but I don't see

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/DexIField.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/DexIField.java
@@ -70,7 +70,7 @@ public class DexIField implements IField {
   /** The declaring class for this method. */
   private final DexIClass myClass;
 
-  /** name of the return type for this method, construct in the get return type method. */
+  // /** name of the return type for this method, construct in the get return type method. */
   // private TypeReference typeReference;
 
   /**

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/DexIMethod.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/DexIMethod.java
@@ -197,13 +197,13 @@ public class DexIMethod implements IBytecodeMethod<Instruction> {
 
   @Override
   public TypeReference[] getDeclaredExceptions() throws UnsupportedOperationException {
-    /** BEGIN Custom change: Variable Names in synth. methods */
+    /* BEGIN Custom change: Variable Names in synth. methods */
     if (myClass.getClassDefItem().getAnnotations() == null) {
       return null;
     }
     ArrayList<String> strings = new ArrayList<>();
     Set<? extends org.jf.dexlib2.iface.Annotation> annotationSet = eMethod.getAnnotations();
-    /** END Custom change: Variable Names in synth. methods */
+    /* END Custom change: Variable Names in synth. methods */
     if (annotationSet != null) {
       for (org.jf.dexlib2.iface.Annotation annotationItem : annotationSet) {
         if (annotationItem.getType().contentEquals("Ldalvik/annotation/Throws;")) {
@@ -637,14 +637,14 @@ public class DexIMethod implements IBytecodeMethod<Instruction> {
     for (TryBlock<? extends org.jf.dexlib2.iface.ExceptionHandler> tryItem : tryBlocks) {
       int startAddress = tryItem.getStartCodeAddress();
       int endAddress = tryItem.getStartCodeAddress() + tryItem.getCodeUnitCount();
-      /**
+      /*
        * The end address points to the address immediately after the end of the last instruction
        * that the try block covers. We want the .catch directive and end_try label to be associated
        * with the last covered instruction, so we need to get the address for that instruction
        */
       int startInst = getInstructionIndex(startAddress);
       int endInst;
-      /**
+      /*
        * The try block can extend to the last instruction in the method. If this is the case then
        * endAddress will be the address immediately following the last instruction. Check to make
        * sure this is the case.

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/dex/instructions/ArrayFill.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/dex/instructions/ArrayFill.java
@@ -46,7 +46,6 @@
  *
  */
 
-/** */
 package com.ibm.wala.dalvik.dex.instructions;
 
 import com.ibm.wala.dalvik.classLoader.DexIMethod;

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/dex/util/config/DexAnalysisScopeReader.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/dex/util/config/DexAnalysisScopeReader.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Jonathan Bardin <astrosus@gmail.com> Steve Suh <suhsteve@gmail.com>

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/dex/util/config/DexAnalysisScopeReader.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/dex/util/config/DexAnalysisScopeReader.java
@@ -55,10 +55,10 @@ public class DexAnalysisScopeReader extends AnalysisScopeReader {
 
   private static final ClassLoader WALA_CLASSLOADER = AnalysisScopeReader.class.getClassLoader();
 
-  /** BEGIN Custom change: Fixes in AndroidAnalysisScope */
+  /* BEGIN Custom change: Fixes in AndroidAnalysisScope */
   // private static final String BASIC_FILE = "conf" + File.separator+ "primordial.txt";
   private static final String BASIC_FILE = "./primordial.txt"; // Path inside jar
-  /** END Custom change: Fixes in AndroidAnalysisScope */
+  /* END Custom change: Fixes in AndroidAnalysisScope */
   public static AnalysisScope makeAndroidBinaryAnalysisScope(URI classPath, String exclusionsFile)
       throws IOException {
     if (classPath == null) {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/AndroidModelParameterManager.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/AndroidModelParameterManager.java
@@ -74,22 +74,22 @@ import java.util.Map;
 public class AndroidModelParameterManager {
 
   private enum ValueStatus {
-    UNUSED,
     /** Value has never been mentioned before */
-    UNALLOCATED,
+    UNUSED,
     /** Awaiting to be set using setAllocation */
-    ALLOCATED,
+    UNALLOCATED,
     /** Set and ready to use */
-    FREE,
+    ALLOCATED,
     /** Has to be assigned using a Phi-Instruction */
-    INVALIDATED,
+    FREE,
     /** Should only be used as argument to a Phi Instruction */
-    CLOSED,
+    INVALIDATED,
     /** Should not be referenced any more */
-    FREE_INVALIDATED,
+    CLOSED,
     /** Well FREE and INVALIDATED */
-    FREE_CLOSED
+    FREE_INVALIDATED,
     /** Well FREE and CLOSED */
+    FREE_CLOSED
   }
 
   // TODO: nextLocal may be 0 on getUnamanged!

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/FlatInstantiator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/FlatInstantiator.java
@@ -384,12 +384,12 @@ public class FlatInstantiator implements IInstantiator {
     return newInstr;
   }
 
-  /**
-   * Add a call to a single clinit to the body.
-   *
-   * @param val the "this" to call clinit on
-   * @param inClass the class to call its clinit of
-   */
+  //  /**
+  //   * Add a call to a single clinit to the body.
+  //   *
+  //   * @param val the "this" to call clinit on
+  //   * @param inClass the class to call its clinit of
+  //   */
   /*private void addCallCLinit(SSAValue val, TypeReference inClass) {
       final int pc = this.body.getNextProgramCounter();
       final MethodReference mRef = MethodReference.findOrCreate(inClass, MethodReference.clinitSelector);
@@ -566,7 +566,7 @@ public class FlatInstantiator implements IInstantiator {
     return ret;
   }
 
-  /** Path back to Object (including T itself). */
+  // /** Path back to Object (including T itself). */
   //    private List<TypeReference> getAllSuper(final TypeReference T) {
   //        if (T.isPrimitiveType()) {
   //            throw new IllegalArgumentException("Not you that call primitive type on :P");
@@ -587,7 +587,7 @@ public class FlatInstantiator implements IInstantiator {
   //        return ret;
   //    }
 
-  /** The Constructor starts with 'this()' or 'super()'. */
+  // /** The Constructor starts with 'this()' or 'super()'. */
   /*private boolean callsCtor(MethodReference ctor) {
       if (ctor == null) {
           throw new IllegalArgumentException("Null ctor");

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/Instantiator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/Instantiator.java
@@ -377,12 +377,12 @@ public class Instantiator implements IInstantiator {
     return newInstr;
   }
 
-  /**
-   * Add a call to a single clinit to the body.
-   *
-   * @param val the "this" to call clinit on
-   * @param inClass the class to call its clinit of
-   */
+  //  /**
+  //   * Add a call to a single clinit to the body.
+  //   *
+  //   * @param val the "this" to call clinit on
+  //   * @param inClass the class to call its clinit of
+  //   */
   /*private void addCallCLinit(SSAValue val, TypeReference inClass) {
       final int pc = this.body.getNextProgramCounter();
       final MethodReference mRef = MethodReference.findOrCreate(inClass, MethodReference.clinitSelector);
@@ -572,7 +572,7 @@ public class Instantiator implements IInstantiator {
     return ret;
   }
 
-  /** The Constructor starts with 'this()' or 'super()'. */
+  // /** The Constructor starts with 'this()' or 'super()'. */
   /*private boolean callsCtor(MethodReference ctor) {
       if (ctor == null) {
           throw new IllegalArgumentException("Null ctor");

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/impl/DexEntryPoint.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/impl/DexEntryPoint.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>) Steve Suh

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/impl/DexEntryPoint.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/impl/DexEntryPoint.java
@@ -47,31 +47,31 @@ import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.TypeReference;
 
 public class DexEntryPoint extends DefaultEntrypoint implements IClassHierarchyDweller {
-  /** BEGIN Custom change */
+  /* BEGIN Custom change */
   private IClassHierarchy cha;
-  /** END Custom change */
+  /* END Custom change */
   public DexEntryPoint(IMethod method, IClassHierarchy cha) {
     super(method, cha);
-    /** BEGIN Custom change */
+    /* BEGIN Custom change */
     this.cha = cha;
-    /** END Custom change */
+    /* END Custom change */
     // TODO Auto-generated constructor stub
   }
 
   public DexEntryPoint(MethodReference method, IClassHierarchy cha) {
     super(method, cha);
-    /** BEGIN Custom change */
+    /* BEGIN Custom change */
     this.cha = cha;
-    /** END Custom change */
+    /* END Custom change */
     // TODO Auto-generated constructor stub
   }
 
-  /** BEGIN Custom change */
+  /* BEGIN Custom change */
   @Override
   public IClassHierarchy getClassHierarchy() {
     return cha;
   }
-  /** END Custom change */
+  /* END Custom change */
   @Override
   protected TypeReference[] makeParameterTypes(IMethod method, int i) {
     TypeReference[] trA = new TypeReference[] {method.getParameterType(i)};

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/AbstractIntRegisterMachine.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/AbstractIntRegisterMachine.java
@@ -89,8 +89,8 @@ public abstract class AbstractIntRegisterMachine implements FixedPointConstants 
   /** The control flow graph to analyze */
   private final DexCFG cfg;
 
-  /** The max height of the stack. */
-  //  final private int maxStackHeight;
+  // /** The max height of the stack. */
+  // final private int maxStackHeight;
 
   /** the max number of locals in play */
   protected final int maxLocals;
@@ -369,14 +369,14 @@ public abstract class AbstractIntRegisterMachine implements FixedPointConstants 
     return changed;
   }
 
-  /**
-   * Evaluate a meet of the stacks of machine states at the entry of a catch block.
-   *
-   * <p>TODO: add some efficiency shortcuts. TODO: clean up and refactor.
-   *
-   * @param bb the basic block at whose entry the meet occurs
-   * @return true if the lhs value changes. false otherwise.
-   */
+  //  /**
+  //   * Evaluate a meet of the stacks of machine states at the entry of a catch block.
+  //   *
+  //   * <p>TODO: add some efficiency shortcuts. TODO: clean up and refactor.
+  //   *
+  //   * @param bb the basic block at whose entry the meet occurs
+  //   * @return true if the lhs value changes. false otherwise.
+  //   */
   //  private boolean meetStacksAtCatchBlock(IVariable lhs, IBasicBlock<Instruction> bb, Meeter
   // meeter) {
   //      boolean changed = false;
@@ -405,14 +405,14 @@ public abstract class AbstractIntRegisterMachine implements FixedPointConstants 
   //      return changed;
   //  }
 
-  /**
-   * Evaluate a meet of the stacks of machine states at the entry of a basic block.
-   *
-   * <p>TODO: add some efficiency shortcuts. TODO: clean up and refactor.
-   *
-   * @param bb the basic block at whose entry the meet occurs
-   * @return true if the lhs value changes. false otherwise.
-   */
+  //  /**
+  //   * Evaluate a meet of the stacks of machine states at the entry of a basic block.
+  //   *
+  //   * <p>TODO: add some efficiency shortcuts. TODO: clean up and refactor.
+  //   *
+  //   * @param bb the basic block at whose entry the meet occurs
+  //   * @return true if the lhs value changes. false otherwise.
+  //   */
   //  private boolean meetStacks(IVariable lhs, IVariable[] rhs, IBasicBlock<Instruction> bb, Meeter
   // meeter) {
   //      boolean changed = false;

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/AbstractIntRegisterMachine.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/AbstractIntRegisterMachine.java
@@ -46,7 +46,6 @@ import com.ibm.wala.shrikeBT.ConstantInstruction;
 import com.ibm.wala.shrikeBT.IArrayLoadInstruction;
 import com.ibm.wala.shrikeBT.IArrayStoreInstruction;
 import com.ibm.wala.shrikeBT.IBinaryOpInstruction;
-import com.ibm.wala.shrikeBT.IConditionalBranchInstruction;
 import com.ibm.wala.shrikeBT.IGetInstruction;
 import com.ibm.wala.shrikeBT.IInvokeInstruction;
 import com.ibm.wala.shrikeBT.IPutInstruction;
@@ -897,7 +896,6 @@ public abstract class AbstractIntRegisterMachine implements FixedPointConstants 
         throw new UnimplementedError();
       }
 
-      /** @see com.ibm.wala.shrikeBT.IInstruction.Visitor#visitComparison(IComparisonInstruction) */
       //          @Override
       //          public void visitComparison(IComparisonInstruction instruction) {
       //              workingState.pop();
@@ -905,10 +903,6 @@ public abstract class AbstractIntRegisterMachine implements FixedPointConstants 
       //              workingState.push(UNANALYZED);
       //          }
 
-      /**
-       * @see
-       *     com.ibm.wala.shrikeBT.IInstruction.Visitor#visitConditionalBranch(IConditionalBranchInstruction)
-       */
       @Override
       public void visitBranch(Branch instruction) {
         // TODO
@@ -925,14 +919,12 @@ public abstract class AbstractIntRegisterMachine implements FixedPointConstants 
         throw new UnimplementedError();
       }
 
-      /** @see com.ibm.wala.shrikeBT.IInstruction.Visitor#visitConversion(IConversionInstruction) */
       //          @Override
       //          public void visitConversion(IConversionInstruction instruction) {
       //              workingState.pop();
       //              workingState.push(UNANALYZED);
       //          }
 
-      /** @see com.ibm.wala.shrikeBT.IInstruction.Visitor#visitDup(DupInstruction) */
       //          @Override
       //          public void visitDup(DupInstruction instruction) {
       //
@@ -1010,14 +1002,12 @@ public abstract class AbstractIntRegisterMachine implements FixedPointConstants 
         throw new UnimplementedError();
       }
 
-      /** @see com.ibm.wala.shrikeBT.IInstruction.Visitor#visitLocalLoad(ILoadInstruction) */
       //          @Override
       //          public void visitLocalLoad(ILoadInstruction instruction) {
       //              int t = workingState.getLocal(instruction.getVarIndex());
       //              workingState.push(t);
       //          }
 
-      /** @see com.ibm.wala.shrikeBT.IInstruction.Visitor#visitLocalStore(IStoreInstruction) */
       //          @Override
       //          public void visitLocalStore(IStoreInstruction instruction) {
       //              int index = instruction.getVarIndex();
@@ -1033,7 +1023,6 @@ public abstract class AbstractIntRegisterMachine implements FixedPointConstants 
         throw new UnimplementedError();
       }
 
-      /** @see com.ibm.wala.shrikeBT.IInstruction.Visitor#visitPop(PopInstruction) */
       //          @Override
       //          public void visitPop(PopInstruction instruction) {
       //              if (instruction.getPoppedCount() > 0) {
@@ -1049,13 +1038,11 @@ public abstract class AbstractIntRegisterMachine implements FixedPointConstants 
         throw new UnimplementedError();
       }
 
-      /** @see com.ibm.wala.shrikeBT.IInstruction.Visitor#visitShift(IShiftInstruction) */
       //          @Override
       //          public void visitShift(IShiftInstruction instruction) {
       //              workingState.pop();
       //          }
 
-      /** @see com.ibm.wala.shrikeBT.IInstruction.Visitor#visitSwap(SwapInstruction) */
       //          @Override
       //          public void visitSwap(SwapInstruction instruction) {
       //              workingState.swap();

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/DexSSABuilder.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/DexSSABuilder.java
@@ -48,7 +48,6 @@ import com.ibm.wala.shrikeBT.GotoInstruction;
 import com.ibm.wala.shrikeBT.IArrayLoadInstruction;
 import com.ibm.wala.shrikeBT.IArrayStoreInstruction;
 import com.ibm.wala.shrikeBT.IBinaryOpInstruction;
-import com.ibm.wala.shrikeBT.IConditionalBranchInstruction;
 import com.ibm.wala.shrikeBT.IGetInstruction;
 import com.ibm.wala.shrikeBT.IInvokeInstruction;
 import com.ibm.wala.shrikeBT.IUnaryOpInstruction;
@@ -616,10 +615,6 @@ public class DexSSABuilder extends AbstractIntRegisterMachine {
                 getCurrentInstructionIndex(), result, val, instruction.type, instruction.isPEI()));
       }
 
-      /**
-       * @see
-       *     com.ibm.wala.shrikeBT.IInstruction.Visitor#visitConditionalBranch(IConditionalBranchInstruction)
-       */
       @Override
       public void visitBranch(Branch instruction) {
         if (instruction instanceof Branch.BinaryBranch) {
@@ -705,7 +700,6 @@ public class DexSSABuilder extends AbstractIntRegisterMachine {
         //              workingState.push(symbol);
       }
 
-      /** @see com.ibm.wala.shrikeBT.IInstruction.Visitor#visitConversion(IConversionInstruction) */
       // TODO: is this just a unary operation?
       //          @Override
       //          public void visitConversion(IConversionInstruction instruction) {
@@ -1041,7 +1035,6 @@ public class DexSSABuilder extends AbstractIntRegisterMachine {
         //              }
       }
 
-      /** @see com.ibm.wala.shrikeBT.IInstruction.Visitor#visitShift(IShiftInstruction) */
       // TODO: this is just a binary operation
       //          @Override
       //          public void visitShift(IShiftInstruction instruction) {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidEntryPointLocator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidEntryPointLocator.java
@@ -190,7 +190,7 @@ public final class AndroidEntryPointLocator {
           // Restrict the set
           bases.add(AndroidTypes.Application);
           bases.add(AndroidTypes.Activity);
-          /** TODO: TODO: add Fragments in getEntryPoints */
+          // TODO: add Fragments in getEntryPoints
           // bases.add(AndroidTypes.Fragment);
           bases.add(AndroidTypes.Service);
           bases.add(AndroidTypes.ContentProvider);

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
@@ -632,7 +632,7 @@ public class AndroidManifestXMLReader {
           }
         }
       } else {
-        /**
+        /*
          * Previously, an exception was thrown but in fact there is no need to crash here. Actions
          * are required, but if there is no action in a particular intent-filter, then no intent
          * will pass the intent filter. See also

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/ApplicationEP.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/androidEntryPoints/ApplicationEP.java
@@ -104,7 +104,7 @@ public final class ApplicationEP {
                 ExecutionOrder.AFTER_LOOP, onConfigurationChanged // XXX ??!
               }));
 
-  /** This method is for use in emulated process environments. */
+  // /** This method is for use in emulated process environments. */
   /*
   public static final AndroidPossibleEntryPoint onTerminate = new AndroidPossibleEntryPoint(AndroidComponent.APPLICATION,
              "onTerminate",

--- a/com.ibm.wala.ide/src/com/ibm/wala/ide/util/ProgressMonitorDelegate.java
+++ b/com.ibm.wala.ide/src/com/ibm/wala/ide/util/ProgressMonitorDelegate.java
@@ -49,7 +49,7 @@ public class ProgressMonitorDelegate implements IProgressMonitor {
     delegate.worked(units);
   }
 
-  /** BEGIN Custom change: subtasks and canceling */
+  /* BEGIN Custom change: subtasks and canceling */
   @Override
   public void subTask(String subTask) {
     delegate.subTask(subTask);
@@ -59,7 +59,7 @@ public class ProgressMonitorDelegate implements IProgressMonitor {
   public void cancel() {
     delegate.setCanceled(true);
   }
-  /** END Custom change: subtasks and canceling */
+  /* END Custom change: subtasks and canceling */
   @Override
   public String getCancelMessage() {
     return "cancelled by eclipse monitor: " + delegate.toString();

--- a/com.ibm.wala.scandroid/source/org/scandroid/domain/StaticFieldElement.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/domain/StaticFieldElement.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/FlowAnalysis.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/FlowAnalysis.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/FlowAnalysis.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/FlowAnalysis.java
@@ -187,7 +187,7 @@ public class FlowAnalysis {
     TabulationSolver<BasicBlockInContext<E>, CGNode, DomainElement> solver =
         TabulationSolver.make(
             problem
-            /** , progressMonitor */
+            // , progressMonitor
             );
 
     try {

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/ISinkPoint.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/ISinkPoint.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/InflowAnalysis.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/InflowAnalysis.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/LocalSinkPoint.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/LocalSinkPoint.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/OutflowAnalysis.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/OutflowAnalysis.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Adam Fuchs <afuchs@cs.umd.edu> Avik Chaudhuri <avik@cs.umd.edu> Steve Suh <suhsteve@gmail.com>

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/StaticFieldSinkPoint.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/StaticFieldSinkPoint.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/functions/CallFlowFunction.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/functions/CallFlowFunction.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/functions/CallNoneToReturnFunction.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/functions/CallNoneToReturnFunction.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/functions/CallToReturnFunction.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/functions/CallToReturnFunction.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/functions/ConstantFlowFunction.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/functions/ConstantFlowFunction.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/functions/GlobalIdentityFunction.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/functions/GlobalIdentityFunction.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/functions/GlobalReturnToNodeFunction.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/functions/GlobalReturnToNodeFunction.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/functions/ReturnFlowFunction.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/functions/ReturnFlowFunction.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/functions/TaintTransferFunctions.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/functions/TaintTransferFunctions.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/functions/TracingFlowFunction.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/functions/TracingFlowFunction.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/types/FieldFlow.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/types/FieldFlow.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/types/FlowType.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/types/FlowType.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Adam Fuchs <afuchs@cs.umd.edu> Avik Chaudhuri <avik@cs.umd.edu>

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/types/IKFlow.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/types/IKFlow.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Adam Fuchs <afuchs@cs.umd.edu> Avik Chaudhuri <avik@cs.umd.edu>

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/types/StaticFieldFlow.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/types/StaticFieldFlow.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/model/AppModelMethod.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/model/AppModelMethod.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>) Steve Suh

--- a/com.ibm.wala.scandroid/source/org/scandroid/spec/EntryRetSinkSpec.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/spec/EntryRetSinkSpec.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/spec/ISpecs.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/spec/ISpecs.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/spec/SourceSpec.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/spec/SourceSpec.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/spec/SpecUtils.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/spec/SpecUtils.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/spec/StaticFieldSinkSpec.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/spec/StaticFieldSinkSpec.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/spec/StaticFieldSourceSpec.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/spec/StaticFieldSourceSpec.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/spec/StaticSpecs.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/spec/StaticSpecs.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/synthmethod/DefaultSCanDroidOptions.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/synthmethod/DefaultSCanDroidOptions.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/synthmethod/SSAtoXMLVisitor.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/synthmethod/SSAtoXMLVisitor.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/synthmethod/XMLSummaryWriter.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/synthmethod/XMLSummaryWriter.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/util/AndroidAnalysisContext.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/util/AndroidAnalysisContext.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Adam Fuchs <afuchs@cs.umd.edu> Avik Chaudhuri <avik@cs.umd.edu> Steve Suh <suhsteve@gmail.com>

--- a/com.ibm.wala.scandroid/source/org/scandroid/util/CGAnalysisContext.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/util/CGAnalysisContext.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/util/CLISCanDroidOptions.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/util/CLISCanDroidOptions.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/util/EntryPoints.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/util/EntryPoints.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/util/IEntryPointSpecifier.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/util/IEntryPointSpecifier.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/util/ISCanDroidOptions.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/util/ISCanDroidOptions.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.scandroid/source/org/scandroid/util/ThrowingSSAInstructionVisitor.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/util/ThrowingSSAInstructionVisitor.java
@@ -7,7 +7,7 @@
  * This file is a derivative of code released under the terms listed below.
  *
  */
-/**
+/*
  * Copyright (c) 2009-2012,
  *
  * <p>Galois, Inc. (Aaron Tomb <atomb@galois.com>, Rogan Creswick <creswick@galois.com>, Adam

--- a/com.ibm.wala.util/src/com/ibm/wala/util/MonitorUtil.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/MonitorUtil.java
@@ -21,12 +21,12 @@ public class MonitorUtil {
 
     void beginTask(String task, int totalWork);
 
-    /** BEGIN Custom change: subtasks and canceling */
+    /* BEGIN Custom change: subtasks and canceling */
     void subTask(String subTask);
 
     void cancel();
 
-    /** END Custom change: subtasks and canceling */
+    /* END Custom change: subtasks and canceling */
     boolean isCanceled();
 
     void done();
@@ -72,7 +72,7 @@ public class MonitorUtil {
       }
     }
   }
-  /** BEGIN Custom change: more on subtasks */
+  /* BEGIN Custom change: more on subtasks */
   public static void subTask(IProgressMonitor progressMonitor, String subTask)
       throws CancelException {
     if (progressMonitor != null) {
@@ -96,7 +96,7 @@ public class MonitorUtil {
       progress.cancel();
     }
   }
-  /** END Custom change: more on subtasks */
+  /* END Custom change: more on subtasks */
 
   //  public static IProgressMonitor subProgress(ProgressMaster progress, int i) {
   //    if (progress == null) {

--- a/com.ibm.wala.util/src/com/ibm/wala/util/NullProgressMonitor.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/NullProgressMonitor.java
@@ -36,7 +36,7 @@ public class NullProgressMonitor implements IProgressMonitor {
     // do nothing
   }
 
-  /** BEGIN Custom change: subtasks and canceling */
+  /* BEGIN Custom change: subtasks and canceling */
   @Override
   public void subTask(String subTask) {
     // do nothing
@@ -47,7 +47,7 @@ public class NullProgressMonitor implements IProgressMonitor {
     // do nothing
   }
 
-  /** END Custom change: subtasks and canceling */
+  /* END Custom change: subtasks and canceling */
   @Override
   public String getCancelMessage() {
     assert false;

--- a/com.ibm.wala.util/src/com/ibm/wala/util/heapTrace/HeapTracer.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/heapTrace/HeapTracer.java
@@ -125,11 +125,6 @@ public class HeapTracer {
   }
 
   /**
-   * @param fdir
-   * @return {@link Collection}&lt;{@link String}&gt; representing the class names in a particular
-   *     file
-   */
-  /**
    * @param rootDir root of the classpath governing file f
    * @param f a File or directory
    * @return {@link Collection}&lt;{@link String}&gt; representing the class names in f

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/MutableSharedBitVectorIntSet.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/MutableSharedBitVectorIntSet.java
@@ -1043,13 +1043,13 @@ public class MutableSharedBitVectorIntSet implements MutableIntSet {
         checkOverflow();
         return size() > 0;
       } else {
-        /** sharedPart == null, privatePart != null */
+        // sharedPart == null, privatePart != null
         boolean result = privatePart.addAllInIntersection(other, filter);
         checkOverflow();
         return result;
       }
     } else {
-      /** sharedPart != null */
+      // sharedPart != null
       if (privatePart == null) {
         privatePart = MutableSparseIntSet.make(sharedPart);
         sharedPart = null;
@@ -1057,7 +1057,7 @@ public class MutableSharedBitVectorIntSet implements MutableIntSet {
         checkOverflow();
         return result;
       } else {
-        /** sharedPart != null, privatePart != null */
+        // sharedPart != null, privatePart != null
         // note that "other" is likely small
         MutableSparseIntSet temp = MutableSparseIntSet.make(other);
         temp.intersectWith(filter);


### PR DESCRIPTION
These commits fix various instances of Javadoc comments without an associated item to comment upon. Such comments arise for a variety of reasons; each commit fixes all instances of one broad category.