### PR TITLE
Gradle 5.6 and minor tweaks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 }
 
 plugins {
-	id 'com.diffplug.gradle.p2.asmaven' version '3.17.3'
+	id 'com.diffplug.gradle.p2.asmaven' version '3.18.0'
 	id 'com.github.hauner.jarTest' version '1.0.1' apply false
 	id 'com.github.sherter.google-java-format' version '0.8'
 	id 'de.set.ecj' version '1.4.1' apply false

--- a/com.ibm.wala.cast.test/xlator_test/build.gradle
+++ b/com.ibm.wala.cast.test/xlator_test/build.gradle
@@ -1,18 +1,18 @@
 plugins {
-    id 'cpp-library'
+	id 'cpp-library'
 }
 
 library {
-    privateHeaders.from '../build/headers'
-    source.from '../harness-src/c/smoke.cpp'
+	privateHeaders.from '../build/headers'
+	source.from '../harness-src/c/smoke.cpp'
 
-    dependencies {
-        implementation project(':com.ibm.wala.cast:cast')
-    }
+	dependencies {
+		implementation project(':com.ibm.wala.cast:cast')
+	}
 
-    addCastLibrary(project, it)
+	addCastLibrary(project, it)
 
-    binaries.whenElementFinalized { binary ->
-        binary.compileTask.get().dependsOn(':com.ibm.wala.cast.test:compileTestJava')
-    }
+	binaries.whenElementFinalized { binary ->
+		binary.compileTask.get().dependsOn(':com.ibm.wala.cast.test:compileTestJava')
+	}
 }

--- a/com.ibm.wala.cast/cast/build.gradle
+++ b/com.ibm.wala.cast/cast/build.gradle
@@ -1,20 +1,20 @@
 plugins {
-    id 'cpp-library'
+	id 'cpp-library'
 }
 
 library {
-    final def cSourceDir = '../source/c'
-    publicHeaders.from "$cSourceDir/include"
-    source.from "$cSourceDir/jni"
+	final def cSourceDir = '../source/c'
+	publicHeaders.from "$cSourceDir/include"
+	source.from "$cSourceDir/jni"
 
-    binaries.whenElementFinalized {
-        if (targetMachine.operatingSystemFamily.macOs) {
-            linkTask.get().configure {
-                final def library = getNativeLibraryOutput(it)
-                linkerArgs.add "-Wl,-install_name,@rpath/$library.name"
-            }
-        }
-    }
+	binaries.whenElementFinalized {
+		if (targetMachine.operatingSystemFamily.macOs) {
+			linkTask.get().configure {
+				final def library = getNativeLibraryOutput(it)
+				linkerArgs.add "-Wl,-install_name,@rpath/$library.name"
+			}
+		}
+	}
 
-    addJvmLibrary(project, it)
+	addJvmLibrary(project, it)
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Update Gradle and the p2-as-Maven Gradle plugin to their respective latest releases.

Indent two `build.gradle` scripts using tabs as our other `build.gradle` scripts already do.