### PR TITLE
Reorganize sections of top-level Gradle build script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,18 +131,6 @@ subprojects { subproject ->
 	}
 }
 
-tasks.register('afterEclipseBuildshipImport', Exec) {
-	commandLine './revert-launchers.sh'
-}
-
-googleJavaFormat {
-	toolVersion = '1.7'
-	// exclude since various tests make assertions based on
-	// source positions in the test inputs.  to auto-format
-	// we also need to update the test assertions
-	exclude 'com.ibm.wala.cast.java.test.data/**/*.java'
-}
-
 
 ////////////////////////////////////////////////////////////////////////
 //
@@ -179,11 +167,41 @@ subprojects {
 }
 
 
+///////////////////////////////////////////////////////////////////////
+//
+//  Javadoc documentation
+//
+
+allprojects {
+	tasks.withType(Javadoc).configureEach {
+		options.addBooleanOption('Xdoclint:all,-missing', true)
+		options.quiet()
+	}
+}
+
+tasks.register('aggregatedJavadocs', Javadoc) {
+	description = 'Generate javadocs from all child projects as if it was a single project'
+	group = 'Documentation'
+	destinationDir = file("$buildDir/docs/javadoc")
+	title = "$project.name $version API"
+	options.author true
+	options.addStringOption 'Xdoclint:none', '-quiet'
+
+	subprojects.each { proj ->
+		proj.tasks.withType(Javadoc).each { javadocTask ->
+			source += javadocTask.source
+			classpath += javadocTask.classpath
+			excludes += javadocTask.excludes
+			includes += javadocTask.includes
+		}
+	}
+}
+
+
 ////////////////////////////////////////////////////////////////////////
 //
 //  linters for various specific languages or file formats
 //
-
 
 // Gradle build scripts
 allprojects {
@@ -198,16 +216,6 @@ allprojects {
 			]
 	}
 }
-
-
-// Javadoc
-allprojects {
-	tasks.withType(Javadoc).configureEach {
-		options.addBooleanOption('Xdoclint:all,-missing', true)
-		options.quiet()
-	}
-}
-
 
 // shell scripts, provided they have ".sh" extension
 tasks.register('shellCheck', Exec) {
@@ -233,7 +241,24 @@ tasks.register('shellCheck', Exec) {
 	}
 }
 
+// Java formatting
+googleJavaFormat {
+	toolVersion = '1.7'
+	// exclude since various tests make assertions based on
+	// source positions in the test inputs.  to auto-format
+	// we also need to update the test assertions
+	exclude 'com.ibm.wala.cast.java.test.data/**/*.java'
+}
 
+// install Java reformatter as git pre-commit hook
+tasks.register('installGitHooks', Copy) {
+	from 'config/hooks/pre-commit-stub'
+	rename { 'pre-commit' }
+	into '.git/hooks'
+	fileMode 0777
+}
+
+// run all known linters
 tasks.register('linters') {
 	group = 'lint'
 	dependsOn(
@@ -248,6 +273,10 @@ tasks.register('linters') {
 //
 //  Eclipse IDE integration
 //
+
+tasks.register('afterEclipseBuildshipImport', Exec) {
+	commandLine './revert-launchers.sh'
+}
 
 // workaround for <https://github.com/gradle/gradle/issues/4802>
 allprojects {
@@ -339,42 +368,9 @@ final def getNativeLibraryOutput(task) {
 
 ////////////////////////////////////////////////////////////////////////
 //
-//  Google Java Format pre-commit hook installation
-//
-
-tasks.register('installGitHooks', Copy) {
-	from 'config/hooks/pre-commit-stub'
-	rename { 'pre-commit' }
-	into '.git/hooks'
-	fileMode 0777
-}
-
-
-////////////////////////////////////////////////////////////////////////
-//
 //  Extra downloads pre-fetcher
 //
 
-
 tasks.register('downloads') {
 	dependsOn allprojects*.tasks*.withType(VerifiedDownload)
-}
-
-tasks.register('aggregatedJavadocs', Javadoc) {
-	description = 'Generate javadocs from all child projects as if it was a single project'
-	group = 'Documentation'
-	destinationDir = file("$buildDir/docs/javadoc")
-	title = "$project.name $version API"
-	options.author true
-	options.links 'http://docs.oracle.com/javase/8/docs/api/'
-	options.addStringOption 'Xdoclint:none', '-quiet'
-
-	subprojects.each { proj ->
-		proj.tasks.withType(Javadoc).each { javadocTask ->
-			source += javadocTask.source
-			classpath += javadocTask.classpath
-			excludes += javadocTask.excludes
-			includes += javadocTask.includes
-		}
-	}
 }


### PR DESCRIPTION
Collect all Javadoc-related material under one new section. Move some Eclipse-related material into the existing Eclipse section. Move some Google Java Format material into the existing linter section.

Nothing very exciting here. This is preparatory clean-up before enacting a few more interesting Gradle changes.