### PR TITLE
Use Arrays.setAll instead of explicit loop where possible

### DIFF
--- a/.idea/inspectionProfiles/No_Back_Sliding.xml
+++ b/.idea/inspectionProfiles/No_Back_Sliding.xml
@@ -409,7 +409,7 @@
     <inspection_tool class="JUnit5MalformedParameterized" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JUnit5MalformedRepeated" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JUnit5Platform" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="Java8ArraySetAll" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="Java8ArraySetAll" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
     <inspection_tool class="Java8CollectionRemoveIf" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="Java9CollectionFactory" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="Java9ModuleExportsPackageToItself" enabled="false" level="WARNING" enabled_by_default="false" />

--- a/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
+++ b/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
@@ -647,9 +647,8 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
     // Make fake args that will be passed
     String[] fakeArguments = new String[superCtor.getParameterTypes().length + 1];
     ArrayList<CAstType> paramTypes = new ArrayList<>(superCtor.getParameterTypes().length);
-    for (int i = 0; i < fakeArguments.length; i++)
-      fakeArguments[i] =
-          (i == 0) ? "this" : ("argument" + i); // TODO: change to invalid name and don't use
+    // TODO: change to invalid name and don't use
+    Arrays.setAll(fakeArguments, i -> (i == 0) ? "this" : ("argument" + i));
     // singlevariabledeclaration below
     for (int i = 1; i < fakeArguments.length; i++) {
       // the name

--- a/com.ibm.wala.cast.java.test.data/src/Array1.java
+++ b/com.ibm.wala.cast.java.test.data/src/Array1.java
@@ -16,6 +16,7 @@ public class Array1 {
     public void foo() {
 	int[] ary = new int[5];
 
+	//noinspection Java8ArraySetAll
 	for(int i= 0; i < ary.length; i++) {
 	    ary[i]= i;
 	}

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionDotCallTargetSelector.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionDotCallTargetSelector.java
@@ -34,6 +34,7 @@ import com.ibm.wala.types.TypeName;
 import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.intset.IntIterator;
 import com.ibm.wala.util.strings.Atom;
+import java.util.Arrays;
 import java.util.Map;
 
 /**
@@ -148,11 +149,9 @@ public class JavaScriptFunctionDotCallTargetSelector implements MethodTargetSele
     CallSiteReference cs =
         new DynamicCallSiteReference(JavaScriptTypes.CodeBody, S.getNumberOfStatements());
     int[] params = new int[nargs - 2];
-    for (int i = 0; i < params.length; i++) {
-      // add 3 to skip v1 (which points to Function.call() itself) and v2 (the
-      // real function being invoked)
-      params[i] = i + 3;
-    }
+    // add 3 to skip v1 (which points to Function.call() itself) and v2 (the
+    // real function being invoked)
+    Arrays.setAll(params, i -> i + 3);
     // function being invoked is in v2
     S.addStatement(
         insts.Invoke(S.getNumberOfStatements(), 2, resultVal, params, resultVal + 1, cs));

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/callgraph/ScriptEntryPoints.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ipa/callgraph/ScriptEntryPoints.java
@@ -20,6 +20,7 @@ import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.collections.HashSetFactory;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Set;
 
@@ -64,9 +65,7 @@ public abstract class ScriptEntryPoints implements Iterable<Entrypoint> {
 
       int functionVn = getMethod().isStatic() ? -1 : makeArgument(m, 0);
       int paramVns[] = new int[Math.max(0, getNumberOfParameters() - 1)];
-      for (int j = 0; j < paramVns.length; j++) {
-        paramVns[j] = makeArgument(m, j + 1);
-      }
+      Arrays.setAll(paramVns, j -> makeArgument(m, j + 1));
 
       return ((ScriptFakeRoot) m).addDirectCall(functionVn, paramVns, site);
     }

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
@@ -2960,9 +2960,9 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
 
       if (original.exposedNames != null) {
         exposedNames = new Pair[original.exposedNames.length];
-        for (int i = 0; i < exposedNames.length; i++) {
-          exposedNames[i] = Pair.make(original.exposedNames[i].fst, original.exposedNames[i].snd);
-        }
+        Arrays.setAll(
+            exposedNames,
+            i -> Pair.make(original.exposedNames[i].fst, original.exposedNames[i].snd));
       } else {
         exposedNames = null;
       }
@@ -3865,9 +3865,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
     int fun = c.getValue(n.getChild(0));
     CAstNode functionName = n.getChild(1);
     int[] args = new int[n.getChildCount() - 2];
-    for (int i = 0; i < args.length; i++) {
-      args[i] = c.getValue(n.getChild(i + 2));
-    }
+    Arrays.setAll(args, i -> c.getValue(n.getChild(i + 2)));
     doCall(context, n, result, exp, functionName, fun, args);
   }
 

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/rewrite/CAstRewriter.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/rewrite/CAstRewriter.java
@@ -25,6 +25,7 @@ import com.ibm.wala.util.collections.EmptyIterator;
 import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.collections.Pair;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -393,9 +394,7 @@ public abstract class CAstRewriter<
     final Map<Pair<CAstNode, K>, CAstNode> nodes = HashMapFactory.make();
     final CAstNode newRoot = copyNodes(root, cfg, rootContext, nodes);
     final CAstNode newDefaults[] = new CAstNode[defaults == null ? 0 : defaults.length];
-    for (int i = 0; i < newDefaults.length; i++) {
-      newDefaults[i] = copyNodes(defaults[i], cfg, rootContext, nodes);
-    }
+    Arrays.setAll(newDefaults, i -> copyNodes(defaults[i], cfg, rootContext, nodes));
 
     return new Rewrite() {
       private CAstControlFlowMap theCfg = null;

--- a/com.ibm.wala.core.testdata/src/arraybounds/Detectable.java
+++ b/com.ibm.wala.core.testdata/src/arraybounds/Detectable.java
@@ -36,6 +36,7 @@ public class Detectable {
   }
 
   public void loop(int[] arr) {
+    //noinspection Java8ArraySetAll
     for (int i = 0; i < arr.length; i++) {
       arr[i] = 0;
     }

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/CloneInterpreter.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/CloneInterpreter.java
@@ -205,10 +205,7 @@ public class CloneInterpreter implements SSAContextInterpreter {
     SSAReturnInstruction R = insts.ReturnInstruction(statements.size(), retValue, false);
     statements.add(R);
 
-    SSAInstruction[] result = new SSAInstruction[statements.size()];
-    Iterator<SSAInstruction> it = statements.iterator();
-    Arrays.setAll(result, i -> it.next());
-    return result;
+    return statements.toArray(new SSAInstruction[0]);
   }
 
   /** @return an IR that encodes the behavior of the clone method for a given type. */

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/CloneInterpreter.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/CloneInterpreter.java
@@ -207,9 +207,7 @@ public class CloneInterpreter implements SSAContextInterpreter {
 
     SSAInstruction[] result = new SSAInstruction[statements.size()];
     Iterator<SSAInstruction> it = statements.iterator();
-    for (int i = 0; i < result.length; i++) {
-      result[i] = it.next();
-    }
+    Arrays.setAll(result, i -> it.next());
     return result;
   }
 

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/GetClassContextInterpeter.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/GetClassContextInterpeter.java
@@ -128,9 +128,7 @@ public class GetClassContextInterpeter implements SSAContextInterpreter {
     }
     SSAInstruction[] result = new SSAInstruction[statements.size()];
     Iterator<SSAInstruction> it = statements.iterator();
-    for (int i = 0; i < result.length; i++) {
-      result[i] = it.next();
-    }
+    Arrays.setAll(result, i -> it.next());
     return result;
   }
 

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/GetClassContextInterpeter.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/GetClassContextInterpeter.java
@@ -126,10 +126,7 @@ public class GetClassContextInterpeter implements SSAContextInterpreter {
       SSAReturnInstruction R = insts.ReturnInstruction(statements.size(), retValue, false);
       statements.add(R);
     }
-    SSAInstruction[] result = new SSAInstruction[statements.size()];
-    Iterator<SSAInstruction> it = statements.iterator();
-    Arrays.setAll(result, i -> it.next());
-    return result;
+    return statements.toArray(new SSAInstruction[0]);
   }
 
   private static IR makeIR(IMethod method, Context context) {

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/GetMethodContextInterpreter.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/GetMethodContextInterpreter.java
@@ -222,9 +222,7 @@ public class GetMethodContextInterpreter implements SSAContextInterpreter {
     }
     SSAInstruction[] result = new SSAInstruction[statements.size()];
     Iterator<SSAInstruction> it = statements.iterator();
-    for (int i = 0; i < result.length; i++) {
-      result[i] = it.next();
-    }
+    Arrays.setAll(result, i -> it.next());
     return result;
   }
 

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/GetMethodContextInterpreter.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/GetMethodContextInterpreter.java
@@ -220,10 +220,7 @@ public class GetMethodContextInterpreter implements SSAContextInterpreter {
       // SSAThrowInstruction t = insts.ThrowInstruction(retValue);
       // statements.add(t);
     }
-    SSAInstruction[] result = new SSAInstruction[statements.size()];
-    Iterator<SSAInstruction> it = statements.iterator();
-    Arrays.setAll(result, i -> it.next());
-    return result;
+    return statements.toArray(new SSAInstruction[0]);
   }
 
   private static SSAInstruction[] makeGetMethodStatements(

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/JavaLangClassContextInterpreter.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/JavaLangClassContextInterpreter.java
@@ -383,10 +383,7 @@ public class JavaLangClassContextInterpreter implements SSAContextInterpreter {
       // SSAThrowInstruction t = insts.ThrowInstruction(retValue);
       // statements.add(t);
     }
-    SSAInstruction[] result = new SSAInstruction[statements.size()];
-    Iterator<SSAInstruction> it = statements.iterator();
-    Arrays.setAll(result, i -> it.next());
-    return result;
+    return statements.toArray(new SSAInstruction[0]);
   }
 
   /**
@@ -421,10 +418,7 @@ public class JavaLangClassContextInterpreter implements SSAContextInterpreter {
       // SSAThrowInstruction t = insts.ThrowInstruction(retValue);
       // statements.add(t);
     }
-    SSAInstruction[] result = new SSAInstruction[statements.size()];
-    Iterator<SSAInstruction> it = statements.iterator();
-    Arrays.setAll(result, i -> it.next());
-    return result;
+    return statements.toArray(new SSAInstruction[0]);
   }
 
   /** create statements for getConstructor() */

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/JavaLangClassContextInterpreter.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/JavaLangClassContextInterpreter.java
@@ -385,9 +385,7 @@ public class JavaLangClassContextInterpreter implements SSAContextInterpreter {
     }
     SSAInstruction[] result = new SSAInstruction[statements.size()];
     Iterator<SSAInstruction> it = statements.iterator();
-    for (int i = 0; i < result.length; i++) {
-      result[i] = it.next();
-    }
+    Arrays.setAll(result, i -> it.next());
     return result;
   }
 
@@ -425,9 +423,7 @@ public class JavaLangClassContextInterpreter implements SSAContextInterpreter {
     }
     SSAInstruction[] result = new SSAInstruction[statements.size()];
     Iterator<SSAInstruction> it = statements.iterator();
-    for (int i = 0; i < result.length; i++) {
-      result[i] = it.next();
-    }
+    Arrays.setAll(result, i -> it.next());
     return result;
   }
 

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/CFGSanitizer.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/CFGSanitizer.java
@@ -153,7 +153,7 @@ public class CFGSanitizer {
   /** What are the exception types which s may throw? */
   private static TypeReference[] computeExceptions(IClassHierarchy cha, IR ir, SSAInstruction s)
       throws InvalidClassFileException {
-    Collection<TypeReference> c = null;
+    final Collection<TypeReference> c;
     Language l = ir.getMethod().getDeclaringClass().getClassLoader().getLanguage();
     if (s instanceof SSAInvokeInstruction) {
       SSAInvokeInstruction call = (SSAInvokeInstruction) s;

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/CFGSanitizer.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/CFGSanitizer.java
@@ -167,9 +167,7 @@ public class CFGSanitizer {
     } else {
       TypeReference[] exceptions = new TypeReference[c.size()];
       Iterator<TypeReference> it = c.iterator();
-      for (int i = 0; i < exceptions.length; i++) {
-        exceptions[i] = it.next();
-      }
+      Arrays.setAll(exceptions, i -> it.next());
       return exceptions;
     }
   }

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/CFGSanitizer.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/CFGSanitizer.java
@@ -29,7 +29,6 @@ import com.ibm.wala.util.debug.Assertions;
 import com.ibm.wala.util.graph.Graph;
 import com.ibm.wala.util.graph.impl.SlowSparseNumberedGraph;
 import java.util.Collection;
-import java.util.Iterator;
 
 /** Utility class to remove exceptional edges to exit() from a CFG */
 public class CFGSanitizer {
@@ -162,13 +161,6 @@ public class CFGSanitizer {
     } else {
       c = s.getExceptionTypes();
     }
-    if (c == null) {
-      return null;
-    } else {
-      TypeReference[] exceptions = new TypeReference[c.size()];
-      Iterator<TypeReference> it = c.iterator();
-      Arrays.setAll(exceptions, i -> it.next());
-      return exceptions;
-    }
+    return c == null ? null : c.toArray(new TypeReference[0]);
   }
 }

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/inter/AnalysisUtil.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/inter/AnalysisUtil.java
@@ -17,6 +17,7 @@ import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.ssa.SSAInstruction;
 import com.ibm.wala.ssa.analysis.IExplodedBasicBlock;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -57,9 +58,7 @@ public final class AnalysisUtil {
     final int[] parameterNumbers = new int[number];
     assert (parameterNumbers.length == invokeInstruction.getNumberOfUses());
 
-    for (int i = 0; i < parameterNumbers.length; i++) {
-      parameterNumbers[i] = invokeInstruction.getUse(i);
-    }
+    Arrays.setAll(parameterNumbers, invokeInstruction::getUse);
 
     return parameterNumbers;
   }

--- a/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/NullPointerTransferFunctionProvider.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/cfg/exc/intra/NullPointerTransferFunctionProvider.java
@@ -49,6 +49,7 @@ import com.ibm.wala.ssa.SymbolTable;
 import com.ibm.wala.ssa.analysis.IExplodedBasicBlock;
 import com.ibm.wala.util.collections.Iterator2Iterable;
 import java.util.ArrayList;
+import java.util.Arrays;
 
 /** @author Juergen Graf &lt;graf@kit.edu&gt; */
 class NullPointerTransferFunctionProvider<T extends ISSABasicBlock>
@@ -139,9 +140,7 @@ class NullPointerTransferFunctionProvider<T extends ISSABasicBlock>
     final ArrayList<UnaryOperator<NullPointerState>> phiTransferFunctions = new ArrayList<>(1);
     for (SSAPhiInstruction phi : Iterator2Iterable.make(node.iteratePhis())) {
       int[] uses = new int[phi.getNumberOfUses()];
-      for (int i = 0; i < uses.length; i++) {
-        uses[i] = phi.getUse(i);
-      }
+      Arrays.setAll(uses, phi::getUse);
       phiTransferFunctions.add(NullPointerState.phiValueMeetFunction(phi.getDef(), uses));
     }
     if (phiTransferFunctions.size() > 0) {
@@ -416,9 +415,7 @@ class NullPointerTransferFunctionProvider<T extends ISSABasicBlock>
     public void visitPhi(SSAPhiInstruction instruction) {
       noIdentity = true;
       int[] uses = new int[instruction.getNumberOfUses()];
-      for (int i = 0; i < uses.length; i++) {
-        uses[i] = instruction.getUse(i);
-      }
+      Arrays.setAll(uses, instruction::getUse);
 
       transfer1 = NullPointerState.phiValueMeetFunction(instruction.getDef(), uses);
       // should not be used as no alternative path exists

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/BytecodeClass.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/BytecodeClass.java
@@ -37,7 +37,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -468,11 +467,6 @@ public abstract class BytecodeClass<T extends IClassLoader> implements IClass {
     }
     inheritCache.put(selector, null);
     return null;
-  }
-
-  protected void populateFieldArrayFromList(List<FieldImpl> L, IField[] A) {
-    Iterator<FieldImpl> it = L.iterator();
-    Arrays.setAll(A, i -> it.next());
   }
 
   /** @return Collection of IClasses, representing the interfaces this class implements. */

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/BytecodeClass.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/BytecodeClass.java
@@ -472,9 +472,7 @@ public abstract class BytecodeClass<T extends IClassLoader> implements IClass {
 
   protected void populateFieldArrayFromList(List<FieldImpl> L, IField[] A) {
     Iterator<FieldImpl> it = L.iterator();
-    for (int i = 0; i < A.length; i++) {
-      A[i] = it.next();
-    }
+    Arrays.setAll(A, i -> it.next());
   }
 
   /** @return Collection of IClasses, representing the interfaces this class implements. */

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/ShrikeBTMethod.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/ShrikeBTMethod.java
@@ -733,11 +733,11 @@ public abstract class ShrikeBTMethod implements IMethod, BytecodeConstants {
       ClassLoaderReference loader = getDeclaringClass().getClassLoader().getReference();
 
       TypeReference[] result = new TypeReference[strings.length];
-      for (int i = 0; i < result.length; i++) {
-        result[i] =
-            TypeReference.findOrCreate(
-                loader, TypeName.findOrCreate(ImmutableByteArray.make('L' + strings[i])));
-      }
+      Arrays.setAll(
+          result,
+          i ->
+              TypeReference.findOrCreate(
+                  loader, TypeName.findOrCreate(ImmutableByteArray.make('L' + strings[i]))));
       return result;
     } catch (InvalidClassFileException e) {
       Assertions.UNREACHABLE();

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/ShrikeCTMethod.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/ShrikeCTMethod.java
@@ -38,6 +38,7 @@ import com.ibm.wala.types.generics.MethodTypeSignature;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.debug.Assertions;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 
 /** A wrapper around a Shrike object that represents a method */
@@ -483,9 +484,7 @@ public final class ShrikeCTMethod extends ShrikeBTMethod implements IBytecodeMet
     int numAnnotatedParams = isStatic() ? getNumberOfParameters() : getNumberOfParameters() - 1;
     @SuppressWarnings("unchecked")
     Collection<Annotation>[] result = new Collection[numAnnotatedParams];
-    for (int i = 0; i < result.length; i++) {
-      result[i] = HashSetFactory.make();
-    }
+    Arrays.setAll(result, i -> HashSetFactory.make());
     try {
       ClassLoaderReference reference = getDeclaringClass().getClassLoader().getReference();
       AnnotationsReader r =

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/ShrikeClass.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/ShrikeClass.java
@@ -105,10 +105,8 @@ public final class ShrikeClass extends JVMClass<IClassLoader> {
           addFieldToList(staticList, name, b, accessFlags, annotations, typeAnnotations, sig);
         }
       }
-      instanceFields = new IField[instanceList.size()];
-      populateFieldArrayFromList(instanceList, instanceFields);
-      staticFields = new IField[staticList.size()];
-      populateFieldArrayFromList(staticList, staticFields);
+      instanceFields = instanceList.toArray(new IField[0]);
+      staticFields = staticList.toArray(new IField[0]);
 
     } catch (InvalidClassFileException e) {
       e.printStackTrace();

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/ShrikeClass.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/ShrikeClass.java
@@ -35,6 +35,7 @@ import com.ibm.wala.util.shrike.ShrikeClassReaderHandle;
 import com.ibm.wala.util.strings.Atom;
 import com.ibm.wala.util.strings.ImmutableByteArray;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -144,9 +145,7 @@ public final class ShrikeClass extends JVMClass<IClassLoader> {
     try {
       String[] s = reader.get().getInterfaceNames();
       interfaceNames = new ImmutableByteArray[s.length];
-      for (int i = 0; i < interfaceNames.length; i++) {
-        interfaceNames[i] = ImmutableByteArray.make('L' + s[i]);
-      }
+      Arrays.setAll(interfaceNames, i -> ImmutableByteArray.make('L' + s[i]));
     } catch (InvalidClassFileException e) {
       Assertions.UNREACHABLE();
     }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/DefaultEntrypoint.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/DefaultEntrypoint.java
@@ -47,9 +47,7 @@ public class DefaultEntrypoint extends Entrypoint {
 
   protected TypeReference[][] makeParameterTypes(IMethod method) {
     TypeReference[][] result = new TypeReference[method.getNumberOfParameters()][];
-    for (int i = 0; i < result.length; i++) {
-      result[i] = makeParameterTypes(method, i);
-    }
+    Arrays.setAll(result, i -> makeParameterTypes(method, i));
 
     return result;
   }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/SubtypesEntrypoint.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/SubtypesEntrypoint.java
@@ -16,6 +16,7 @@ import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.collections.HashSetFactory;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
 
@@ -33,9 +34,7 @@ public class SubtypesEntrypoint extends DefaultEntrypoint {
   @Override
   protected TypeReference[][] makeParameterTypes(IMethod method) {
     TypeReference[][] result = new TypeReference[method.getNumberOfParameters()][];
-    for (int i = 0; i < result.length; i++) {
-      result[i] = makeParameterTypes(method, i);
-    }
+    Arrays.setAll(result, i -> makeParameterTypes(method, i));
 
     return result;
   }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/SSAPropagationCallGraphBuilder.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/SSAPropagationCallGraphBuilder.java
@@ -1785,9 +1785,7 @@ public abstract class SSAPropagationCallGraphBuilder extends PropagationCallGrap
       // we better always be interested in the receiver
       // assert this.dispatchIndices[0] == 0;
       previousPtrs = new MutableIntSet[dispatchIndices.size()];
-      for (int i = 0; i < previousPtrs.length; i++) {
-        previousPtrs[i] = IntSetUtil.getDefaultIntSetFactory().make();
-      }
+      Arrays.setAll(previousPtrs, i -> IntSetUtil.getDefaultIntSetFactory().make());
     }
 
     private byte cpa(final PointsToSetVariable[] rhs) {

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/MethodSummary.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/MethodSummary.java
@@ -120,14 +120,7 @@ public class MethodSummary {
   }
 
   public SSAInstruction[] getStatements() {
-    if (statements == null) {
-      return NO_STATEMENTS;
-    } else {
-      SSAInstruction[] result = new SSAInstruction[statements.size()];
-      Iterator<SSAInstruction> it = statements.iterator();
-      Arrays.setAll(result, i -> it.next());
-      return result;
-    }
+    return statements == null ? NO_STATEMENTS : statements.toArray(new SSAInstruction[0]);
   }
 
   public Map<Integer, ConstantValue> getConstants() {

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/MethodSummary.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/MethodSummary.java
@@ -18,7 +18,6 @@ import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.strings.Atom;
 import com.ibm.wala.util.warnings.Warning;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.Map;
 
 /** Summary information for a method. */
@@ -126,9 +125,7 @@ public class MethodSummary {
     } else {
       SSAInstruction[] result = new SSAInstruction[statements.size()];
       Iterator<SSAInstruction> it = statements.iterator();
-      for (int i = 0; i < result.length; i++) {
-        result[i] = it.next();
-      }
+      Arrays.setAll(result, i -> it.next());
       return result;
     }
   }

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/SymbolTable.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/SymbolTable.java
@@ -41,9 +41,7 @@ public class SymbolTable implements Cloneable {
       throw new IllegalArgumentException("Illegal numberOfParameters: " + numberOfParameters);
     }
     parameters = new int[numberOfParameters];
-    for (int i = 0; i < parameters.length; i++) {
-      parameters[i] = getNewValueNumber();
-    }
+    Arrays.setAll(parameters, i -> getNewValueNumber());
   }
 
   /**

--- a/com.ibm.wala.core/src/com/ibm/wala/types/annotations/Annotation.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/types/annotations/Annotation.java
@@ -98,9 +98,7 @@ public class Annotation {
     if (r != null) {
       AnnotationAttribute[][] allAnnots = r.getAllParameterAnnotations();
       Collection<Annotation>[] result = new Collection[allAnnots.length];
-      for (int i = 0; i < result.length; i++) {
-        result[i] = convertToAnnotations(clRef, allAnnots[i]);
-      }
+      Arrays.setAll(result, i -> convertToAnnotations(clRef, allAnnots[i]));
       return result;
     } else {
       return null;

--- a/com.ibm.wala.core/src/com/ibm/wala/types/generics/FormalTypeParameter.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/types/generics/FormalTypeParameter.java
@@ -150,10 +150,7 @@ public class FormalTypeParameter extends Signature {
       sigs.add(s.substring(beginToken, endToken));
       beginToken = endToken;
     }
-    Iterator<String> it = sigs.iterator();
-    String[] result = new String[sigs.size()];
-    Arrays.setAll(result, j -> it.next());
-    return result;
+    return sigs.toArray(new String[0]);
   }
 
   public TypeSignature[] getInterfaceBounds() {

--- a/com.ibm.wala.core/src/com/ibm/wala/types/generics/FormalTypeParameter.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/types/generics/FormalTypeParameter.java
@@ -17,7 +17,6 @@ import com.ibm.wala.classLoader.ShrikeClass;
 import com.ibm.wala.shrikeCT.InvalidClassFileException;
 import com.ibm.wala.types.TypeReference;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -153,9 +152,7 @@ public class FormalTypeParameter extends Signature {
     }
     Iterator<String> it = sigs.iterator();
     String[] result = new String[sigs.size()];
-    for (int j = 0; j < result.length; j++) {
-      result[j] = it.next();
-    }
+    Arrays.setAll(result, j -> it.next());
     return result;
   }
 

--- a/com.ibm.wala.core/src/com/ibm/wala/types/generics/TypeArgument.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/types/generics/TypeArgument.java
@@ -12,6 +12,7 @@ package com.ibm.wala.types.generics;
 
 import com.ibm.wala.types.TypeReference;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 
 /**
@@ -78,9 +79,7 @@ public class TypeArgument extends Signature {
     }
     String[] args = parseForTypeArguments(s);
     TypeArgument[] result = new TypeArgument[args.length];
-    for (int i = 0; i < result.length; i++) {
-      result[i] = makeTypeArgument(args[i]);
-    }
+    Arrays.setAll(result, i -> makeTypeArgument(args[i]));
     return result;
   }
 

--- a/com.ibm.wala.core/src/com/ibm/wala/util/ssa/ParameterAccessor.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/ssa/ParameterAccessor.java
@@ -53,6 +53,7 @@ import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.PrimitiveAssignability;
 import com.ibm.wala.util.ssa.SSAValue.WeaklyNamedKey;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -1244,9 +1245,7 @@ public class ParameterAccessor {
     // ****
     // Implementation starts here
 
-    for (int i = 0; i < params.length; ++i) {
-      params[i] = args.get(i).getNumber();
-    }
+    Arrays.setAll(params, i -> args.get(i).getNumber());
 
     return params;
   }

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/DexIMethod.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/classLoader/DexIMethod.java
@@ -105,6 +105,7 @@ import com.ibm.wala.types.annotations.Annotation;
 import com.ibm.wala.util.strings.Atom;
 import com.ibm.wala.util.strings.ImmutableByteArray;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -223,11 +224,11 @@ public class DexIMethod implements IBytecodeMethod<Instruction> {
     ClassLoaderReference loader = getDeclaringClass().getClassLoader().getReference();
 
     TypeReference[] result = new TypeReference[strings.size()];
-    for (int i = 0; i < result.length; i++) {
-      result[i] =
-          TypeReference.findOrCreate(
-              loader, TypeName.findOrCreate(ImmutableByteArray.make(strings.get(i))));
-    }
+    Arrays.setAll(
+        result,
+        i ->
+            TypeReference.findOrCreate(
+                loader, TypeName.findOrCreate(ImmutableByteArray.make(strings.get(i)))));
     return result;
   }
 

--- a/com.ibm.wala.scandroid/source/org/scandroid/spec/CallArgSinkSpec.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/spec/CallArgSinkSpec.java
@@ -71,7 +71,7 @@ public class CallArgSinkSpec extends SinkSpec {
     if (argNums == null) {
       SSAInvokeInstruction i = (SSAInvokeInstruction) block.getLastInstruction();
       argNums = new int[i.getDeclaredTarget().getNumberOfParameters()];
-      for (int p = 0; p < argNums.length; p++) argNums[p] = p;
+      Arrays.setAll(argNums, p -> p);
     }
     for (int arg : argNums) {
       flowSet.add(new ParameterFlow<>(block, arg, false));

--- a/com.ibm.wala.scandroid/source/org/scandroid/spec/SinkSpec.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/spec/SinkSpec.java
@@ -60,9 +60,7 @@ public abstract class SinkSpec implements ISinkSpec {
 
   public static int[] getNewArgNums(int n) {
     int[] newArgNums = new int[n];
-    for (int i = 0; i < n; i++) {
-      newArgNums[i] = i + 1;
-    }
+    Arrays.setAll(newArgNums, i -> i + 1);
     return newArgNums;
   }
 

--- a/com.ibm.wala.scandroid/source/org/scandroid/spec/SourceSpec.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/spec/SourceSpec.java
@@ -48,6 +48,7 @@ import com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis;
 import com.ibm.wala.ipa.cfg.BasicBlockInContext;
 import com.ibm.wala.ssa.ISSABasicBlock;
 import com.ibm.wala.ssa.SSAInvokeInstruction;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 import org.scandroid.domain.CodeElement;
@@ -61,9 +62,7 @@ public abstract class SourceSpec implements ISourceSpec {
 
   public static int[] getNewArgNums(int n) {
     int[] newArgNums = new int[n];
-    for (int i = 0; i < n; i++) {
-      newArgNums[i] = i + 1;
-    }
+    Arrays.setAll(newArgNums, i -> i + 1);
     return newArgNums;
   }
 

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrike/copywriter/CopyWriter.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrike/copywriter/CopyWriter.java
@@ -39,6 +39,7 @@ import com.ibm.wala.shrikeCT.SourceFileWriter;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.zip.ZipEntry;
 
 public class CopyWriter {
@@ -216,9 +217,7 @@ public class CopyWriter {
           ExceptionsReader lr = new ExceptionsReader(iter);
           ExceptionsWriter lw = new ExceptionsWriter(w);
           int[] table = lr.getRawTable();
-          for (int i = 0; i < table.length; i++) {
-            table[i] = transformCPIndex(table[i]);
-          }
+          Arrays.setAll(table, i -> transformCPIndex(table[i]));
           lw.setRawTable(table);
           return lw;
         }

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/ConstantInstruction.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/ConstantInstruction.java
@@ -12,6 +12,7 @@ package com.ibm.wala.shrikeBT;
 
 import com.ibm.wala.shrikeCT.BootstrapMethodsReader.BootstrapMethod;
 import com.ibm.wala.shrikeCT.ConstantPoolParser;
+import java.util.Arrays;
 
 /** A ConstantInstruction pushes some constant value onto the stack. */
 public abstract class ConstantInstruction extends Instruction {
@@ -134,9 +135,7 @@ public abstract class ConstantInstruction extends Instruction {
 
     private static ConstInt[] preallocate() {
       ConstInt[] r = new ConstInt[256];
-      for (int i = 0; i < r.length; i++) {
-        r[i] = new ConstInt(OP_bipush, i - 128);
-      }
+      Arrays.setAll(r, i -> new ConstInt(OP_bipush, i - 128));
       for (int i = -1; i <= 5; i++) {
         r[i + 128] = new ConstInt((short) (i - (-1) + OP_iconst_m1), i);
       }

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Decoder.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Decoder.java
@@ -1108,7 +1108,7 @@ public abstract class Decoder implements Constants {
         }
       }
     } else {
-      Arrays.setAll(handlers, i -> noHandlers);
+      Arrays.fill(handlers, noHandlers);
     }
 
     decoded = null;

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Decoder.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Decoder.java
@@ -1108,9 +1108,7 @@ public abstract class Decoder implements Constants {
         }
       }
     } else {
-      for (int i = 0; i < handlers.length; i++) {
-        handlers[i] = noHandlers;
-      }
+      Arrays.setAll(handlers, i -> noHandlers);
     }
 
     decoded = null;

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/DupInstruction.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/DupInstruction.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.shrikeBT;
 
+import java.util.Arrays;
+
 /**
  * This class represents dup instructions. There are two kinds of dup instructions, dup and dup_x1:
  *
@@ -31,9 +33,7 @@ public final class DupInstruction extends Instruction {
   private static DupInstruction[] preallocate() {
     DupInstruction[] r = new DupInstruction[9];
 
-    for (int i = 0; i < r.length; i++) {
-      r[i] = new DupInstruction((byte) (i / 3), (byte) (i % 3));
-    }
+    Arrays.setAll(r, i -> new DupInstruction((byte) (i / 3), (byte) (i % 3)));
     return r;
   }
 

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/GotoInstruction.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/GotoInstruction.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.shrikeBT;
 
+import java.util.Arrays;
+
 /** This class represents goto and goto_w instructions. */
 public final class GotoInstruction extends Instruction {
   private final int[] label;
@@ -24,9 +26,7 @@ public final class GotoInstruction extends Instruction {
 
   private static GotoInstruction[] preallocate() {
     GotoInstruction[] r = new GotoInstruction[256];
-    for (int i = 0; i < r.length; i++) {
-      r[i] = new GotoInstruction(i);
-    }
+    Arrays.setAll(r, GotoInstruction::new);
     return r;
   }
 

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/MethodData.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/MethodData.java
@@ -59,9 +59,7 @@ public final class MethodData {
     ExceptionHandler[][] handlers = new ExceptionHandler[instructions.length][];
     Arrays.fill(handlers, new ExceptionHandler[0]);
     int[] i2b = new int[instructions.length];
-    for (int i = 0; i < i2b.length; i++) {
-      i2b[i] = i;
-    }
+    Arrays.setAll(i2b, i -> i);
     return new MethodData(access, classType, name, signature, instructions, handlers, i2b);
   }
 

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/ReturnInstruction.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/ReturnInstruction.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.shrikeBT;
 
+import java.util.Arrays;
+
 /** This instruction represents all return instructions. */
 public final class ReturnInstruction extends Instruction {
   protected ReturnInstruction(short opcode) {
@@ -22,9 +24,7 @@ public final class ReturnInstruction extends Instruction {
 
   private static ReturnInstruction[] preallocate() {
     ReturnInstruction[] r = new ReturnInstruction[OP_areturn - OP_ireturn + 1];
-    for (int i = 0; i < r.length; i++) {
-      r[i] = new ReturnInstruction((short) (OP_ireturn + i));
-    }
+    Arrays.setAll(r, i -> new ReturnInstruction((short) (OP_ireturn + i)));
     return r;
   }
 

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/ShiftInstruction.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/ShiftInstruction.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.shrikeBT;
 
+import java.util.Arrays;
+
 /**
  * ShiftInstructions are distinguished from BinaryOpInstructions because most binary operations in
  * the JVM require both parameters to be the same type, but shifts always take one int parameter.
@@ -23,9 +25,7 @@ public final class ShiftInstruction extends Instruction implements IShiftInstruc
 
   private static ShiftInstruction[] preallocate() {
     ShiftInstruction[] r = new ShiftInstruction[OP_lushr - OP_ishl + 1];
-    for (int i = 0; i < r.length; i++) {
-      r[i] = new ShiftInstruction((short) (i + OP_ishl));
-    }
+    Arrays.setAll(r, i -> new ShiftInstruction((short) (i + OP_ishl)));
     return r;
   }
 

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/UnaryOpInstruction.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/UnaryOpInstruction.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.shrikeBT;
 
+import java.util.Arrays;
+
 /** This class represents unary operators where the result is the same type as the operand. */
 public final class UnaryOpInstruction extends Instruction implements IUnaryOpInstruction {
   protected UnaryOpInstruction(short opcode) {
@@ -20,9 +22,7 @@ public final class UnaryOpInstruction extends Instruction implements IUnaryOpIns
 
   private static UnaryOpInstruction[] preallocate() {
     UnaryOpInstruction[] r = new UnaryOpInstruction[OP_dneg - OP_ineg + 1];
-    for (int i = 0; i < r.length; i++) {
-      r[i] = new UnaryOpInstruction((short) (OP_ineg + i));
-    }
+    Arrays.setAll(r, i -> new UnaryOpInstruction((short) (OP_ineg + i)));
     return r;
   }
 

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/CTUtils.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/CTUtils.java
@@ -19,6 +19,7 @@ import com.ibm.wala.shrikeCT.ClassWriter.Element;
 import com.ibm.wala.shrikeCT.CodeWriter;
 import com.ibm.wala.shrikeCT.InvalidClassFileException;
 import com.ibm.wala.shrikeCT.LineNumberTableWriter;
+import java.util.Arrays;
 
 /**
  * This is a dumping ground for useful functions that manipulate class info.
@@ -86,9 +87,7 @@ public class CTUtils {
 
       // WRONG: int[] newLineMap = new int[md.getInstructions().length];
       int[] newLineMap = new int[code.getCodeLength()];
-      for (int i = 0; i < newLineMap.length; i++) {
-        newLineMap[i] = i;
-      }
+      Arrays.setAll(newLineMap, i -> i);
       int[] rawTable = LineNumberTableWriter.makeRawTable(newLineMap);
       lines = new LineNumberTableWriter(classWriter);
       lines.setRawTable(rawTable);

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/ClassInstrumenter.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/ClassInstrumenter.java
@@ -164,9 +164,7 @@ public final class ClassInstrumenter {
     ExceptionHandler[][] handlers = new ExceptionHandler[instructions.length][];
     Arrays.fill(handlers, noHandlers);
     int[] i2b = new int[instructions.length];
-    for (int i = 0; i < i2b.length; i++) {
-      i2b[i] = i;
-    }
+    Arrays.setAll(i2b, i -> i);
     MethodData md = null;
     try {
       md =
@@ -363,9 +361,7 @@ public final class ClassInstrumenter {
       }
     } else if (createFakeLineNumbers) {
       newLineMap = new int[output.getCode().length];
-      for (int i = 0; i < newLineMap.length; i++) {
-        newLineMap[i] = i + fakeLineOffset;
-      }
+      Arrays.setAll(newLineMap, i -> i + fakeLineOffset);
     } else {
       return null;
     }

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/ExceptionsReader.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/ExceptionsReader.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.shrikeCT;
 
+import java.util.Arrays;
+
 /** This class reads Exceptions attributes. */
 public final class ExceptionsReader extends AttributeReader {
   /** Build a reader for the attribute 'iter'. */
@@ -25,9 +27,7 @@ public final class ExceptionsReader extends AttributeReader {
   public int[] getRawTable() {
     int count = cr.getUShort(attr + 6);
     int[] r = new int[count];
-    for (int i = 0; i < r.length; i++) {
-      r[i] = cr.getUShort(attr + 8 + i * 2);
-    }
+    Arrays.setAll(r, i -> cr.getUShort(attr + 8 + i * 2));
     return r;
   }
 

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/InnerClassesReader.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/InnerClassesReader.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.shrikeCT;
 
+import java.util.Arrays;
+
 /** This class reads InnerClasses attributes. */
 public final class InnerClassesReader extends AttributeReader {
   /** Build a reader for the attribute 'iter'. */
@@ -25,9 +27,7 @@ public final class InnerClassesReader extends AttributeReader {
   public int[] getRawTable() {
     int count = cr.getUShort(attr + 6);
     int[] r = new int[count * 4];
-    for (int i = 0; i < r.length; i++) {
-      r[i] = cr.getUShort(attr + 8 + i * 2);
-    }
+    Arrays.setAll(r, i -> cr.getUShort(attr + 8 + i * 2));
     return r;
   }
 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/heapTrace/HeapTracer.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/heapTrace/HeapTracer.java
@@ -118,9 +118,7 @@ public class HeapTracer {
     }
     String[] result = new String[classFileNames.size()];
     Iterator<String> it = classFileNames.iterator();
-    for (int i = 0; i < result.length; i++) {
-      result[i] = it.next();
-    }
+    Arrays.setAll(result, i -> it.next());
     return result;
   }
 
@@ -460,9 +458,7 @@ public class HeapTracer {
       }
       Field[] result = new Field[s.size()];
       Object[] temp = s.toArray();
-      for (int i = 0; i < result.length; i++) {
-        result[i] = (Field) temp[i];
-      }
+      Arrays.setAll(result, i -> (Field) temp[i]);
       allReferenceFieldsCache.put(c, result);
       return result;
     }

--- a/com.ibm.wala.util/src/com/ibm/wala/util/heapTrace/HeapTracer.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/heapTrace/HeapTracer.java
@@ -24,7 +24,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
-import java.util.Iterator;
 import java.util.Set;
 import java.util.Stack;
 import java.util.StringTokenizer;
@@ -116,10 +115,7 @@ public class HeapTracer {
       File fdir = new File(dir);
       classFileNames.addAll(findClassNames(dir, fdir));
     }
-    String[] result = new String[classFileNames.size()];
-    Iterator<String> it = classFileNames.iterator();
-    Arrays.setAll(result, i -> it.next());
-    return result;
+    return classFileNames.toArray(new String[0]);
   }
 
   /**
@@ -456,9 +452,7 @@ public class HeapTracer {
         }
         klass = klass.getSuperclass();
       }
-      Field[] result = new Field[s.size()];
-      Object[] temp = s.toArray();
-      Arrays.setAll(result, i -> (Field) temp[i]);
+      Field[] result = s.toArray(new Field[0]);
       allReferenceFieldsCache.put(c, result);
       return result;
     }

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/IntSetUtil.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/IntSetUtil.java
@@ -53,9 +53,7 @@ public class IntSetUtil {
   }
 
   public static IntSet make(Set<Integer> x) {
-    int[] vals = new int[x.size()];
-    Iterator<Integer> vs = x.iterator();
-    Arrays.setAll(vals, i -> vs.next());
+    int[] vals = x.stream().mapToInt(Integer::intValue).toArray();
     return make(vals);
   }
 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/IntSetUtil.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/IntSetUtil.java
@@ -12,7 +12,6 @@ package com.ibm.wala.util.intset;
 
 import com.ibm.wala.util.debug.Assertions;
 import com.ibm.wala.util.debug.UnimplementedError;
-import java.util.Iterator;
 import java.util.Set;
 
 /** Utilities for dealing with {@link IntSet}s */
@@ -56,9 +55,7 @@ public class IntSetUtil {
   public static IntSet make(Set<Integer> x) {
     int[] vals = new int[x.size()];
     Iterator<Integer> vs = x.iterator();
-    for (int i = 0; i < vals.length; i++) {
-      vals[i] = vs.next();
-    }
+    Arrays.setAll(vals, i -> vs.next());
     return make(vals);
   }
 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/MutableSparseLongSetFactory.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/MutableSparseLongSetFactory.java
@@ -10,6 +10,7 @@
  */
 package com.ibm.wala.util.intset;
 
+import java.util.Arrays;
 import java.util.TreeSet;
 
 /** An object that creates mutable sparse int sets. */
@@ -43,7 +44,7 @@ public class MutableSparseLongSetFactory implements MutableLongSetFactory {
   public MutableLongSet parse(String string) throws NumberFormatException {
     int[] backingStore = SparseIntSet.parseIntArray(string);
     long[] bs = new long[backingStore.length];
-    for (int i = 0; i < bs.length; i++) bs[i] = backingStore[i];
+    Arrays.setAll(bs, i -> backingStore[i]);
     return new MutableSparseLongSet(bs);
   }
 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/MutableSparseLongSetFactory.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/MutableSparseLongSetFactory.java
@@ -43,8 +43,7 @@ public class MutableSparseLongSetFactory implements MutableLongSetFactory {
   @Override
   public MutableLongSet parse(String string) throws NumberFormatException {
     int[] backingStore = SparseIntSet.parseIntArray(string);
-    long[] bs = new long[backingStore.length];
-    Arrays.setAll(bs, i -> backingStore[i]);
+    long[] bs = Arrays.stream(backingStore).asLongStream().toArray();
     return new MutableSparseLongSet(bs);
   }
 


### PR DESCRIPTION
The `Arrays.setAll` version is certainly concise, especially where the second argument is a method reference, as in `Arrays.setAll(uses, phi::getUse);`.  However, I could imagine the heavy use of method
references and lambdas being a performance concern.  Let’s consider this group of changes carefully.

We could potentially use `Arrays.parallelSetAll` in cases where the values computed for each slot are independent of those computed for other slots.  However, I don’t know which of the arrays are typically
large enough to make parallel execution a good idea.