### PR TITLE
Add "linters" and "shellCheck" tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -177,9 +177,11 @@ subprojects {
 
 ////////////////////////////////////////////////////////////////////////
 //
-//  optional lint checking of Gradle scripts
+//  linters for various specific languages or file formats
 //
 
+
+// Gradle build scripts
 allprojects {
 	apply plugin: 'nebula.lint'
 	gradleLint.alwaysRun = false
@@ -194,16 +196,22 @@ allprojects {
 }
 
 
-////////////////////////////////////////////////////////////////////////
-//
-//  Javadoc linter
-//
-
+// Javadoc
 allprojects {
 	tasks.withType(Javadoc).configureEach {
 		options.addBooleanOption('Xdoclint:all,-missing', true)
 		options.quiet()
 	}
+}
+
+
+tasks.register('linters') {
+	group = 'lint'
+	dependsOn(
+			'lintGradle',
+			'shellCheck',
+			'verifyGoogleJavaFormat',
+	)
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -217,10 +217,15 @@ tasks.register('shellCheck', Exec) {
 	inputs.files fileTree('.').exclude('**/build').include('**/*.sh')
 	outputs.file "$temporaryDir/log"
 
-	executable 'shellcheck'
-	args inputs.files
-
 	doFirst {
+		// quietly succeed if "shellcheck" is not available
+		executable 'shellcheck'
+		final def execPaths = System.getenv('PATH').split(File.pathSeparator)
+		final def isAvailable = execPaths.any { file("$it/$executable").exists() }
+		if (!isAvailable) executable 'true'
+
+		args inputs.files
+
 		final def consoleOutput = System.out
 		final def fileOutput = new FileOutputStream(outputs.files.singleFile)
 		final def bothOutput = new org.apache.tools.ant.util.TeeOutputStream(consoleOutput, fileOutput)

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,10 @@
 //  plugin configuration must precede everything else
 //
 
+buildscript {
+	dependencies.classpath 'commons-io:commons-io:2.4'
+}
+
 plugins {
 	id 'com.diffplug.gradle.p2.asmaven' version '3.17.3'
 	id 'com.github.hauner.jarTest' version '1.0.1' apply false
@@ -201,6 +205,26 @@ allprojects {
 	tasks.withType(Javadoc).configureEach {
 		options.addBooleanOption('Xdoclint:all,-missing', true)
 		options.quiet()
+	}
+}
+
+
+// shell scripts, provided they have ".sh" extension
+tasks.register('shellCheck', Exec) {
+	description 'Check all shell scripts using shellcheck, if available'
+	group 'lint'
+
+	inputs.files fileTree('.').exclude('**/build').include('**/*.sh')
+	outputs.file "$temporaryDir/log"
+
+	executable 'shellcheck'
+	args inputs.files
+
+	doFirst {
+		final def consoleOutput = System.out
+		final def fileOutput = new FileOutputStream(outputs.files.singleFile)
+		final def bothOutput = new org.apache.tools.ant.util.TeeOutputStream(consoleOutput, fileOutput)
+		standardOutput = errorOutput = bothOutput
 	}
 }
 

--- a/travis/script-gradle
+++ b/travis/script-gradle
@@ -28,10 +28,9 @@ then
 else
   run_gradle \
     -PjavaCompiler=ecj \
-    verifyGoogleJavaFormat \
+    linters \
     compileJava \
     compileTestJava \
-    lintGradle \
     ${documentation:+$SUBMODULE_PREFIX$documentation}
   run_gradle "$SUBMODULE_PREFIX"build
 fi


### PR DESCRIPTION
Create a common `linters` task for extra checkers. These extra checkers are things we want to test for, but which are not Java JUnit tests. @msridhar has expressed a preference in the past for not simply adding these extra checks as dependencies of the `check` task. So instead we now have a distinct `linters` task as a single collection point for these other checks.

Also add a `shellCheck` task: a [`shellcheck`](https://www.shellcheck.net/)-based linter for all shell scripts. This `shellCheck` task assumes that shell scripts are OK if `shellcheck` is absent. For example, Travis CI has `shellcheck` preinstalled on Linux images, but not on macOS images. So our Travis CI Linux jobs will lint-check shell scripts, but on macOS we just optimistically assume that everything is OK. `shellcheck` certainly *can* be installed on macOS, although this may take some effort because `shellcheck` is written in Haskell. If some WALA developer or contributor does install `shellcheck`, then he or she will get the extra checks too.