### PR TITLE
Fix two bugs with handling of lambdas

### DIFF
--- a/com.ibm.wala.core.testdata/src/lambda/MethodRefs.java
+++ b/com.ibm.wala.core.testdata/src/lambda/MethodRefs.java
@@ -1,0 +1,74 @@
+package lambda;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class MethodRefs {
+
+  static interface I {
+    void target();
+  }
+
+  static class C1 implements I {
+
+    @Override
+    public void target() {}
+  }
+
+  static class C2 implements I {
+
+    @Override
+    public void target() {}
+  }
+
+  static class C3 implements I {
+
+    @Override
+    public void target() {}
+  }
+
+  static class C4 implements I {
+
+    @Override
+    public void target() {}
+  }
+
+  static class C5 implements I {
+
+    @Override
+    public void target() {}
+  }
+
+  static class Dummy {
+
+    Dummy(I i) {
+      i.target();
+    }
+  }
+
+  static void fun1(I i) {
+    i.target();
+  }
+
+  static void fun1Ref() {
+    Consumer<I> c = MethodRefs::fun1;
+    I x = new C1();
+    c.accept(x);
+  }
+
+  void fun2(I i) {
+    i.target();
+  }
+
+  public static void main(String[] args) {
+    fun1Ref();
+    MethodRefs r = new MethodRefs();
+    Consumer<I> c = r::fun2;
+    c.accept(new C2());
+    BiConsumer<MethodRefs, I> bc = MethodRefs::fun2;
+    bc.accept(r, new C3());
+    Function<I, Dummy> f = Dummy::new;
+    f.apply(new C4());
+  }
+}

--- a/com.ibm.wala.core.testdata/src/lambda/ParamsAndCapture.java
+++ b/com.ibm.wala.core.testdata/src/lambda/ParamsAndCapture.java
@@ -1,0 +1,57 @@
+package lambda;
+
+public class ParamsAndCapture {
+
+  static interface A {
+
+    void target();
+  }
+
+  static class C1 implements A {
+
+    @Override
+    public void target() {}
+  }
+
+  static class C2 implements A {
+
+    @Override
+    public void target() {}
+  }
+
+  static class C3 implements A {
+
+    @Override
+    public void target() {}
+  }
+
+  static class C4 implements A {
+
+    @Override
+    public void target() {}
+  }
+
+  static class C5 implements A {
+
+    @Override
+    public void target() {}
+  }
+
+  static interface Params {
+
+    void m(A a1, A a2, A a3);
+  }
+
+  public static void main(String[] args) {
+    A x = new C4(), y = new C5();
+    Params p =
+        (p1, p2, p3) -> {
+          x.target();
+          y.target();
+          p1.target();
+          p2.target();
+          p3.target();
+        };
+    p.m(new C1(), new C2(), new C3());
+  }
+}

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/LambdaTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/LambdaTest.java
@@ -196,13 +196,12 @@ public class LambdaTest extends WalaTestCase {
         CallGraphTestUtil.buildZeroCFA(options, new AnalysisCacheImpl(), cha, scope, false);
 
     Function<String, MethodReference> getTargetRef =
-        (klass) -> {
-          return MethodReference.findOrCreate(
-              TypeReference.findOrCreate(
-                  ClassLoaderReference.Application, "Llambda/ParamsAndCapture$" + klass),
-              Atom.findOrCreateUnicodeAtom("target"),
-              Descriptor.findOrCreateUTF8("()V"));
-        };
+        (klass) ->
+            MethodReference.findOrCreate(
+                TypeReference.findOrCreate(
+                    ClassLoaderReference.Application, "Llambda/ParamsAndCapture$" + klass),
+                Atom.findOrCreateUnicodeAtom("target"),
+                Descriptor.findOrCreateUTF8("()V"));
 
     System.out.println(cg);
     Consumer<String> checkCalledFromOneSite =

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/LambdaTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/LambdaTest.java
@@ -156,13 +156,12 @@ public class LambdaTest extends WalaTestCase {
         CallGraphTestUtil.buildZeroCFA(options, new AnalysisCacheImpl(), cha, scope, false);
 
     Function<String, MethodReference> getTargetRef =
-        (klass) -> {
-          return MethodReference.findOrCreate(
-              TypeReference.findOrCreate(
-                  ClassLoaderReference.Application, "Llambda/MethodRefs$" + klass),
-              Atom.findOrCreateUnicodeAtom("target"),
-              Descriptor.findOrCreateUTF8("()V"));
-        };
+        (klass) ->
+            MethodReference.findOrCreate(
+                TypeReference.findOrCreate(
+                    ClassLoaderReference.Application, "Llambda/MethodRefs$" + klass),
+                Atom.findOrCreateUnicodeAtom("target"),
+                Descriptor.findOrCreateUTF8("()V"));
 
     System.out.println(cg);
     Assert.assertEquals(

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/LambdaSummaryClass.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/LambdaSummaryClass.java
@@ -395,7 +395,7 @@ public class LambdaSummaryClass extends SyntheticClass {
     return method;
   }
 
-  private Dispatch getDispatchForMethodHandleKind(int kind) {
+  private static Dispatch getDispatchForMethodHandleKind(int kind) {
     Dispatch code;
     switch (kind) {
       case REF_INVOKEVIRTUAL:

--- a/com.ibm.wala.dalvik.test/source/com/ibm/wala/dalvik/test/util/Util.java
+++ b/com.ibm.wala.dalvik.test/source/com/ibm/wala/dalvik/test/util/Util.java
@@ -56,8 +56,11 @@ public class Util {
     File f = File.createTempFile("convert", ".dex");
     // f.deleteOnExit();
     System.err.println(f);
+    // pass --min-sdk-version 26 to allow for invokedynamic
     com.android.dx.command.Main.main(
-        new String[] {"--dex", "--output=" + f.getAbsolutePath(), jarFile});
+        new String[] {
+          "--dex", "--min-sdk-version", "26", "--output=" + f.getAbsolutePath(), jarFile
+        });
     return f;
   }
 


### PR DESCRIPTION
This PR fixes two issues with handling of lambdas in WALA:
* handling of method references to constructors (#445)
* handling of cases where the lambda both has parameters and captures values

See the new test cases `testMethodRefs()` and `testParamsAndCapture()`.

As part of the fixes, we significantly refactor the logic for generating trampoline methods in `LambdaSummaryClass` for ease of understanding.

Fixes #445 