### PR TITLE
Suppress some IntelliJ IDEA warnings in test code

### DIFF
--- a/com.ibm.wala.cast.java.test.data/src/SimpleCalls.java
+++ b/com.ibm.wala.cast.java.test.data/src/SimpleCalls.java
@@ -24,6 +24,7 @@ public class SimpleCalls implements ISimpleCalls {
 		System.out.println("another call");
 		return 5;
 	}
+	@SuppressWarnings("AssignmentReplaceableWithOperatorAssignment")
 	public static void main (String args[]) {
 		SimpleCalls sc = new SimpleCalls();
 		ISimpleCalls isc = sc;

--- a/com.ibm.wala.cast.java.test.data/src/bugfixes/VarDeclInSwitch.java
+++ b/com.ibm.wala.cast.java.test.data/src/bugfixes/VarDeclInSwitch.java
@@ -39,6 +39,7 @@ package bugfixes;
 
 public class VarDeclInSwitch {
 	static int y = 7;
+	@SuppressWarnings("AssignmentReplaceableWithOperatorAssignment")
 	public static void main(String args[]) {
 		int x = 5;
 		x = x + x;

--- a/com.ibm.wala.cast.java.test.data/src/foo/QualifiedNames.java
+++ b/com.ibm.wala.cast.java.test.data/src/foo/QualifiedNames.java
@@ -43,6 +43,7 @@ public class QualifiedNames {
         public QualifiedNames(int xx) {
         	x = xx;
         }
+        @SuppressWarnings("AssignmentReplaceableWithOperatorAssignment")
         public static void main(String args[]) {
         	QualifiedNames qn = new QualifiedNames(5);
         	int y = 3;

--- a/com.ibm.wala.cast.java.test.data/src/javaonepointfive/EnumSwitch.java
+++ b/com.ibm.wala.cast.java.test.data/src/javaonepointfive/EnumSwitch.java
@@ -62,6 +62,7 @@ public class EnumSwitch {
 			System.out.println("gold"); break;
 		case COPAS:
 			total = x * x;
+			//noinspection AssignmentReplaceableWithOperatorAssignment
 			y = y + y;
 			System.out.println("cups"); break;
 		case ESPADAS:

--- a/com.ibm.wala.cast.java.test.data/src/javaonepointfive/ExplicitBoxingTest.java
+++ b/com.ibm.wala.cast.java.test.data/src/javaonepointfive/ExplicitBoxingTest.java
@@ -44,6 +44,7 @@ public class ExplicitBoxingTest {
 		(new ExplicitBoxingTest()).doit();
 	}
 	
+	@SuppressWarnings("AssignmentReplaceableWithOperatorAssignment")
 	private void doit() {
 		int a = 6;
 		a = a + a;

--- a/com.ibm.wala.core.testdata/src/slice/TestCD4.java
+++ b/com.ibm.wala.core.testdata/src/slice/TestCD4.java
@@ -22,6 +22,7 @@ public class TestCD4 {
     doNothing(k);
   }
 
+  @SuppressWarnings("AssignmentReplaceableWithOperatorAssignment")
   static int foo(int i, int j) {
     int k = 0;
     if (i == 3) {

--- a/com.ibm.wala.core.testdata/src/string/SimpleStringOps.java
+++ b/com.ibm.wala.core.testdata/src/string/SimpleStringOps.java
@@ -16,6 +16,7 @@ public class SimpleStringOps {
     System.out.println(s.substring(5) + " and other garbage");
   }
 
+  @SuppressWarnings("AssignmentReplaceableWithOperatorAssignment")
   public static void main(String[] args) {
     if (args.length > 0) {
       @SuppressWarnings("NonConstantStringShouldBeStringBuffer")


### PR DESCRIPTION
Test code often does things that we would not consider ideal coding practice, for the sake of keeping tests small, simple, and probative.