### PR TITLE
Suppress suggestion to use Map.computeIfAbsent

### DIFF
--- a/com.ibm.wala.util/src/com/ibm/wala/util/intset/BitVectorRepository.java
+++ b/com.ibm.wala.util/src/com/ibm/wala/util/intset/BitVectorRepository.java
@@ -17,6 +17,7 @@ import java.util.LinkedList;
 import java.util.Map;
 
 /** A repository for shared bit vectors as described by Heintze */
+@SuppressWarnings("Java8MapApi")
 public class BitVectorRepository {
 
   private static final boolean STATS = false;


### PR DESCRIPTION
`Map.computeIfAbsent` can do the same thing we need here, but might only perform one `Map` lookup instead of two (if implemented efficiently).