### PR TITLE
Exclude node.js lib from "WALA-Controlled" file scope

### DIFF
--- a/.idea/scopes/WALA_Controlled.xml
+++ b/.idea/scopes/WALA_Controlled.xml
@@ -1,3 +1,3 @@
 <component name="DependencyValidationManager">
-  <scope name="WALA-Controlled" pattern="!file[com.ibm.wala.cast.java.test.data_test]:JLex//*&amp;&amp;!file[com.ibm.wala.cast.js.test.data_test]:*/&amp;&amp;!file:bin//*&amp;&amp;!file:target//*" />
+  <scope name="WALA-Controlled" pattern="!file[com.ibm.wala.cast.java.test.data_test]:JLex//*&amp;&amp;!file[com.ibm.wala.cast.js.test.data_test]:*/&amp;&amp;!file:bin//*&amp;&amp;!file:target//*&amp;&amp;!file[com.ibm.wala.cast.js.nodejs_main]:core-modules//*" />
 </component>


### PR DESCRIPTION
JavaScript files in `com.ibm.wala.cast.js.nodejs/dat/core-modules` are downloaded and moved into place by the `unpackNodeJSLib` Gradle task. Running IntelliJ IDEA inspections on these files is not useful, since we don't control them anyway.