### PR TITLE
Use Ubuntu 14.04 (Trusty) for most Travis CI Linux tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,10 +47,12 @@ matrix:
       language: java
       jdk: openjdk11
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle
       language: java
       jdk: oraclejdk8
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=maven
       language: android
       jdk: oraclejdk8
@@ -60,156 +62,187 @@ matrix:
       language: java
       jdk: oraclejdk8
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast:cast
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.java
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.java.ecj
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.java.test
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.java.test.data
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.js
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.js.html.nu_validator
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.js.nodejs
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.js.nodejs.test
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.js.rhino
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.js.rhino.test
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.js.test
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.js.test.data
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.test
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.test:smoke_main
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.cast.test:xlator_test
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.core
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.core.testdata
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.core.tests
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.dalvik
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.dalvik.test
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.ide
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.ide.jdt
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.ide.jdt.test
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.ide.jsdt
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.ide.jsdt.tests
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.ide.tests
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.scandroid
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.shrike
       language: java
       jdk: oraclejdk8
       if: type = cron
     - os: linux
+      dist: trusty
       env: BUILD_SYSTEM=gradle BUILD_ONLY_SUBMODULE=com.ibm.wala.util
       language: java
       jdk: oraclejdk8


### PR DESCRIPTION
Travis CI made Ubuntu 16.04 (Xenial) the default in late April: <https://changelog.travis-ci.com/xenial-as-the-default-build-environment-99476>, <https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment>. However, we are only testing under Xenial in a few limited configurations.  For the most part, WALA still requires Java 8, and on Travis CI that requires Ubuntu 14.04 (Trusty).