### PR TITLE
Fix small code nits detected by IntelliJ IDEA 2019.1 inspections

### DIFF
--- a/.idea/scopes/WALA_Controlled.xml
+++ b/.idea/scopes/WALA_Controlled.xml
@@ -1,3 +1,3 @@
 <component name="DependencyValidationManager">
-  <scope name="WALA-Controlled" pattern="!file[com.ibm.wala.cast.java.test.data_test]:JLex//*&amp;&amp;!file:bin//*&amp;&amp;!file:target//*" />
+  <scope name="WALA-Controlled" pattern="!file[com.ibm.wala.cast.java.test.data_test]:JLex//*&amp;&amp;!file[com.ibm.wala.cast.js.test.data_test]:*/&amp;&amp;!file:bin//*&amp;&amp;!file:target//*" />
 </component>

--- a/com.ibm.wala.cast.java.test/src/com/ibm/wala/cast/java/test/JavaIRTests.java
+++ b/com.ibm.wala.cast.java.test/src/com/ibm/wala/cast/java/test/JavaIRTests.java
@@ -199,7 +199,7 @@ public abstract class JavaIRTests extends IRTests {
         rtJar,
         simpleTestEntryPoint(),
         Collections.singletonList(
-            /**
+            /*
              * 'foo' has four array instructions: - 2 SSAArrayLengthInstruction - 1
              * SSAArrayLoadInstruction - 1 SSAArrayStoreInstruction
              */
@@ -382,7 +382,7 @@ public abstract class JavaIRTests extends IRTests {
               // ((JavaSourceLoaderImpl.JavaClass)iClass).getEnclosingClass());
               // todo: is there the concept of CompilationUnit?
 
-              /**
+              /*
                * {@link JavaCAst2IRTranslator#getEnclosingType} return null for static inner
                * classes..?
                */

--- a/com.ibm.wala.cast.js.rhino/source/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
+++ b/com.ibm.wala.cast.js.rhino/source/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
@@ -269,11 +269,10 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
         return CAstOperator.OP_BIT_XOR;
 
       case Token.EQ:
+      case Token.IFEQ:
         return CAstOperator.OP_EQ;
       case Token.SHEQ:
         return CAstOperator.OP_STRICT_EQ;
-      case Token.IFEQ:
-        return CAstOperator.OP_EQ;
       case Token.GE:
         return CAstOperator.OP_GE;
       case Token.GT:
@@ -283,11 +282,10 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
       case Token.LT:
         return CAstOperator.OP_LT;
       case Token.NE:
+      case Token.IFNE:
         return CAstOperator.OP_NE;
       case Token.SHNE:
         return CAstOperator.OP_STRICT_NE;
-      case Token.IFNE:
-        return CAstOperator.OP_NE;
 
       case Token.BITNOT:
         return CAstOperator.OP_BITNOT;
@@ -1301,9 +1299,6 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
             return Ast.makeConstant(false);
           }
         case Token.NULL:
-          {
-            return Ast.makeConstant(null);
-          }
         case Token.DEBUGGER:
           {
             return Ast.makeConstant(null);

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/CorrelatedPairExtractionPolicy.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/CorrelatedPairExtractionPolicy.java
@@ -127,13 +127,13 @@ public class CorrelatedPairExtractionPolicy extends ExtractionPolicy {
     if (startNodes.size() == 2 && endNodes.equals(startNodes)) {
       startNode = iter.next();
       endNode = iter.next();
-    } else if (startNodes.size() > 1 || startNodes.size() == 0) {
+    } else if (startNodes.size() != 1) {
       if (DEBUG)
         System.err.println(
             "Couldn't find unique start node for correlation "
                 + corr.pp(correlations.getPositions()));
       return false;
-    } else if (endNodes.size() > 1 || endNodes.size() == 0) {
+    } else if (endNodes.size() != 1) {
       if (DEBUG)
         System.err.println(
             "Couldn't find unique end node for correlation "

--- a/com.ibm.wala.core.testdata/src/arraybounds/NotInBound.java
+++ b/com.ibm.wala.core.testdata/src/arraybounds/NotInBound.java
@@ -70,6 +70,7 @@ public class NotInBound {
 
   public int unboundNegativeLoop(int[] arr, int index) {
     int sum = 0;
+    //noinspection OverflowingLoopIndex
     for (int i = 5; i < arr.length; i--) {
       sum += arr[i];
     }

--- a/com.ibm.wala.core.testdata/src/bug144/A.java
+++ b/com.ibm.wala.core.testdata/src/bug144/A.java
@@ -8,6 +8,7 @@ import java.util.stream.Stream;
 class A {
   void m() {
     Set<Object> set = new HashSet<>();
+    @SuppressWarnings("RedundantOperationOnEmptyContainer")
     Stream<Object> stream = set.parallelStream();
     stream.sorted();
     stream.collect(Collectors.toList()); // this call forces the error.

--- a/com.ibm.wala.core.testdata/src/cfg/exc/intra/FieldAccess.java
+++ b/com.ibm.wala.core.testdata/src/cfg/exc/intra/FieldAccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of the Joana IFC project. It is developed at the Programming Paradigms Group of
  * the Karlsruhe Institute of Technology.
  *

--- a/com.ibm.wala.core.testdata/src/cfg/exc/intra/FieldAccessDynamic.java
+++ b/com.ibm.wala.core.testdata/src/cfg/exc/intra/FieldAccessDynamic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of the Joana IFC project. It is developed at the Programming Paradigms Group of
  * the Karlsruhe Institute of Technology.
  *

--- a/com.ibm.wala.core.testdata/src/demandpa/TestFieldsHarder.java
+++ b/com.ibm.wala.core.testdata/src/demandpa/TestFieldsHarder.java
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  */
 
-/**
+/*
  * Refinement Analysis Tools is Copyright (c) 2007 The Regents of the University of California
  * (Regents). Provided that this notice and the following two paragraphs are included in any
  * distribution of Refinement Analysis Tools or its derivative work, Regents agrees not to assert

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/exceptionpruning/ExceptionAnalysis2EdgeFilterTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/exceptionpruning/ExceptionAnalysis2EdgeFilterTest.java
@@ -189,13 +189,11 @@ public class ExceptionAnalysis2EdgeFilterTest {
           assertEquals(text, 12, value);
           break;
         case "testTryCatchOwnException":
+        case "testTryCatchImplicitException":
           assertEquals(text, 5, value);
           break;
         case "testTryCatchSuper":
           assertEquals(text, 3, value);
-          break;
-        case "testTryCatchImplicitException":
-          assertEquals(text, 5, value);
           break;
         case "main":
           assertEquals(text, 4, value);

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/demandpa/driver/CompareToZeroOneCFADriver.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/demandpa/driver/CompareToZeroOneCFADriver.java
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  */
 
-/**
+/*
  * Refinement Analysis Tools is Copyright (c) 2007 The Regents of the University of California
  * (Regents). Provided that this notice and the following two paragraphs are included in any
  * distribution of Refinement Analysis Tools or its derivative work, Regents agrees not to assert

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/demandpa/driver/TestAgainstSimpleDriver.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/demandpa/driver/TestAgainstSimpleDriver.java
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  */
 
-/**
+/*
  * Refinement Analysis Tools is Copyright (c) 2007 The Regents of the University of California
  * (Regents). Provided that this notice and the following two paragraphs are included in any
  * distribution of Refinement Analysis Tools or its derivative work, Regents agrees not to assert

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/arraybounds/ConditionNormalizer.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/arraybounds/ConditionNormalizer.java
@@ -86,7 +86,6 @@ public class ConditionNormalizer {
   private static Operator swapOperator(Operator op) {
     switch (op) {
       case EQ:
-        return op;
       case NE:
         return op;
       case LT:

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/JavaLanguage.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/JavaLanguage.java
@@ -720,6 +720,14 @@ public class JavaLanguage extends LanguageImpl implements BytecodeLanguage, Cons
       case OP_invokevirtual:
       case OP_invokespecial:
       case OP_invokeinterface:
+      case OP_monitorenter:
+      case OP_monitorexit:
+        // we're currently ignoring MonitorStateExceptions, since J2EE stuff
+        // should be
+        // logically single-threaded
+      case OP_athrow:
+        // N.B: the caller must handle the explicitly-thrown exception
+      case OP_arraylength:
         return getNullPointerException();
       case OP_idiv:
       case OP_irem:
@@ -732,19 +740,8 @@ public class JavaLanguage extends LanguageImpl implements BytecodeLanguage, Cons
       case OP_anewarray:
       case OP_multianewarray:
         return newArrayExceptions;
-      case OP_arraylength:
-        return getNullPointerException();
-      case OP_athrow:
-        // N.B: the caller must handle the explicitly-thrown exception
-        return getNullPointerException();
       case OP_checkcast:
         return getClassCastException();
-      case OP_monitorenter:
-      case OP_monitorexit:
-        // we're currently ignoring MonitorStateExceptions, since J2EE stuff
-        // should be
-        // logically single-threaded
-        return getNullPointerException();
       case OP_ldc_w:
         if (((ConstantInstruction) pei).getType().equals(TYPE_Class))
           return getClassNotFoundException();

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/HeapReachingDefs.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/HeapReachingDefs.java
@@ -416,6 +416,8 @@ public class HeapReachingDefs<T extends InstanceKey> {
                   pointerKeyMod.get(r.getLocation()).intersection(v.getValue()), domain);
             }
           }
+        case HEAP_PARAM_CALLEE:
+          // no statements in this method will def the heap being passed in
         case NORMAL_RET_CALLEE:
         case NORMAL_RET_CALLER:
         case PARAM_CALLEE:
@@ -427,9 +429,6 @@ public class HeapReachingDefs<T extends InstanceKey> {
         case CATCH:
         case METHOD_ENTRY:
         case METHOD_EXIT:
-          return OrdinalSet.empty();
-        case HEAP_PARAM_CALLEE:
-          // no statements in this method will def the heap being passed in
           return OrdinalSet.empty();
         default:
           Assertions.UNREACHABLE(s.getKind().toString());

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/SliceFunctions.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/SliceFunctions.java
@@ -35,6 +35,9 @@ public class SliceFunctions implements IPartiallyBalancedFlowFunctions<Statement
       case PARAM_CALLER:
       case EXC_RET_CALLER:
         // uh oh. anything that flows into the missing function will be killed.
+      case NORMAL:
+        // only control dependence flows into the missing function.
+        // this control dependence does not flow back to the caller.
         return ReachabilityFunctions.KILL_FLOW;
       case HEAP_PARAM_CALLEE:
       case HEAP_PARAM_CALLER:
@@ -51,10 +54,6 @@ public class SliceFunctions implements IPartiallyBalancedFlowFunctions<Statement
         } else {
           return ReachabilityFunctions.KILL_FLOW;
         }
-      case NORMAL:
-        // only control dependence flows into the missing function.
-        // this control dependence does not flow back to the caller.
-        return ReachabilityFunctions.KILL_FLOW;
       default:
         Assertions.UNREACHABLE(s.getKind().toString());
         return null;

--- a/com.ibm.wala.core/src/com/ibm/wala/util/ssa/ParameterAccessor.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/ssa/ParameterAccessor.java
@@ -918,7 +918,6 @@ public class ParameterAccessor {
   public TypeReference getParameterType(final int no) { // XXX Remove?
     switch (this.base) {
       case IMETHOD:
-        return this.method.getParameterType(getParameterNo(no));
       case METHOD_REFERENCE:
         return this.method.getParameterType(getParameterNo(no));
       default:

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/DexCFG.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/DexCFG.java
@@ -475,6 +475,18 @@ public class DexCFG extends AbstractCFG<Instruction, DexCFG.BasicBlock> implemen
           //      case OP_invokevirtual:
           //      case OP_invokespecial:
           //      case OP_invokeinterface:
+        case ARRAY_LENGTH:
+          //      case OP_arraylength:
+        case MONITOR_ENTER:
+        case MONITOR_EXIT:
+          //      case OP_monitorenter:
+          //      case OP_monitorexit:
+          // we're currently ignoring MonitorStateExceptions, since J2EE stuff
+          // should be
+          // logically single-threaded
+        case THROW:
+          //      case OP_athrow:
+          // N.B: the caller must handle the explicitly-thrown exception
           return JavaLanguage.getNullPointerException();
         case DIV_INT:
         case DIV_INT_2ADDR:
@@ -503,24 +515,9 @@ public class DexCFG extends AbstractCFG<Instruction, DexCFG.BasicBlock> implemen
           //      case OP_anewarray:
           //      case OP_multianewarray:
           return JavaLanguage.getNewArrayExceptions();
-        case ARRAY_LENGTH:
-          //      case OP_arraylength:
-          return JavaLanguage.getNullPointerException();
-        case THROW:
-          //      case OP_athrow:
-          // N.B: the caller must handle the explicitly-thrown exception
-          return JavaLanguage.getNullPointerException();
         case CHECK_CAST:
           //      case OP_checkcast:
           return JavaLanguage.getClassCastException();
-        case MONITOR_ENTER:
-        case MONITOR_EXIT:
-          //      case OP_monitorenter:
-          //      case OP_monitorexit:
-          // we're currently ignoring MonitorStateExceptions, since J2EE stuff
-          // should be
-          // logically single-threaded
-          return JavaLanguage.getNullPointerException();
 
           // I Don't think dalvik has to worry about this?
           //      case OP_ldc_w:

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/DexIMethod.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/DexIMethod.java
@@ -963,6 +963,7 @@ public class DexIMethod implements IBytecodeMethod<Instruction> {
           }
           break;
         case MOVE:
+        case MOVE_OBJECT:
           instructions.add(
               new UnaryOperation(
                   instLoc,
@@ -973,6 +974,7 @@ public class DexIMethod implements IBytecodeMethod<Instruction> {
                   this));
           break;
         case MOVE_FROM16:
+        case MOVE_OBJECT_FROM16:
           instructions.add(
               new UnaryOperation(
                   instLoc,
@@ -1019,26 +1021,6 @@ public class DexIMethod implements IBytecodeMethod<Instruction> {
                   UnaryOperation.OpID.MOVE_WIDE,
                   ((Instruction32x) inst).getRegisterA(),
                   ((Instruction32x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case MOVE_OBJECT:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  UnaryOperation.OpID.MOVE,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case MOVE_OBJECT_FROM16:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  UnaryOperation.OpID.MOVE,
-                  ((Instruction22x) inst).getRegisterA(),
-                  ((Instruction22x) inst).getRegisterB(),
                   inst.getOpcode(),
                   this));
           break;

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/dex/instructions/BinaryLiteralOperation.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/dex/instructions/BinaryLiteralOperation.java
@@ -128,85 +128,58 @@ public class BinaryLiteralOperation extends Instruction {
   public IBinaryOpInstruction.IOperator getOperator() {
     switch (op) {
       case CMPL_FLOAT:
-        return DalvikBinaryOp.LT;
-      case CMPG_FLOAT:
-        return DalvikBinaryOp.GT;
       case CMPL_DOUBLE:
-        return DalvikBinaryOp.LT;
-      case CMPG_DOUBLE:
-        return DalvikBinaryOp.GT;
       case CMPL_LONG:
-        return DalvikBinaryOp.LT;
-      case CMPG_LONG:
-        return DalvikBinaryOp.GT;
       case CMPL_INT:
         return DalvikBinaryOp.LT;
+      case CMPG_FLOAT:
+      case CMPG_DOUBLE:
+      case CMPG_LONG:
       case CMPG_INT:
         return DalvikBinaryOp.GT;
       case ADD_INT:
-        return IBinaryOpInstruction.Operator.ADD;
-      case RSUB_INT:
-        return IBinaryOpInstruction.Operator.SUB;
-      case MUL_INT:
-        return IBinaryOpInstruction.Operator.MUL;
-      case DIV_INT:
-        return IBinaryOpInstruction.Operator.DIV;
-      case REM_INT:
-        return IBinaryOpInstruction.Operator.REM;
-      case AND_INT:
-        return IBinaryOpInstruction.Operator.AND;
-      case OR_INT:
-        return IBinaryOpInstruction.Operator.OR;
-      case XOR_INT:
-        return IBinaryOpInstruction.Operator.XOR;
-      case SHL_INT:
-        return IShiftInstruction.Operator.SHL;
-      case SHR_INT:
-        return IShiftInstruction.Operator.SHR;
-      case USHR_INT:
-        return IShiftInstruction.Operator.USHR;
       case ADD_LONG:
-        return IBinaryOpInstruction.Operator.ADD;
-      case RSUB_LONG:
-        return IBinaryOpInstruction.Operator.SUB;
-      case MUL_LONG:
-        return IBinaryOpInstruction.Operator.MUL;
-      case DIV_LONG:
-        return IBinaryOpInstruction.Operator.DIV;
-      case REM_LONG:
-        return IBinaryOpInstruction.Operator.REM;
-      case AND_LONG:
-        return IBinaryOpInstruction.Operator.AND;
-      case OR_LONG:
-        return IBinaryOpInstruction.Operator.OR;
-      case XOR_LONG:
-        return IBinaryOpInstruction.Operator.XOR;
-      case SHL_LONG:
-        return IShiftInstruction.Operator.SHL;
-      case SHR_LONG:
-        return IShiftInstruction.Operator.SHR;
-      case USHR_LONG:
-        return IShiftInstruction.Operator.USHR;
+      case ADD_DOUBLE:
       case ADD_FLOAT:
         return IBinaryOpInstruction.Operator.ADD;
+      case RSUB_INT:
+      case RSUB_LONG:
+      case RSUB_DOUBLE:
       case RSUB_FLOAT:
         return IBinaryOpInstruction.Operator.SUB;
+      case MUL_INT:
+      case MUL_LONG:
+      case MUL_DOUBLE:
       case MUL_FLOAT:
         return IBinaryOpInstruction.Operator.MUL;
+      case DIV_INT:
+      case DIV_LONG:
+      case DIV_DOUBLE:
       case DIV_FLOAT:
         return IBinaryOpInstruction.Operator.DIV;
+      case REM_INT:
+      case REM_LONG:
+      case REM_DOUBLE:
       case REM_FLOAT:
         return IBinaryOpInstruction.Operator.REM;
-      case ADD_DOUBLE:
-        return IBinaryOpInstruction.Operator.ADD;
-      case RSUB_DOUBLE:
-        return IBinaryOpInstruction.Operator.SUB;
-      case MUL_DOUBLE:
-        return IBinaryOpInstruction.Operator.MUL;
-      case DIV_DOUBLE:
-        return IBinaryOpInstruction.Operator.DIV;
-      case REM_DOUBLE:
-        return IBinaryOpInstruction.Operator.REM;
+      case AND_INT:
+      case AND_LONG:
+        return IBinaryOpInstruction.Operator.AND;
+      case OR_INT:
+      case OR_LONG:
+        return IBinaryOpInstruction.Operator.OR;
+      case XOR_INT:
+      case XOR_LONG:
+        return IBinaryOpInstruction.Operator.XOR;
+      case SHL_INT:
+      case SHL_LONG:
+        return IShiftInstruction.Operator.SHL;
+      case SHR_INT:
+      case SHR_LONG:
+        return IShiftInstruction.Operator.SHR;
+      case USHR_INT:
+      case USHR_LONG:
+        return IShiftInstruction.Operator.USHR;
       default:
         return null;
     }

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/dex/instructions/BinaryOperation.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/dex/instructions/BinaryOperation.java
@@ -131,85 +131,58 @@ public class BinaryOperation extends Instruction {
   public IBinaryOpInstruction.IOperator getOperator() {
     switch (op) {
       case CMPL_FLOAT:
-        return DalvikBinaryOp.LT;
-      case CMPG_FLOAT:
-        return DalvikBinaryOp.GT;
+      case CMPL_INT:
+      case CMPL_LONG:
       case CMPL_DOUBLE:
         return DalvikBinaryOp.LT;
+      case CMPG_FLOAT:
+      case CMPG_INT:
+      case CMPG_LONG:
       case CMPG_DOUBLE:
         return DalvikBinaryOp.GT;
-      case CMPL_LONG:
-        return DalvikBinaryOp.LT;
-      case CMPG_LONG:
-        return DalvikBinaryOp.GT;
-      case CMPL_INT:
-        return DalvikBinaryOp.LT;
-      case CMPG_INT:
-        return DalvikBinaryOp.GT;
       case ADD_INT:
-        return IBinaryOpInstruction.Operator.ADD;
-      case SUB_INT:
-        return IBinaryOpInstruction.Operator.SUB;
-      case MUL_INT:
-        return IBinaryOpInstruction.Operator.MUL;
-      case DIV_INT:
-        return IBinaryOpInstruction.Operator.DIV;
-      case REM_INT:
-        return IBinaryOpInstruction.Operator.REM;
-      case AND_INT:
-        return IBinaryOpInstruction.Operator.AND;
-      case OR_INT:
-        return IBinaryOpInstruction.Operator.OR;
-      case XOR_INT:
-        return IBinaryOpInstruction.Operator.XOR;
-      case SHL_INT:
-        return IShiftInstruction.Operator.SHL;
-      case SHR_INT:
-        return IShiftInstruction.Operator.SHR;
-      case USHR_INT:
-        return IShiftInstruction.Operator.USHR;
+      case ADD_DOUBLE:
+      case ADD_FLOAT:
       case ADD_LONG:
         return IBinaryOpInstruction.Operator.ADD;
+      case SUB_INT:
+      case SUB_DOUBLE:
+      case SUB_FLOAT:
       case SUB_LONG:
         return IBinaryOpInstruction.Operator.SUB;
+      case MUL_INT:
+      case MUL_DOUBLE:
+      case MUL_FLOAT:
       case MUL_LONG:
         return IBinaryOpInstruction.Operator.MUL;
+      case DIV_INT:
+      case DIV_DOUBLE:
+      case DIV_FLOAT:
       case DIV_LONG:
         return IBinaryOpInstruction.Operator.DIV;
+      case REM_INT:
+      case REM_DOUBLE:
+      case REM_FLOAT:
       case REM_LONG:
         return IBinaryOpInstruction.Operator.REM;
+      case AND_INT:
       case AND_LONG:
         return IBinaryOpInstruction.Operator.AND;
+      case OR_INT:
       case OR_LONG:
         return IBinaryOpInstruction.Operator.OR;
+      case XOR_INT:
       case XOR_LONG:
         return IBinaryOpInstruction.Operator.XOR;
+      case SHL_INT:
       case SHL_LONG:
         return IShiftInstruction.Operator.SHL;
+      case SHR_INT:
       case SHR_LONG:
         return IShiftInstruction.Operator.SHR;
+      case USHR_INT:
       case USHR_LONG:
         return IShiftInstruction.Operator.USHR;
-      case ADD_FLOAT:
-        return IBinaryOpInstruction.Operator.ADD;
-      case SUB_FLOAT:
-        return IBinaryOpInstruction.Operator.SUB;
-      case MUL_FLOAT:
-        return IBinaryOpInstruction.Operator.MUL;
-      case DIV_FLOAT:
-        return IBinaryOpInstruction.Operator.DIV;
-      case REM_FLOAT:
-        return IBinaryOpInstruction.Operator.REM;
-      case ADD_DOUBLE:
-        return IBinaryOpInstruction.Operator.ADD;
-      case SUB_DOUBLE:
-        return IBinaryOpInstruction.Operator.SUB;
-      case MUL_DOUBLE:
-        return IBinaryOpInstruction.Operator.MUL;
-      case DIV_DOUBLE:
-        return IBinaryOpInstruction.Operator.DIV;
-      case REM_DOUBLE:
-        return IBinaryOpInstruction.Operator.REM;
       default:
         return null;
     }

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/dex/instructions/UnaryOperation.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/dex/instructions/UnaryOperation.java
@@ -148,18 +148,13 @@ public class UnaryOperation extends Instruction {
     switch (op) {
         // SSA unary ops
       case NOT:
-        return DalvikUnaryOp.BITNOT;
-      case NEGINT:
-        return IUnaryOpInstruction.Operator.NEG;
+      case NOTLONG:
       case NOTINT:
         return DalvikUnaryOp.BITNOT;
-      case NEGLONG:
-        return IUnaryOpInstruction.Operator.NEG;
-      case NOTLONG:
-        return DalvikUnaryOp.BITNOT;
-      case NEGFLOAT:
-        return IUnaryOpInstruction.Operator.NEG;
+      case NEGINT:
       case NEGDOUBLE:
+      case NEGFLOAT:
+      case NEGLONG:
         return IUnaryOpInstruction.Operator.NEG;
       default:
         Assertions.UNREACHABLE();

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/FlatInstantiator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/FlatInstantiator.java
@@ -426,7 +426,7 @@ public class FlatInstantiator implements IInstantiator {
     final IMethod cTor = lookupConstructor(val.getType());
     final ParameterAccessor ctorAcc = new ParameterAccessor(cTor);
     assert (ctorAcc.hasImplicitThis()) : "CTor detected as not having implicit this pointer";
-    logger.debug("Acc for: %", this.scope);
+    logger.debug("Acc for: {}", this.scope);
     final ParameterAccessor acc =
         new ParameterAccessor(this.scope, false); // TODO pm needs a connectThrough too!
     // TODO false is false

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/Instantiator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/Instantiator.java
@@ -418,7 +418,7 @@ public class Instantiator implements IInstantiator {
     final IMethod cTor = lookupConstructor(val.getType());
     final ParameterAccessor ctorAcc = new ParameterAccessor(cTor);
     assert (ctorAcc.hasImplicitThis()) : "CTor detected as not having implicit this pointer";
-    logger.debug("Acc for: %", this.scope);
+    logger.debug("Acc for: {}", this.scope);
     final ParameterAccessor acc =
         new ParameterAccessor(this.scope, false); // TODO pm needs a connectThrough too!
     // TODO false is false

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidSettingFactory.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidSettingFactory.java
@@ -256,13 +256,6 @@ public class AndroidSettingFactory {
           ret = new InternalIntent(action);
         }
         break;
-      case STANDARD_ACTION:
-        if (uri != null) {
-          ret = new StandardIntent(action, mUri);
-        } else {
-          ret = new StandardIntent(action);
-        }
-        break;
       default:
         if (uri != null) {
           ret = new StandardIntent(action, mUri);

--- a/com.ibm.wala.ide.jdt.test/source/com/ibm/wala/demandpa/driver/DemandCastChecker.java
+++ b/com.ibm.wala.ide.jdt.test/source/com/ibm/wala/demandpa/driver/DemandCastChecker.java
@@ -9,7 +9,7 @@
  *     IBM Corporation - initial API and implementation
  */
 
-/**
+/*
  * Refinement Analysis Tools is Copyright (c) 2007 The Regents of the University of California
  * (Regents). Provided that this notice and the following two paragraphs are included in any
  * distribution of Refinement Analysis Tools or its derivative work, Regents agrees not to assert

--- a/com.ibm.wala.scandroid/source/org/scandroid/util/EntryPoints.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/util/EntryPoints.java
@@ -333,8 +333,6 @@ public class EntryPoints {
 
   private ArrayList<String[]> chooseIntentList(String name) {
     switch (name) {
-      case "activity":
-        return ActivityIntentList;
       case "receiver":
         return ReceiverIntentList;
       case "service":

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/ClassWriter.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/ClassWriter.java
@@ -849,11 +849,6 @@ public class ClassWriter implements ClassConstants {
                   }
                 case REF_invokeVirtual:
                 case REF_newInvokeSpecial:
-                  {
-                    int x = addCPMethodRef(handle.c, handle.n, handle.t);
-                    setUShort(buf, offset + 2, x);
-                    break;
-                  }
                 case REF_invokeSpecial:
                 case REF_invokeStatic:
                   {

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/ConstantPoolParser.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/ConstantPoolParser.java
@@ -600,6 +600,7 @@ public final class ConstantPoolParser implements ClassConstants {
       switch (tag) {
         case CONSTANT_String:
         case CONSTANT_Class:
+        case CONSTANT_MethodType:
           itemLen = 2;
           break;
         case CONSTANT_NameAndType:
@@ -608,6 +609,7 @@ public final class ConstantPoolParser implements ClassConstants {
         case CONSTANT_InterfaceMethodRef:
         case CONSTANT_Integer:
         case CONSTANT_Float:
+        case CONSTANT_InvokeDynamic:
           itemLen = 4;
           break;
         case CONSTANT_Long:
@@ -620,12 +622,6 @@ public final class ConstantPoolParser implements ClassConstants {
           break;
         case CONSTANT_MethodHandle:
           itemLen = 3;
-          break;
-        case CONSTANT_MethodType:
-          itemLen = 2;
-          break;
-        case CONSTANT_InvokeDynamic:
-          itemLen = 4;
           break;
         default:
           throw new InvalidClassFileException(offset, "unknown constant pool entry type" + tag);


### PR DESCRIPTION
Updated inspections in IntelliJ IDEA 2019.1 found some minor code nits that previously went unnoticed. These fixes are not specific to IntelliJ IDEA 2019.1, though: we can merge them now without waiting for the IntelliJ IDEA 2019.1 project configuration updates in #443.