### PR TITLE
Convert to java-library Gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 	id 'com.github.sherter.google-java-format' version '0.8'
 	id 'de.set.ecj' version '1.4.1' apply false
 	id 'de.undercouch.download'
-	id 'nebula.lint' version '9.2.0'
+	id 'nebula.lint' version '11.5.0'
 	id 'nebula.source-jar' version '9.5.0' apply false
 }
 
@@ -192,10 +192,10 @@ allprojects {
 	gradleLint {
 		rules = ['all-dependency']
 		excludedRules = [
-			'duplicate-dependency-class',
-			'transitive-duplicate-dependency-class',
-			'unused-dependency',
-			]
+				// <https://github.com/nebula-plugins/gradle-lint-plugin/issues/203>
+				'undeclared-dependency',
+				'unused-dependency',
+		]
 	}
 }
 
@@ -294,13 +294,17 @@ final def addJvmLibrary(project, recipient) {
 						case 'linux':
 							osIncludeSubdir = 'linux'
 							final def subdirs = ['jre/lib/amd64/server', 'lib/amd64/server', 'lib/server']
-							final def candidates = subdirs.collect { file("$currentJavaHome/$it/libjvm.so") }
+							final def candidates = subdirs.collect {
+								file("$currentJavaHome/$it/libjvm.so")
+							}
 							libJVM = candidates.find { it.exists() }
 							break
 						case 'macos':
 							osIncludeSubdir = 'darwin'
 							final def subdirs = ['jre/lib/server', 'lib/server']
-							final def candidates = subdirs.collect { file("$currentJavaHome/$it/libjvm.dylib") }
+							final def candidates = subdirs.collect {
+								file("$currentJavaHome/$it/libjvm.dylib")
+							}
 							libJVM = candidates.find { it.exists() }
 							break
 						case 'windows':

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ subprojects { subproject ->
 			return
 	}
 
-	apply plugin: 'java'
+	apply plugin: 'java-library'
 	apply plugin: 'nebula.source-jar'
 
 	version rootProject.version

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -3,5 +3,5 @@ repositories {
 }
 
 dependencies {
-	compile 'de.undercouch:gradle-download-task:3.4.3'
+	implementation 'de.undercouch:gradle-download-task:3.4.3'
 }

--- a/com.ibm.wala.cast.java.ecj/build.gradle
+++ b/com.ibm.wala.cast.java.ecj/build.gradle
@@ -1,15 +1,15 @@
 sourceSets.main.java.srcDirs = ['src']
 
 dependencies {
-	compile(
-		project(':com.ibm.wala.cast'),
-		project(':com.ibm.wala.cast.java'),
-		project(':com.ibm.wala.core'),
-		project(':com.ibm.wala.shrike'),
-		project(':com.ibm.wala.util'),
-                'org.eclipse.core:org.eclipse.core.runtime:3.7.0',
-                'org.eclipse.jdt:org.eclipse.jdt.core:3.10.0'
-		)
+	implementation(
+			'org.eclipse.core:org.eclipse.core.runtime:3.7.0',
+			'org.eclipse.jdt:org.eclipse.jdt.core:3.10.0',
+			project(':com.ibm.wala.cast'),
+			project(':com.ibm.wala.cast.java'),
+			project(':com.ibm.wala.core'),
+			project(':com.ibm.wala.shrike'),
+			project(':com.ibm.wala.util'),
+	)
 }
 
 apply from: rootProject.file("gradle-mvn-push.gradle")

--- a/com.ibm.wala.cast.java.test/build.gradle
+++ b/com.ibm.wala.cast.java.test/build.gradle
@@ -11,16 +11,16 @@ sourceSets.test {
 }
 
 dependencies {
-	testCompile(
-		'junit:junit:4.12',
-		'org.osgi:org.osgi.core:4.2.0',
-		project(':com.ibm.wala.cast'),
-		project(':com.ibm.wala.cast.java'),
-		project(':com.ibm.wala.core'),
-		project(':com.ibm.wala.shrike'),
-		project(':com.ibm.wala.util'),
-		project(configuration: 'testArchives', path: ':com.ibm.wala.core.tests'),
-		)
+	testImplementation(
+			'junit:junit:4.12',
+			'org.osgi:org.osgi.core:4.2.0',
+			project(':com.ibm.wala.cast'),
+			project(':com.ibm.wala.cast.java'),
+			project(':com.ibm.wala.core'),
+			project(':com.ibm.wala.shrike'),
+			project(':com.ibm.wala.util'),
+			project(configuration: 'testArchives', path: ':com.ibm.wala.core.tests'),
+	)
 }
 
 tasks.named('test') {

--- a/com.ibm.wala.cast.java/build.gradle
+++ b/com.ibm.wala.cast.java/build.gradle
@@ -7,12 +7,12 @@ eclipse.project.natures 'org.eclipse.pde.PluginNature'
 sourceSets.main.java.srcDirs = ['src']
 
 dependencies {
-	compile(
-		project(':com.ibm.wala.cast'),
-		project(':com.ibm.wala.core'),
-		project(':com.ibm.wala.shrike'),
-		project(':com.ibm.wala.util'),
-		)
+	implementation(
+			project(':com.ibm.wala.cast'),
+			project(':com.ibm.wala.core'),
+			project(':com.ibm.wala.shrike'),
+			project(':com.ibm.wala.util'),
+	)
 }
 
 apply from: rootProject.file("gradle-mvn-push.gradle")

--- a/com.ibm.wala.cast.js.html.nu_validator/build.gradle
+++ b/com.ibm.wala.cast.js.html.nu_validator/build.gradle
@@ -4,18 +4,19 @@ sourceSets {
 }
 
 dependencies {
-	compile(
-		'nu.validator.htmlparser:htmlparser:1.4',
-		project(':com.ibm.wala.cast'),
-		project(':com.ibm.wala.cast.js'),
-		project(':com.ibm.wala.util'),
-		)
-	testCompile(
-		project(':com.ibm.wala.cast.test'),
-		project(':com.ibm.wala.core.tests'),
-		project(configuration: 'testArchives', path: ':com.ibm.wala.cast.js.rhino.test'),
-		project(configuration: 'testArchives', path: ':com.ibm.wala.cast.js.test'),
-		)
+	implementation(
+			'nu.validator.htmlparser:htmlparser:1.4',
+			project(':com.ibm.wala.cast'),
+			project(':com.ibm.wala.cast.js'),
+			project(':com.ibm.wala.util')
+	)
+	testImplementation(
+			project(':com.ibm.wala.cast.test'),
+			project(':com.ibm.wala.cast.js.test'),
+			project(':com.ibm.wala.core.tests'),
+			project(configuration: 'testArchives', path: ':com.ibm.wala.cast.js.rhino.test'),
+			project(configuration: 'testArchives', path: ':com.ibm.wala.cast.js.test'),
+	)
 }
 
 tasks.named('processTestResources') {

--- a/com.ibm.wala.cast.js.nodejs.test/build.gradle
+++ b/com.ibm.wala.cast.js.nodejs.test/build.gradle
@@ -4,11 +4,11 @@ sourceSets.test {
 }
 
 dependencies {
-	testCompile(
-		'junit:junit:4.12',
-		project(':com.ibm.wala.cast.js.nodejs'),
-		project(':com.ibm.wala.core'),
-		)
+	testImplementation(
+			'junit:junit:4.12',
+			project(':com.ibm.wala.cast.js.nodejs'),
+			project(':com.ibm.wala.core'),
+	)
 }
 
 tasks.named('test') {

--- a/com.ibm.wala.cast.js.nodejs/build.gradle
+++ b/com.ibm.wala.cast.js.nodejs/build.gradle
@@ -1,13 +1,15 @@
 dependencies {
-	compile(
-		'commons-io:commons-io:2.4',
-		'org.json:json:20160212',
-		project(':com.ibm.wala.cast'),
-		project(':com.ibm.wala.cast.js'),
-		project(':com.ibm.wala.cast.js.rhino'),
-		project(':com.ibm.wala.core'),
-		project(':com.ibm.wala.util'),
-		)
+	api(project(':com.ibm.wala.cast.js')) {
+		because 'public class NodejsCallGraphBuilderUtil extends class JSCallGraphUtil'
+	}
+	implementation(
+			'commons-io:commons-io:2.4',
+			'org.json:json:20160212',
+			project(':com.ibm.wala.cast'),
+			project(':com.ibm.wala.cast.js.rhino'),
+			project(':com.ibm.wala.core'),
+			project(':com.ibm.wala.util'),
+	)
 }
 
 final def downloadNodeJS = tasks.register('downloadNodeJS', VerifiedDownload) {

--- a/com.ibm.wala.cast.js.rhino.test/build.gradle
+++ b/com.ibm.wala.cast.js.rhino.test/build.gradle
@@ -5,20 +5,24 @@ plugins {
 sourceSets.test.java.srcDirs = ['harness-src']
 
 dependencies {
-	testCompile(
-		'junit:junit:4.12',
-		'commons-io:commons-io:2.4',
-		'net.htmlparser.jericho:jericho-html:3.2',
-		project(':com.ibm.wala.cast'),
-		project(':com.ibm.wala.cast.js'),
-		project(':com.ibm.wala.cast.js.rhino'),
-		project(':com.ibm.wala.core'),
-		project(':com.ibm.wala.shrike'),
-		project(':com.ibm.wala.util'),
-		project(configuration: 'testArchives', path: ':com.ibm.wala.cast.js.test'),
-		project(configuration: 'testArchives', path: ':com.ibm.wala.cast.test'),
-		project(configuration: 'testArchives', path: ':com.ibm.wala.core.tests'),
-		)
+	testArchives(
+			'junit:junit:4.12',
+			project(':com.ibm.wala.cast.js.rhino'),
+	)
+	testImplementation(
+			'commons-io:commons-io:2.4',
+			'junit:junit:4.12',
+			'net.htmlparser.jericho:jericho-html:3.2',
+			project(':com.ibm.wala.cast'),
+			project(':com.ibm.wala.cast.js'),
+			project(':com.ibm.wala.cast.js.rhino'),
+			project(':com.ibm.wala.core'),
+			project(':com.ibm.wala.shrike'),
+			project(':com.ibm.wala.util'),
+			project(configuration: 'testArchives', path: ':com.ibm.wala.cast.js.test'),
+			project(configuration: 'testArchives', path: ':com.ibm.wala.cast.test'),
+			project(configuration: 'testArchives', path: ':com.ibm.wala.core.tests'),
+	)
 }
 
 tasks.named('processTestResources') {

--- a/com.ibm.wala.cast.js.rhino/build.gradle
+++ b/com.ibm.wala.cast.js.rhino/build.gradle
@@ -1,13 +1,13 @@
 sourceSets.main.java.srcDirs = ['source']
 
 dependencies {
-	compile(
-		'org.mozilla:rhino:1.7.10',
-		project(':com.ibm.wala.cast'),
-		project(':com.ibm.wala.cast.js'),
-		project(':com.ibm.wala.core'),
-		project(':com.ibm.wala.util'),
-		)
+	implementation(
+			'org.mozilla:rhino:1.7.10',
+			project(':com.ibm.wala.cast'),
+			project(':com.ibm.wala.cast.js'),
+			project(':com.ibm.wala.core'),
+			project(':com.ibm.wala.util'),
+	)
 }
 
 apply from: rootProject.file("gradle-mvn-push.gradle")

--- a/com.ibm.wala.cast.js.test/build.gradle
+++ b/com.ibm.wala.cast.js.test/build.gradle
@@ -5,19 +5,19 @@ plugins {
 sourceSets.test.java.srcDirs = ['harness-src']
 
 dependencies {
-	testCompile(
-		'junit:junit:4.12',
-		'commons-io:commons-io:2.4',
-		'net.htmlparser.jericho:jericho-html:3.2',
-		project(':com.ibm.wala.cast'),
-		project(':com.ibm.wala.cast.js'),
-		project(':com.ibm.wala.cast.js.rhino'),
-		project(':com.ibm.wala.core'),
-		project(':com.ibm.wala.shrike'),
-		project(':com.ibm.wala.util'),
-		project(configuration: 'testArchives', path: ':com.ibm.wala.cast.test'),
-		project(configuration: 'testArchives', path: ':com.ibm.wala.core.tests'),
-		)
+	testImplementation(
+			'commons-io:commons-io:2.4',
+			'junit:junit:4.12',
+			'net.htmlparser.jericho:jericho-html:3.2',
+			project(':com.ibm.wala.cast'),
+			project(':com.ibm.wala.cast.js'),
+			project(':com.ibm.wala.cast.js.rhino'),
+			project(':com.ibm.wala.core'),
+			project(':com.ibm.wala.shrike'),
+			project(':com.ibm.wala.util'),
+			project(configuration: 'testArchives', path: ':com.ibm.wala.cast.test'),
+			project(configuration: 'testArchives', path: ':com.ibm.wala.core.tests'),
+	)
 }
 
 tasks.named('processTestResources') {

--- a/com.ibm.wala.cast.js/build.gradle
+++ b/com.ibm.wala.cast.js/build.gradle
@@ -4,14 +4,16 @@ sourceSets.main {
 }
 
 dependencies {
-	compile(
-		'commons-io:commons-io:2.4',
-		'net.htmlparser.jericho:jericho-html:3.2',
-		project(':com.ibm.wala.cast'),
-		project(':com.ibm.wala.core'),
-		project(':com.ibm.wala.shrike'),
-		project(':com.ibm.wala.util'),
-		)
+	api(project(':com.ibm.wala.cast')) {
+		because 'public class JSCallGraphUtil extends class CAstCallGraphUtil'
+	}
+	implementation(
+			'commons-io:commons-io:2.4',
+			'net.htmlparser.jericho:jericho-html:3.2',
+			project(':com.ibm.wala.core'),
+			project(':com.ibm.wala.shrike'),
+			project(':com.ibm.wala.util'),
+	)
 }
 
 tasks.register('createPackageList', CreatePackageList) {

--- a/com.ibm.wala.cast.test/build.gradle
+++ b/com.ibm.wala.cast.test/build.gradle
@@ -18,12 +18,17 @@ tasks.named('compileTestJava') {
 }
 
 dependencies {
-	testCompile(
-		'junit:junit:4.12',
-		project(':com.ibm.wala.cast'),
-		project(':com.ibm.wala.core'),
-		project(':com.ibm.wala.util'),
-		)
+/*
+	api(project(configuration: 'testArchives', path: ':com.ibm.wala.core.tests')) {
+		because 'public class TestCallGraphShape extends class WalaTestCase'
+	}
+*/
+	testImplementation(
+			'junit:junit:4.12',
+			project(':com.ibm.wala.cast'),
+			project(':com.ibm.wala.core'),
+			project(':com.ibm.wala.util'),
+	)
 }
 
 tasks.named('test') {

--- a/com.ibm.wala.cast.test/smoke_main/build.gradle
+++ b/com.ibm.wala.cast.test/smoke_main/build.gradle
@@ -1,61 +1,62 @@
 plugins {
-    id 'cpp-application'
+	id 'cpp-application'
 }
 
 evaluationDependsOn(':com.ibm.wala.cast.test:xlator_test')
 
 application {
-    source.from "../harness-src/c/${project.name}.cpp"
+	source.from "../harness-src/c/${project.name}.cpp"
 
-    dependencies {
-        implementation project(':com.ibm.wala.cast.test:xlator_test')
-    }
+	dependencies {
+		implementation project(':com.ibm.wala.cast:cast')
+		implementation project(':com.ibm.wala.cast.test:xlator_test')
+	}
 
-    addCastLibrary(project, it)
+	addCastLibrary(project, it)
 
-    binaries.whenElementFinalized { binary ->
-        binary.linkTask.get().configure { linkTask ->
-            final def libxlator_test = getNativeLibraryOutput(project(':com.ibm.wala.cast.test:xlator_test').tasks.getByName(linkTask.name))
-            addRpath(linkTask, libxlator_test)
+	binaries.whenElementFinalized { binary ->
+		binary.linkTask.get().configure { linkTask ->
+			final def libxlator_test = getNativeLibraryOutput(project(':com.ibm.wala.cast.test:xlator_test').tasks.getByName(linkTask.name))
+			addRpath(linkTask, libxlator_test)
 
-            if (binary.debuggable && !binary.optimized) {
-                tasks.register('checkSmoke_main', Exec) {
-                    dependsOn linkTask
+			if (binary.debuggable && !binary.optimized) {
+				tasks.register('checkSmoke_main', Exec) {
+					dependsOn linkTask
 
-                    // main executable to run for test
-                    def executableBinary = binary.executableFile.get()
-                    executable executableBinary
+					// main executable to run for test
+					def executableBinary = binary.executableFile.get()
+					executable executableBinary
 
-                    // xlator Java bytecode + implementation of native methods
-                    def pathElements = ['../build/classes/java/test', libxlator_test.parent]
+					// xlator Java bytecode + implementation of native methods
+					def pathElements = ['../build/classes/java/test', libxlator_test.parent]
 
-                    // "primordial.txt" resource loaded during test
-                    def coreResources = project(':com.ibm.wala.core').processResources
-                    dependsOn coreResources
-                    pathElements << coreResources.destinationDir
+					// "primordial.txt" resource loaded during test
+					def coreResources = project(':com.ibm.wala.core').processResources
+					dependsOn coreResources
+					pathElements << coreResources.destinationDir
 
-                    // additional supporting Java class files
-                    ['cast', 'core', 'util'].each {
-                        def compileJava = project(":com.ibm.wala.$it").compileJava
-                        dependsOn compileJava
-                        pathElements << compileJava.destinationDir
-                    }
+					// additional supporting Java class files
+					['cast', 'core', 'util'].each {
+						def compileJava = project(":com.ibm.wala.$it").compileJava
+						dependsOn compileJava
+						pathElements << compileJava.destinationDir
+					}
 
-                    // all combined as a colon-delimited path list
-                    args pathElements.join(':')
+					// all combined as a colon-delimited path list
+					args pathElements.join(':')
 
-                    // log output to file, although we don't validate it
-                    final def outFile = file("$temporaryDir/stdout-and-stderr.log")
-                    outputs.file outFile
-                    doFirst {
-                        final def fileStream = new FileOutputStream(outFile)
-                        standardOutput fileStream
-                        errorOutput fileStream
-                    }
-                }
+					// log output to file, although we don't validate it
+					final def outFile = file("$temporaryDir/stdout-and-stderr.log")
+					outputs.file outFile
+					doFirst {
+						final def fileStream = new FileOutputStream(outFile)
+						standardOutput fileStream
+						errorOutput fileStream
+					}
+				}
 
-                check.dependsOn checkSmoke_main
-            }
-        }
-    }
+				check.dependsOn checkSmoke_main
+			}
+		}
+	}
 }

--- a/com.ibm.wala.cast.test/xlator_test/build.gradle
+++ b/com.ibm.wala.cast.test/xlator_test/build.gradle
@@ -7,7 +7,7 @@ library {
     source.from '../harness-src/c/smoke.cpp'
 
     dependencies {
-        api project(':com.ibm.wala.cast:cast')
+        implementation project(':com.ibm.wala.cast:cast')
     }
 
     addCastLibrary(project, it)

--- a/com.ibm.wala.cast/build.gradle
+++ b/com.ibm.wala.cast/build.gradle
@@ -7,9 +7,11 @@ eclipse.project.natures 'org.eclipse.pde.PluginNature'
 sourceSets.main.java.srcDirs = ['source/java']
 
 dependencies {
+	api(project(':com.ibm.wala.core')) {
+		because 'public method AstCGNode.addTarget receives an argument of type CGNode'
+	}
 	implementation(
 			'commons-io:commons-io:2.4',
-			project(':com.ibm.wala.core'),
 			project(':com.ibm.wala.shrike'),
 			project(':com.ibm.wala.util'),
 	)
@@ -32,7 +34,7 @@ tasks.named('javadoc') {
 // in "META-INF/MANIFEST.MF" and "build.properties"
 
 tasks.register('copyJarsIntoLib', Sync) {
-	def commonsIoJar = configurations.runtimeClasspath.files[0]
+	def commonsIoJar = configurations.runtimeClasspath.files[1]
 	assert commonsIoJar.name.startsWith('commons-io-')
 	from commonsIoJar
 	into 'lib'

--- a/com.ibm.wala.cast/build.gradle
+++ b/com.ibm.wala.cast/build.gradle
@@ -7,12 +7,12 @@ eclipse.project.natures 'org.eclipse.pde.PluginNature'
 sourceSets.main.java.srcDirs = ['source/java']
 
 dependencies {
-	compile(
-		'commons-io:commons-io:2.4',
-		project(':com.ibm.wala.core'),
-		project(':com.ibm.wala.shrike'),
-		project(':com.ibm.wala.util'),
-		)
+	implementation(
+			'commons-io:commons-io:2.4',
+			project(':com.ibm.wala.core'),
+			project(':com.ibm.wala.shrike'),
+			project(':com.ibm.wala.util'),
+	)
 }
 
 tasks.named('javadoc') {

--- a/com.ibm.wala.core.tests/build.gradle
+++ b/com.ibm.wala.core.tests/build.gradle
@@ -11,15 +11,16 @@ sourceSets.test {
 }
 
 dependencies {
-	testCompile(
-		'junit:junit:4.12',
-		'org.apache.ant:ant:1.8.2',
-		'org.hamcrest:hamcrest-core:1.3',
-		'org.osgi:org.osgi.core:4.2.0',
-		project(':com.ibm.wala.core'),
-		project(':com.ibm.wala.shrike'),
-		project(':com.ibm.wala.util'),
-		)
+	testArchives 'org.apache.ant:ant:1.8.2'
+	testImplementation(
+			'junit:junit:4.12',
+			'org.apache.ant:ant:1.8.2',
+			'org.hamcrest:hamcrest-core:1.3',
+			'org.osgi:org.osgi.core:4.2.0',
+			project(':com.ibm.wala.core'),
+			project(':com.ibm.wala.shrike'),
+			project(':com.ibm.wala.util'),
+	)
 }
 
 tasks.named('processTestResources') {
@@ -41,21 +42,21 @@ tasks.named('test') {
 	systemProperty 'com.ibm.wala.junit.analyzingJar', 'true'
 	systemProperty 'com.ibm.wala.junit.profile', 'short'
 	classpath += files project(':com.ibm.wala.core.testdata').sourceSets.test.java.outputDir
-        testLogging {
-            exceptionFormat = 'full'
-        }
-        // temporarily turn off some tests on JDK 11
-        if (JavaVersion.current() == JavaVersion.VERSION_11) {
-           exclude '**/callGraph/CallGraphTest.class'
-           exclude '**/callGraph/Java7CallGraphTest.class'
-           exclude '**/callGraph/CloneTest.class'
-           exclude '**/callGraph/DebuggingBitsetCallGraphTest.class'
-           exclude '**/callGraph/KawaCallGraphTest.class'
-           exclude '**/exceptionpruning/ExceptionAnalysisTest.class'
-           exclude '**/exceptionpruning/ExceptionAnalysis2EdgeFilterTest.class'
-           exclude '**/cha/LibraryVersionTest.class'
-           exclude '**/ir/TypeAnnotationTest.class'
-        }
+	testLogging {
+		exceptionFormat = 'full'
+	}
+	// temporarily turn off some tests on JDK 11
+	if (JavaVersion.current() == JavaVersion.VERSION_11) {
+		exclude '**/callGraph/CallGraphTest.class'
+		exclude '**/callGraph/Java7CallGraphTest.class'
+		exclude '**/callGraph/CloneTest.class'
+		exclude '**/callGraph/DebuggingBitsetCallGraphTest.class'
+		exclude '**/callGraph/KawaCallGraphTest.class'
+		exclude '**/exceptionpruning/ExceptionAnalysisTest.class'
+		exclude '**/exceptionpruning/ExceptionAnalysis2EdgeFilterTest.class'
+		exclude '**/cha/LibraryVersionTest.class'
+		exclude '**/ir/TypeAnnotationTest.class'
+	}
 }
 
 tasks.register('cleanTestExtras', Delete) {

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cha/MissingMethodRefTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/cha/MissingMethodRefTest.java
@@ -16,7 +16,6 @@ import com.ibm.wala.core.tests.util.WalaTestCase;
 import com.ibm.wala.ipa.callgraph.AnalysisCacheImpl;
 import com.ibm.wala.ipa.callgraph.AnalysisOptions;
 import com.ibm.wala.ipa.callgraph.AnalysisScope;
-import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.ibm.wala.ipa.callgraph.Entrypoint;
 import com.ibm.wala.ipa.cha.ClassHierarchy;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
@@ -44,7 +43,6 @@ public class MissingMethodRefTest extends WalaTestCase {
     AnalysisOptions options = CallGraphTestUtil.makeAnalysisOptions(scope, entrypoints);
 
     // should not throw an NPE
-    CallGraph cg =
-        CallGraphTestUtil.buildZeroCFA(options, new AnalysisCacheImpl(), cha, scope, false);
+    CallGraphTestUtil.buildZeroCFA(options, new AnalysisCacheImpl(), cha, scope, false);
   }
 }

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -6,20 +6,22 @@ eclipse.project.natures 'org.eclipse.pde.PluginNature'
 
 sourceSets.main {
 	java {
-	     srcDir 'src'
-	     exclude 'wala.properties'
+		srcDir 'src'
+		exclude 'wala.properties'
 	}
 	resources.srcDirs = [
-		'dat',
-		'lib',
+			'dat',
+			'lib',
 	]
 }
 
 dependencies {
-	compile(
-		project(':com.ibm.wala.shrike'),
-		project(':com.ibm.wala.util'),
-		)
+	api(project(':com.ibm.wala.shrike')) {
+		because 'public class Entrypoint implements interface BytecodeConstraints'
+	}
+	api(project(':com.ibm.wala.util')) {
+		because 'public interface CallGraph extends interface NumberedGraph'
+	}
 }
 
 tasks.named('javadoc') {

--- a/com.ibm.wala.dalvik.test/build.gradle
+++ b/com.ibm.wala.dalvik.test/build.gradle
@@ -150,17 +150,18 @@ configurations {
 
 dependencies {
 	sampleCup 'java_cup:java_cup:0.9e:sources'
-	testCompile(
-		'junit:junit:4.12',
-		'org.osgi:org.osgi.core:4.2.0',
-		files("${copyDxJar.get().destinationDir}/dx.jar"),
-		project(':com.ibm.wala.core'),
-		project(':com.ibm.wala.dalvik'),
-		project(':com.ibm.wala.shrike'),
-		project(':com.ibm.wala.util'),
-		project(configuration: 'testArchives', path: ':com.ibm.wala.core.tests'),
-		)
-	testRuntime files("${copyAndroidJar.destinationDir}/android.jar")
+	testImplementation(
+			'junit:junit:4.12',
+			'org.osgi:org.osgi.core:4.2.0',
+			'org.smali:dexlib2:2.2.6',
+			files("${copyDxJar.get().destinationDir}/dx.jar"),
+			project(':com.ibm.wala.core'),
+			project(':com.ibm.wala.dalvik'),
+			project(':com.ibm.wala.shrike'),
+			project(':com.ibm.wala.util'),
+			project(configuration: 'testArchives', path: ':com.ibm.wala.core.tests'),
+	)
+	testRuntimeOnly files("${copyAndroidJar.destinationDir}/android.jar")
 }
 
 tasks.named('processTestResources') {

--- a/com.ibm.wala.dalvik/build.gradle
+++ b/com.ibm.wala.dalvik/build.gradle
@@ -1,13 +1,13 @@
 sourceSets.main.java.srcDirs = ['src']
 
 dependencies {
-	compile(
-		'org.slf4j:slf4j-api:1.7.2',
-		'org.smali:dexlib2:2.2.6',
-		project(':com.ibm.wala.core'),
-		project(':com.ibm.wala.shrike'),
-		project(':com.ibm.wala.util'),
-		)
+	implementation(
+			'org.slf4j:slf4j-api:1.7.2',
+			'org.smali:dexlib2:2.2.6',
+			project(':com.ibm.wala.core'),
+			project(':com.ibm.wala.shrike'),
+			project(':com.ibm.wala.util'),
+	)
 }
 
 tasks.register('createPackageList', CreatePackageList) {

--- a/com.ibm.wala.ide.jdt.test/build.gradle
+++ b/com.ibm.wala.ide.jdt.test/build.gradle
@@ -4,28 +4,26 @@ sourceSets.test {
 }
 
 dependencies {
-	testCompile(
-		'eclipse-deps:org.eclipse.core.runtime:+',
-		'eclipse-deps:org.eclipse.jdt.core:+',
-		'eclipse-deps:org.eclipse.osgi:+',
-		'junit:junit:4.12',
-		'org.osgi:org.osgi.core:4.2.0',
-		project(':com.ibm.wala.cast'),
-		project(':com.ibm.wala.cast.java'),
-		project(':com.ibm.wala.cast.java.ecj'),
-		project(':com.ibm.wala.core'),
-		project(':com.ibm.wala.ide'),
-		project(':com.ibm.wala.ide.jdt'),
-		project(':com.ibm.wala.shrike'),
-		project(':com.ibm.wala.util'),
-		project(configuration: 'testArchives', path: ':com.ibm.wala.cast.java.test'),
-		project(configuration: 'testArchives', path: ':com.ibm.wala.core.tests'),
-		project(configuration: 'testArchives', path: ':com.ibm.wala.ide.tests'),
-		)
-	testRuntime(
-		'eclipse-deps:org.eclipse.core.contenttype:+',
-		'eclipse-deps:org.eclipse.equinox.preferences:+',
-		)
+	testImplementation(
+			'eclipse-deps:org.eclipse.core.runtime:+',
+			'eclipse-deps:org.eclipse.jdt.core:+',
+			'eclipse-deps:org.eclipse.osgi:+',
+			'junit:junit:4.12',
+			'org.osgi:org.osgi.core:4.2.0',
+			project(':com.ibm.wala.cast'),
+			project(':com.ibm.wala.cast.java'),
+			project(':com.ibm.wala.cast.java.ecj'),
+			project(':com.ibm.wala.core'),
+			project(':com.ibm.wala.ide'),
+			project(':com.ibm.wala.ide.jdt'),
+			project(':com.ibm.wala.shrike'),
+			project(':com.ibm.wala.util'),
+			project(configuration: 'testArchives', path: ':com.ibm.wala.cast.java.test'),
+			project(configuration: 'testArchives', path: ':com.ibm.wala.core.tests'),
+			project(configuration: 'testArchives', path: ':com.ibm.wala.ide.tests'),
+			'eclipse-deps:org.eclipse.core.contenttype:+',
+			'eclipse-deps:org.eclipse.equinox.preferences:+',
+	)
 }
 
 tasks.named('test') {

--- a/com.ibm.wala.ide.jdt/build.gradle
+++ b/com.ibm.wala.ide.jdt/build.gradle
@@ -1,22 +1,24 @@
 sourceSets.main.java.srcDirs = ['source']
 
 dependencies {
-	compile(
-		'eclipse-deps:org.eclipse.core.jobs:+',
-		'eclipse-deps:org.eclipse.core.resources:+',
-		'eclipse-deps:org.eclipse.core.runtime:+',
-		'eclipse-deps:org.eclipse.equinox.app:+',
-		'eclipse-deps:org.eclipse.equinox.common:+',
-		'eclipse-deps:org.eclipse.jdt.core:+',
-		'eclipse-deps:org.eclipse.jface:+',
-		'eclipse-deps:org.eclipse.osgi:+',
-		'eclipse-deps:org.eclipse.ui.workbench:+',
-		'org.osgi:org.osgi.core:4.2.0',
-		project(':com.ibm.wala.cast'),
-		project(':com.ibm.wala.cast.java'),
-		project(':com.ibm.wala.cast.java.ecj'),
-		project(':com.ibm.wala.core'),
-		project(':com.ibm.wala.ide'),
-		project(':com.ibm.wala.util'),
-		)
+	api('eclipse-deps:org.eclipse.equinox.common:+') {
+		because 'protected method createProjectPath in public class JDTJavaSourceAnalysisEngine may throw exception CoreException'
+	}
+	implementation(
+			'eclipse-deps:org.eclipse.core.jobs:+',
+			'eclipse-deps:org.eclipse.core.resources:+',
+			'eclipse-deps:org.eclipse.core.runtime:+',
+			'eclipse-deps:org.eclipse.equinox.app:+',
+			'eclipse-deps:org.eclipse.jdt.core:+',
+			'eclipse-deps:org.eclipse.jface:+',
+			'eclipse-deps:org.eclipse.osgi:+',
+			'eclipse-deps:org.eclipse.ui.workbench:+',
+			'org.osgi:org.osgi.core:4.2.0',
+			project(':com.ibm.wala.cast'),
+			project(':com.ibm.wala.cast.java'),
+			project(':com.ibm.wala.cast.java.ecj'),
+			project(':com.ibm.wala.core'),
+			project(':com.ibm.wala.ide'),
+			project(':com.ibm.wala.util'),
+	)
 }

--- a/com.ibm.wala.ide.jsdt.tests/build.gradle
+++ b/com.ibm.wala.ide.jsdt.tests/build.gradle
@@ -4,21 +4,21 @@ sourceSets.test {
 }
 
 dependencies {
-	testCompile(
-		'eclipse-deps:org.eclipse.core.runtime:+',
-		'eclipse-deps:org.eclipse.equinox.common:+',
-		'eclipse-deps:org.eclipse.osgi:+',
-		'junit:junit:4.12',
-		'org.osgi:org.osgi.core:4.2.0',
-		'wst-deps:org.eclipse.wst.jsdt.core:+',
-		project(':com.ibm.wala.cast'),
-		project(':com.ibm.wala.cast.js'),
-		project(':com.ibm.wala.cast.js.rhino'),
-		project(':com.ibm.wala.core'),
-		project(':com.ibm.wala.ide.jsdt'),
-		project(':com.ibm.wala.util'),
-		project(configuration: 'testArchives', path: ':com.ibm.wala.ide.tests'),
-		)
+	testImplementation(
+			'eclipse-deps:org.eclipse.core.runtime:+',
+			'eclipse-deps:org.eclipse.equinox.common:+',
+			'eclipse-deps:org.eclipse.osgi:+',
+			'junit:junit:4.12',
+			'org.osgi:org.osgi.core:4.2.0',
+			'wst-deps:org.eclipse.wst.jsdt.core:+',
+			project(':com.ibm.wala.cast'),
+			project(':com.ibm.wala.cast.js'),
+			project(':com.ibm.wala.cast.js.rhino'),
+			project(':com.ibm.wala.core'),
+			project(':com.ibm.wala.ide.jsdt'),
+			project(':com.ibm.wala.util'),
+			project(configuration: 'testArchives', path: ':com.ibm.wala.ide.tests'),
+	)
 }
 
 tasks.named('test') {

--- a/com.ibm.wala.ide.jsdt/build.gradle
+++ b/com.ibm.wala.ide.jsdt/build.gradle
@@ -1,19 +1,22 @@
 sourceSets.main.java.srcDirs = ['source']
 
 dependencies {
-	compile(
-		'eclipse-deps:org.eclipse.core.resources:+',
-		'eclipse-deps:org.eclipse.core.runtime:+',
-		'eclipse-deps:org.eclipse.equinox.common:+',
-		'eclipse-deps:org.eclipse.osgi:+',
-		'eclipse-deps:org.eclipse.ui.workbench:+',
-		'wst-deps:org.eclipse.wst.jsdt.core:+',
-		'wst-deps:org.eclipse.wst.jsdt.ui:+',
-		project(':com.ibm.wala.cast'),
-		project(':com.ibm.wala.cast.js'),
-		project(':com.ibm.wala.cast.js.rhino'),
-		project(':com.ibm.wala.core'),
-		project(':com.ibm.wala.ide'),
-		project(':com.ibm.wala.util'),
-		)
+	api(project(':com.ibm.wala.ide')) {
+		because 'public class JavaScriptHeadlessUtil extends class HeadlessUtil'
+	}
+	implementation(
+			'eclipse-deps:org.eclipse.core.jobs:+',
+			'eclipse-deps:org.eclipse.core.resources:+',
+			'eclipse-deps:org.eclipse.core.runtime:+',
+			'eclipse-deps:org.eclipse.equinox.common:+',
+			'eclipse-deps:org.eclipse.osgi:+',
+			'eclipse-deps:org.eclipse.ui.workbench:+',
+			'wst-deps:org.eclipse.wst.jsdt.core:+',
+			'wst-deps:org.eclipse.wst.jsdt.ui:+',
+			project(':com.ibm.wala.cast'),
+			project(':com.ibm.wala.cast.js'),
+			project(':com.ibm.wala.cast.js.rhino'),
+			project(':com.ibm.wala.core'),
+			project(':com.ibm.wala.util'),
+	)
 }

--- a/com.ibm.wala.ide.tests/build.gradle
+++ b/com.ibm.wala.ide.tests/build.gradle
@@ -8,19 +8,21 @@ eclipse.project.natures 'org.eclipse.pde.PluginNature'
 sourceSets.test.java.srcDirs = ['src']
 
 dependencies {
-	testCompile(
-		'eclipse-deps:org.eclipse.core.resources:+',
-		'eclipse-deps:org.eclipse.core.runtime:+',
-		'eclipse-deps:org.eclipse.equinox.common:+',
-		'eclipse-deps:org.eclipse.jface:+',
-		'eclipse-deps:org.eclipse.osgi:+',
-		'eclipse-deps:org.eclipse.ui.ide:+',
-		'eclipse-deps:org.eclipse.ui.workbench:+',
-		'org.osgi:org.osgi.core:4.2.0',
-		project(':com.ibm.wala.core'),
-		project(':com.ibm.wala.ide'),
-		project(':com.ibm.wala.util'),
-		project(configuration: 'testArchives', path: ':com.ibm.wala.core.tests'),
-		)
-	testRuntime project(':com.ibm.wala.ide.jdt')
+	testImplementation(
+			'eclipse-deps:org.eclipse.core.commands:+',
+			'eclipse-deps:org.eclipse.core.jobs:+',
+			'eclipse-deps:org.eclipse.core.resources:+',
+			'eclipse-deps:org.eclipse.core.runtime:+',
+			'eclipse-deps:org.eclipse.equinox.common:+',
+			'eclipse-deps:org.eclipse.jface:+',
+			'eclipse-deps:org.eclipse.osgi:+',
+			'eclipse-deps:org.eclipse.ui.ide:+',
+			'eclipse-deps:org.eclipse.ui.workbench:+',
+			'org.osgi:org.osgi.core:4.2.0',
+			project(':com.ibm.wala.core'),
+			project(':com.ibm.wala.ide'),
+			project(':com.ibm.wala.util'),
+			project(configuration: 'testArchives', path: ':com.ibm.wala.core.tests'),
+	)
+	testRuntimeOnly project(':com.ibm.wala.ide.jdt')
 }

--- a/com.ibm.wala.ide/build.gradle
+++ b/com.ibm.wala.ide/build.gradle
@@ -7,6 +7,9 @@ eclipse.project.natures 'org.eclipse.pde.PluginNature'
 sourceSets.main.java.srcDirs = ['src']
 
 dependencies {
+	api('eclipse-deps:org.eclipse.pde.core:+') {
+		because 'otherwise ECJ fails to compile "JavaScriptEclipseProjectPath.java" and "JavaEclipseProjectPath.java", reporting that org.eclipse.pde.core.plugin.IPluginModelBase cannot be resolved, even though IPluginModelBase is only used by local variables and private methods within "EclipseProjectPath.java"'
+	}
 	implementation(
 			'eclipse-deps:org.eclipse.core.commands:+',
 			'eclipse-deps:org.eclipse.core.jobs:+',
@@ -16,7 +19,6 @@ dependencies {
 			'eclipse-deps:org.eclipse.jdt.core:+',
 			'eclipse-deps:org.eclipse.jface:+',
 			'eclipse-deps:org.eclipse.osgi:+',
-			'eclipse-deps:org.eclipse.pde.core:+',
 			'eclipse-deps:org.eclipse.swt.${osgi.platform}:+',
 			'eclipse-deps:org.eclipse.ui.workbench:+',
 			project(':com.ibm.wala.core'),

--- a/com.ibm.wala.ide/build.gradle
+++ b/com.ibm.wala.ide/build.gradle
@@ -7,19 +7,19 @@ eclipse.project.natures 'org.eclipse.pde.PluginNature'
 sourceSets.main.java.srcDirs = ['src']
 
 dependencies {
-	compile(
-		'eclipse-deps:org.eclipse.core.commands:+',
-		'eclipse-deps:org.eclipse.core.jobs:+',
-		'eclipse-deps:org.eclipse.core.resources:+',
-		'eclipse-deps:org.eclipse.core.runtime:+',
-		'eclipse-deps:org.eclipse.equinox.common:+',
-		'eclipse-deps:org.eclipse.jdt.core:+',
-		'eclipse-deps:org.eclipse.jface:+',
-		'eclipse-deps:org.eclipse.osgi:+',
-		'eclipse-deps:org.eclipse.pde.core:+',
-		'eclipse-deps:org.eclipse.swt.${osgi.platform}:+',
-		'eclipse-deps:org.eclipse.ui.workbench:+',
-		project(':com.ibm.wala.core'),
-		project(':com.ibm.wala.util'),
-		)
+	implementation(
+			'eclipse-deps:org.eclipse.core.commands:+',
+			'eclipse-deps:org.eclipse.core.jobs:+',
+			'eclipse-deps:org.eclipse.core.resources:+',
+			'eclipse-deps:org.eclipse.core.runtime:+',
+			'eclipse-deps:org.eclipse.equinox.common:+',
+			'eclipse-deps:org.eclipse.jdt.core:+',
+			'eclipse-deps:org.eclipse.jface:+',
+			'eclipse-deps:org.eclipse.osgi:+',
+			'eclipse-deps:org.eclipse.pde.core:+',
+			'eclipse-deps:org.eclipse.swt.${osgi.platform}:+',
+			'eclipse-deps:org.eclipse.ui.workbench:+',
+			project(':com.ibm.wala.core'),
+			project(':com.ibm.wala.util'),
+	)
 }

--- a/com.ibm.wala.scandroid/build.gradle
+++ b/com.ibm.wala.scandroid/build.gradle
@@ -1,14 +1,14 @@
 sourceSets.main.java.srcDirs = ['source']
 
 dependencies {
-	compile(
-		'com.google.guava:guava:18.0',
-		'commons-cli:commons-cli:1.4',
-		project(':com.ibm.wala.core'),
-		project(':com.ibm.wala.dalvik'),
-		project(':com.ibm.wala.shrike'),
-		project(':com.ibm.wala.util'),
-		)
+	implementation(
+			'com.google.guava:guava:18.0',
+			'commons-cli:commons-cli:1.4',
+			project(':com.ibm.wala.core'),
+			project(':com.ibm.wala.dalvik'),
+			project(':com.ibm.wala.shrike'),
+			project(':com.ibm.wala.util'),
+	)
 }
 
 apply from: rootProject.file("gradle-mvn-push.gradle")

--- a/com.ibm.wala.shrike/build.gradle
+++ b/com.ibm.wala.shrike/build.gradle
@@ -7,7 +7,7 @@ eclipse.project.natures 'org.eclipse.pde.PluginNature'
 sourceSets.main.java.srcDirs = ['src']
 
 dependencies {
-	compile project(':com.ibm.wala.util')
+	implementation project(':com.ibm.wala.util')
 }
 
 apply from: rootProject.file("gradle-mvn-push.gradle")


### PR DESCRIPTION
The `java-library` plugin distinguishes dependencies needed only for a library’s internal implementation from dependencies that form part of a library’s external API. A library’s implementation dependencies are not transitively made available to other components that depend on that library. This keeps classpaths shorter and helps reduce recompilation. See [the `java-library` plugin documentation](https://docs.gradle.org/current/userguide/java_library_plugin.html) for more information.

I took an empirical approach to determining which dependencies are implementation dependencies and which are API dependencies. In general, one should prefer the more restrictive implementation categorization wherever possible. What I’ve done here is to use implementation dependencies everywhere I could, and only switch to an API dependency where required for compilation to succeed. For example, if class `A` in library `Alpha` is a subclass of class `B` in class `Beta`, then code that tries to create a new `A` will fail to compile unless `Beta` was also brought along as an API dependency of `Alpha`.

In all cases where an API dependency was required, I have included an explanation identifying at least one specific reason why, such as `public class A extends class B`. Such explanations are optional, but seem like a good idea and are even directly supported by Gradle’s dependency-declaration API.

It is definitely possible that some current implementation dependencies should really be API dependencies. This would most likely happen if third-party code uses WALA APIs in ways that WALA’s own tests do not. Returning to the `A`/`Alpha`/`B`/`Beta` example above, if no WALA test actually uses class `A`, then we would we unaware of the need for `Alpha` to propagate an API dependency on `Beta`. A third-party application or library code can work around such a misclassification by explicitly adding its own dependency on Beta, so this is not a show-stopping error. It just makes WALA a bit less convenient to use by requiring more explicit listing of dependencies that previously would have been picked up implicitly. We can certainly reclassify implementation dependencies as API dependencies wherever appropriate in the future.