### PR TITLE
Leverage Java 8 high-level Map methods

### DIFF
--- a/.idea/inspectionProfiles/No_Back_Sliding.xml
+++ b/.idea/inspectionProfiles/No_Back_Sliding.xml
@@ -411,7 +411,6 @@
     <inspection_tool class="JUnit5Platform" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="Java8ArraySetAll" enabled="false" level="INFORMATION" enabled_by_default="false" />
     <inspection_tool class="Java8CollectionRemoveIf" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="Java8MapApi" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="Java9CollectionFactory" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="Java9ModuleExportsPackageToItself" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="Java9RedundantRequiresStatement" enabled="false" level="WARNING" enabled_by_default="false" />

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/CorrelatedPairExtractionPolicy.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/CorrelatedPairExtractionPolicy.java
@@ -158,8 +158,8 @@ public class CorrelatedPairExtractionPolicy extends ExtractionPolicy {
       return false;
     }
 
-    List<ExtractionRegion> regions = region_map.get(region_info.fst);
-    if (regions == null) region_map.put(region_info.fst, regions = new LinkedList<>());
+    List<ExtractionRegion> regions =
+        region_map.computeIfAbsent(region_info.fst, k -> new LinkedList<>());
     for (int i = 0; i < regions.size(); ++i) {
       ExtractionRegion region2 = regions.get(i);
       if (region2.getEnd() <= region_info.snd.getStart()) continue;

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/impl/CAstControlFlowRecorder.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/impl/CAstControlFlowRecorder.java
@@ -100,20 +100,12 @@ public class CAstControlFlowRecorder implements CAstControlFlowMap {
   @Override
   public Collection<Object> getTargetLabels(CAstNode from) {
     Object node = CAstToNode.get(from);
-    if (labelMap.containsKey(node)) {
-      return labelMap.get(node);
-    } else {
-      return Collections.emptySet();
-    }
+    return labelMap.getOrDefault(node, Collections.emptySet());
   }
 
   @Override
   public Set<Object> getSourceNodes(CAstNode to) {
-    if (sourceMap.containsKey(CAstToNode.get(to))) {
-      return sourceMap.get(CAstToNode.get(to));
-    } else {
-      return Collections.emptySet();
-    }
+    return sourceMap.getOrDefault(CAstToNode.get(to), Collections.emptySet());
   }
 
   @Override
@@ -149,12 +141,10 @@ public class CAstControlFlowRecorder implements CAstControlFlowMap {
 
     table.put(new Key(label, from), to);
 
-    Set<Object> ls = labelMap.get(from);
-    if (ls == null) labelMap.put(from, ls = new LinkedHashSet<>(2));
+    Set<Object> ls = labelMap.computeIfAbsent(from, k -> new LinkedHashSet<>(2));
     ls.add(label);
 
-    Set<Object> ss = sourceMap.get(to);
-    if (ss == null) sourceMap.put(to, ss = new LinkedHashSet<>(2));
+    Set<Object> ss = sourceMap.computeIfAbsent(to, k -> new LinkedHashSet<>(2));
     ss.add(from);
   }
 

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/impl/CAstControlFlowRecorder.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/impl/CAstControlFlowRecorder.java
@@ -100,12 +100,14 @@ public class CAstControlFlowRecorder implements CAstControlFlowMap {
   @Override
   public Collection<Object> getTargetLabels(CAstNode from) {
     Object node = CAstToNode.get(from);
-    return labelMap.getOrDefault(node, Collections.emptySet());
+    Set<Object> found = labelMap.get(node);
+    return found == null ? Collections.emptySet() : found;
   }
 
   @Override
   public Set<Object> getSourceNodes(CAstNode to) {
-    return sourceMap.getOrDefault(CAstToNode.get(to), Collections.emptySet());
+    Set<Object> found = sourceMap.get(CAstToNode.get(to));
+    return found == null ? Collections.emptySet() : found;
   }
 
   @Override

--- a/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/TabulationSolver.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/TabulationSolver.java
@@ -912,11 +912,7 @@ public class TabulationSolver<T, P, F> {
           };
       for (T n : supergraph) {
         P proc = supergraph.getProcOf(n);
-        TreeSet<T> s = map.get(proc);
-        if (s == null) {
-          s = new TreeSet<>(c);
-          map.put(proc, s);
-        }
+        TreeSet<T> s = map.computeIfAbsent(proc, k -> new TreeSet<>(c));
         s.add(n);
       }
 

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/cfa/ZeroXInstanceKeys.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/cfa/ZeroXInstanceKeys.java
@@ -219,12 +219,7 @@ public class ZeroXInstanceKeys implements InstanceKeyFactory {
     for (NewSiteReference n : Iterator2Iterable.make(contextInterpreter.iterateNewSites(node))) {
       IClass alloc = cha.lookupClass(n.getDeclaredType());
       if (alloc != null) {
-        Integer old = count.get(alloc);
-        if (old == null) {
-          count.put(alloc, 1);
-        } else {
-          count.put(alloc, old + 1);
-        }
+        count.merge(alloc, 1, Integer::sum);
       }
     }
     return count;

--- a/com.ibm.wala.core/src/com/ibm/wala/util/PrimitiveAssignability.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/PrimitiveAssignability.java
@@ -163,11 +163,7 @@ public class PrimitiveAssignability {
     final Primitive f = namePrimitiveMap.get(from);
     final Primitive t = namePrimitiveMap.get(to);
 
-    if (assignability.get(f).containsKey(t)) {
-      return assignability.get(f).get(t);
-    } else {
-      return AssignabilityKind.UNASSIGNABLE;
-    }
+    return assignability.get(f).getOrDefault(t, AssignabilityKind.UNASSIGNABLE);
   }
 
   /** Does an expression c1 x := c2 y typecheck? */

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModelClass.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModelClass.java
@@ -247,11 +247,7 @@ public final /* singleton */ class AndroidModelClass extends SyntheticClass {
 
   @Override
   public IField getField(Atom name) {
-    if (fields.containsKey(name)) {
-      return fields.get(name);
-    } else {
-      return null;
-    }
+    return fields.getOrDefault(name, null);
   }
 
   public void putField(Atom name, TypeReference type) {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
@@ -333,11 +333,7 @@ public class AndroidManifestXMLReader {
     public static Tag fromString(String tag) {
       tag = tag.toLowerCase();
 
-      if (reverseMap.containsKey(tag)) {
-        return reverseMap.get(tag);
-      } else {
-        return Tag.UNIMPORTANT;
-      }
+      return reverseMap.getOrDefault(tag, Tag.UNIMPORTANT);
     }
 
     /** The Tag appears in the XML File using this name. */

--- a/com.ibm.wala.scandroid/source/org/scandroid/domain/IFDSTaintDomain.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/domain/IFDSTaintDomain.java
@@ -75,11 +75,7 @@ public class IFDSTaintDomain<E extends ISSABasicBlock>
   }
 
   private void index(DomainElement e) {
-    Set<DomainElement> elements = elementIndex.get(e.codeElement);
-    if (elements == null) {
-      elements = new HashSet<>();
-      elementIndex.put(e.codeElement, elements);
-    }
+    Set<DomainElement> elements = elementIndex.computeIfAbsent(e.codeElement, k -> new HashSet<>());
     elements.add(e);
   }
 

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/InflowAnalysis.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/InflowAnalysis.java
@@ -80,17 +80,10 @@ public class InflowAnalysis {
       BasicBlockInContext<E> block,
       FlowType taintType,
       Set<CodeElement> newElements) {
-    Map<FlowType<E>, Set<CodeElement>> blockMap = taintMap.get(block);
-    if (blockMap == null) {
-      blockMap = new HashMap<>();
-      taintMap.put(block, blockMap);
-    }
+    Map<FlowType<E>, Set<CodeElement>> blockMap =
+        taintMap.computeIfAbsent(block, k -> new HashMap<>());
 
-    Set<CodeElement> elements = blockMap.get(taintType);
-    if (elements == null) {
-      elements = new HashSet<>();
-      blockMap.put(taintType, elements);
-    }
+    Set<CodeElement> elements = blockMap.computeIfAbsent(taintType, k -> new HashSet<>());
     elements.addAll(newElements);
   }
 

--- a/com.ibm.wala.scandroid/source/org/scandroid/flow/OutflowAnalysis.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/flow/OutflowAnalysis.java
@@ -110,11 +110,7 @@ public class OutflowAnalysis {
       Map<FlowType<IExplodedBasicBlock>, Set<FlowType<IExplodedBasicBlock>>> graph,
       FlowType<IExplodedBasicBlock> source,
       FlowType<IExplodedBasicBlock> dest) {
-    Set<FlowType<IExplodedBasicBlock>> dests = graph.get(source);
-    if (dests == null) {
-      dests = new HashSet<>();
-      graph.put(source, dests);
-    }
+    Set<FlowType<IExplodedBasicBlock>> dests = graph.computeIfAbsent(source, k -> new HashSet<>());
     dests.add(dest);
   }
 

--- a/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/PrefixTransferGraph.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/PrefixTransferGraph.java
@@ -231,17 +231,9 @@ public class PrefixTransferGraph implements Graph<InstanceKeySite> {
 
   @Override
   public void addEdge(InstanceKeySite src, InstanceKeySite dst) {
-    Set<InstanceKeySite> predSet = predecessors.get(dst);
-    if (predSet == null) {
-      predSet = new HashSet<>();
-      predecessors.put(dst, predSet);
-    }
+    Set<InstanceKeySite> predSet = predecessors.computeIfAbsent(dst, k -> new HashSet<>());
     predSet.add(src);
-    Set<InstanceKeySite> succSet = successors.get(src);
-    if (succSet == null) {
-      succSet = new HashSet<>();
-      successors.put(src, succSet);
-    }
+    Set<InstanceKeySite> succSet = successors.computeIfAbsent(src, k -> new HashSet<>());
     succSet.add(dst);
   }
 

--- a/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/UriPrefixTransferGraph.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/UriPrefixTransferGraph.java
@@ -370,18 +370,10 @@ public class UriPrefixTransferGraph implements Graph<InstanceKeySite> {
 
   @Override
   public void addEdge(final InstanceKeySite src, final InstanceKeySite dst) {
-    Set<InstanceKeySite> predSet = predecessors.get(dst);
-    if (predSet == null) {
-      predSet = new HashSet<>();
-      predecessors.put(dst, predSet);
-    }
+    Set<InstanceKeySite> predSet = predecessors.computeIfAbsent(dst, k -> new HashSet<>());
     predSet.add(src);
 
-    Set<InstanceKeySite> succSet = successors.get(src);
-    if (succSet == null) {
-      succSet = new HashSet<>();
-      successors.put(src, succSet);
-    }
+    Set<InstanceKeySite> succSet = successors.computeIfAbsent(src, k -> new HashSet<>());
     succSet.add(dst);
   }
 

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrike/cg/OfflineDynamicCallGraph.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrike/cg/OfflineDynamicCallGraph.java
@@ -468,11 +468,7 @@ public class OfflineDynamicCallGraph {
             }
 
             private int findExistingEntry(Object o) {
-              if (entries.containsKey(o)) {
-                return entries.get(o);
-              } else {
-                return -1;
-              }
+              return entries.getOrDefault(o, -1);
             }
 
             @Override

--- a/com.ibm.wala.util/src/com/ibm/wala/util/collections/MapUtil.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/collections/MapUtil.java
@@ -87,11 +87,7 @@ public class MapUtil {
     if (M == null) {
       throw new IllegalArgumentException("M is null");
     }
-    List<T> result = M.get(key);
-    if (result == null) {
-      result = new ArrayList<>();
-      M.put(key, result);
-    }
+    List<T> result = M.computeIfAbsent(key, k -> new ArrayList<>());
     return result;
   }
 
@@ -145,11 +141,7 @@ public class MapUtil {
     if (M == null) {
       throw new IllegalArgumentException("M is null");
     }
-    WeakHashMap<K, V> result = M.get(key);
-    if (result == null) {
-      result = new WeakHashMap<>(2);
-      M.put(key, result);
-    }
+    WeakHashMap<K, V> result = M.computeIfAbsent(key, k -> new WeakHashMap<>(2));
     return result;
   }
 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/BitVectorRepository.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/BitVectorRepository.java
@@ -72,11 +72,8 @@ public class BitVectorRepository {
       }
     }
     // didn't find one. create one.
-    LinkedList<WeakReference<BitVectorIntSet>> m = buckets.get(size);
-    if (m == null) {
-      m = new LinkedList<>();
-      buckets.put(size, m);
-    }
+    LinkedList<WeakReference<BitVectorIntSet>> m =
+        buckets.computeIfAbsent(size, k -> new LinkedList<>());
     BitVectorIntSet bv = new BitVectorIntSet(value);
     m.add(new WeakReference<>(bv));
     return bv;


### PR DESCRIPTION
`Map.getOrDefault` seems like a clear win when the default value is a constant (e.g., `-1` or `null`).

`Map.computeIfAbsent` adds a lambda, which might be a performance concern. `Map.computeIfAbsent` *can* be implemented in a manner that turns two lookups (`Map.get` followed by `Map.put`) into just one, which might help performance. There is no hard *requirement* that `Map.computeIfAbsent` incorporate that optimization, though.

To assess any performance impact empirically, I performed 20 repetitions of the `com.ibm.wala.core.tests.callGraph` tests before and after the commits in this pull request:

|Revision|Mean Execution Time (M:SS.SS)|
|-|-|
|before|6:31.23|
|after|6:30.75|

Inter-trial variance (not shown here) is significantly larger than the small difference in means shown above. More formally, the slight speedup after these changes is not statistically significant according to a two-tailed, unpaired Student’s _t_-test. I conclude that this change does not adversely affect performance in the tested configuration: for these tests, run on this JVM, using this Java compiler, etc.