### PR TITLE
Allow dead code due to DEBUG_LEVEL setting

### DIFF
--- a/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/TabulationSolver.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/dataflow/IFDS/TabulationSolver.java
@@ -446,6 +446,7 @@ public class TabulationSolver<T, P, F> {
    * @param D5 facts to propagate to return site
    * @param edge the path edge ending at the exit site of the callee
    */
+  @SuppressWarnings("unused")
   private void propToReturnSite(
       final T c,
       final T[] entries,


### PR DESCRIPTION
We want to make this code easy to enable simply by changing `DEBUG_LEVEL`, even if it is dead with `DEBUG_LEVEL` at its standard setting.