### PR TITLE
Relocate some jar files and simplify "clean*" tasks

### DIFF
--- a/com.ibm.wala.core.testdata/build.gradle
+++ b/com.ibm.wala.core.testdata/build.gradle
@@ -176,10 +176,6 @@ tasks.register('downloadJavaCup', VerifiedDownload) {
 	checksum '2bda8c40abd0cbc295d3038643d6e4ec'
 }
 
-tasks.register('cleanDownloadJavaCup', Delete) {
-	delete downloadJavaCup
-}
-
 tasks.named('clean') {
 	dependsOn 'cleanDownloadJavaCup'
 }
@@ -195,10 +191,6 @@ tasks.register('collectJLex', Jar) {
 	include 'JLex/'
 	archiveFileName.set 'JLex.jar'
 	destinationDirectory.set projectDir
-}
-
-tasks.register('cleanCollectJLex', Delete) {
-	delete collectJLex
 }
 
 tasks.named('clean') {
@@ -243,11 +235,12 @@ tasks.register('generateHelloHashJar', JavaExec) {
 	args ocamlSource, '-o', jarTarget
 }
 
-tasks.register('cleanGenerateHelloHashJar', Delete) {
-	delete generateHelloHashJar
-	delete fileTree('ocaml') {
-		exclude '*.ml'
-		exclude '.gitignore'
+tasks.named('cleanGenerateHelloHashJar', Delete) {
+	doLast {
+		delete fileTree('ocaml') {
+			exclude '*.ml'
+			exclude '.gitignore'
+		}
 	}
 }
 
@@ -267,10 +260,6 @@ tasks.register('collectTestData', Jar) {
 	from 'classes'
 	includeEmptyDirs false
 	destinationDirectory.set projectDir
-}
-
-tasks.register('cleanCollectTestData', Delete) {
-	delete collectTestData
 }
 
 tasks.named('clean') {
@@ -294,10 +283,6 @@ final def collectTestDataA = tasks.register('collectTestDataA', Jar) {
 		'**/SortingExample.class',
 		'**/A.class',
 		)
-}
-
-tasks.register('cleanColllectTestDataA', Delete) {
-	delete collectTestDataA
 }
 
 tasks.named('clean') {

--- a/com.ibm.wala.core.testdata/build.gradle
+++ b/com.ibm.wala.core.testdata/build.gradle
@@ -22,7 +22,7 @@ final def downloadKawa = tasks.register('downloadKawa', VerifiedDownload) {
 
 tasks.register('extractKawa') {
 	inputs.files downloadKawa.get()
-	outputs.file "$temporaryDir/kawa.jar"
+	outputs.file 'kawa.jar'
 
 	doLast {
 		copy {
@@ -36,6 +36,10 @@ tasks.register('extractKawa') {
 			includeEmptyDirs false
 		}
 	}
+}
+
+tasks.named('clean') {
+	dependsOn 'cleanExtractKawa'
 }
 
 
@@ -64,6 +68,7 @@ class CompileKawaJar extends Jar {
 		compile.dependsOn dependsOn
 		from compile
 		archiveVersion.set null
+		destinationDirectory.set project.projectDir
 	}
 
 	void setArgs(Object... args) {
@@ -111,6 +116,10 @@ tasks.register('buildChessJar', CompileKawaJar) {
 	baseName 'kawachess'
 }
 
+tasks.named('clean') {
+	dependsOn 'cleanBuildChessJar'
+}
+
 
 ////////////////////////////////////////////////////////////////////////
 //
@@ -122,6 +131,10 @@ tasks.register('buildKawaTestJar', CompileKawaJar) {
 	args schemeFile
 	inputs.files schemeFile
 	baseName 'kawatest'
+}
+
+tasks.named('clean') {
+	dependsOn 'cleanBuildKawaTestJar'
 }
 
 


### PR DESCRIPTION
Hoist some jar files out of `com.ibm.wala.core.testdata/build`. The `com.ibm.wala.core.testdata/build.properties` file that Eclipse uses expects to find these jar files directly in the `com.ibm.wala.core.testdata` directory, not in the `com.ibm.wala.core.testdata/build` subdirectory.

Let Gradle generate some `clean*` tasks automatically. Previously we had to (or thought we had to) create these ourselves, but Gradle actually creates them correctly on its own.