### PR TITLE
Switch to maven Gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ plugins {
 	id 'de.undercouch.download'
 	id 'nebula.lint' version '9.2.0'
 	id 'nebula.source-jar' version '9.5.0' apply false
-	id 'maven-publish'
 }
 
 repositories {
@@ -73,7 +72,6 @@ subprojects { subproject ->
 	}
 
 	apply plugin: 'java'
-	apply plugin: 'maven-publish'
 	apply plugin: 'nebula.source-jar'
 
 	version rootProject.version
@@ -86,12 +84,6 @@ subprojects { subproject ->
 	}
 
 	jar.manifest.from('META-INF/MANIFEST.MF')
-
-	publishing.publications {
-		mavenJava(MavenPublication) {
-			from components.java
-		}
-	}
 
 	tasks.register('afterEclipseBuildshipImport') {
 		dependsOn 'processTestResources'

--- a/com.ibm.wala.cast.java.ecj/build.gradle
+++ b/com.ibm.wala.cast.java.ecj/build.gradle
@@ -2,14 +2,14 @@ sourceSets.main.java.srcDirs = ['src']
 
 dependencies {
 	compile(
-		'eclipse-deps:org.eclipse.core.runtime:+',
-		'eclipse-deps:org.eclipse.equinox.common:+',
-		'eclipse-deps:org.eclipse.jdt.core:+',
-		'org.osgi:org.osgi.core:4.2.0',
 		project(':com.ibm.wala.cast'),
 		project(':com.ibm.wala.cast.java'),
 		project(':com.ibm.wala.core'),
 		project(':com.ibm.wala.shrike'),
 		project(':com.ibm.wala.util'),
+                'org.eclipse.core:org.eclipse.core.runtime:3.7.0',
+                'org.eclipse.jdt:org.eclipse.jdt.core:3.10.0'
 		)
 }
+
+apply from: rootProject.file("gradle-mvn-push.gradle")

--- a/com.ibm.wala.cast.java.ecj/gradle.properties
+++ b/com.ibm.wala.cast.java.ecj/gradle.properties
@@ -1,0 +1,3 @@
+POM_NAME=WALA CAst Java ECJ
+POM_ARTIFACT_ID=com.ibm.wala.cast.java.ecj
+POM_PACKAGING=jar

--- a/com.ibm.wala.cast.java.test/build.gradle
+++ b/com.ibm.wala.cast.java.test/build.gradle
@@ -10,12 +10,6 @@ sourceSets.test {
 	resources.srcDirs = ['data']
 }
 
-publishing.publications {
-	mavenJava(MavenPublication) {
-		artifact jarTest
-	}
-}
-
 dependencies {
 	testCompile(
 		'junit:junit:4.12',

--- a/com.ibm.wala.cast.java/build.gradle
+++ b/com.ibm.wala.cast.java/build.gradle
@@ -14,3 +14,6 @@ dependencies {
 		project(':com.ibm.wala.util'),
 		)
 }
+
+apply from: rootProject.file("gradle-mvn-push.gradle")
+

--- a/com.ibm.wala.cast.java/gradle.properties
+++ b/com.ibm.wala.cast.java/gradle.properties
@@ -1,0 +1,3 @@
+POM_NAME=WALA CAst Java
+POM_ARTIFACT_ID=com.ibm.wala.cast.java
+POM_PACKAGING=jar

--- a/com.ibm.wala.cast.js.rhino.test/build.gradle
+++ b/com.ibm.wala.cast.js.rhino.test/build.gradle
@@ -4,12 +4,6 @@ plugins {
 
 sourceSets.test.java.srcDirs = ['harness-src']
 
-publishing.publications {
-	mavenJava(MavenPublication) {
-		artifact jarTest
-	}
-}
-
 dependencies {
 	testCompile(
 		'junit:junit:4.12',

--- a/com.ibm.wala.cast.js.rhino/build.gradle
+++ b/com.ibm.wala.cast.js.rhino/build.gradle
@@ -9,3 +9,5 @@ dependencies {
 		project(':com.ibm.wala.util'),
 		)
 }
+
+apply from: rootProject.file("gradle-mvn-push.gradle")

--- a/com.ibm.wala.cast.js.rhino/gradle.properties
+++ b/com.ibm.wala.cast.js.rhino/gradle.properties
@@ -1,0 +1,3 @@
+POM_NAME=WALA CAst JavaScript Rhino
+POM_ARTIFACT_ID=com.ibm.wala.cast.js.rhino
+POM_PACKAGING=jar

--- a/com.ibm.wala.cast.js.test/build.gradle
+++ b/com.ibm.wala.cast.js.test/build.gradle
@@ -4,12 +4,6 @@ plugins {
 
 sourceSets.test.java.srcDirs = ['harness-src']
 
-publishing.publications {
-	mavenJava(MavenPublication) {
-		artifact jarTest
-	}
-}
-
 dependencies {
 	testCompile(
 		'junit:junit:4.12',

--- a/com.ibm.wala.cast.js/build.gradle
+++ b/com.ibm.wala.cast.js/build.gradle
@@ -26,3 +26,5 @@ tasks.named('javadoc') {
 		classpath += files project(rhinoName).compileJava
 	}
 }
+
+apply from: rootProject.file("gradle-mvn-push.gradle")

--- a/com.ibm.wala.cast.js/gradle.properties
+++ b/com.ibm.wala.cast.js/gradle.properties
@@ -1,0 +1,3 @@
+POM_NAME=WALA CAst JavaScript
+POM_ARTIFACT_ID=com.ibm.wala.cast.js
+POM_PACKAGING=jar

--- a/com.ibm.wala.cast.test/build.gradle
+++ b/com.ibm.wala.cast.test/build.gradle
@@ -9,12 +9,6 @@ sourceSets.test.java.srcDirs = ['harness-src/java']
 
 compileTestJava.options.headerOutputDirectory.set file('build/headers')
 
-publishing.publications {
-	mavenJava(MavenPublication) {
-		artifact jarTest
-	}
-}
-
 dependencies {
 	testCompile(
 		'junit:junit:4.12',

--- a/com.ibm.wala.cast/build.gradle
+++ b/com.ibm.wala.cast/build.gradle
@@ -45,3 +45,5 @@ tasks.named('assemble') {
 tasks.named('clean') {
 	dependsOn 'cleanCopyJarsIntoLib'
 }
+
+apply from: rootProject.file("gradle-mvn-push.gradle")

--- a/com.ibm.wala.cast/gradle.properties
+++ b/com.ibm.wala.cast/gradle.properties
@@ -1,0 +1,3 @@
+POM_NAME=WALA Cast
+POM_ARTIFACT_ID=com.ibm.wala.cast
+POM_PACKAGING=jar

--- a/com.ibm.wala.core.tests/build.gradle
+++ b/com.ibm.wala.core.tests/build.gradle
@@ -10,12 +10,6 @@ sourceSets.test {
 	resources.srcDirs = ['dat']
 }
 
-publishing.publications {
-	mavenJava(MavenPublication) {
-		artifact jarTest
-	}
-}
-
 dependencies {
 	testCompile(
 		'junit:junit:4.12',

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -30,3 +30,5 @@ tasks.named('javadoc') {
 		classpath += files project(dalvik).compileJava
 	}
 }
+
+apply from: rootProject.file("gradle-mvn-push.gradle")

--- a/com.ibm.wala.core/gradle.properties
+++ b/com.ibm.wala.core/gradle.properties
@@ -1,0 +1,3 @@
+POM_NAME=WALA Core
+POM_ARTIFACT_ID=com.ibm.wala.core
+POM_PACKAGING=jar

--- a/com.ibm.wala.dalvik.test/build.gradle
+++ b/com.ibm.wala.dalvik.test/build.gradle
@@ -144,12 +144,6 @@ tasks.named('clean') {
 	dependsOn 'cleanDownloadSampleLex'
 }
 
-publishing.publications {
-	mavenJava(MavenPublication) {
-		artifact jarTest
-	}
-}
-
 configurations {
 	sampleCup
 }

--- a/com.ibm.wala.dalvik/build.gradle
+++ b/com.ibm.wala.dalvik/build.gradle
@@ -20,3 +20,5 @@ tasks.named('javadoc') {
 		options.linksOffline outputDirectory.path, createPackageList.packageList.parent
 	}
 }
+
+apply from: rootProject.file("gradle-mvn-push.gradle")

--- a/com.ibm.wala.dalvik/gradle.properties
+++ b/com.ibm.wala.dalvik/gradle.properties
@@ -1,0 +1,3 @@
+POM_NAME=WALA Dalvik
+POM_ARTIFACT_ID=com.ibm.wala.dalvik
+POM_PACKAGING=jar

--- a/com.ibm.wala.scandroid/build.gradle
+++ b/com.ibm.wala.scandroid/build.gradle
@@ -10,3 +10,5 @@ dependencies {
 		project(':com.ibm.wala.util'),
 		)
 }
+
+apply from: rootProject.file("gradle-mvn-push.gradle")

--- a/com.ibm.wala.scandroid/gradle.properties
+++ b/com.ibm.wala.scandroid/gradle.properties
@@ -1,0 +1,3 @@
+POM_NAME=WALA Scandroid
+POM_ARTIFACT_ID=com.ibm.wala.scandroid
+POM_PACKAGING=jar

--- a/com.ibm.wala.shrike/build.gradle
+++ b/com.ibm.wala.shrike/build.gradle
@@ -9,3 +9,5 @@ sourceSets.main.java.srcDirs = ['src']
 dependencies {
 	compile project(':com.ibm.wala.util')
 }
+
+apply from: rootProject.file("gradle-mvn-push.gradle")

--- a/com.ibm.wala.shrike/gradle.properties
+++ b/com.ibm.wala.shrike/gradle.properties
@@ -1,0 +1,3 @@
+POM_NAME=WALA Shrike
+POM_ARTIFACT_ID=com.ibm.wala.shrike
+POM_PACKAGING=jar

--- a/com.ibm.wala.util/build.gradle
+++ b/com.ibm.wala.util/build.gradle
@@ -15,3 +15,5 @@ tasks.named('javadoc') {
 	}
 	options.links 'https://docs.oracle.com/javase/8/docs/api/'
 }
+
+apply from: rootProject.file("gradle-mvn-push.gradle")

--- a/com.ibm.wala.util/gradle.properties
+++ b/com.ibm.wala.util/gradle.properties
@@ -1,0 +1,3 @@
+POM_NAME=WALA Util
+POM_ARTIFACT_ID=com.ibm.wala.util
+POM_PACKAGING=jar

--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+// This script is derived from the version here:
+// https://github.com/uber/android-template/blob/master/gradle/gradle-mvn-push.gradle
+
 apply plugin: 'maven'
 apply plugin: 'signing'
 
@@ -95,6 +98,7 @@ afterEvaluate { project ->
     sign configurations.archives
   }
 
+  // only sign the archives if we are uploading a release build
   tasks.withType(Sign) {
     onlyIf { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
   }
@@ -207,14 +211,6 @@ afterEvaluate { project ->
       from javadoc.destinationDir
     }
   }
-
-  // if (JavaVersion.current().isJava8Compatible()) {
-  //   allprojects {
-  //     tasks.withType(Javadoc) {
-  //       options.addStringOption('Xdoclint:none', '-quiet')
-  //     }
-  //   }
-  // }
 
   artifacts {
     if (project.getPlugins().hasPlugin('com.android.application') ||

--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -94,6 +94,8 @@ afterEvaluate { project ->
   }
 
   signing {
+    // Use external gpg cmd.  This makes it easy to use gpg-agent,
+    // to avoid being prompted for a password once per artifact
     useGpgCmd()
     sign configurations.archives
   }

--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -1,0 +1,229 @@
+/*
+ * Copyright (C) Chris Banes
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: 'maven'
+apply plugin: 'signing'
+
+version = VERSION_NAME
+group = GROUP
+
+def isReleaseBuild() {
+  return VERSION_NAME.contains("SNAPSHOT") == false
+}
+
+def getReleaseRepositoryUrl() {
+  return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
+          : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+}
+
+def getSnapshotRepositoryUrl() {
+  return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
+          : "https://oss.sonatype.org/content/repositories/snapshots/"
+}
+
+def getRepositoryUsername() {
+  return hasProperty('SONATYPE_NEXUS_USERNAME') ? SONATYPE_NEXUS_USERNAME : ""
+}
+
+def getRepositoryPassword() {
+  return hasProperty('SONATYPE_NEXUS_PASSWORD') ? SONATYPE_NEXUS_PASSWORD : ""
+}
+
+afterEvaluate { project ->
+  uploadArchives {
+    repositories {
+      mavenDeployer {
+        beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+        pom.groupId = GROUP
+        pom.artifactId = POM_ARTIFACT_ID
+        pom.version = VERSION_NAME
+
+        repository(url: getReleaseRepositoryUrl()) {
+          authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+        }
+        snapshotRepository(url: getSnapshotRepositoryUrl()) {
+          authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+        }
+
+        pom.project {
+          name POM_NAME
+          packaging POM_PACKAGING
+          description POM_DESCRIPTION
+          url POM_URL
+
+          scm {
+            url POM_SCM_URL
+            connection POM_SCM_CONNECTION
+            developerConnection POM_SCM_DEV_CONNECTION
+          }
+
+          licenses {
+            license {
+              name POM_LICENCE_NAME
+              url POM_LICENCE_URL
+              distribution POM_LICENCE_DIST
+            }
+          }
+
+          developers {
+            developer {
+              id POM_DEVELOPER_ID
+              name POM_DEVELOPER_NAME
+            }
+          }
+        }
+      }
+    }
+  }
+
+  signing {
+    useGpgCmd()
+    sign configurations.archives
+  }
+
+  tasks.withType(Sign) {
+    onlyIf { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
+  }
+
+  if (project.getPlugins().hasPlugin('com.android.application') ||
+          project.getPlugins().hasPlugin('com.android.library')) {
+    task install(type: Upload, dependsOn: assemble) {
+      repositories.mavenInstaller {
+        configuration = configurations.archives
+
+        pom.groupId = GROUP
+        pom.artifactId = POM_ARTIFACT_ID
+        pom.version = VERSION_NAME
+
+        pom.project {
+          name POM_NAME
+          packaging POM_PACKAGING
+          description POM_DESCRIPTION
+          url POM_URL
+
+          scm {
+            url POM_SCM_URL
+            connection POM_SCM_CONNECTION
+            developerConnection POM_SCM_DEV_CONNECTION
+          }
+
+          licenses {
+            license {
+              name POM_LICENCE_NAME
+              url POM_LICENCE_URL
+              distribution POM_LICENCE_DIST
+            }
+          }
+
+          developers {
+            developer {
+              id POM_DEVELOPER_ID
+              name POM_DEVELOPER_NAME
+            }
+          }
+        }
+      }
+    }
+
+    task androidJavadocs(type: Javadoc) {
+      if (!project.plugins.hasPlugin('kotlin-android')) {
+        source = android.sourceSets.main.java.srcDirs
+      }
+      classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+      exclude '**/internal/*'
+
+      if (JavaVersion.current().isJava8Compatible()) {
+        options.addStringOption('Xdoclint:none', '-quiet')
+      }
+    }
+
+    task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
+      classifier = 'javadoc'
+      from androidJavadocs.destinationDir
+    }
+
+    task androidSourcesJar(type: Jar) {
+      classifier = 'sources'
+      from android.sourceSets.main.java.sourceFiles
+    }
+  } else {
+    install {
+      repositories.mavenInstaller {
+        pom.groupId = GROUP
+        pom.artifactId = POM_ARTIFACT_ID
+        pom.version = VERSION_NAME
+
+        pom.project {
+          name POM_NAME
+          packaging POM_PACKAGING
+          description POM_DESCRIPTION
+          url POM_URL
+
+          scm {
+            url POM_SCM_URL
+            connection POM_SCM_CONNECTION
+            developerConnection POM_SCM_DEV_CONNECTION
+          }
+
+          licenses {
+            license {
+              name POM_LICENCE_NAME
+              url POM_LICENCE_URL
+              distribution POM_LICENCE_DIST
+            }
+          }
+
+          developers {
+            developer {
+              id POM_DEVELOPER_ID
+              name POM_DEVELOPER_NAME
+            }
+          }
+        }
+      }
+    }
+
+    task sourcesJar(type: Jar, dependsOn: classes) {
+      classifier = 'sources'
+      from sourceSets.main.allSource
+    }
+
+    task javadocJar(type: Jar, dependsOn: javadoc) {
+      classifier = 'javadoc'
+      from javadoc.destinationDir
+    }
+  }
+
+  // if (JavaVersion.current().isJava8Compatible()) {
+  //   allprojects {
+  //     tasks.withType(Javadoc) {
+  //       options.addStringOption('Xdoclint:none', '-quiet')
+  //     }
+  //   }
+  // }
+
+  artifacts {
+    if (project.getPlugins().hasPlugin('com.android.application') ||
+            project.getPlugins().hasPlugin('com.android.library')) {
+      archives androidSourcesJar
+      archives androidJavadocsJar
+    } else {
+      archives sourcesJar
+      archives javadocJar
+    }
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,19 @@
 org.gradle.caching=true
 org.gradle.parallel=true
+
+GROUP=com.ibm.wala
+VERSION_NAME=1.5.3-SNAPSHOT
+
+POM_DESCRIPTION=T. J. Watson Libraries for Analysis
+
+POM_URL=https://github.com/wala/WALA
+POM_SCM_URL=https://github.com/wala/WALA
+POM_SCM_CONNECTION=scm:git:git://github.com/wala/WALA.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/wala/WALA.git
+
+POM_LICENCE_NAME=Eclipse Public License
+POM_LICENCE_URL=https://www.eclipse.org/legal/epl-v10.html
+POM_LICENCE_DIST=repo
+
+POM_DEVELOPER_ID=msridhar
+POM_DEVELOPER_NAME=Manu Sridharan


### PR DESCRIPTION
We should use Gradle for creating Maven artifacts, to enable deprecation of WALA Maven builds.  I couldn't get proper artifacts built with the maven-publish plugin, so this PR switches to the maven plugin.  It makes use of the [gradle-mvn-push](https://github.com/chrisbanes/gradle-mvn-push/blob/master/gradle-mvn-push.gradle) script, with slight modifications.

I've tested locally and successfully installed artifacts to the local M2 repository.  Once this lands, I plan to enable uploading of snapshots on every successful CI build of master, so that will give us some testing on CI.

To test locally, run `./gradlew install` and then check the contents of `~/.m2/repository/com/ibm/wala` for the artifacts.