### PR TITLE
Optionally use ECJ in Gradle builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,6 @@ matrix:
       language: java
       jdk: oraclejdk8
     - os: linux
-      env: BUILD_SYSTEM=gradle JAVA_COMPILER=ecj
-      language: java
-      jdk: oraclejdk8
-    - os: linux
       env: BUILD_SYSTEM=maven
       language: android
       jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,10 @@ matrix:
       language: java
       jdk: oraclejdk8
     - os: linux
+      env: BUILD_SYSTEM=gradle JAVA_COMPILER=ecj
+      language: java
+      jdk: oraclejdk8
+    - os: linux
       env: BUILD_SYSTEM=maven
       language: android
       jdk: oraclejdk8

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
 	id 'com.diffplug.gradle.p2.asmaven' version '3.17.3'
 	id 'com.github.hauner.jarTest' version '1.0.1' apply false
 	id 'com.github.sherter.google-java-format' version '0.8'
+	id 'de.set.ecj' version '1.4.1' apply false
 	id 'de.undercouch.download'
 	id 'nebula.lint' version '9.2.0'
 	id 'nebula.source-jar' version '9.5.0' apply false
@@ -97,6 +98,32 @@ subprojects { subproject ->
 		exclude '**/*AndroidLibs*.class'
 
 		maxParallelForks = Integer.MAX_VALUE
+	}
+
+	// Stash the original Java compiler toolchain in case needed.  This is actually only used by
+	// :com.ibm.wala.cast.test:compileTestJava, which requires JNI support that ECJ does not offer.
+	tasks.withType(JavaCompile) {
+		it.ext.originalToolChain = it.toolChain
+	}
+
+	// Use ECJ instead of default Java compiler if "javaCompiler" project property is set to either
+	// "ecj" or "eclipse" (case-insensitive).  For example, use "-PjavaCompiler=ecj" on Gradle
+	// command line or add "javaCompiler=ecj" to the "gradle.properties" file.
+	final def javaCompilerProperty = subproject.findProperty('javaCompiler')?.toLowerCase()
+	switch (javaCompilerProperty) {
+		case 'ecj':
+		case 'eclipse':
+			apply plugin: 'de.set.ecj'
+			tasks.withType(JavaCompile) {
+				options.compilerArgs << '-properties' << "$projectDir/.settings/org.eclipse.jdt.core.prefs"
+			}
+			break
+		case 'default':
+		case '':
+		case null:
+			break
+		default:
+			throw new InvalidUserDataException("unrecognized Java compiler \"$javaCompilerProperty\"")
 	}
 }
 

--- a/com.ibm.wala.cast.test/build.gradle
+++ b/com.ibm.wala.cast.test/build.gradle
@@ -7,7 +7,15 @@ eclipse.project.natures 'org.eclipse.pde.PluginNature'
 
 sourceSets.test.java.srcDirs = ['harness-src/java']
 
-compileTestJava.options.headerOutputDirectory.set file('build/headers')
+tasks.named('compileTestJava') {
+	options.headerOutputDirectory.set file('build/headers')
+
+	// ECJ does not implement the "-h" flag required when the
+	// headerOutputDirectory option is used, so we must switch
+	// back to the default Java compiler for this one task.
+	toolChain = it.ext.originalToolChain
+	options.compilerArgs = []
+}
 
 dependencies {
 	testCompile(

--- a/travis/script-gradle
+++ b/travis/script-gradle
@@ -22,9 +22,11 @@ if [ "$MY_JDK_VERSION" = "openjdk11" ]
 then
     # only test WALA core on JDK 11 for now
     $headless ./gradlew --continue --no-build-cache --stacktrace \
+	      -PjavaCompiler="${JAVA_COMPILER-}" \
               :com.ibm.wala.core.tests:test
 else
     $headless ./gradlew --continue --no-build-cache --stacktrace \
+	      -PjavaCompiler="${JAVA_COMPILER-}" \
 	      verifyGoogleJavaFormat \
 	      "$SUBMODULE_PREFIX"build \
 	      ${documentation:+$SUBMODULE_PREFIX$documentation} \

--- a/travis/script-gradle
+++ b/travis/script-gradle
@@ -16,19 +16,22 @@ case "$SUBMODULE_PREFIX" in
     ;;
 esac
 
+run_gradle() {
+  $headless ./gradlew --continue --no-build-cache --stacktrace "$@"
+}
+
 # TRAVIS_JDK_VERSION is unset on Mac with JDK 8
-MY_JDK_VERSION=${TRAVIS_JDK_VERSION:-}
-if [ "$MY_JDK_VERSION" = "openjdk11" ]
+if [ "${TRAVIS_JDK_VERSION:-}" = openjdk11 ]
 then
-    # only test WALA core on JDK 11 for now
-    $headless ./gradlew --continue --no-build-cache --stacktrace \
-	      -PjavaCompiler="${JAVA_COMPILER-}" \
-              :com.ibm.wala.core.tests:test
+  # only test WALA core on JDK 11 for now
+  run_gradle :com.ibm.wala.core.tests:test
 else
-    $headless ./gradlew --continue --no-build-cache --stacktrace \
-	      -PjavaCompiler="${JAVA_COMPILER-}" \
-	      verifyGoogleJavaFormat \
-	      "$SUBMODULE_PREFIX"build \
-	      ${documentation:+$SUBMODULE_PREFIX$documentation} \
-	      lintGradle
+  run_gradle \
+    -PjavaCompiler=ecj \
+    verifyGoogleJavaFormat \
+    compileJava \
+    compileTestJava \
+    lintGradle \
+    ${documentation:+$SUBMODULE_PREFIX$documentation}
+  run_gradle "$SUBMODULE_PREFIX"build
 fi


### PR DESCRIPTION
Java compilation uses ECJ instead of the default Java compiler if the `javaCompiler` project property is set to either `ecj` or `eclipse` (case-insensitive).  For example, use `-PjavaCompiler=ecj` on the Gradle command line or add `javaCompiler=ecj` to the `gradle.properties` file. Fixes #466.

When using ECJ, diagnostics use the same per-subproject settings that Eclipse uses, as stored in `*/.settings/org.eclipse.jdt.core.prefs` files.

In Travis CI, use ECJ for static checks only. [Six of WALA’s JUnit tests fail when using ECJ as the Java compiler.](https://travis-ci.org/wala/WALA/jobs/528368589) [It’s not clear that anyone really cares whether ECJ-compiled WALA runs correctly, though.](https://github.com/wala/WALA/issues/466#issuecomment-489456520) What we do care about is that WALA produce no unexpected errors in Eclipse.

Therefore, have Travis CI compile all Java code using ECJ, but treat this more as a linter pass, akin to the existing `verifyGoogleJavaFormat` task.  Once that’s done, switch back to the default Java compiler to (re)build and test everything.