### PR TITLE
Reenable Mac JDK 11 Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,11 @@ matrix:
       env: BUILD_SYSTEM=gradle
       language: java
       jdk: openjdk11
-    # - os: osx
-    #   osx_image: xcode8.3
-    #   env: BUILD_SYSTEM=gradle
-    #   language: java
-    #   jdk: openjdk11
+    - os: osx
+      osx_image: xcode8.3
+      env: BUILD_SYSTEM=gradle
+      language: java
+      jdk: openjdk11
     - os: linux
       env: BUILD_SYSTEM=gradle
       language: java


### PR DESCRIPTION
The underlying Travis issue is [fixed now](https://travis-ci.community/t/install-of-openjdk11-is-failing-again/3061/27).