### PR TITLE
Fix likely bug in array size calculation

### DIFF
--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/callgraph/ScriptEntryPoints.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/callgraph/ScriptEntryPoints.java
@@ -63,7 +63,7 @@ public abstract class ScriptEntryPoints implements Iterable<Entrypoint> {
       }
 
       int functionVn = getMethod().isStatic() ? -1 : makeArgument(m, 0);
-      int paramVns[] = new int[Math.min(0, getNumberOfParameters() - 1)];
+      int paramVns[] = new int[Math.max(0, getNumberOfParameters() - 1)];
       for (int j = 0; j < paramVns.length; j++) {
         paramVns[j] = makeArgument(m, j + 1);
       }


### PR DESCRIPTION
Using `Math.min(0, other)` as the length of an array was surely not intended here. If `other` is zero or positive, then this would allocate a 0-element array. If `other` is negative, then this would fail after trying to allocate a negative-sized array.

Evidently we have no tests that trigger this code.  I don’t feel well-informed enough to add a suitable test myself. I’m guessing what the correct size calculation should be based on context, but this is presumably still untested.