### PR TITLE
Minor project metadata updates for IntelliJ IDEA 2019.2

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="delegatedBuild" value="true" />
+        <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">
@@ -48,7 +50,6 @@
             <option value="$PROJECT_DIR$/com.ibm.wala_feature" />
           </set>
         </option>
-        <option name="testRunner" value="GRADLE" />
         <option name="useAutoImport" value="true" />
       </GradleProjectSettings>
     </option>


### PR DESCRIPTION
These changes were not prompted by any explicit settings change from me. They appear to simply be a change in what project information IntelliJ IDEA 2019.2 stores explicitly versus earlier IntelliJ IDEA versions.