### PR TITLE
Download `parser.cup` from Maven, not Georgia Tech

### DIFF
--- a/com.ibm.wala.dalvik.test/build.gradle
+++ b/com.ibm.wala.dalvik.test/build.gradle
@@ -116,10 +116,18 @@ tasks.register('copyAndroidJar', Sync) {
 	into temporaryDir
 }
 
-tasks.register('downloadSampleCup', VerifiedDownload) {
-	src 'http://www.cc.gatech.edu/gvu/people/faculty/hudson/java_cup/classes.v0.9e/java_cup/parser.cup'
-	dest 'data/sample.cup'
-	checksum '76b549e7c6e802b811a374248175ecf4'
+tasks.register('downloadSampleCup') {
+	inputs.file configurations.sampleCup.singleFile
+	outputs.file 'data/sample.cup'
+
+	doLast {
+		copy {
+			from zipTree(inputs.files.singleFile)
+			include 'parser.cup'
+			rename { outputs.files.singleFile.name }
+			into outputs.files.singleFile.parent
+		}
+	}
 }
 
 tasks.named('clean') {
@@ -142,7 +150,12 @@ publishing.publications {
 	}
 }
 
+configurations {
+	sampleCup
+}
+
 dependencies {
+	sampleCup 'java_cup:java_cup:0.9e:sources'
 	testCompile(
 		'junit:junit:4.12',
 		'org.osgi:org.osgi.core:4.2.0',


### PR DESCRIPTION
Fixes #455, wherein Georgia Tech downloads were failing. Even if those faillures were only temporary, Maven should be a more reliable long-term source for this file.

Furthermore, extracting this file from a Maven-tracked artifact means that we can use Gradle’s standard mechanisms for declaring dependencies and resolving those dependencies in online repositories like Maven Central. Nice! I wish more of WALA’s required downloads were available from Maven repositories as well.

The rebuilt `downloadSampleCup` task looks like it should be a `Copy` task, since all it does is extract a file from a Jar archive. However, a `Copy` task will always treat the entire destination directory as its task outputs. This specific task is only adding one file to an existing directory; the rest of the directory is not this task’s responsibility. We want more fine-grained control over what this task declares as its outputs. Therefore, we implement `downloadSampleCup` as a generic task that uses the `Project.copy` method rather than as a `Copy` task.