### PR TITLE
Mark and optionally exclude slow tests

### DIFF
--- a/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/TestSimpleCallGraphShape.java
+++ b/com.ibm.wala.cast.js.test/harness-src/com/ibm/wala/cast/js/test/TestSimpleCallGraphShape.java
@@ -14,6 +14,7 @@ import com.ibm.wala.cast.ipa.callgraph.CAstCallGraphUtil;
 import com.ibm.wala.cast.js.ipa.callgraph.JSCFABuilder;
 import com.ibm.wala.cast.js.ipa.callgraph.PropertyNameContextSelector;
 import com.ibm.wala.cast.js.util.JSCallGraphBuilderUtil;
+import com.ibm.wala.core.tests.util.SlowTests;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.ibm.wala.ipa.callgraph.CallGraphBuilderCancelException;
@@ -29,6 +30,7 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
 
@@ -474,6 +476,7 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
   }
 
   @Test
+  @Category(SlowTests.class)
   public void testStackOverflowOnSsaConversionBug()
       throws IOException, IllegalArgumentException, CancelException, WalaException {
     JSCallGraphBuilderUtil.makeScriptCG("tests", "stack_overflow_on_ssa_conversion.js");
@@ -925,6 +928,7 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
   }
 
   @Test(expected = CallGraphBuilderCancelException.class)
+  @Category(SlowTests.class)
   public void testManyStrings()
       throws IllegalArgumentException, IOException, CancelException, WalaException {
     SSAPropagationCallGraphBuilder B =

--- a/com.ibm.wala.core.tests/build.gradle
+++ b/com.ibm.wala.core.tests/build.gradle
@@ -57,6 +57,11 @@ tasks.named('test') {
 		exclude '**/cha/LibraryVersionTest.class'
 		exclude '**/ir/TypeAnnotationTest.class'
 	}
+	if (project.hasProperty('excludeSlowTests')) {
+		useJUnit {
+			excludeCategories 'com.ibm.wala.core.tests.util.SlowTests'
+		}
+	}
 }
 
 tasks.register('cleanTestExtras', Delete) {

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/KawaCallGraphTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/KawaCallGraphTest.java
@@ -19,6 +19,7 @@ import com.ibm.wala.classLoader.Language;
 import com.ibm.wala.classLoader.Module;
 import com.ibm.wala.classLoader.ResourceJarFileModule;
 import com.ibm.wala.core.tests.shrike.DynamicCallGraphTestBase;
+import com.ibm.wala.core.tests.util.SlowTests;
 import com.ibm.wala.ipa.callgraph.AnalysisCacheImpl;
 import com.ibm.wala.ipa.callgraph.AnalysisOptions;
 import com.ibm.wala.ipa.callgraph.AnalysisOptions.ReflectionOptions;
@@ -42,7 +43,9 @@ import com.ibm.wala.util.strings.Atom;
 import java.io.IOException;
 import java.util.Set;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
+@Category(SlowTests.class)
 public class KawaCallGraphTest extends DynamicCallGraphTestBase {
 
   @Test

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/util/SlowTests.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/util/SlowTests.java
@@ -1,0 +1,9 @@
+package com.ibm.wala.core.tests.util;
+
+/**
+ * JUnit category marker for slow tests
+ *
+ * <p>Add “{@code -PexcludeSlowTests}” to the Gradle command line for faster test turnaround at the
+ * expense of worse test coverage.
+ */
+public interface SlowTests {}


### PR DESCRIPTION
837160d2c35f9655828bf1aa4e470accbe719d95 adds the ability to categorize specific JUnit tests or test classes as slow, and to optionally exclude this category when running Gradle tests:

* To mark a test method or class as slow, annotate it with
`@org.junit.experimental.categories.Category(com.ibm.wala.core.tests.util.SlowTests.class)`.

* To exclude tests categorized as slow, add `-PexcludeSlowTests` to your Gradle command line, or use [any other method you prefer](https://docs.gradle.org/current/userguide/build_environment.html#sec:project_properties) to set the `excludeSlowTests` Gradle project property.

1418e0dbd6c8029c32b6212625c330a2194f505a applies this `SlowTests` category to several tests based on my empirical measurements of test execution times. See that commit’s message for more details about which tests were so categorized and why.