### PR TITLE
Update Gradle download plugin to v4.0.0

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -3,5 +3,5 @@ repositories {
 }
 
 dependencies {
-	implementation 'de.undercouch:gradle-download-task:3.4.3'
+	implementation 'de.undercouch:gradle-download-task:4.0.0'
 }


### PR DESCRIPTION
Nothing interesting for us in this version, but it’s good practice to keep current, especially given that this is a new major release.