### PR TITLE
Small Gradle tweaks for Google Java Format

### DIFF
--- a/com.ibm.wala.dalvik.test/build.gradle
+++ b/com.ibm.wala.dalvik.test/build.gradle
@@ -191,3 +191,9 @@ tasks.register('cleanTestExtras', Delete) {
 tasks.named('cleanTest') {
 	dependsOn 'cleanTestExtras'
 }
+
+googleJavaFormat {
+	// generated files
+	exclude "$name/parser.java"
+	exclude "$name/sym.java"
+}

--- a/travis/install-gradle
+++ b/travis/install-gradle
@@ -1,3 +1,3 @@
 #!/bin/sh -eux
 
-./gradlew --continue --no-build-cache "$SUBMODULE_PREFIX"assemble verGJF
+./gradlew --continue --no-build-cache "$SUBMODULE_PREFIX"assemble verifyGoogleJavaFormat


### PR DESCRIPTION
Two small tweaks to our Gradle integration of Google Java Format (GJF):

- Exclude generated Java code from GJF rules
- Use the full name of a GJF task