### PR TITLE
Javadoc fixes and IntelliJ IDEA Javadoc inspection updates

### DIFF
--- a/.idea/inspectionProfiles/No_Back_Sliding.xml
+++ b/.idea/inspectionProfiles/No_Back_Sliding.xml
@@ -59,6 +59,7 @@
     <inspection_tool class="GrUnresolvedAccess" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="GroovyAssignabilityCheck" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="GroovyPointlessBoolean" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="HtmlTagCanBeJavadocTag" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="HtmlUnknownTag" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="myValues">
         <value>
@@ -94,6 +95,7 @@
     <inspection_tool class="JSValidateTypes" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="JavaReflectionInvocation" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JavaReflectionMemberAccess" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JavadocHtmlLint" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="JsonStandardCompliance" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="LoopConditionNotUpdatedInsideLoop" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="ignoreIterators" value="false" />
@@ -113,6 +115,7 @@
       </option>
     </inspection_tool>
     <inspection_tool class="MismatchedStringBuilderQueryUpdate" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MissingDeprecatedAnnotation" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="MisspelledHeader" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="NullArgumentToVariableArgMethod" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="NullableProblems" enabled="false" level="WARNING" enabled_by_default="false">
@@ -125,6 +128,7 @@
       <option name="REPORT_ANNOTATION_NOT_PROPAGATED_TO_OVERRIDERS" value="true" />
       <option name="REPORT_NULLS_PASSED_TO_NON_ANNOTATED_METHOD" value="true" />
     </inspection_tool>
+    <inspection_tool class="PackageInfoWithoutPackage" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="PackageJsonMismatchedDependency" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="ParameterCanBeLocal" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="PointlessArithmeticExpression" enabled="false" level="WARNING" enabled_by_default="false">
@@ -191,6 +195,7 @@
     <inspection_tool class="UnnecessaryConditionalExpression" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UnnecessaryContinue" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UnnecessaryEnumModifier" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryInheritDoc" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnnecessaryInterfaceModifier" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UnnecessaryJavaDocLink" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreInlineLinkToSuper" value="false" />
@@ -203,6 +208,7 @@
     </inspection_tool>
     <inspection_tool class="UnnecessaryLocalVariableJS" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="m_ignoreImmediatelyReturnedVariables" value="false" />
+      <option name="m_ignoreAnnotatedVariables" value="false" />
     </inspection_tool>
     <inspection_tool class="UnnecessaryModuleDependencyInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UnnecessaryQualifiedReference" enabled="false" level="WARNING" enabled_by_default="false" />

--- a/.idea/inspectionProfiles/No_Back_Sliding.xml
+++ b/.idea/inspectionProfiles/No_Back_Sliding.xml
@@ -192,6 +192,9 @@
     <inspection_tool class="UnnecessaryContinue" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UnnecessaryEnumModifier" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UnnecessaryInterfaceModifier" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnnecessaryJavaDocLink" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoreInlineLinkToSuper" value="false" />
+    </inspection_tool>
     <inspection_tool class="UnnecessaryLabelOnBreakStatement" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UnnecessaryLabelOnContinueStatement" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UnnecessaryLocalVariable" enabled="false" level="WARNING" enabled_by_default="false">

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/GetMethodContextSelector.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/GetMethodContextSelector.java
@@ -61,7 +61,7 @@ public class GetMethodContextSelector implements ContextSelector {
    *   <li>the first argument is a constant,
    * </ul>
    *
-   * then return a {@link GetMethodContextSelector}.
+   * then return a {@code GetMethodContextSelector}.
    */
   @Override
   public Context getCalleeTarget(

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/GetMethodContextSelector.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/reflection/GetMethodContextSelector.java
@@ -41,7 +41,7 @@ import java.util.Collection;
  */
 public class GetMethodContextSelector implements ContextSelector {
 
-  /** If <tt>true</tt>, debug information is emitted. */
+  /** If {@code true}, debug information is emitted. */
   protected static final boolean DEBUG = false;
 
   /** whether to only follow get method calls on application classes, ignoring system ones */
@@ -111,8 +111,8 @@ public class GetMethodContextSelector implements ContextSelector {
   }
 
   /**
-   * If <tt>instance</tt> is a {@link ConstantKey} and its value is an instance of {@link IClass},
-   * return that value. Otherwise, return <tt>null</tt>.
+   * If {@code instance} is a {@link ConstantKey} and its value is an instance of {@link IClass},
+   * return that value. Otherwise, return {@code null}.
    */
   private static IClass getTypeConstant(InstanceKey instance) {
     if (instance instanceof ConstantKey) {

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/IR.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/IR.java
@@ -705,7 +705,7 @@ public abstract class IR implements IRView {
     return cfg.getBasicBlock(bb);
   }
 
-  /** @return the {@link SSAOptions} which controlled how this {@link IR} was built */
+  /** @return the {@link SSAOptions} which controlled how this {@code IR} was built */
   public SSAOptions getOptions() {
     return options;
   }

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/SSAIndirectionData.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/SSAIndirectionData.java
@@ -39,7 +39,7 @@ import java.util.Collection;
  * <p>As a more complex example, when we have lexical scoping, we can have the following IR
  * generated, which passes a local by reference:
  *
- * <p>Example B: <tt> foo: v3 = AddressOf v2; bar(v3) (1) bar(v1): StoreIndirect v1, #7. </tt>
+ * <p>Example B: {@code foo: v3 = AddressOf v2; bar(v3) (1) bar(v1): StoreIndirect v1, #7.}
  *
  * <p>In this case, the instruction (1) potentially defs the locals aliased by v2. The lexical
  * scoping support could/should use this information to rebuild SSA accounting for the fact that (1)

--- a/com.ibm.wala.core/src/com/ibm/wala/types/TypeReference.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/types/TypeReference.java
@@ -466,7 +466,7 @@ public final class TypeReference implements Serializable {
   }
 
   /**
-   * Find or create the canonical {@link TypeReference} instance for the given pair.
+   * Find or create the canonical {@code TypeReference} instance for the given pair.
    *
    * @param cl the classloader (defining/initiating depending on usage)
    * @param typeName something like "Ljava/util/Arrays"

--- a/com.ibm.wala.core/src/com/ibm/wala/types/annotations/TypeAnnotation.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/types/annotations/TypeAnnotation.java
@@ -146,7 +146,7 @@ public class TypeAnnotation {
    *   <li>{@link ShrikeClass#getTypeAnnotations(boolean)}
    * </ul>
    *
-   * @return A {@link TypeAnnotation} comprised of annotation, typePath and targetType
+   * @return A {@code TypeAnnotation} comprised of annotation, typePath and targetType
    */
   public static TypeAnnotation make(
       Annotation annotation,
@@ -168,7 +168,7 @@ public class TypeAnnotation {
    *   <li>{@link ShrikeClass#getTypeAnnotations(boolean)}
    * </ul>
    *
-   * @return A {@link TypeAnnotation} comprised of annotation, an empty typePath, and targetType
+   * @return A {@code TypeAnnotation} comprised of annotation, an empty typePath, and targetType
    */
   public static TypeAnnotation make(
       Annotation annotation, TypeAnnotationTarget typeAnnotationTarget, TargetType targetType) {
@@ -964,13 +964,13 @@ public class TypeAnnotation {
     };
   }
 
-  /** @return the {@link Annotation} of this {@link TypeAnnotation} */
+  /** @return the {@link Annotation} of this {@code TypeAnnotation} */
   public Annotation getAnnotation() {
     return annotation;
   }
 
   /**
-   * @return the typePath of this {@link TypeAnnotation}
+   * @return the typePath of this {@code TypeAnnotation}
    * @see <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.20.2">JLS
    *     (SE8), 4.7.20.2</a>
    */
@@ -978,12 +978,12 @@ public class TypeAnnotation {
     return typePath;
   }
 
-  /** @return the {@link TypeAnnotationTarget} of this {@link TypeAnnotation} */
+  /** @return the {@link TypeAnnotationTarget} of this {@code TypeAnnotation} */
   public TypeAnnotationTarget getTypeAnnotationTarget() {
     return typeAnnotationTarget;
   }
 
-  /** @return the {@link TargetType} of this {@link TypeAnnotation} */
+  /** @return the {@link TargetType} of this {@code TypeAnnotation} */
   public TargetType getTargetType() {
     return targetType;
   }

--- a/com.ibm.wala.util/src/com/ibm/wala/fixpoint/AbstractVariable.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/fixpoint/AbstractVariable.java
@@ -37,7 +37,7 @@ public abstract class AbstractVariable<T extends AbstractVariable<T>> extends No
    *
    * <ul>
    *   <li>we need this to be extremely fast .. it's in the inner loop of lots of stuff.
-   *   <li>these objects will probably only be hashed with each other {@link AbstractVariable}s, in
+   *   <li>these objects will probably only be hashed with each other {@code AbstractVariable}s, in
    *       which case incrementing hash codes is OK.
    *   <li>we want determinism, so we don't want to rely on System.identityHashCode
    * </ul>

--- a/com.ibm.wala.util/src/com/ibm/wala/fixpoint/IFixedPointSolver.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/fixpoint/IFixedPointSolver.java
@@ -16,7 +16,7 @@ import com.ibm.wala.util.MonitorUtil.IProgressMonitor;
 /** Solves a set of constraints */
 public interface IFixedPointSolver<T extends IVariable<T>> {
 
-  /** @return the set of statements solved by this {@link IFixedPointSolver} */
+  /** @return the set of statements solved by this {@code IFixedPointSolver} */
   public IFixedPointSystem<T> getFixedPointSystem();
 
   /**


### PR DESCRIPTION
Use `{@code …}` in Javadoc, not `<tt>…</tt>`. Javadoc from JDK 1.8 allows either, but more recent JDK releases may disallow `<tt>…</tt>`.

Remove unnecessary Javadoc links to containing class.

Enable additional IntelliJ IDEA Javadoc inspections that find nothing.