### PR TITLE
Remove redundant assignments to project version and group

### DIFF
--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -20,9 +20,6 @@
 apply plugin: 'maven'
 apply plugin: 'signing'
 
-version = VERSION_NAME
-group = GROUP
-
 def isReleaseBuild() {
   return VERSION_NAME.contains("SNAPSHOT") == false
 }


### PR DESCRIPTION
`version` and `group` were already set in the top-level `build.gradle`, and are inherited by all subprojects.

The `com.ibm.wala.*-1.5.4-SNAPSHOT.pom` files installed under `~/.m2` are unaffected by this change.