### PR TITLE
Avoid configuring installGitHooks task unless needed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -286,7 +286,7 @@ final def getNativeLibraryOutput(task) {
 //  Google Java Format pre-commit hook installation
 //
 
-task installGitHooks(type: Copy) {
+tasks.register('installGitHooks', Copy) {
 	from(file('config/hooks/pre-commit-stub')) {
 		rename 'pre-commit-stub', 'pre-commit'
 	}


### PR DESCRIPTION
This maintains our existing effort to leverage the [Gradle task configuration avoidance APIs](
https://docs.gradle.org/current/userguide/task_configuration_avoidance.html) as much as possible.