### PR TITLE
Fix Linux OpenJDK 11 builds and disable Mac OpenJDK11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,11 @@ matrix:
       env: BUILD_SYSTEM=gradle
       language: java
       jdk: openjdk11
-    - os: osx
-      osx_image: xcode8.3
-      env: BUILD_SYSTEM=gradle
-      language: java
-      jdk: openjdk11
+    # - os: osx
+    #   osx_image: xcode8.3
+    #   env: BUILD_SYSTEM=gradle
+    #   language: java
+    #   jdk: openjdk11
     - os: linux
       env: BUILD_SYSTEM=gradle
       language: java

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ matrix:
       dist: xenial
       env: BUILD_SYSTEM=gradle
       language: java
-      jdk: openjdk11
     - os: osx
       osx_image: xcode8.3
       env: BUILD_SYSTEM=gradle

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ matrix:
       dist: xenial
       env: BUILD_SYSTEM=gradle
       language: java
+      jdk: openjdk11
     - os: osx
       osx_image: xcode8.3
       env: BUILD_SYSTEM=gradle

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ env:
 matrix:
   include:
     - os: linux
+      dist: xenial
       env: BUILD_SYSTEM=gradle
       language: java
       jdk: openjdk11


### PR DESCRIPTION
If we use the Xenial Ubuntu release we get JDK 11 by default.  Mac JDK 11 builds are still broken, so we disable them for now.