### PR TITLE
Only print warning when directory is non-null

### DIFF
--- a/com.ibm.wala.core/src/com/ibm/wala/properties/WalaProperties.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/properties/WalaProperties.java
@@ -65,7 +65,10 @@ public final class WalaProperties {
     }
 
     String dir = p.getProperty(WalaProperties.J2SE_DIR);
-    if (dir == null || !(new File(dir)).isDirectory()) {
+    if (dir == null) {
+      return PlatformUtil.getBootClassPathJars();
+    }
+    if (!(new File(dir)).isDirectory()) {
       System.err.println(
           "WARNING: java_runtime_dir "
               + dir


### PR DESCRIPTION
This debug warning prints much more often after #447, which can cause a lot of log noise.  Only print the warning when the `wala.properties` file actually has an invalid directory in it.