### PR TITLE
Couple of fixes for build scripts

### DIFF
--- a/change-version.py
+++ b/change-version.py
@@ -21,7 +21,7 @@ runAndPrint("mvn clean -q")
 
 runAndPrint("find -E ./ -regex \".*(pom|mvncentral)\.xml\" | xargs -n 1 perl -pi -e \'s/" + oldVersion + "/" + newVersion + "/g\'")
 
-runAndPrint("perl -pi -e \'s/" + oldVersion + "/" + newVersion + "/g\' build.gradle")
+runAndPrint("perl -pi -e \'s/" + oldVersion + "/" + newVersion + "/g\' build.gradle gradle.properties")
 
 oldIsSnapshot = oldVersion.endswith("SNAPSHOT")
 newIsSnapShot = newVersion.endswith("SNAPSHOT")

--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -46,7 +46,7 @@ def getRepositoryPassword() {
 }
 
 def needsSigning() {
-  return isReleaseBuild() && gradle.taskGraph.hasTask('uploadArchives')
+  return isReleaseBuild() && gradle.taskGraph.allTasks.any { it.name.equals('uploadArchives') }
 }
 
 afterEvaluate { project ->


### PR DESCRIPTION
* Update `change-version.py` to also update `gradle.properties`
* Fix `needsSigning()` in `gradle-mvn-push.gradle` to match on `name` rather than using `hasTask` (which requires the fully-qualified task name)