### PR TITLE
Retry failed downloads up to five times

### DIFF
--- a/buildSrc/src/main/groovy/verified-download.groovy
+++ b/buildSrc/src/main/groovy/verified-download.groovy
@@ -37,6 +37,7 @@ class VerifiedDownload extends org.gradle.api.DefaultTask {
 			overwrite true
 			onlyIfModified true
 			useETag this.useETag
+			retries 5
 		}
 		project.verifyChecksum {
 			src destFile


### PR DESCRIPTION
WALA downloads many things, and some of those are from slow or flaky servers that chronically time out.  The [recent update of our Gradle download plugin](https://github.com/wala/WALA/pull/526) finally gives us a tidy way to cope with this:  retrying failed downloads.

We could tweak this for each individual download task, but I think that's overkill.  Let's start by simply retrying *any* failed download up to five times.