### PR TITLE
Remove redundant Javadoc task configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -185,7 +185,6 @@ tasks.register('aggregatedJavadocs', Javadoc) {
 	destinationDir = file("$buildDir/docs/javadoc")
 	title = "$project.name $version API"
 	options.author true
-	options.addStringOption 'Xdoclint:none', '-quiet'
 
 	subprojects.each { proj ->
 		proj.tasks.withType(Javadoc).each { javadocTask ->


### PR DESCRIPTION
The `tasks.withType(Javadoc).configureEach` closure appearing [slightly earlier](https://github.com/wala/WALA/blob/667dd100e6d8b82451aa0f3e7deffea485f4cd92/build.gradle#L176) will take care of setting the appropriate `Xdoclint` and quietness options. That works even though this configuration closure appeared before the `aggregatedJavadocs` task was registered, thanks to the magic of Gradle’s on-demand task configuration system.