### PR TITLE
cache the p2asmaven directory on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ cache:
   - "$HOME/.m2"
   - "$HOME/apache-maven-3.5.0"
   - "$TRAVIS_BUILD_DIR/com.ibm.wala.core.testdata/ocaml/ocamljava-2.0-alpha1/lib"
+  - "$TRAVIS_BUILD_DIR/build/p2asmaven"
 env:
   global:
     - secure: KcugjQYnBqeZ7XenZD5QY7jhekVPO0QpQyjDUteLytaokhyRK2g6eNvr/pPerN2uWUvsPwO18P9F+oOupge1cpPZf4cEY8RzLIromyUoRWd6JA0SKciUYdN2kSqnC4uZSJGXeGLoroyEEL4Q2sqimpkbIGxgxYtVniWgJULOyR4=

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ cache:
   - "$HOME/.gradle/wrapper"
   - "$HOME/.m2"
   - "$HOME/apache-maven-3.5.0"
-  - "$TRAVIS_BUILD_DIR/com.ibm.wala.core.testdata/ocaml/ocamljava-2.0-alpha1/lib"
   - "$TRAVIS_BUILD_DIR/build/p2asmaven"
+  - "$TRAVIS_BUILD_DIR/com.ibm.wala.core.testdata/ocaml/ocamljava-2.0-alpha1/lib"
 env:
   global:
     - secure: KcugjQYnBqeZ7XenZD5QY7jhekVPO0QpQyjDUteLytaokhyRK2g6eNvr/pPerN2uWUvsPwO18P9F+oOupge1cpPZf4cEY8RzLIromyUoRWd6JA0SKciUYdN2kSqnC4uZSJGXeGLoroyEEL4Q2sqimpkbIGxgxYtVniWgJULOyR4=

--- a/travis/before-cache-gradle
+++ b/travis/before-cache-gradle
@@ -8,3 +8,4 @@ rm -rf \
 
 find "$caches" -name '*.lock' -delete
 find "$caches" -name '*.bin' -delete
+find "$caches" -name 'cache.properties' -delete

--- a/travis/before-cache-gradle
+++ b/travis/before-cache-gradle
@@ -3,11 +3,10 @@
 caches="$HOME/.gradle/caches"
 
 rm -rf \
-   "$caches/modules-2/modules-2.lock" \
    "$caches"/*/plugin-resolution
 
-find "$caches" -name '*.lock' -delete
-find "$caches" -name '*.bin' -delete
-find "$caches" -name 'cache.properties' -delete
-find "$caches" -name workerMain -type d -prune -exec rm -r "{}" \;
 find "$caches" -name buildSrc.jar -delete
+find "$caches" -name cache.properties -delete
+find "$caches" -name workerMain -type d -prune -exec rm -r "{}" \;
+find "$caches" -name '*.bin' -delete
+find "$caches" -name '*.lock' -delete

--- a/travis/before-cache-gradle
+++ b/travis/before-cache-gradle
@@ -5,3 +5,6 @@ caches="$HOME/.gradle/caches"
 rm -rf \
    "$caches/modules-2/modules-2.lock" \
    "$caches"/*/plugin-resolution
+
+find "$caches" -name '*.lock' -delete
+find "$caches" -name '*.bin' -delete

--- a/travis/before-cache-gradle
+++ b/travis/before-cache-gradle
@@ -9,3 +9,5 @@ rm -rf \
 find "$caches" -name '*.lock' -delete
 find "$caches" -name '*.bin' -delete
 find "$caches" -name 'cache.properties' -delete
+find "$caches" -name workerMain -type d -exec rm -r "{}" \;
+find "$caches" -name buildSrc.jar -delete

--- a/travis/before-cache-gradle
+++ b/travis/before-cache-gradle
@@ -9,5 +9,5 @@ rm -rf \
 find "$caches" -name '*.lock' -delete
 find "$caches" -name '*.bin' -delete
 find "$caches" -name 'cache.properties' -delete
-find "$caches" -name workerMain -type d -exec rm -r "{}" \;
+find "$caches" -name workerMain -type d -prune -exec rm -r "{}" \;
 find "$caches" -name buildSrc.jar -delete


### PR DESCRIPTION
Fixes #446 

Beyond caching this directory, update the cleanup script to remove a few other files inside the Gradle cache that seem to change needlessly between runs.  If we don't remove these files, Travis is forced to re-upload on each build, which takes about a minute.  I've confirmed by repeatedly running a build job that deleting these files does not put the cache in an inconsistent state that breaks future builds.  I also filed gradle/gradle#9175 as a start at trying to get some root cause issues fixed.