### PR TITLE
Modernize use of Ant Java task’s argument APIs

### DIFF
--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/shrike/DynamicCallGraphTestBase.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/shrike/DynamicCallGraphTestBase.java
@@ -122,13 +122,11 @@ public abstract class DynamicCallGraphTestBase extends WalaTestCase {
               "exclusions.txt", getClass().getClassLoader().getResource(exclusionsFile));
       jvmArgs += " -DdynamicCGFilter=" + tmpFile.getCanonicalPath();
     }
-    childJvm.setJvmargs(jvmArgs);
+    childJvm.createJvmarg().setLine(jvmArgs);
 
-    StringBuilder argsStr = new StringBuilder();
     for (String a : args) {
-      argsStr.append(a).append(' ');
+      childJvm.createArg().setValue(a);
     }
-    childJvm.setArgs(argsStr.toString());
 
     childJvm.setFailonerror(true);
     childJvm.setFork(true);


### PR DESCRIPTION
The `Java.setArgs` and `Java.setJvmargs` APIs claim to be deprecated in output from tests that use them.