### PR TITLE
Minor code clean-ups relating to assignments

### DIFF
--- a/.idea/inspectionProfiles/No_Back_Sliding.xml
+++ b/.idea/inspectionProfiles/No_Back_Sliding.xml
@@ -5,6 +5,7 @@
     <inspection_tool class="Annotator" enabled="false" level="ERROR" enabled_by_default="false" />
     <inspection_tool class="ArrayEquals" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="ArrayHashCode" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="AssignmentUsedAsCondition" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="BashSimpleVarUsage" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="BashUnresolvedVariable" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="BashUnusedFunctionParams" enabled="false" level="WARNING" enabled_by_default="false" />
@@ -58,6 +59,10 @@
     <inspection_tool class="GrMethodMayBeStatic" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="GrUnresolvedAccess" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="GroovyAssignabilityCheck" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="GroovyAssignmentCanBeOperatorAssignment" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoreLazyOperators" value="true" />
+      <option name="ignoreObscureOperators" value="false" />
+    </inspection_tool>
     <inspection_tool class="GroovyPointlessBoolean" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="HtmlTagCanBeJavadocTag" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="HtmlUnknownTag" enabled="false" level="WARNING" enabled_by_default="false">
@@ -148,6 +153,10 @@
     <inspection_tool class="RefusedBequest" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="ignoreEmptySuperMethods" value="false" />
       <option name="onlyReportWhenAnnotated" value="true" />
+    </inspection_tool>
+    <inspection_tool class="ReplaceAssignmentWithOperatorAssignment" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoreLazyOperators" value="true" />
+      <option name="ignoreObscureOperators" value="false" />
     </inspection_tool>
     <inspection_tool class="RequiredAttributes" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="myAdditionalRequiredHtmlAttributes" value="" />

--- a/com.ibm.wala.cast.java.test.data/src/foo/QualifiedNames.java
+++ b/com.ibm.wala.cast.java.test.data/src/foo/QualifiedNames.java
@@ -53,7 +53,7 @@ public class QualifiedNames {
                 x = x / x / x;
 
                 field = 5;
-                field = QualifiedNames.field + field;
+                field += QualifiedNames.field;
                 this.x = 6;
                 QualifiedNames.field = 6;
                 QualifiedNames.this.x = 6;

--- a/com.ibm.wala.core.testdata/build.gradle
+++ b/com.ibm.wala.core.testdata/build.gradle
@@ -285,7 +285,7 @@ tasks.named('clean') {
 //  collect "com.ibm.wala.core.testdata_1.0.0a.jar"
 //
 
-final def collectTestDataA = tasks.register('collectTestDataA', Jar) {
+tasks.register('collectTestDataA', Jar) {
 	archiveFileName.set 'com.ibm.wala.core.testdata_1.0.0a.jar'
 	from compileTestJava
 	from 'classes'

--- a/com.ibm.wala.core.testdata/build.gradle
+++ b/com.ibm.wala.core.testdata/build.gradle
@@ -71,7 +71,7 @@ class CompileKawaJar extends Jar {
 		destinationDirectory.set project.projectDir
 	}
 
-	void setArgs(Object... args) {
+	void args(Object... args) {
 		compile.args args
 	}
 

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/examples/analysis/SimpleThreadEscapeAnalysis.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/examples/analysis/SimpleThreadEscapeAnalysis.java
@@ -127,10 +127,10 @@ public class SimpleThreadEscapeAnalysis
       javaHomePath = System.getProperty("java.home");
 
       if (!javaHomePath.endsWith(File.separator)) {
-        javaHomePath = javaHomePath + File.separator;
+        javaHomePath += File.separator;
       }
 
-      javaHomePath = javaHomePath + "lib";
+      javaHomePath += "lib";
     }
 
     // find jars from chosen JRE lib path

--- a/com.ibm.wala.core/src/com/ibm/wala/classLoader/SourceDirectoryTreeModule.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/classLoader/SourceDirectoryTreeModule.java
@@ -36,7 +36,7 @@ public class SourceDirectoryTreeModule extends DirectoryTreeModule {
   protected FileModule makeFile(File file) {
     String rootPath = root.getAbsolutePath();
     if (!rootPath.endsWith(File.separator)) {
-      rootPath = rootPath + File.separator;
+      rootPath += File.separator;
     }
 
     String filePath = file.getAbsolutePath();

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/SSAPropagationCallGraphBuilder.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/propagation/SSAPropagationCallGraphBuilder.java
@@ -2031,7 +2031,7 @@ public abstract class SSAPropagationCallGraphBuilder extends PropagationCallGrap
           if (cs != null) {
             for (InstanceKey c : cs) {
               if (c != null) {
-                h = h ^ c.hashCode();
+                h ^= c.hashCode();
               }
             }
           }

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/SSABuilder.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/SSABuilder.java
@@ -230,7 +230,7 @@ public class SSABuilder extends AbstractIntStackMachine {
         }
       }
       // check the remaining values
-      for (i = i + 1; i < rhs.length; i++) {
+      for (i++; i < rhs.length; i++) {
         if (rhs[i] != x && rhs[i] != TOP) return false;
       }
       return true;

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/DexSSABuilder.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/DexSSABuilder.java
@@ -253,7 +253,7 @@ public class DexSSABuilder extends AbstractIntRegisterMachine {
         }
       }
       // check the remaining values
-      for (i = i + 1; i < rhs.length; i++) {
+      for (i++; i < rhs.length; i++) {
         if (rhs[i] != x && rhs[i] != TOP) return false;
       }
       return true;

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/StackMapTableWriter.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeCT/StackMapTableWriter.java
@@ -90,7 +90,7 @@ public class StackMapTableWriter extends Element {
     int position = sms.next().getOffset();
     positions[0] = oldToNew.get(position);
     while (sms.hasNext()) {
-      position = position + sms.next().getOffset() + 1;
+      position += sms.next().getOffset() + 1;
       positions[i++] = oldToNew.get(position);
     }
 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/graph/GraphIntegrity.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/graph/GraphIntegrity.java
@@ -171,7 +171,7 @@ public class GraphIntegrity {
         msg = msg + ", 2nd iterator contained " + first;
         return new UnsoundGraphException(msg);
       } else {
-        msg = msg + "set2.size = 0";
+        msg += "set2.size = 0";
         return new UnsoundGraphException(msg);
       }
     }

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/BitVector.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/BitVector.java
@@ -350,7 +350,7 @@ public class BitVector extends BitVectorBase<BitVector> {
     int ai = 0;
     int bi = 0;
     for (ai = 0, bi = 0; ai < bits.length && bi < vector.bits.length; ai++, bi++) {
-      bits[ai] = bits[ai] & (~vector.bits[bi]);
+      bits[ai] &= ~vector.bits[bi];
     }
   }
 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/BitVectorIntSet.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/BitVectorIntSet.java
@@ -315,7 +315,7 @@ public final class BitVectorIntSet implements MutableIntSet {
       }
       for (int i = 0; i < 31; i++) {
         startingIndex++;
-        word = word >>> 1;
+        word >>>= 1;
         if ((word & 0x1) != 0) {
           action.act(startingIndex);
         }

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/Bits.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/Bits.java
@@ -48,7 +48,7 @@ public class Bits {
 
   /** Does an int literal val fit in bits bits? */
   public static boolean fits(int val, int bits) {
-    val = val >> (bits - 1);
+    val >>= bits - 1;
     return (val == 0 || val == -1);
   }
 

--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/OffsetBitVector.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/OffsetBitVector.java
@@ -56,7 +56,7 @@ public final class OffsetBitVector extends BitVectorBase<OffsetBitVector> {
     if (offset < 0) {
       throw new IllegalArgumentException("invalid offset: " + offset);
     }
-    offset = (offset & ~LOW_MASK);
+    offset &= ~LOW_MASK;
     this.offset = offset;
     this.bits = new int[subscript(nbits) + 1];
   }


### PR DESCRIPTION
Prefer operator assignments where possible, such as `x += y` instead of `x = x + y`.

Enable more assignment-related IntelliJ IDEA inspections

In Gradle code, remove an unused assignment, and clean up an inconsistency regarding property setters versus standard methods.