### PR TITLE
IntelliJ IDEA 2019.2 metadata churn

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -116,7 +116,6 @@
       <option name="DOWHILE_BRACE_FORCE" value="3" />
       <option name="WHILE_BRACE_FORCE" value="3" />
       <option name="FOR_BRACE_FORCE" value="3" />
-      <option name="PARENT_SETTINGS_INSTALLED" value="true" />
     </codeStyleSettings>
     <codeStyleSettings language="Groovy">
       <indentOptions>


### PR DESCRIPTION
Nothing interesting here; just a minor change to how IntelliJ IDEA
2019.2 stores some project metadata.