### PR TITLE
Rejuvenate log levels

### DIFF
--- a/com.ibm.wala.util/src/com/ibm/wala/util/processes/Launcher.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/processes/Launcher.java
@@ -89,7 +89,7 @@ public abstract class Launcher {
       throw new IllegalArgumentException("cmd cannot be null");
     }
     if (logger != null) {
-      logger.info("spawning process " + cmd);
+      logger.finest("spawning process " + cmd);
     }
     String[] ev = getEnv() == null ? null : buildEnv(getEnv());
     Process p = Runtime.getRuntime().exec(cmd, ev, getWorkingDir());
@@ -106,7 +106,7 @@ public abstract class Launcher {
       throw new IllegalArgumentException("cmd cannot be null");
     }
     if (logger != null) {
-      logger.info("spawning process " + Arrays.toString(cmd));
+      logger.finest("spawning process " + Arrays.toString(cmd));
     }
     String[] ev = getEnv() == null ? null : buildEnv(getEnv());
     Process p = Runtime.getRuntime().exec(cmd, ev, getWorkingDir());
@@ -236,7 +236,7 @@ public abstract class Launcher {
             repeat = false;
             blockingDrain();
             if (logger != null) {
-              logger.fine("process terminated with exit code " + p.exitValue());
+              logger.finest("process terminated with exit code " + p.exitValue());
             }
           } catch (IllegalThreadStateException e) {
             // this means the process has not yet terminated.


### PR DESCRIPTION
## Introduction

We are in the process of evaluating our [research prototype Eclipse plug-in](https://github.com/ponder-lab/Logging-Level-Evolution-Plugin) that "rejuvenates" log statement levels based on how "interesting" the enclosing methods are to the developers. We hypothesize that portions of a system that are worked on more and more recently should have higher log levels (e.g., `INFO` as compared to `FINEST`) and vice-versa. This places event logs related to tasks that are currently more important to the forefront while pushing event logs pertaining to tasks worked on in the past to the background. The goal is to reduce information overload, bring more relevant events to developers' attention, and alleviate developers from manually making log level changes.

The transformation decision is made by analyzing the "degree of interest" (DOI) values of enclosing methods for logging invocations. DOI value is a kind of real number for a program element which shows how developers are interested in it. It is computed from the interaction events between developer and program elements, such as edits. In this project, we calculate the DOI using the project's git history.

## Feedback Request

We are looking for feedback on our tool from developers. If you can, we would appreciate if you can comment on *each* of the transformations (if possible) in the case that this PR is not accepted. If there there are too many transformations to review, letting us know where you left off would be helpful. Of course, we would also love to contribute to your project if you wish.

## Settings

We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

1. Treat CONFIG levels as a category and not a traditional level, i.e., our tool ignores these log levels.
1. Never lower the logging level of logging statements within catch blocks.
1. Never lower the logging level of logging statements containing certain (important) keywords.
1. Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
1. The greatest number of commits evaluated: 300.

The head at time of analysis was: 590703b31a7b166bd6041926dd32c5e23bcb1314