### PR TITLE
Move responsibilities among Travis CI lifecycle scripts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -293,3 +293,14 @@ task installGitHooks(type: Copy) {
 	into file('.git/hooks')
 	fileMode 0777
 }
+
+
+////////////////////////////////////////////////////////////////////////
+//
+//  Extra downloads pre-fetcher
+//
+
+
+tasks.register('downloads') {
+	dependsOn allprojects*.tasks*.withType(VerifiedDownload)
+}

--- a/travis/install-gradle
+++ b/travis/install-gradle
@@ -1,3 +1,3 @@
 #!/bin/sh -eux
 
-./gradlew --continue --no-build-cache "$SUBMODULE_PREFIX"assemble verifyGoogleJavaFormat
+./gradlew --continue --no-build-cache "$SUBMODULE_PREFIX"downloads

--- a/travis/script-gradle
+++ b/travis/script-gradle
@@ -19,4 +19,5 @@ esac
 $headless ./gradlew --continue --no-build-cache --stacktrace \
 	  "$SUBMODULE_PREFIX"build \
 	  ${documentation:+$SUBMODULE_PREFIX$documentation} \
-	  lintGradle
+	  lintGradle \
+	  verifyGoogleJavaFormat

--- a/travis/script-gradle
+++ b/travis/script-gradle
@@ -17,7 +17,7 @@ case "$SUBMODULE_PREFIX" in
 esac
 
 $headless ./gradlew --continue --no-build-cache --stacktrace \
+	  verifyGoogleJavaFormat \
 	  "$SUBMODULE_PREFIX"build \
 	  ${documentation:+$SUBMODULE_PREFIX$documentation} \
-	  lintGradle \
-	  verifyGoogleJavaFormat
+	  lintGradle


### PR DESCRIPTION
Per <https://docs.travis-ci.com/user/job-lifecycle/>, the `install` stage should "install any dependencies required", while the `script` stage should "run the build script".

For our purposes, it makes sense to treat WALA's many assorted extra download tasks as `install`-stage dependencies: `downloadAndroidSdk`, `downloadBcel`, `downloadJavaCup`, etc.  If any of these fails, I believe Travis CI will treat that job as "errored" rather than "failed".  That might make it easier for us to quickly recognize when the problem was a transient inability to download (which happens often).

Having moved pre-build downloads into the `install` stage, it makes sense for the `script` stage to encompass both building WALA and running all of its various checks/tests.  In particular, `verifyGoogleJavaFormat` is now done in the `script` stage rather than the `install` stage.