### PR TITLE
Miscellaneous cleanups for IntelliJ IDEA 2019.2

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -2,6 +2,7 @@
 /compiler.xml
 /libraries/*.xml
 /modules.xml
+/shelf/
 /tasks.xml
 /usage.statistics.xml
 /workspace.xml

--- a/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
+++ b/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
@@ -4023,7 +4023,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
     }
   }
 
-  private class AssignmentContext extends DelegatingContext {
+  private static class AssignmentContext extends DelegatingContext {
 
     protected AssignmentContext(WalkContext parent) {
       super(parent);
@@ -4079,7 +4079,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
     }
   }
 
-  private class BreakContext extends DelegatingContext {
+  private static class BreakContext extends DelegatingContext {
     protected final String label;
 
     private final ASTNode breakTo;
@@ -4096,7 +4096,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
     }
   }
 
-  private class LoopContext extends BreakContext {
+  private static class LoopContext extends BreakContext {
     private final ASTNode continueTo;
 
     protected LoopContext(WalkContext parent, String label, ASTNode breakTo, ASTNode continueTo) {

--- a/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/JDTTypeDictionary.java
+++ b/com.ibm.wala.cast.java.ecj/src/com/ibm/wala/cast/java/translator/jdt/JDTTypeDictionary.java
@@ -208,7 +208,7 @@ public class JDTTypeDictionary extends CAstTypeDictionaryImpl<ITypeBinding> {
     }
   }
 
-  public final class JdtUnionType implements Union {
+  public static final class JdtUnionType implements Union {
     private final Set<CAstType> constituents;
 
     public JdtUnionType(Set<CAstType> constituents) {

--- a/com.ibm.wala.cast.java.test.data/src/javaonepointfive/MoreOverriddenGenerics.java
+++ b/com.ibm.wala.cast.java.test.data/src/javaonepointfive/MoreOverriddenGenerics.java
@@ -38,6 +38,7 @@
 package javaonepointfive;
 
 public class MoreOverriddenGenerics {
+	@SuppressWarnings("InnerClassMayBeStatic")
 	class Super<T> {
 		T x;
 

--- a/com.ibm.wala.cast.java.test.data/src/javaonepointseven/BinaryLiterals.java
+++ b/com.ibm.wala.cast.java.test.data/src/javaonepointseven/BinaryLiterals.java
@@ -74,6 +74,7 @@ public class BinaryLiterals {
     }
   }
 
+  @SuppressWarnings("InnerClassMayBeStatic")
   class State {
     int state = 0;
 

--- a/com.ibm.wala.cast.java.test.data/src/javaonepointseven/TypeInferenceforGenericInstanceCreation.java
+++ b/com.ibm.wala.cast.java.test.data/src/javaonepointseven/TypeInferenceforGenericInstanceCreation.java
@@ -9,6 +9,7 @@ import java.util.List;
  *     <a href="https://docs.oracle.com/javase/7/docs/technotes/guides/language/type-inference-generic-instance-creation.html">Java 7 docs</a>
  */
 public class TypeInferenceforGenericInstanceCreation {
+  @SuppressWarnings("InnerClassMayBeStatic")
   class MyClass<X> {
     X a;
     <T> MyClass(T t) {

--- a/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/examples/ast/SynchronizedBlockDuplicator.java
+++ b/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/examples/ast/SynchronizedBlockDuplicator.java
@@ -41,7 +41,7 @@ public class SynchronizedBlockDuplicator
    * key type used for cloning the synchronized blocks and the true and false branches of the
    * introduced conditional
    */
-  class UnwindKey implements CAstRewriter.CopyKey<UnwindKey> {
+  static class UnwindKey implements CAstRewriter.CopyKey<UnwindKey> {
     /** are we on the true or false branch? */
     private boolean testDirection;
 
@@ -110,7 +110,7 @@ public class SynchronizedBlockDuplicator
   }
 
   /** context used within synchronized blocks */
-  class SyncContext implements RewriteContext<UnwindKey> {
+  static class SyncContext implements RewriteContext<UnwindKey> {
     /** context used for the parent AST node of the synchronized block */
     private final CAstRewriter.RewriteContext<UnwindKey> parent;
 

--- a/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/ipa/callgraph/AstJavaSSAPropagationCallGraphBuilder.java
+++ b/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/ipa/callgraph/AstJavaSSAPropagationCallGraphBuilder.java
@@ -118,7 +118,7 @@ public class AstJavaSSAPropagationCallGraphBuilder extends AstSSAPropagationCall
     return ti;
   }
 
-  protected class AstJavaInterestingVisitor extends AstInterestingVisitor
+  protected static class AstJavaInterestingVisitor extends AstInterestingVisitor
       implements AstJavaInstructionVisitor {
     protected AstJavaInterestingVisitor(int vn) {
       super(vn);

--- a/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/loader/JavaSourceLoaderImpl.java
+++ b/com.ibm.wala.cast.java/src/com/ibm/wala/cast/java/loader/JavaSourceLoaderImpl.java
@@ -276,7 +276,7 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
    *
    * @author rfuhrer
    */
-  protected class JavaField extends AstField {
+  protected static class JavaField extends AstField {
     protected JavaField(
         CAstEntity fieldEntity,
         IClassLoader loader,

--- a/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/TestPointerAnalyses.java
+++ b/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/TestPointerAnalyses.java
@@ -67,7 +67,7 @@ import org.junit.Test;
 
 public abstract class TestPointerAnalyses {
 
-  private final class CheckPointers
+  private static final class CheckPointers
       implements Predicate<
           Pair<Set<Pair<CGNode, NewSiteReference>>, Set<Pair<CGNode, NewSiteReference>>>> {
     private Set<Pair<String, Integer>> map(Set<Pair<CGNode, NewSiteReference>> sites) {

--- a/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/TestPointerAnalyses.java
+++ b/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/TestPointerAnalyses.java
@@ -70,7 +70,7 @@ public abstract class TestPointerAnalyses {
   private static final class CheckPointers
       implements Predicate<
           Pair<Set<Pair<CGNode, NewSiteReference>>, Set<Pair<CGNode, NewSiteReference>>>> {
-    private Set<Pair<String, Integer>> map(Set<Pair<CGNode, NewSiteReference>> sites) {
+    private static Set<Pair<String, Integer>> map(Set<Pair<CGNode, NewSiteReference>> sites) {
       Set<Pair<String, Integer>> result = HashSetFactory.make();
       for (Pair<CGNode, NewSiteReference> s : sites) {
         result.add(Pair.make(s.fst.getMethod().toString(), s.snd.getProgramCounter()));

--- a/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/translator/PropertyReadExpander.java
+++ b/com.ibm.wala.cast.js/source/com/ibm/wala/cast/js/translator/PropertyReadExpander.java
@@ -69,7 +69,7 @@ public class PropertyReadExpander
   }
 
   /** for handling property reads within assignments with pre or post-ops, e.g., x.f++ */
-  private final class AssignPreOrPostOpContext extends RewriteContext {
+  private static final class AssignPreOrPostOpContext extends RewriteContext {
     private CAstNode receiverTemp;
 
     private CAstNode elementTemp;

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/SSAConversion.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/ssa/SSAConversion.java
@@ -106,7 +106,7 @@ public class SSAConversion extends AbstractSSAConversion {
     }
   }
 
-  public class PhiUseRecord {
+  public static class PhiUseRecord {
     final int BBnumber;
 
     final int phiNumber;

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
@@ -770,7 +770,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
     }
   }
 
-  protected final class UnwindState {
+  protected static final class UnwindState {
     final CAstNode unwindAst;
 
     final WalkContext astContext;
@@ -1563,7 +1563,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
 
   private static final boolean DEBUG = false;
 
-  protected class FinalCAstSymbol implements CAstSymbol {
+  protected static class FinalCAstSymbol implements CAstSymbol {
     private final String _name;
     private final CAstType type;
 

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/rewrite/AstConstantFolder.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/rewrite/AstConstantFolder.java
@@ -23,7 +23,7 @@ public class AstConstantFolder {
     return false;
   }
 
-  class AssignSkipContext extends NonCopyingContext {
+  static class AssignSkipContext extends NonCopyingContext {
     private Set<CAstNode> skip = HashSetFactory.make();
   }
 

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/rewrite/AstLoopUnwinder.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/tree/rewrite/AstLoopUnwinder.java
@@ -81,7 +81,7 @@ public class AstLoopUnwinder
     }
   }
 
-  private class LoopContext implements RewriteContext<UnwindKey> {
+  private static class LoopContext implements RewriteContext<UnwindKey> {
     private final CAstRewriter.RewriteContext<UnwindKey> parent;
     private final int iteration;
 

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/util/SourceBuffer.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/util/SourceBuffer.java
@@ -55,7 +55,7 @@ public class SourceBuffer {
         }
       }
     } else {
-      lines.add(currentLine.substring(p.getFirstCol() < 0 ? 0 : p.getFirstCol()));
+      lines.add(currentLine.substring(Math.max(p.getFirstCol(), 0)));
     }
 
     while (p.getLastOffset() >= 0 ? p.getLastOffset() >= offset : p.getLastLine() >= line) {

--- a/com.ibm.wala.cast/source/java/com/ibm/wala/cast/util/test/TestCallGraphShape.java
+++ b/com.ibm.wala.cast/source/java/com/ibm/wala/cast/util/test/TestCallGraphShape.java
@@ -114,6 +114,7 @@ public abstract class TestCallGraphShape {
           for (String localName : localNames) {
             if (localName.equals(name.name)) {
               found = true;
+              break;
             }
           }
 

--- a/com.ibm.wala.core.testdata/src/annotations/TypeAnnotatedClass2.java
+++ b/com.ibm.wala.core.testdata/src/annotations/TypeAnnotatedClass2.java
@@ -79,18 +79,20 @@ public class TypeAnnotatedClass2 extends @TypeAnnotationTypeUse Object {
 }
 
 class Outer {
+  @SuppressWarnings("InnerClassMayBeStatic")
   class Middle {
     class Inner {}
   }
 }
 
 class Outer2 {
-  @SuppressWarnings("unused")
+  @SuppressWarnings({"unused", "InnerClassMayBeStatic"})
   class Middle<S> {
     class Inner<T> {}
   }
 }
 
 class Foo {
+  @SuppressWarnings("InnerClassMayBeStatic")
   class Bar {}
 }

--- a/com.ibm.wala.core.testdata/src/arraybounds/Detectable.java
+++ b/com.ibm.wala.core.testdata/src/arraybounds/Detectable.java
@@ -6,7 +6,7 @@ package arraybounds;
  *
  * @author Stephan Gocht {@code <stephan@gobro.de>}
  */
-@SuppressWarnings("IfStatementMissingBreakInLoop")
+@SuppressWarnings({"IfStatementMissingBreakInLoop", "ManualMinMaxCalculation"})
 public class Detectable {
   private int[] memberArr = new int[5];
 

--- a/com.ibm.wala.core.testdata/src/arraybounds/Detectable.java
+++ b/com.ibm.wala.core.testdata/src/arraybounds/Detectable.java
@@ -6,6 +6,7 @@ package arraybounds;
  *
  * @author Stephan Gocht {@code <stephan@gobro.de>}
  */
+@SuppressWarnings("IfStatementMissingBreakInLoop")
 public class Detectable {
   private int[] memberArr = new int[5];
 

--- a/com.ibm.wala.core.testdata/src/inner/TestInner.java
+++ b/com.ibm.wala.core.testdata/src/inner/TestInner.java
@@ -12,5 +12,6 @@ package inner;
 
 public class TestInner {
 
+  @SuppressWarnings("InnerClassMayBeStatic")
   public class A {}
 }

--- a/com.ibm.wala.core.testdata/src/shrike/StackMaps.java
+++ b/com.ibm.wala.core.testdata/src/shrike/StackMaps.java
@@ -1,5 +1,6 @@
 package shrike;
 
+@SuppressWarnings("ManualMinMaxCalculation")
 public class StackMaps {
   private int field1;
   private int field2;

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/basic/WelshPowellTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/basic/WelshPowellTest.java
@@ -45,7 +45,7 @@ public class WelshPowellTest {
     }
   }
 
-  private class TypedNode<T> extends NodeWithNumberedEdges {
+  private static class TypedNode<T> extends NodeWithNumberedEdges {
     private final T data;
 
     private TypedNode(T data) {

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ir/AnnotationTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ir/AnnotationTest.java
@@ -37,7 +37,7 @@ import java.util.Collection;
 import java.util.Set;
 import org.junit.Test;
 
-public class AnnotationTest extends WalaTestCase {
+public abstract class AnnotationTest extends WalaTestCase {
 
   private final IClassHierarchy cha;
 

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ir/CFGTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ir/CFGTest.java
@@ -35,7 +35,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /** Test integrity of CFGs */
-public class CFGTest extends WalaTestCase {
+public abstract class CFGTest extends WalaTestCase {
 
   private final IClassHierarchy cha;
 

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ir/DeterministicIRTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ir/DeterministicIRTest.java
@@ -37,7 +37,7 @@ import org.junit.Test;
  * <p>Introduced 05-AUG-03; the default implementation of hashCode was being invoked.
  * Object.hashCode is a source of random numbers and has no place in a deterministic program.
  */
-public class DeterministicIRTest extends WalaTestCase {
+public abstract class DeterministicIRTest extends WalaTestCase {
 
   private IClassHierarchy cha;
 

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ir/TypeAnnotationTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ir/TypeAnnotationTest.java
@@ -44,7 +44,7 @@ import java.util.List;
 import java.util.Map;
 import org.junit.Test;
 
-public class TypeAnnotationTest extends WalaTestCase {
+public abstract class TypeAnnotationTest extends WalaTestCase {
 
   private final IClassHierarchy cha;
 

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/shrike/DynamicCallGraphTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/shrike/DynamicCallGraphTest.java
@@ -27,7 +27,7 @@ import com.ibm.wala.util.CancelException;
 import java.io.IOException;
 import org.junit.Test;
 
-public class DynamicCallGraphTest extends DynamicCallGraphTestBase {
+public abstract class DynamicCallGraphTest extends DynamicCallGraphTestBase {
 
   protected final String testJarLocation;
 

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/examples/analysis/dataflow/ContextSensitiveReachingDefs.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/examples/analysis/dataflow/ContextSensitiveReachingDefs.java
@@ -63,7 +63,7 @@ public class ContextSensitiveReachingDefs {
   }
 
   /** controls numbering of putstatic instructions for use in tabulation */
-  private class ReachingDefsDomain extends MutableMapping<Pair<CGNode, Integer>>
+  private static class ReachingDefsDomain extends MutableMapping<Pair<CGNode, Integer>>
       implements TabulationDomain<Pair<CGNode, Integer>, BasicBlockInContext<IExplodedBasicBlock>> {
 
     private static final long serialVersionUID = 4014252274660361965L;

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/examples/analysis/dataflow/StaticInitializer.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/examples/analysis/dataflow/StaticInitializer.java
@@ -66,7 +66,7 @@ public class StaticInitializer {
   }
 
   /** controls numbering of putstatic instructions for use in tabulation */
-  private class InitializerDomain extends MutableMapping<IClass>
+  private static class InitializerDomain extends MutableMapping<IClass>
       implements TabulationDomain<IClass, BasicBlockInContext<IExplodedBasicBlock>> {
 
     private static final long serialVersionUID = -1897766113586243833L;

--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/arraybounds/ArrayBoundsGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/arraybounds/ArrayBoundsGraph.java
@@ -182,7 +182,7 @@ public class ArrayBoundsGraph extends DirectedHyperGraph<Integer> {
 
   public HyperNode<Integer> addNode(Integer value) {
     HyperNode<Integer> result;
-    if (!this.getNodes().keySet().contains(value)) {
+    if (!this.getNodes().containsKey(value)) {
       result = new HyperNode<>(value);
       this.getNodes().put(value, result);
     } else {
@@ -211,7 +211,7 @@ public class ArrayBoundsGraph extends DirectedHyperGraph<Integer> {
    * [var] is set to 0 it will stay 0.
    */
   public void createSourceVar(Integer var) {
-    if (this.getNodes().keySet().contains(var)) {
+    if (this.getNodes().containsKey(var)) {
       throw new AssertionError("Source variables should only be created once.");
     }
 

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/BasicCallGraph.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/callgraph/impl/BasicCallGraph.java
@@ -159,7 +159,7 @@ public abstract class BasicCallGraph<T> extends AbstractNumberedGraph<CGNode> im
   }
 
   /** A class that represents the a normal node in a call graph. */
-  public abstract class NodeImpl extends NodeWithNumber implements CGNode {
+  public abstract static class NodeImpl extends NodeWithNumber implements CGNode {
 
     /** The method this node represents. */
     protected final IMethod method;

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/modref/ModRefFieldAccess.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/modref/ModRefFieldAccess.java
@@ -36,7 +36,7 @@ import java.util.Set;
  */
 public final class ModRefFieldAccess {
 
-  private class TwoMaps {
+  private static class TwoMaps {
     private Map<IClass, Set<IField>> mods;
     private Map<IClass, Set<IField>> refs;
 

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/XMLMethodSummaryReader.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/XMLMethodSummaryReader.java
@@ -483,7 +483,7 @@ public class XMLMethodSummaryReader implements BytecodeConstants {
       String defVar = atts.getValue(A_DEF);
       if (defVar != null) {
 
-        if (symbolTable.keySet().contains(defVar)) {
+        if (symbolTable.containsKey(defVar)) {
           Assertions.UNREACHABLE("Cannot def variable twice: " + defVar + " in " + governingMethod);
         }
 
@@ -518,7 +518,7 @@ public class XMLMethodSummaryReader implements BytecodeConstants {
 
       // register the local variable defined by this allocation
       String defVar = atts.getValue(A_DEF);
-      if (symbolTable.keySet().contains(defVar)) {
+      if (symbolTable.containsKey(defVar)) {
         Assertions.UNREACHABLE("Cannot def variable twice: " + defVar + " in " + governingMethod);
       }
       if (defVar == null) {
@@ -594,7 +594,7 @@ public class XMLMethodSummaryReader implements BytecodeConstants {
 
       // get the value def'fed
       String defVar = atts.getValue(A_DEF);
-      if (symbolTable.keySet().contains(defVar)) {
+      if (symbolTable.containsKey(defVar)) {
         Assertions.UNREACHABLE("Cannot def variable twice: " + defVar + " in " + governingMethod);
       }
       if (defVar == null) {
@@ -767,7 +767,7 @@ public class XMLMethodSummaryReader implements BytecodeConstants {
       }
       // get the value def'fed
       String defVar = atts.getValue(A_DEF);
-      if (symbolTable.keySet().contains(defVar)) {
+      if (symbolTable.containsKey(defVar)) {
         Assertions.UNREACHABLE("Cannot def variable twice: " + defVar + " in " + governingMethod);
       }
       if (defVar == null) {

--- a/com.ibm.wala.core/src/com/ibm/wala/ssa/analysis/DeadAssignmentElimination.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ssa/analysis/DeadAssignmentElimination.java
@@ -131,7 +131,7 @@ public class DeadAssignmentElimination {
           if (trivialDead.contains(ud)) {
             // do nothing ... u will not keep def live
           } else {
-            if (!vars.keySet().contains(ud)) {
+            if (!vars.containsKey(ud)) {
               // u is not potentially dead ... certainly v is live.
               // record this.
               B.set(true);

--- a/com.ibm.wala.core/src/com/ibm/wala/viz/viewer/CgPanel.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/viz/viewer/CgPanel.java
@@ -42,6 +42,7 @@ public class CgPanel extends JSplitPane {
     final IrAndSourceViewer irViewer = new IrAndSourceViewer();
     this.setRightComponent(irViewer.getComponent());
 
+    //noinspection Convert2Lambda
     tree.addTreeSelectionListener(
         new TreeSelectionListener() {
 

--- a/com.ibm.wala.core/src/com/ibm/wala/viz/viewer/ChaPanel.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/viz/viewer/ChaPanel.java
@@ -42,6 +42,7 @@ public class ChaPanel extends JSplitPane {
     JList<String> methodList = new JList<>(methodListModel);
     this.setRightComponent(methodList);
 
+    //noinspection Convert2Lambda
     tree.addTreeSelectionListener(
         new TreeSelectionListener() {
 

--- a/com.ibm.wala.core/src/com/ibm/wala/viz/viewer/IrViewer.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/viz/viewer/IrViewer.java
@@ -60,6 +60,7 @@ public class IrViewer extends JPanel {
             ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED),
         BorderLayout.CENTER);
 
+    //noinspection Convert2Lambda
     irLines.addListSelectionListener(
         new ListSelectionListener() {
 

--- a/com.ibm.wala.core/src/com/ibm/wala/viz/viewer/PaPanel.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/viz/viewer/PaPanel.java
@@ -120,6 +120,7 @@ public class PaPanel extends JSplitPane {
           public void treeCollapsed(TreeExpansionEvent event) {}
         });
 
+    //noinspection Convert2Lambda
     heapTree.addTreeSelectionListener(
         new TreeSelectionListener() {
 

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/AbstractIntRegisterMachine.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ssa/AbstractIntRegisterMachine.java
@@ -852,7 +852,7 @@ public abstract class AbstractIntRegisterMachine implements FixedPointConstants 
     public abstract Instruction[] getInstructions();
 
     /** Update the machine state to account for an instruction */
-    protected class BasicRegisterMachineVisitor extends Visitor {
+    protected static class BasicRegisterMachineVisitor extends Visitor {
 
       /**
        * @see com.ibm.wala.shrikeBT.IInstruction.Visitor#visitArrayLength(ArrayLengthInstruction)

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
@@ -117,7 +117,7 @@ public class AndroidManifestXMLReader {
     }
   }
 
-  private void readXML(InputStream xml)
+  private static void readXML(InputStream xml)
       throws SAXException, IOException, ParserConfigurationException {
     assert (xml != null) : "xmlFile may not be null";
 

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
@@ -715,7 +715,7 @@ public class AndroidManifestXMLReader {
     }
   }
 
-  private class SAXHandler extends DefaultHandler {
+  private static class SAXHandler extends DefaultHandler {
     private int unimportantDepth = 0;
 
     public SAXHandler() {

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidPreFlightChecks.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidPreFlightChecks.java
@@ -250,6 +250,7 @@ public class AndroidPreFlightChecks {
         if (type.equals(
             TypeReference.JavaLangObject.getName())) { // Why if JavaLangObjectName private? .. narf
           pass = false;
+          break;
         }
       }
     }

--- a/com.ibm.wala.ide.jdt.test/source/com/ibm/wala/cast/java/test/JDTJavaIRTests.java
+++ b/com.ibm.wala.ide.jdt.test/source/com/ibm/wala/cast/java/test/JDTJavaIRTests.java
@@ -46,7 +46,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
-public class JDTJavaIRTests extends JavaIRTests {
+public abstract class JDTJavaIRTests extends JavaIRTests {
 
   public static final String PROJECT_NAME = "com.ibm.wala.cast.java.test.data";
 

--- a/com.ibm.wala.ide.jdt.test/source/com/ibm/wala/demandpa/driver/DemandCastChecker.java
+++ b/com.ibm.wala.ide.jdt.test/source/com/ibm/wala/demandpa/driver/DemandCastChecker.java
@@ -231,6 +231,7 @@ public class DemandCastChecker {
           for (TypeReference t : declaredResultTypes) {
             if (!t.isPrimitiveType()) {
               primOnly = false;
+              break;
             }
           }
           if (primOnly) {

--- a/com.ibm.wala.scandroid/source/org/scandroid/domain/IFDSTaintDomain.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/domain/IFDSTaintDomain.java
@@ -129,7 +129,7 @@ public class IFDSTaintDomain<E extends ISSABasicBlock>
 
   @Override
   public boolean hasMappedIndex(DomainElement o) {
-    return table.keySet().contains(o);
+    return table.containsKey(o);
   }
 
   @Override

--- a/com.ibm.wala.scandroid/source/org/scandroid/model/AppModelMethod.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/model/AppModelMethod.java
@@ -101,7 +101,7 @@ public class AppModelMethod {
 
   private Map<TypeReference, TypeReference> aClassToTR = new HashMap<>();
 
-  private class MethodParams {
+  private static class MethodParams {
     public IMethod im;
     public int params[];
 

--- a/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/StringBuilderUseAnalysis.java
+++ b/com.ibm.wala.scandroid/source/org/scandroid/prefixtransfer/StringBuilderUseAnalysis.java
@@ -166,7 +166,7 @@ public class StringBuilderUseAnalysis {
     return null;
   }
 
-  public class StringBuilderToStringInstanceKeySite extends InstanceKeySite {
+  public static class StringBuilderToStringInstanceKeySite extends InstanceKeySite {
 
     final ArrayList<Integer> concatenatedInstanceKeys;
     final int instanceID;

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Compiler.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Compiler.java
@@ -413,7 +413,7 @@ public abstract class Compiler implements Constants {
     computeStackWordsAt(0, 0, new byte[instructions.length * 2], new boolean[instructions.length]);
   }
 
-  abstract class Patch {
+  abstract static class Patch {
     final int instrStart;
 
     final int instrOffset;

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Compiler.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Compiler.java
@@ -1535,6 +1535,7 @@ public abstract class Compiler implements Constants {
         for (int j = 0; back != null && j < back.length; j++) {
           if (back[j] < start || back[j] >= start + len) {
             outsideBranch = true;
+            break;
           }
         }
         if (outsideBranch) {
@@ -1564,6 +1565,7 @@ public abstract class Compiler implements Constants {
         for (int target : targets) {
           if (target < start || target >= start + len) {
             outsideBranch = true;
+            break;
           }
         }
         if (outsideBranch) {
@@ -1586,12 +1588,14 @@ public abstract class Compiler implements Constants {
           int h = element.handler;
           if (h < start || h >= start + len) {
             out = true;
+            break;
           }
         }
         int[] targets = instructions[i].getBranchTargets();
         for (int t : targets) {
           if (t < start || t >= start + len) {
             out = true;
+            break;
           }
         }
         if (out) {

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Util.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/Util.java
@@ -552,9 +552,7 @@ public final class Util {
 
   private static byte[] makeTypeIndices() {
     byte[] r = new byte[128];
-    for (int i = 0; i < r.length; i++) {
-      r[i] = -1;
-    }
+    Arrays.fill(r, (byte) -1);
     r['I'] = 0;
     r['J'] = 1;
     r['F'] = 2;

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/analysis/Analyzer.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/analysis/Analyzer.java
@@ -834,7 +834,7 @@ public class Analyzer {
     computeTypes(0, v, makeTypesAt, wantPath ? new ArrayList<>() : null);
   }
 
-  public abstract class TypeVisitor extends IInstruction.Visitor {
+  public abstract static class TypeVisitor extends IInstruction.Visitor {
     public abstract void setState(
         int index, List<PathElement> path, String[] curStack, String[] curLocals);
 

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/tools/BatchVerifier.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/shrikeCT/tools/BatchVerifier.java
@@ -54,6 +54,7 @@ public class BatchVerifier {
     for (String arg : args) {
       if (arg.equals("-d")) {
         disasm = true;
+        break;
       }
     }
 

--- a/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/tools/OfflineInstrumenterBase.java
+++ b/com.ibm.wala.shrike/src/com/ibm/wala/shrikeBT/tools/OfflineInstrumenterBase.java
@@ -72,7 +72,7 @@ public abstract class OfflineInstrumenterBase {
   /**
    * This class represents a resource which can be opened and read; either a file or a JAR entry.
    */
-  abstract class Input {
+  abstract static class Input {
     private String className;
 
     /** Tell us what the classname is supposed to be, if it's a class file. */
@@ -165,7 +165,7 @@ public abstract class OfflineInstrumenterBase {
    * This class represents a plain old class file in the filesystem. Non-class file resources are
    * not supported.
    */
-  final class ClassInput extends Input {
+  static final class ClassInput extends Input {
     private final File file;
     private final File baseDirectory;
 


### PR DESCRIPTION
Clean up various warnings revealed by inspections under IntelliJ IDEA 2019.2.

Includes suppression of some lambda suggestions that break Android builds, to avoid reversion of b51d9c38192a0d6dcf1b3f94805b79bfa92459a7, as [suggested by @msridhar](https://github.com/wala/WALA/commit/b51d9c38192a0d6dcf1b3f94805b79bfa92459a7#commitcomment-34450011).