### PR TITLE
Reimplement a function in a stream’y, functional style

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -305,12 +305,10 @@ final def addCastLibrary(project, recipient) {
 	addJvmLibrary(project, recipient)
 }
 
-final findJvmLibrary(extension, currentJavaHome, subdirs) {
-	for (final subdir : subdirs) {
-		final candidate = file "$currentJavaHome/$subdir/libjvm.$extension"
-		if (candidate.exists())
-			return candidate
-	}
+final File findJvmLibrary(extension, currentJavaHome, subdirs) {
+	return subdirs
+			.collect { file "$currentJavaHome/$it/libjvm.$extension" }
+			.find { it.exists() }
 }
 
 final def addJvmLibrary(project, recipient) {


### PR DESCRIPTION
Also add an explicit return type to help IntelliJ IDEA’s Gradle checkers understand what it returns.  Apparently even in its original form, those checkers were unable to infer a return type more specific than `Object`.