### PR TITLE
Have git ignore JVM crash logs

### DIFF
--- a/com.ibm.wala.cast.test/smoke_main/.gitignore
+++ b/com.ibm.wala.cast.test/smoke_main/.gitignore
@@ -1,0 +1,1 @@
+/hs_err_pid*.log


### PR DESCRIPTION
Crash logs shouldn’t arise when tests are passing, but if a regression causes `smoke_main` to fail, then these crash logs will appear. We won’t ever want to check them into git, though, so git should ignore them.