### PR TITLE
Use Java 7 language/library features for clarity and simplicity

### DIFF
--- a/.idea/inspectionProfiles/No_Back_Sliding.xml
+++ b/.idea/inspectionProfiles/No_Back_Sliding.xml
@@ -105,7 +105,6 @@
     <inspection_tool class="ContinueOrBreakFromFinallyBlockJS" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="Contract" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="ControlFlowStatementWithoutBraces" enabled="false" level="INFORMATION" enabled_by_default="false" />
-    <inspection_tool class="Convert2Diamond" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="Convert2Lambda" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="Convert2MethodRef" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="Convert2streamapi" enabled="false" level="INFORMATION" enabled_by_default="false" />

--- a/.idea/inspectionProfiles/No_Back_Sliding.xml
+++ b/.idea/inspectionProfiles/No_Back_Sliding.xml
@@ -209,7 +209,6 @@
     <inspection_tool class="EqualsBetweenInconvertibleTypes" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="EqualsHashCodeCalledOnUrl" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="EqualsOnSuspiciousObject" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="EqualsReplaceableByObjectsCall" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="EqualsWhichDoesntCheckParameterClass" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="EqualsWithItself" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="ExceptionCaughtLocallyJS" enabled="false" level="WARNING" enabled_by_default="false" />

--- a/.idea/inspectionProfiles/No_Back_Sliding.xml
+++ b/.idea/inspectionProfiles/No_Back_Sliding.xml
@@ -43,6 +43,7 @@
     <inspection_tool class="BashUnusedFunction" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="BashUnusedFunctionParams" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="BashWrapFunction" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="BigDecimalLegacyMethod" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="BigDecimalMethodWithoutRoundingCalled" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="BlockingMethodInNonBlockingContext" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="BooleanMethodIsAlwaysInverted" enabled="false" level="WARNING" enabled_by_default="false" />
@@ -77,6 +78,7 @@
     <inspection_tool class="CodeBlock2Expr" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="CollectionAddedToSelf" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="CollectionContainsUrl" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="CollectionsFieldAccessReplaceableByMethodCall" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="CommaExpressionJS" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="CommandLineInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="ComparatorCombinators" enabled="false" level="WARNING" enabled_by_default="false" />
@@ -453,7 +455,6 @@
     <inspection_tool class="MarkedForRemoval" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="MathRandomCastToInt" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="MetaAnnotationWithoutRuntimeRetention" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="MethodCanBeVariableArityMethod" enabled="false" level="INFORMATION" enabled_by_default="false" />
     <inspection_tool class="MethodNameSameAsClassName" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="MethodRefCanBeReplacedWithLambda" enabled="false" level="INFORMATION" enabled_by_default="false" />
     <inspection_tool class="MismatchedArrayReadWrite" enabled="false" level="WARNING" enabled_by_default="false" />
@@ -687,7 +688,6 @@
     <inspection_tool class="StaticInitializerReferencesSubClass" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="StaticPseudoFunctionalStyleMethod" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="StreamToLoop" enabled="false" level="INFORMATION" enabled_by_default="false" />
-    <inspection_tool class="StringBufferReplaceableByStringBuilder" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="StringBufferToStringInConcatenation" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="StringEquality" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="StringEqualsCharSequence" enabled="false" level="WARNING" enabled_by_default="false" />

--- a/.idea/inspectionProfiles/No_Back_Sliding.xml
+++ b/.idea/inspectionProfiles/No_Back_Sliding.xml
@@ -522,9 +522,6 @@
     <inspection_tool class="PointlessBitwiseExpression" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="m_ignoreExpressionsContainingConstants" value="true" />
     </inspection_tool>
-    <inspection_tool class="PointlessBitwiseExpressionJS" enabled="false" level="WARNING" enabled_by_default="false">
-      <option name="m_ignoreExpressionsContainingConstants" value="false" />
-    </inspection_tool>
     <inspection_tool class="PointlessBooleanExpression" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="m_ignoreExpressionsContainingConstants" value="true" />
     </inspection_tool>
@@ -660,7 +657,6 @@
     <inspection_tool class="ReturnFromFinallyBlock" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="ReturnFromFinallyBlockJS" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="ReturnSeparatedFromComputation" enabled="false" level="INFORMATION" enabled_by_default="false" />
-    <inspection_tool class="SafeVarargsDetector" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="SameParameterValue" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="SameReturnValue" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="ScheduledForRemoval" enabled="false" level="WARNING" enabled_by_default="false" />
@@ -792,7 +788,6 @@
     </inspection_tool>
     <inspection_tool class="UnnecessaryLocalVariableJS" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="m_ignoreImmediatelyReturnedVariables" value="false" />
-      <option name="m_ignoreAnnotatedVariables" value="false" />
     </inspection_tool>
     <inspection_tool class="UnnecessaryModuleDependencyInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UnnecessaryParentheses" enabled="false" level="INFORMATION" enabled_by_default="false">

--- a/.idea/inspectionProfiles/No_Back_Sliding.xml
+++ b/.idea/inspectionProfiles/No_Back_Sliding.xml
@@ -202,6 +202,8 @@
     <inspection_tool class="EmptyTryBlock" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="EndBlockNamesInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="EndlessStream" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="EnhancedSwitchBackwardMigration" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="EnhancedSwitchMigration" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="EnumSwitchStatementWhichMissesCases" enabled="false" level="INFORMATION" enabled_by_default="false">
       <option name="ignoreSwitchStatementsWithDefault" value="true" />
     </inspection_tool>
@@ -691,6 +693,7 @@
     <inspection_tool class="StringEqualsCharSequence" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="StringEqualsEmptyString" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="StringOperationCanBeSimplified" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="StringRepeatCanBeUsed" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="StringReplaceableByStringBuffer" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="onlyWarnOnLoop" value="true" />
     </inspection_tool>

--- a/.idea/inspectionProfiles/No_Back_Sliding.xml
+++ b/.idea/inspectionProfiles/No_Back_Sliding.xml
@@ -742,7 +742,6 @@
     <inspection_tool class="TrivialStringConcatenation" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TryFinallyCanBeTryWithResources" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="TryStatementWithMultipleResources" enabled="false" level="INFORMATION" enabled_by_default="false" />
-    <inspection_tool class="TryWithIdenticalCatches" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="TypeCustomizer" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="TypeParameterExtendsObject" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="TypeParameterHidesVisibleType" enabled="false" level="WARNING" enabled_by_default="false" />

--- a/.idea/inspectionProfiles/No_Back_Sliding.xml
+++ b/.idea/inspectionProfiles/No_Back_Sliding.xml
@@ -740,7 +740,6 @@
     <inspection_tool class="TrivialIf" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="TrivialIfJS" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="TrivialStringConcatenation" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="TryFinallyCanBeTryWithResources" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="TryStatementWithMultipleResources" enabled="false" level="INFORMATION" enabled_by_default="false" />
     <inspection_tool class="TypeCustomizer" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="TypeParameterExtendsObject" enabled="false" level="WARNING" enabled_by_default="false" />

--- a/com.ibm.wala.cast.java.test/src/com/ibm/wala/cast/java/test/JavaIRTests.java
+++ b/com.ibm.wala.cast.java.test/src/com/ibm/wala/cast/java/test/JavaIRTests.java
@@ -606,13 +606,7 @@ public abstract class JavaIRTests extends IRTests {
   public void testSwitch1() {
     try {
       runTest(singleTestSrc(), rtJar, simpleTestEntryPoint(), emptyList, true, null);
-    } catch (IllegalArgumentException e) {
-      // TODO Auto-generated catch block
-      e.printStackTrace();
-    } catch (CancelException e) {
-      // TODO Auto-generated catch block
-      e.printStackTrace();
-    } catch (IOException e) {
+    } catch (IllegalArgumentException | IOException | CancelException e) {
       // TODO Auto-generated catch block
       e.printStackTrace();
     }

--- a/com.ibm.wala.cast.java.test/src/com/ibm/wala/cast/java/test/JavaIRTests.java
+++ b/com.ibm.wala.cast.java.test/src/com/ibm/wala/cast/java/test/JavaIRTests.java
@@ -394,8 +394,7 @@ public abstract class JavaIRTests extends IRTests {
 
   @Test
   public void testCastFromNull() throws IllegalArgumentException, CancelException, IOException {
-    runTest(
-        singleTestSrc(), rtJar, simpleTestEntryPoint(), new ArrayList<IRAssertion>(), true, null);
+    runTest(singleTestSrc(), rtJar, simpleTestEntryPoint(), new ArrayList<>(), true, null);
   }
 
   @Test
@@ -428,20 +427,13 @@ public abstract class JavaIRTests extends IRTests {
 
   @Test
   public void testNullArrayInit() throws IllegalArgumentException, CancelException, IOException {
-    runTest(
-        singleTestSrc(), rtJar, simpleTestEntryPoint(), new ArrayList<IRAssertion>(), true, null);
+    runTest(singleTestSrc(), rtJar, simpleTestEntryPoint(), new ArrayList<>(), true, null);
   }
 
   @Test
   public void testInnerClassA() throws IllegalArgumentException, CancelException, IOException {
     Pair<CallGraph, PointerAnalysis<? extends InstanceKey>> x =
-        runTest(
-            singleTestSrc(),
-            rtJar,
-            simpleTestEntryPoint(),
-            new ArrayList<IRAssertion>(),
-            true,
-            null);
+        runTest(singleTestSrc(), rtJar, simpleTestEntryPoint(), new ArrayList<>(), true, null);
 
     // can't do an IRAssertion() -- we need the pointer analysis
 
@@ -507,13 +499,7 @@ public abstract class JavaIRTests extends IRTests {
   @Test
   public void testInnerClassSuper() throws IllegalArgumentException, CancelException, IOException {
     Pair<CallGraph, PointerAnalysis<? extends InstanceKey>> x =
-        runTest(
-            singleTestSrc(),
-            rtJar,
-            simpleTestEntryPoint(),
-            new ArrayList<IRAssertion>(),
-            true,
-            null);
+        runTest(singleTestSrc(), rtJar, simpleTestEntryPoint(), new ArrayList<>(), true, null);
 
     // can't do an IRAssertion() -- we need the pointer analysis
 

--- a/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/examples/ast/SynchronizedBlockDuplicator.java
+++ b/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/examples/ast/SynchronizedBlockDuplicator.java
@@ -21,6 +21,7 @@ import com.ibm.wala.cast.tree.rewrite.CAstRewriter;
 import com.ibm.wala.classLoader.CallSiteReference;
 import com.ibm.wala.util.collections.Pair;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * transforms each synchronized block to execute under a conditional test calling some method m(),
@@ -76,7 +77,7 @@ public class SynchronizedBlockDuplicator
       return (o instanceof UnwindKey)
           && ((UnwindKey) o).testDirection == testDirection
           && ((UnwindKey) o).syncNode == syncNode
-          && (rest == null ? ((UnwindKey) o).rest == null : rest.equals(((UnwindKey) o).rest));
+          && Objects.equals(rest, ((UnwindKey) o).rest);
     }
 
     @Override

--- a/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/loader/JavaSourceLoaderImpl.java
+++ b/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/loader/JavaSourceLoaderImpl.java
@@ -48,8 +48,6 @@ import com.ibm.wala.classLoader.CallSiteReference;
 import com.ibm.wala.classLoader.ClassLoaderImpl;
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IClassLoader;
-import com.ibm.wala.classLoader.IField;
-import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.classLoader.JavaLanguage.JavaInstructionFactory;
 import com.ibm.wala.classLoader.Language;
 import com.ibm.wala.classLoader.Module;
@@ -114,8 +112,8 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
           TypeName.string2TypeName(typeName),
           loader,
           (short) mapToInt(qualifiers),
-          new HashMap<Atom, IField>(),
-          new HashMap<Selector, IMethod>());
+          new HashMap<>(),
+          new HashMap<>());
       this.superTypeNames = superTypeNames;
       this.enclosingClass = enclosingClass;
       this.annotations = annotations;

--- a/com.ibm.wala.cast.js.html.nu_validator/src/com/ibm/wala/cast/js/html/nu_validator/NuValidatorHtmlParser.java
+++ b/com.ibm.wala.cast.js.html.nu_validator/src/com/ibm/wala/cast/js/html/nu_validator/NuValidatorHtmlParser.java
@@ -214,9 +214,7 @@ public class NuValidatorHtmlParser implements IHtmlParser {
                   return v;
                 }
               }));
-    } catch (IOException e) {
-      assert false : e.toString();
-    } catch (SAXException e) {
+    } catch (IOException | SAXException e) {
       assert false : e.toString();
     }
   }

--- a/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/TestCorrelatedPairExtraction.java
+++ b/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/TestCorrelatedPairExtraction.java
@@ -82,9 +82,7 @@ public abstract class TestCorrelatedPairExtraction {
         Assert.assertEquals(testName, expected, actual);
       }
 
-    } catch (IOException e) {
-      e.printStackTrace();
-    } catch (ClassHierarchyException e) {
+    } catch (IOException | ClassHierarchyException e) {
       e.printStackTrace();
     } finally {
       if (tmp != null && tmp.exists()) tmp.delete();

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/LoadFileTargetSelector.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/LoadFileTargetSelector.java
@@ -29,7 +29,6 @@ import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashSet;
 import java.util.Set;
@@ -89,11 +88,7 @@ public class LoadFileTargetSelector implements MethodTargetSelector {
                           TypeReference.findOrCreate(cl.getReference(), 'L' + url.getFile()));
               return script.getMethod(AstMethodReference.fnSelector);
             }
-          } catch (MalformedURLException e1) {
-            // do nothing, fall through and return 'target'
-          } catch (IOException e) {
-            // do nothing, fall through and return 'target'
-          } catch (RuntimeException e) {
+          } catch (RuntimeException | IOException e1) {
             // do nothing, fall through and return 'target'
           }
         }

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/CAstRewriterExt.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/CAstRewriterExt.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.Stack;
 
@@ -73,7 +74,7 @@ public abstract class CAstRewriterExt extends CAstRewriter<NodePos, NoKey> {
       if (!(obj instanceof Edge)) return false;
       Edge that = (Edge) obj;
       return this.from.equals(that.from)
-          && (this.label == null ? that.label == null : this.label.equals(that.label))
+          && Objects.equals(this.label, that.label)
           && this.to.equals(that.to);
     }
   }

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/AstIRFactory.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/AstIRFactory.java
@@ -44,7 +44,7 @@ public class AstIRFactory<T extends IMethod> implements IRFactory<T> {
     private final AstIRFactory<T> astFactory;
 
     public AstDefaultIRFactory() {
-      this(new AstIRFactory<T>());
+      this(new AstIRFactory<>());
     }
 
     public AstDefaultIRFactory(AstIRFactory<T> astFactory) {

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/AstLexicalAccess.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/AstLexicalAccess.java
@@ -14,6 +14,7 @@ import com.ibm.wala.ssa.SSAInstruction;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.collections.Pair;
 import java.util.Collection;
+import java.util.Objects;
 
 /**
  * This abstract class provides helper functionality for recording lexical uses and/or definitions.
@@ -59,9 +60,7 @@ public abstract class AstLexicalAccess extends SSAInstruction {
       return (other instanceof Access)
           && variableName.equals(((Access) other).variableName)
           && valueNumber == ((Access) other).valueNumber
-          && (variableDefiner == null
-              ? ((Access) other).variableDefiner == null
-              : variableDefiner.equals(((Access) other).variableDefiner));
+          && Objects.equals(variableDefiner, ((Access) other).variableDefiner);
     }
 
     @Override

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/SSAConversion.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/SSAConversion.java
@@ -722,28 +722,22 @@ public class SSAConversion extends AbstractSSAConversion {
 
   public static SSAInformation convert(
       AstMethod M, final AstIRFactory.AstIR ir, SSAOptions options, final IntSet values) {
-    try {
-      if (DEBUG) {
-        System.err.println(("starting conversion for " + values));
-        System.err.println(ir);
-      }
-      if (DEBUG_UNDO) System.err.println((">>> starting " + ir.getMethod()));
-      SSAConversion ssa =
-          new SSAConversion(M, ir, options) {
-            final int limit = ir.getSymbolTable().getMaxValueNumber();
-
-            @Override
-            protected boolean skip(int i) {
-              return (i >= 0) && (i <= limit) && (!values.contains(i));
-            }
-          };
-      ssa.perform();
-      if (DEBUG_UNDO) System.err.println(("<<< done " + ir.getMethod()));
-      return ssa.getComputedLocalMap();
-    } catch (RuntimeException | Error e) {
-      //      System.err.println(("exception or error " + e + " while converting:"));
-      //      System.err.println(ir);
-      throw e;
+    if (DEBUG) {
+      System.err.println(("starting conversion for " + values));
+      System.err.println(ir);
     }
+    if (DEBUG_UNDO) System.err.println((">>> starting " + ir.getMethod()));
+    SSAConversion ssa =
+        new SSAConversion(M, ir, options) {
+          final int limit = ir.getSymbolTable().getMaxValueNumber();
+
+          @Override
+          protected boolean skip(int i) {
+            return (i >= 0) && (i <= limit) && (!values.contains(i));
+          }
+        };
+    ssa.perform();
+    if (DEBUG_UNDO) System.err.println(("<<< done " + ir.getMethod()));
+    return ssa.getComputedLocalMap();
   }
 }

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/SSAConversion.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/SSAConversion.java
@@ -740,12 +740,8 @@ public class SSAConversion extends AbstractSSAConversion {
       ssa.perform();
       if (DEBUG_UNDO) System.err.println(("<<< done " + ir.getMethod()));
       return ssa.getComputedLocalMap();
-    } catch (RuntimeException e) {
-      //      System.err.println(("exception " + e + " while converting:"));
-      //      System.err.println(ir);
-      throw e;
-    } catch (Error e) {
-      //      System.err.println(("error " + e + " while converting:"));
+    } catch (RuntimeException | Error e) {
+      //      System.err.println(("exception or error " + e + " while converting:"));
       //      System.err.println(ir);
       throw e;
     }

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/TranslatorToCAst.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/TranslatorToCAst.java
@@ -256,7 +256,7 @@ public interface TranslatorToCAst {
     @Override
     public void addScopedEntity(CAstNode construct, CAstEntity e) {
       if (!scopedEntities.containsKey(construct)) {
-        scopedEntities.put(construct, new HashSet<CAstEntity>(1));
+        scopedEntities.put(construct, new HashSet<>(1));
       }
       scopedEntities.get(construct).add(e);
     }

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/loader/AstDynamicPropertyClass.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/loader/AstDynamicPropertyClass.java
@@ -31,8 +31,7 @@ public abstract class AstDynamicPropertyClass extends AstClass {
       short modifiers,
       Map<Selector, IMethod> declaredMethods,
       TypeReference defaultDescriptor) {
-    super(
-        sourcePosition, typeName, loader, modifiers, new HashMap<Atom, IField>(), declaredMethods);
+    super(sourcePosition, typeName, loader, modifiers, new HashMap<>(), declaredMethods);
     this.defaultDescriptor = defaultDescriptor;
   }
 

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/impl/CAstControlFlowRecorder.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/impl/CAstControlFlowRecorder.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -71,9 +72,7 @@ public class CAstControlFlowRecorder implements CAstControlFlowMap {
 
     @Override
     public boolean equals(Object o) {
-      return (o instanceof Key)
-          && from == ((Key) o).from
-          && ((label == null) ? ((Key) o).label == null : label.equals(((Key) o).label));
+      return (o instanceof Key) && from == ((Key) o).from && Objects.equals(label, ((Key) o).label);
     }
 
     @Override

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/rewrite/AstLoopUnwinder.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/rewrite/AstLoopUnwinder.java
@@ -18,6 +18,7 @@ import com.ibm.wala.cast.tree.CAstSourcePositionMap;
 import com.ibm.wala.cast.tree.impl.CAstOperator;
 import com.ibm.wala.util.collections.Pair;
 import java.util.Map;
+import java.util.Objects;
 
 public class AstLoopUnwinder
     extends CAstRewriter<
@@ -46,7 +47,7 @@ public class AstLoopUnwinder
     public boolean equals(Object o) {
       return (o instanceof UnwindKey)
           && ((UnwindKey) o).iteration == iteration
-          && (rest == null ? ((UnwindKey) o).rest == null : rest.equals(((UnwindKey) o).rest));
+          && Objects.equals(rest, ((UnwindKey) o).rest);
     }
 
     @Override

--- a/com.ibm.wala.core.testdata/src/cornerCases/TryFinally.java
+++ b/com.ibm.wala.core.testdata/src/cornerCases/TryFinally.java
@@ -17,7 +17,7 @@ import java.io.InputStream;
 
 public class TryFinally {
 
-  @SuppressWarnings("resource")
+  @SuppressWarnings({"resource", "TryFinallyCanBeTryWithResources"})
   public void test1(InputStream i1, InputStream i2) throws IOException {
     BufferedInputStream in = new BufferedInputStream(i1);
     try {

--- a/com.ibm.wala.core.testdata/src/demandpa/TestArrayList.java
+++ b/com.ibm.wala.core.testdata/src/demandpa/TestArrayList.java
@@ -42,8 +42,8 @@ import java.util.ArrayList;
 public class TestArrayList {
 
   public static void main(String[] args) {
-    ArrayList<Object> l1 = new ArrayList<Object>();
-    ArrayList<Object> l2 = new ArrayList<Object>();
+    ArrayList<Object> l1 = new ArrayList<>();
+    ArrayList<Object> l2 = new ArrayList<>();
     l1.add(new Object());
     l2.add(new Object());
     Object o1 = l1.get(0);

--- a/com.ibm.wala.core.testdata/src/dynamicCG/CallbacksMainClass.java
+++ b/com.ibm.wala.core.testdata/src/dynamicCG/CallbacksMainClass.java
@@ -19,7 +19,7 @@ public class CallbacksMainClass {
   }
 
   public static void main(String[] args) {
-    Set<CallbacksMainClass> junk = new HashSet<CallbacksMainClass>();
+    Set<CallbacksMainClass> junk = new HashSet<>();
     junk.add(instance);
     System.err.println(junk.iterator().next().toString());
   }

--- a/com.ibm.wala.core.testdata/src/exceptionpruning/TestPruning.java
+++ b/com.ibm.wala.core.testdata/src/exceptionpruning/TestPruning.java
@@ -64,6 +64,7 @@ public class TestPruning {
   public int testTryCatchMultipleExceptions(int i) {
     int res = 0;
 
+    //noinspection TryWithIdenticalCatches
     try {
       int[] a = new int[] {1, 3, 4};
 

--- a/com.ibm.wala.core.testdata/src/slice/Slice6.java
+++ b/com.ibm.wala.core.testdata/src/slice/Slice6.java
@@ -17,7 +17,7 @@ public class Slice6 {
 
   public static void main(String[] args) {
 
-    messages = new Vector<Integer>();
+    messages = new Vector<>();
     messages.add(5);
 
     int message = messages.elementAt(0);

--- a/com.ibm.wala.core.testdata/src/slice/Slice7.java
+++ b/com.ibm.wala.core.testdata/src/slice/Slice7.java
@@ -15,6 +15,6 @@ import java.util.Hashtable;
 public class Slice7 {
   public static void main(String args[]) {
     @SuppressWarnings("unused")
-    Hashtable<Object, Object> abc = new Hashtable<Object, Object>(3, 0.75f);
+    Hashtable<Object, Object> abc = new Hashtable<>(3, 0.75f);
   }
 }

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/demandpa/driver/CompareToZeroOneCFADriver.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/demandpa/driver/CompareToZeroOneCFADriver.java
@@ -41,7 +41,6 @@ import com.ibm.wala.core.tests.demandpa.TestInfo;
 import com.ibm.wala.demandpa.alg.DemandRefinementPointsTo;
 import com.ibm.wala.demandpa.alg.IDemandPointerAnalysis;
 import com.ibm.wala.demandpa.alg.statemachine.DummyStateMachine;
-import com.ibm.wala.demandpa.flowgraph.IFlowLabel;
 import com.ibm.wala.demandpa.util.CallGraphMapUtil;
 import com.ibm.wala.demandpa.util.MemoryAccessMap;
 import com.ibm.wala.demandpa.util.SimpleMemoryAccessMap;
@@ -240,7 +239,7 @@ public class CompareToZeroOneCFADriver {
     // return new TestNewGraphPointsTo(cg, builder, fam, cha, warnings);
     DemandRefinementPointsTo fullDemandPointsTo =
         DemandRefinementPointsTo.makeWithDefaultFlowGraph(
-            cg, builder, fam, cha, options, new DummyStateMachine.Factory<IFlowLabel>());
+            cg, builder, fam, cha, options, new DummyStateMachine.Factory<>());
     // fullDemandPointsTo.setOnTheFly(true);
     // fullDemandPointsTo.setRefineFields(true);
     return fullDemandPointsTo;

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/demandpa/driver/TestAgainstSimpleDriver.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/demandpa/driver/TestAgainstSimpleDriver.java
@@ -44,7 +44,6 @@ import com.ibm.wala.demandpa.alg.refinepolicy.AlwaysRefineCGPolicy;
 import com.ibm.wala.demandpa.alg.refinepolicy.AlwaysRefineFieldsPolicy;
 import com.ibm.wala.demandpa.alg.refinepolicy.SinglePassRefinementPolicy;
 import com.ibm.wala.demandpa.alg.statemachine.DummyStateMachine;
-import com.ibm.wala.demandpa.flowgraph.IFlowLabel;
 import com.ibm.wala.demandpa.util.MemoryAccessMap;
 import com.ibm.wala.demandpa.util.SimpleMemoryAccessMap;
 import com.ibm.wala.ipa.callgraph.AnalysisCacheImpl;
@@ -171,7 +170,7 @@ public class TestAgainstSimpleDriver {
     // return new TestNewGraphPointsTo(cg, builder, fam, cha, warnings);
     DemandRefinementPointsTo fullDemandPointsTo =
         DemandRefinementPointsTo.makeWithDefaultFlowGraph(
-            cg, builder, fam, cha, options, new DummyStateMachine.Factory<IFlowLabel>());
+            cg, builder, fam, cha, options, new DummyStateMachine.Factory<>());
     // fullDemandPointsTo.setCGRefinePolicy(new AlwaysRefineCGPolicy());
     // fullDemandPointsTo.setFieldRefinePolicy(new AlwaysRefineFieldsPolicy());
     fullDemandPointsTo.setRefinementPolicyFactory(

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/examples/analysis/dataflow/InitializerTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/examples/analysis/dataflow/InitializerTest.java
@@ -73,10 +73,7 @@ public class InitializerTest {
     CallGraph cg = null;
     try {
       cg = builder.makeCallGraph(options, null);
-    } catch (IllegalArgumentException e) {
-      // TODO Auto-generated catch block
-      e.printStackTrace();
-    } catch (CallGraphBuilderCancelException e) {
+    } catch (IllegalArgumentException | CallGraphBuilderCancelException e) {
       // TODO Auto-generated catch block
       e.printStackTrace();
     }

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/examples/drivers/PDFCallGraph.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/examples/drivers/PDFCallGraph.java
@@ -121,10 +121,7 @@ public class PDFCallGraph {
       String gvExe = p.getProperty(WalaExamplesProperties.PDFVIEW_EXE);
       return PDFViewUtil.launchPDFView(pdfFile, gvExe);
 
-    } catch (WalaException e) {
-      e.printStackTrace();
-      return null;
-    } catch (IOException e) {
+    } catch (WalaException | IOException e) {
       e.printStackTrace();
       return null;
     }

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/arraybounds/hypergraph/DirectedHyperGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/arraybounds/hypergraph/DirectedHyperGraph.java
@@ -57,8 +57,8 @@ public class DirectedHyperGraph<T> {
    */
   public void updateNodeEdges() {
     for (final HyperNode<T> node : this.getNodes().values()) {
-      node.setOutEdges(new HashSet<DirectedHyperEdge<T>>());
-      node.setInEdges(new HashSet<DirectedHyperEdge<T>>());
+      node.setOutEdges(new HashSet<>());
+      node.setInEdges(new HashSet<>());
     }
 
     for (final DirectedHyperEdge<T> edge : this.edges) {

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/exceptionanalysis/ExceptionAnalysis.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/exceptionanalysis/ExceptionAnalysis.java
@@ -78,7 +78,7 @@ public class ExceptionAnalysis {
     this.cha = cha;
     this.cg = callgraph;
     if (filter == null) {
-      this.filter = new IgnoreExceptionsInterFilter<>(new DummyFilter<SSAInstruction>());
+      this.filter = new IgnoreExceptionsInterFilter<>(new DummyFilter<>());
     } else {
       this.filter = filter;
     }

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/inter/InterprocNullPointerAnalysis.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/inter/InterprocNullPointerAnalysis.java
@@ -101,7 +101,7 @@ public final class InterprocNullPointerAnalysis {
 
     // we start with the first node
     final CGNode firstNode = cgFiltered.getNode(0);
-    findAndInjectInvokes(firstNode, new ParameterState(), new HashSet<CGNode>(), progress);
+    findAndInjectInvokes(firstNode, new ParameterState(), new HashSet<>(), progress);
   }
 
   /**

--- a/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/TabulationSolver.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/TabulationSolver.java
@@ -191,11 +191,7 @@ public class TabulationSolver<T, P, F> {
       forwardTabulateSLRPs();
       Result r = new Result();
       return r;
-    } catch (CancelException e) {
-      // store a partially-tabulated result in the thrown exception.
-      Result r = new Result();
-      throw new TabulationCancelException(e, r);
-    } catch (CancelRuntimeException e) {
+    } catch (CancelException | CancelRuntimeException e) {
       // store a partially-tabulated result in the thrown exception.
       Result r = new Result();
       throw new TabulationCancelException(e, r);

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/AnalysisScope.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/AnalysisScope.java
@@ -356,7 +356,7 @@ public class AnalysisScope {
   /** @return the rt.jar (1.4) or core.jar (1.5) file, or null if not found. */
   private JarFile getRtJar() {
     return RtJar.getRtJar(
-        new MapIterator<Module, JarFile>(
+        new MapIterator<>(
             new FilterIterator<>(
                 getModules(getPrimordialLoader()).iterator(), JarFileModule.class::isInstance),
             M -> ((JarFileModule) M).getJarFile()));

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/cha/CHACallGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/cha/CHACallGraph.java
@@ -157,7 +157,7 @@ public class CHACallGraph extends BasicCallGraph<CHAContextInterpreter> {
   @Override
   public Set<CGNode> getPossibleTargets(CGNode node, CallSiteReference site) {
     return Iterator2Collection.toSet(
-        new MapIterator<IMethod, CGNode>(
+        new MapIterator<>(
             new FilterIterator<>(getPossibleTargets(site), this::isRelevantMethod),
             object -> {
               try {

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/ConstantKey.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/ConstantKey.java
@@ -17,6 +17,7 @@ import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.ibm.wala.util.collections.EmptyIterator;
 import com.ibm.wala.util.collections.Pair;
 import java.util.Iterator;
+import java.util.Objects;
 
 /** An instance key which represents a unique, constant object. */
 public final class ConstantKey<T> implements InstanceKey {
@@ -34,9 +35,7 @@ public final class ConstantKey<T> implements InstanceKey {
   public boolean equals(Object obj) {
     if (obj instanceof ConstantKey) {
       ConstantKey<?> other = (ConstantKey<?>) obj;
-      return valueClass.equals(other.valueClass)
-          ? (value == null ? other.value == null : value.equals(other.value))
-          : false;
+      return valueClass.equals(other.valueClass) ? Objects.equals(value, other.value) : false;
     } else {
       return false;
     }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PropagationCallGraphBuilder.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/PropagationCallGraphBuilder.java
@@ -249,12 +249,7 @@ public abstract class PropagationCallGraphBuilder implements CallGraphBuilder<In
     solver = makeSolver();
     try {
       solver.solve(monitor);
-    } catch (CancelException e) {
-      CallGraphBuilderCancelException c =
-          CallGraphBuilderCancelException.createCallGraphBuilderCancelException(
-              e, callGraph, system.extractPointerAnalysis(this));
-      throw c;
-    } catch (CancelRuntimeException e) {
+    } catch (CancelException | CancelRuntimeException e) {
       CallGraphBuilderCancelException c =
           CallGraphBuilderCancelException.createCallGraphBuilderCancelException(
               e, callGraph, system.extractPointerAnalysis(this));

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/modref/ModRefFieldAccess.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/modref/ModRefFieldAccess.java
@@ -105,10 +105,10 @@ public final class ModRefFieldAccess {
 
     for (CGNode cgNode : cg) {
       if (!refs.containsKey(cgNode)) {
-        refs.put(cgNode, new HashMap<IClass, Set<IField>>());
+        refs.put(cgNode, new HashMap<>());
       }
       if (!mods.containsKey(cgNode)) {
-        mods.put(cgNode, new HashMap<IClass, Set<IField>>());
+        mods.put(cgNode, new HashMap<>());
       }
 
       final IR ir = cgNode.getIR();
@@ -126,7 +126,7 @@ public final class ModRefFieldAccess {
             IClass cls = field.getDeclaringClass();
             if (cls != null) {
               if (!refs.get(cgNode).containsKey(cls)) {
-                refs.get(cgNode).put(cls, new HashSet<IField>());
+                refs.get(cgNode).put(cls, new HashSet<>());
               }
               refs.get(cgNode).get(cls).add(field);
             }
@@ -139,7 +139,7 @@ public final class ModRefFieldAccess {
             IClass cls = field.getDeclaringClass();
             if (cls != null) {
               if (!mods.get(cgNode).containsKey(cls)) {
-                mods.get(cgNode).put(cls, new HashSet<IField>());
+                mods.get(cgNode).put(cls, new HashSet<>());
               }
               mods.get(cgNode).get(cls).add(field);
             }
@@ -153,10 +153,10 @@ public final class ModRefFieldAccess {
 
   private TwoMaps recAdd(CGNode node) {
     if (!trefs.containsKey(node)) {
-      trefs.put(node, new HashMap<IClass, Set<IField>>());
+      trefs.put(node, new HashMap<>());
     }
     if (!tmods.containsKey(node)) {
-      tmods.put(node, new HashMap<IClass, Set<IField>>());
+      tmods.put(node, new HashMap<>());
     }
 
     final IR ir = node.getIR();
@@ -170,7 +170,7 @@ public final class ModRefFieldAccess {
             IClass cls = field.getDeclaringClass();
             if (cls != null) {
               if (!trefs.get(node).containsKey(cls)) {
-                trefs.get(node).put(cls, new HashSet<IField>());
+                trefs.get(node).put(cls, new HashSet<>());
               }
               trefs.get(node).get(cls).add(field);
             }
@@ -183,7 +183,7 @@ public final class ModRefFieldAccess {
             IClass cls = field.getDeclaringClass();
             if (cls != null) {
               if (!tmods.get(node).containsKey(cls)) {
-                tmods.get(node).put(cls, new HashSet<IField>());
+                tmods.get(node).put(cls, new HashSet<>());
               }
               tmods.get(node).get(cls).add(field);
             }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/SDG.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/slicer/SDG.java
@@ -107,7 +107,7 @@ public class SDG<T extends InstanceKey> extends AbstractNumberedGraph<Statement>
       PointerAnalysis<T> pa,
       DataDependenceOptions dOptions,
       ControlDependenceOptions cOptions) {
-    this(cg, pa, new ModRef<T>(), dOptions, cOptions, null);
+    this(cg, pa, new ModRef<>(), dOptions, cOptions, null);
   }
 
   public SDG(

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/SymbolTable.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/SymbolTable.java
@@ -354,9 +354,7 @@ public class SymbolTable implements Cloneable {
   public PhiValue getPhiValue(int valueNumber) {
     try {
       return (PhiValue) values[valueNumber];
-    } catch (ArrayIndexOutOfBoundsException e) {
-      throw new IllegalArgumentException("invalid valueNumber: " + valueNumber, e);
-    } catch (ClassCastException e) {
+    } catch (ArrayIndexOutOfBoundsException | ClassCastException e) {
       throw new IllegalArgumentException("invalid valueNumber: " + valueNumber, e);
     }
   }

--- a/com.ibm.wala.core/src/com/ibm/wala/util/config/AnalysisScopeReader.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/config/AnalysisScopeReader.java
@@ -262,9 +262,7 @@ public class AnalysisScopeReader {
           }
         }
       }
-    } catch (IOException e) {
-      Assertions.UNREACHABLE(e.toString());
-    } catch (InvalidClassFileException e) {
+    } catch (IOException | InvalidClassFileException e) {
       Assertions.UNREACHABLE(e.toString());
     }
   }

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/DexIClass.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/DexIClass.java
@@ -305,7 +305,7 @@ public class DexIClass extends BytecodeClass<IClassLoader> {
     for (MethodParameter as : m.getParameters()) {
       for (org.jf.dexlib2.iface.Annotation a : as.getAnnotations()) {
         if (!result.containsKey(i)) {
-          result.put(i, new ArrayList<Annotation>());
+          result.put(i, new ArrayList<>());
         }
         result.get(i).add(DexUtil.getAnnotation(a, getClassLoader().getReference()));
       }

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/DexIMethod.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/DexIMethod.java
@@ -631,7 +631,7 @@ public class DexIMethod implements IBytecodeMethod<Instruction> {
 
     ArrayList<ArrayList<ExceptionHandler>> temp_array = new ArrayList<>();
     for (int i = 0; i < instructions().size(); i++) {
-      temp_array.add(new ArrayList<ExceptionHandler>());
+      temp_array.add(new ArrayList<>());
     }
 
     for (TryBlock<? extends org.jf.dexlib2.iface.ExceptionHandler> tryItem : tryBlocks) {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidEntryPointManager.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidEntryPointManager.java
@@ -60,6 +60,7 @@ import com.ibm.wala.util.ssa.TypeSafeInstructionFactory;
 import com.ibm.wala.util.strings.StringStuff;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -279,13 +280,10 @@ public final /* singleton */ class AndroidEntryPointManager implements Serializa
               "Canot find the constructor of " + this.abstractAndroidModel);
         }
         return ctor.newInstance(body, insts, paramManager, entryPoints);
-      } catch (java.lang.InstantiationException e) {
-        throw new IllegalStateException(e);
-      } catch (java.lang.IllegalAccessException e) {
-        throw new IllegalStateException(e);
-      } catch (java.lang.reflect.InvocationTargetException e) {
-        throw new IllegalStateException(e);
-      } catch (java.lang.NoSuchMethodException e) {
+      } catch (InstantiationException
+          | NoSuchMethodException
+          | InvocationTargetException
+          | IllegalAccessException e) {
         throw new IllegalStateException(e);
       }
     }

--- a/com.ibm.wala.ide.jdt/source/com/ibm/wala/cast/java/translator/jdt/JDTSourceModuleTranslator.java
+++ b/com.ibm.wala.ide.jdt/source/com/ibm/wala/cast/java/translator/jdt/JDTSourceModuleTranslator.java
@@ -169,7 +169,7 @@ public class JDTSourceModuleTranslator implements SourceModuleTranslator {
       EclipseSourceFileModule entry = (EclipseSourceFileModule) m;
       IProject proj = entry.getIFile().getProject();
       if (!projectsFiles.containsKey(proj)) {
-        projectsFiles.put(proj, new HashMap<ICompilationUnit, EclipseSourceFileModule>());
+        projectsFiles.put(proj, new HashMap<>());
       }
       projectsFiles.get(proj).put(JavaCore.createCompilationUnitFrom(entry.getIFile()), entry);
     }

--- a/com.ibm.wala.ide.jdt/source/com/ibm/wala/ide/AbstractJavaAnalysisAction.java
+++ b/com.ibm.wala.ide.jdt/source/com/ibm/wala/ide/AbstractJavaAnalysisAction.java
@@ -189,9 +189,7 @@ public abstract class AbstractJavaAnalysisAction
     IProgressService progressService = PlatformUI.getWorkbench().getProgressService();
     try {
       progressService.busyCursorWhile(this);
-    } catch (InvocationTargetException e) {
-      e.printStackTrace();
-    } catch (InterruptedException e) {
+    } catch (InvocationTargetException | InterruptedException e) {
       e.printStackTrace();
     }
   }

--- a/com.ibm.wala.ide.tests/src/com/ibm/wala/ide/tests/util/EclipseTestUtil.java
+++ b/com.ibm.wala.ide.tests/src/com/ibm/wala/ide/tests/util/EclipseTestUtil.java
@@ -14,7 +14,6 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
-import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspaceRoot;
@@ -116,9 +115,7 @@ public class EclipseTestUtil {
     importOp.setOverwriteResources(true);
     try {
       importOp.run(monitor);
-    } catch (InvocationTargetException e) {
-      e.printStackTrace();
-    } catch (InterruptedException e) {
+    } catch (InvocationTargetException | InterruptedException e) {
       e.printStackTrace();
     }
   }
@@ -145,8 +142,6 @@ public class EclipseTestUtil {
     if (file != null) {
       try {
         return new ZipFile(file);
-      } catch (ZipException e) {
-        reportException(e);
       } catch (IOException e) {
         reportException(e);
       }

--- a/com.ibm.wala.ide/src/com/ibm/wala/ide/util/EclipseProjectPath.java
+++ b/com.ibm.wala.ide/src/com/ibm/wala/ide/util/EclipseProjectPath.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.jar.JarFile;
-import java.util.zip.ZipException;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
@@ -139,11 +138,8 @@ public abstract class EclipseProjectPath<E, P> {
     JarFile j;
     try {
       j = new JarFile(file);
-    } catch (ZipException z) {
-      // a corrupted file. ignore it.
-      return;
     } catch (IOException z) {
-      // should ignore directories as well..
+      // may be a corrupted zip file or a directory. ignore it.
       return;
     }
     if (isPrimordialJarFile()) {
@@ -191,11 +187,8 @@ public abstract class EclipseProjectPath<E, P> {
                 ? includeSource
                 : false);
       }
-    } catch (CoreException e1) {
+    } catch (CoreException | IOException e1) {
       e1.printStackTrace();
-      Assertions.UNREACHABLE();
-    } catch (IOException e) {
-      e.printStackTrace();
       Assertions.UNREACHABLE();
     }
   }

--- a/com.ibm.wala.ide/src/com/ibm/wala/ide/util/HeadlessUtil.java
+++ b/com.ibm.wala.ide/src/com/ibm/wala/ide/util/HeadlessUtil.java
@@ -91,7 +91,7 @@ public class HeadlessUtil {
         EclipseSourceFileModule entry = (EclipseSourceFileModule) m;
         IProject proj = entry.getIFile().getProject();
         if (!projectsFiles.containsKey(proj)) {
-          projectsFiles.put(proj, new HashMap<Unit, EclipseSourceFileModule>());
+          projectsFiles.put(proj, new HashMap<>());
         }
         projectsFiles.get(proj).put(compiler.getCompilationUnit(entry.getIFile()), entry);
       }

--- a/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/PrefixTransferGraph.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/PrefixTransferGraph.java
@@ -199,8 +199,8 @@ public class PrefixTransferGraph implements Graph<InstanceKeySite> {
 
   @Override
   public void addNode(InstanceKeySite n) {
-    predecessors.put(n, new HashSet<InstanceKeySite>());
-    successors.put(n, new HashSet<InstanceKeySite>());
+    predecessors.put(n, new HashSet<>());
+    successors.put(n, new HashSet<>());
     nodes.add(n);
   }
 

--- a/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/UriPrefixTransferGraph.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/UriPrefixTransferGraph.java
@@ -338,8 +338,8 @@ public class UriPrefixTransferGraph implements Graph<InstanceKeySite> {
 
   @Override
   public void addNode(final InstanceKeySite n) {
-    predecessors.put(n, new HashSet<InstanceKeySite>());
-    successors.put(n, new HashSet<InstanceKeySite>());
+    predecessors.put(n, new HashSet<>());
+    successors.put(n, new HashSet<>());
     nodes.add(n);
   }
 

--- a/com.ibm.wala.scandroid/source/org/scandroid/synthmethod/XMLSummaryWriter.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/synthmethod/XMLSummaryWriter.java
@@ -53,7 +53,6 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
@@ -141,11 +140,7 @@ public class XMLSummaryWriter {
 
       StreamResult result = new StreamResult(baos);
       transformer.transform(source, result);
-    } catch (TransformerConfigurationException e) {
-      e.printStackTrace();
-    } catch (IllegalArgumentException e) {
-      e.printStackTrace();
-    } catch (TransformerException e) {
+    } catch (TransformerException | IllegalArgumentException e) {
       e.printStackTrace();
     }
 

--- a/com.ibm.wala.scandroid/source/org/scandroid/util/CGAnalysisContext.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/util/CGAnalysisContext.java
@@ -107,7 +107,7 @@ public class CGAnalysisContext<E extends ISSABasicBlock> {
 
   public CGAnalysisContext(AndroidAnalysisContext analysisContext, IEntryPointSpecifier specifier)
       throws IOException {
-    this(analysisContext, specifier, new ArrayList<InputStream>());
+    this(analysisContext, specifier, new ArrayList<>());
   }
 
   @SuppressWarnings({"rawtypes", "unchecked"})

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Decoder.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Decoder.java
@@ -854,10 +854,7 @@ public abstract class Decoder implements Constants {
       } catch (InvalidBytecodeException ex) {
         ex.setIndex(index);
         throw ex;
-      } catch (Error ex) {
-        System.err.println("Fatal error at index " + index);
-        throw ex;
-      } catch (RuntimeException ex) {
+      } catch (Error | RuntimeException ex) {
         System.err.println("Fatal error at index " + index);
         throw ex;
       }

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/ExceptionHandler.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/ExceptionHandler.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.shrikeBT;
 
+import java.util.Objects;
+
 /**
  * An ExceptionHandler represents a single handler covering a single instruction. It simply tells us
  * what kind of exception to catch and where to dispatch the exception to.
@@ -71,8 +73,7 @@ public final class ExceptionHandler {
     if (h == null) {
       throw new IllegalArgumentException("h is null");
     }
-    return h.handler == handler
-        && (catchClass == null ? h.catchClass == null : catchClass.equals(h.catchClass));
+    return h.handler == handler && Objects.equals(catchClass, h.catchClass);
   }
 
   @Override

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Util.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Util.java
@@ -388,9 +388,7 @@ public final class Util {
       Field f = c.getField(name);
       return GetInstruction.make(
           makeType(f.getType()), makeType(c), name, (f.getModifiers() & Constants.ACC_STATIC) != 0);
-    } catch (SecurityException e) {
-      throw new IllegalArgumentException(e.getMessage());
-    } catch (NoSuchFieldException e) {
+    } catch (SecurityException | NoSuchFieldException e) {
       throw new IllegalArgumentException(e.getMessage());
     }
   }
@@ -409,9 +407,7 @@ public final class Util {
       Field f = c.getField(name);
       return PutInstruction.make(
           makeType(f.getType()), makeType(c), name, (f.getModifiers() & Constants.ACC_STATIC) != 0);
-    } catch (SecurityException e) {
-      throw new IllegalArgumentException(e.getMessage());
-    } catch (NoSuchFieldException e) {
+    } catch (SecurityException | NoSuchFieldException e) {
       throw new IllegalArgumentException(e.getMessage());
     }
   }

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/analysis/Analyzer.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/analysis/Analyzer.java
@@ -833,7 +833,7 @@ public class Analyzer {
   public final void computeTypes(TypeVisitor v, BitSet makeTypesAt, boolean wantPath)
       throws FailureException {
     initTypeInfo();
-    computeTypes(0, v, makeTypesAt, wantPath ? new ArrayList<PathElement>() : null);
+    computeTypes(0, v, makeTypesAt, wantPath ? new ArrayList<>() : null);
   }
 
   public abstract class TypeVisitor extends IInstruction.Visitor {

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/analysis/ClassHierarchy.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/analysis/ClassHierarchy.java
@@ -140,7 +140,7 @@ public final class ClassHierarchy {
     } else {
       int v = checkSupertypesContain(hierarchy, t1, t2);
       if (v == MAYBE) {
-        v = checkSubtypesContain(hierarchy, t2, t1, new HashSet<String>());
+        v = checkSubtypesContain(hierarchy, t2, t1, new HashSet<>());
       }
       return v;
     }

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/ClassInstrumenter.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/ClassInstrumenter.java
@@ -302,10 +302,7 @@ public final class ClassInstrumenter {
 
           try {
             comp.compile();
-          } catch (Error ex) {
-            ex.printStackTrace();
-            throw new Error("Error compiling method " + md + ": " + ex.getMessage());
-          } catch (Exception ex) {
+          } catch (Error | Exception ex) {
             ex.printStackTrace();
             throw new Error("Error compiling method " + md + ": " + ex.getMessage());
           }

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/tools/ClassPrinter.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/tools/ClassPrinter.java
@@ -135,9 +135,7 @@ public class ClassPrinter {
         int val;
         try {
           val = element.getInt(null);
-        } catch (IllegalArgumentException e) {
-          throw new Error(e.getMessage());
-        } catch (IllegalAccessException e) {
+        } catch (IllegalArgumentException | IllegalAccessException e) {
           throw new Error(e.getMessage());
         }
         if ((flags & val) != 0) {

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/BootstrapMethodsReader.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/BootstrapMethodsReader.java
@@ -152,7 +152,7 @@ public class BootstrapMethodsReader extends AttributeReader {
                   | NoSuchMethodException
                   | ClassNotFoundException
                   | InvalidClassFileException e) {
-                assert false : e;
+                throw new RuntimeException(e);
               }
               return null;
             }

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/BootstrapMethodsReader.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/BootstrapMethodsReader.java
@@ -146,17 +146,12 @@ public class BootstrapMethodsReader extends AttributeReader {
                   default:
                     assert false : "invalid type " + t;
                 }
-              } catch (IllegalArgumentException e) {
-                assert false : e;
-              } catch (InvalidClassFileException e) {
-                assert false : e;
-              } catch (ClassNotFoundException e) {
-                assert false : e;
-              } catch (NoSuchMethodException e) {
-                assert false : e;
-              } catch (SecurityException e) {
-                assert false : e;
-              } catch (IllegalAccessException e) {
+              } catch (IllegalArgumentException
+                  | IllegalAccessException
+                  | SecurityException
+                  | NoSuchMethodException
+                  | ClassNotFoundException
+                  | InvalidClassFileException e) {
                 assert false : e;
               }
               return null;

--- a/com.ibm.wala.util/src/com/ibm/wala/util/collections/Iterator2Collection.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/collections/Iterator2Collection.java
@@ -31,7 +31,7 @@ public abstract class Iterator2Collection<T> implements Collection<T> {
     if (i == null) {
       throw new IllegalArgumentException("i == null");
     }
-    return new Iterator2Set<>(i, new LinkedHashSet<T>(5));
+    return new Iterator2Set<>(i, new LinkedHashSet<>(5));
   }
 
   /** Returns a {@link List} containing all elements in i, preserving duplicates. */
@@ -40,7 +40,7 @@ public abstract class Iterator2Collection<T> implements Collection<T> {
     if (i == null) {
       throw new IllegalArgumentException("i == null");
     }
-    return new Iterator2List<>(i, new ArrayList<T>(5));
+    return new Iterator2List<>(i, new ArrayList<>(5));
   }
 
   @Override

--- a/com.ibm.wala.util/src/com/ibm/wala/util/collections/Pair.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/collections/Pair.java
@@ -14,6 +14,7 @@ import com.ibm.wala.util.debug.Assertions;
 import java.io.Serializable;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 public class Pair<T, U> implements Serializable {
 
@@ -27,7 +28,7 @@ public class Pair<T, U> implements Serializable {
   }
 
   private static boolean check(Object x, Object y) {
-    return (x == null) ? (y == null) : x.equals(y);
+    return Objects.equals(x, y);
   }
 
   @SuppressWarnings("rawtypes")

--- a/com.ibm.wala.util/src/com/ibm/wala/util/heapTrace/HeapTracer.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/heapTrace/HeapTracer.java
@@ -495,11 +495,7 @@ public class HeapTracer {
       HeapTracer.Result r = (new HeapTracer(traceStatics)).perform();
       System.err.println("HeapTracer Analysis:");
       System.err.println(r.toString());
-    } catch (IllegalArgumentException e) {
-      e.printStackTrace();
-    } catch (ClassNotFoundException e) {
-      e.printStackTrace();
-    } catch (IllegalAccessException e) {
+    } catch (IllegalArgumentException | IllegalAccessException | ClassNotFoundException e) {
       e.printStackTrace();
     }
   }
@@ -525,11 +521,7 @@ public class HeapTracer {
       System.err.println("HeapTracer Analysis:");
       System.err.println(r.toString());
       return r;
-    } catch (IllegalArgumentException e) {
-      e.printStackTrace();
-    } catch (ClassNotFoundException e) {
-      e.printStackTrace();
-    } catch (IllegalAccessException e) {
+    } catch (IllegalArgumentException | IllegalAccessException | ClassNotFoundException e) {
       e.printStackTrace();
     }
     return null;


### PR DESCRIPTION
These changes put various Java 7 language and library features to use for improved code clarity and simplicity. All were found and applied using various IntelliJ IDEA inspections, followed by manual examination (and in a few cases. reversal) of the changes.