### PR TITLE
List some required IntelliJ IDEA plugins

### DIFF
--- a/.idea/externalDependencies.xml
+++ b/.idea/externalDependencies.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalDependencies">
+    <plugin id="com.intellij" min-version="191" />
+    <plugin id="Git4Idea" />
+    <plugin id="google-java-format" />
+    <plugin id="JUnit" />
+    <plugin id="org.jetbrains.plugins.gradle" />
+  </component>
+</project>

--- a/.idea/externalDependencies.xml
+++ b/.idea/externalDependencies.xml
@@ -2,7 +2,6 @@
 <project version="4">
   <component name="ExternalDependencies">
     <plugin id="com.intellij" min-version="191" />
-    <plugin id="Git4Idea" />
     <plugin id="google-java-format" />
     <plugin id="JUnit" />
     <plugin id="org.jetbrains.plugins.gradle" />


### PR DESCRIPTION
"Required" here is interpreted broadly.  Strictly speaking, one doesn't _need_ to have the Google Java formatter, Git integration, or JUnit integration.  But these are strongly recommended, so let's try requiring them and see if anyone complains.

A more strict treatment of "required" would list only the Gradle plugin and the version of IntelliJ IDEA itself.  Regarding the latter, unfortunately I haven't actually been able to get IntelliJ IDEA to complain no matter what "min-version" I list for the IDE itself.  Not sure what I'm doing wrong here.