### PR TITLE
Stop using Eclipse P2 repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 }
 
 plugins {
-	id 'com.diffplug.gradle.p2.asmaven' version '3.18.1'
+	id 'com.diffplug.gradle.eclipse.mavencentral' version '3.18.1' apply false
 	id 'com.github.hauner.jarTest' version '1.0.1' apply false
 	id 'com.github.sherter.google-java-format' version '0.8'
 	id 'de.set.ecj' version '1.4.1' apply false
@@ -25,45 +25,15 @@ repositories {
 
 ////////////////////////////////////////////////////////////////////////
 //
-//  required Eclipse components
-//
-
-p2AsMaven {
-	group 'eclipse-deps', {
-		repoEclipse '4.7.2'
-		slicingOption 'latestVersionOnly', 'true'
-		iu 'org.eclipse.core.commands'
-		iu 'org.eclipse.core.contenttype'
-		iu 'org.eclipse.core.jobs'
-		iu 'org.eclipse.core.resources'
-		iu 'org.eclipse.core.runtime'
-		iu 'org.eclipse.equinox.app'
-		iu 'org.eclipse.equinox.common'
-		iu 'org.eclipse.equinox.preferences'
-		iu 'org.eclipse.jdt.core'
-		iu 'org.eclipse.jface'
-		iu 'org.eclipse.osgi'
-		iu 'org.eclipse.pde.core'
-		iu 'org.eclipse.swt'
-		iu 'org.eclipse.ui.ide'
-		iu 'org.eclipse.ui.workbench'
-	}
-	group 'wst-deps', {
-		repo 'http://download.eclipse.org/releases/oxygen'
-		slicingOption 'latestVersionOnly', 'true'
-		iu 'org.eclipse.wst.jsdt.core'
-		iu 'org.eclipse.wst.jsdt.ui'
-	}
-}
-
-
-////////////////////////////////////////////////////////////////////////
-//
 //  common Java setup shared by multiple projects
 //
 
 group name
 version VERSION_NAME
+
+// version of Eclipse JARs to use for Eclipse-integrated WALA components
+ext.eclipseVersion = '4.7.2'
+ext.eclipseWstJsdtVersion = '1.0.201.v2010012803'
 
 subprojects { subproject ->
 	// skip generic Java setup for the few projects that have no Java code whatsoever
@@ -84,9 +54,6 @@ subprojects { subproject ->
 
 	repositories {
 		mavenCentral()
-		maven {
-			url "$rootProject.buildDir/p2asmaven/maven"
-		}
 	}
 
 	jar.manifest.from('META-INF/MANIFEST.MF')
@@ -129,41 +96,6 @@ subprojects { subproject ->
 			break
 		default:
 			throw new InvalidUserDataException("unrecognized Java compiler \"$javaCompilerProperty\"")
-	}
-}
-
-
-////////////////////////////////////////////////////////////////////////
-//
-//  find platform-specific SWT implementations
-//
-
-def osgi_platform
-
-switch (System.getProperty('os.name')) {
-	case ~/Mac OS X/:
-		osgi_platform = 'cocoa.macosx.x86_64'
-		break
-	case ~/Windows.*/:
-		osgi_platform = 'win32.win32.x86_64'
-		break
-	case ~/Linux/:
-		osgi_platform = 'gtk.linux.x86_64'
-		break
-	default:
-		throw new GradleException("unrecognized operating system name \"${System.getProperty('os.name')}\"")
-}
-
-System.setProperty('osgi.platform', osgi_platform)
-
-subprojects {
-	configurations.all {
-		resolutionStrategy {
-			// failOnVersionConflict()
-			dependencySubstitution {
-				substitute module('eclipse-deps:org.eclipse.swt.${osgi.platform}') with module("eclipse-deps:org.eclipse.swt.${System.getProperty('osgi.platform')}:3.+")
-			}
-		}
 	}
 }
 

--- a/com.ibm.wala.ide.jdt.test/build.gradle
+++ b/com.ibm.wala.ide.jdt.test/build.gradle
@@ -1,13 +1,27 @@
+plugins {
+	id 'com.diffplug.gradle.eclipse.mavencentral'
+}
+
 sourceSets.test {
 	java.srcDirs = ['source']
 	resources.srcDirs = ['testdata']
 }
 
+eclipseMavenCentral {
+	release eclipseVersion, {
+		[
+				'org.eclipse.core.contenttype',
+				'org.eclipse.core.runtime',
+				'org.eclipse.equinox.preferences',
+				'org.eclipse.jdt.core',
+				'org.eclipse.osgi',
+		].each { dep 'testImplementation', it }
+		useNativesForRunningPlatform()
+	}
+}
+
 dependencies {
 	testImplementation(
-			'eclipse-deps:org.eclipse.core.runtime:+',
-			'eclipse-deps:org.eclipse.jdt.core:+',
-			'eclipse-deps:org.eclipse.osgi:+',
 			'junit:junit:4.12',
 			'org.osgi:org.osgi.core:4.2.0',
 			project(':com.ibm.wala.cast'),
@@ -21,8 +35,6 @@ dependencies {
 			project(configuration: 'testArchives', path: ':com.ibm.wala.cast.java.test'),
 			project(configuration: 'testArchives', path: ':com.ibm.wala.core.tests'),
 			project(configuration: 'testArchives', path: ':com.ibm.wala.ide.tests'),
-			'eclipse-deps:org.eclipse.core.contenttype:+',
-			'eclipse-deps:org.eclipse.equinox.preferences:+',
 	)
 }
 

--- a/com.ibm.wala.ide.jdt/build.gradle
+++ b/com.ibm.wala.ide.jdt/build.gradle
@@ -1,18 +1,28 @@
+plugins {
+	id 'com.diffplug.gradle.eclipse.mavencentral'
+}
+
 sourceSets.main.java.srcDirs = ['source']
 
-dependencies {
-	api('eclipse-deps:org.eclipse.equinox.common:+') {
-		because 'protected method createProjectPath in public class JDTJavaSourceAnalysisEngine may throw exception CoreException'
+eclipseMavenCentral {
+	release eclipseVersion, {
+		api 'org.eclipse.equinox.common'
+		[
+				'org.eclipse.core.jobs',
+				'org.eclipse.core.resources',
+				'org.eclipse.core.runtime',
+				'org.eclipse.equinox.app',
+				'org.eclipse.jdt.core',
+				'org.eclipse.jface',
+				'org.eclipse.osgi',
+				'org.eclipse.ui.workbench',
+		].each it.&implementation
+		useNativesForRunningPlatform()
 	}
+}
+
+dependencies {
 	implementation(
-			'eclipse-deps:org.eclipse.core.jobs:+',
-			'eclipse-deps:org.eclipse.core.resources:+',
-			'eclipse-deps:org.eclipse.core.runtime:+',
-			'eclipse-deps:org.eclipse.equinox.app:+',
-			'eclipse-deps:org.eclipse.jdt.core:+',
-			'eclipse-deps:org.eclipse.jface:+',
-			'eclipse-deps:org.eclipse.osgi:+',
-			'eclipse-deps:org.eclipse.ui.workbench:+',
 			'org.osgi:org.osgi.core:4.2.0',
 			project(':com.ibm.wala.cast'),
 			project(':com.ibm.wala.cast.java'),

--- a/com.ibm.wala.ide.jsdt.tests/build.gradle
+++ b/com.ibm.wala.ide.jsdt.tests/build.gradle
@@ -1,16 +1,37 @@
+plugins {
+	id 'com.diffplug.gradle.eclipse.mavencentral'
+}
+
 sourceSets.test {
 	java.srcDirs = ['src']
 	resources.srcDirs = ['testdata']
 }
 
+repositories {
+	maven {
+		url 'https://artifacts.alfresco.com/nexus/content/repositories/public/'
+		content {
+			includeGroup 'org.eclipse.wst.jsdt'
+		}
+	}
+}
+
+eclipseMavenCentral {
+	release eclipseVersion, {
+		[
+				'org.eclipse.core.runtime',
+				'org.eclipse.equinox.common',
+				'org.eclipse.osgi',
+		].each { dep 'testImplementation', it }
+		useNativesForRunningPlatform()
+	}
+}
+
 dependencies {
 	testImplementation(
-			'eclipse-deps:org.eclipse.core.runtime:+',
-			'eclipse-deps:org.eclipse.equinox.common:+',
-			'eclipse-deps:org.eclipse.osgi:+',
 			'junit:junit:4.12',
+			"org.eclipse.wst.jsdt:core:$eclipseWstJsdtVersion",
 			'org.osgi:org.osgi.core:4.2.0',
-			'wst-deps:org.eclipse.wst.jsdt.core:+',
 			project(':com.ibm.wala.cast'),
 			project(':com.ibm.wala.cast.js'),
 			project(':com.ibm.wala.cast.js.rhino'),

--- a/com.ibm.wala.ide.jsdt/build.gradle
+++ b/com.ibm.wala.ide.jsdt/build.gradle
@@ -1,18 +1,39 @@
+plugins {
+	id 'com.diffplug.gradle.eclipse.mavencentral'
+}
+
 sourceSets.main.java.srcDirs = ['source']
+
+repositories {
+	maven {
+		url 'https://artifacts.alfresco.com/nexus/content/repositories/public/'
+		content {
+			includeGroup 'org.eclipse.wst.jsdt'
+		}
+	}
+}
+
+eclipseMavenCentral {
+	release eclipseVersion, {
+		[
+				'org.eclipse.core.jobs',
+				'org.eclipse.core.resources',
+				'org.eclipse.core.runtime',
+				'org.eclipse.equinox.common',
+				'org.eclipse.osgi',
+				'org.eclipse.ui.workbench',
+		].each it.&implementation
+		useNativesForRunningPlatform()
+	}
+}
 
 dependencies {
 	api(project(':com.ibm.wala.ide')) {
 		because 'public class JavaScriptHeadlessUtil extends class HeadlessUtil'
 	}
 	implementation(
-			'eclipse-deps:org.eclipse.core.jobs:+',
-			'eclipse-deps:org.eclipse.core.resources:+',
-			'eclipse-deps:org.eclipse.core.runtime:+',
-			'eclipse-deps:org.eclipse.equinox.common:+',
-			'eclipse-deps:org.eclipse.osgi:+',
-			'eclipse-deps:org.eclipse.ui.workbench:+',
-			'wst-deps:org.eclipse.wst.jsdt.core:+',
-			'wst-deps:org.eclipse.wst.jsdt.ui:+',
+			"org.eclipse.wst.jsdt:core:$eclipseWstJsdtVersion",
+			"org.eclipse.wst.jsdt:ui:$eclipseWstJsdtVersion",
 			project(':com.ibm.wala.cast'),
 			project(':com.ibm.wala.cast.js'),
 			project(':com.ibm.wala.cast.js.rhino'),

--- a/com.ibm.wala.ide.tests/build.gradle
+++ b/com.ibm.wala.ide.tests/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+	id 'com.diffplug.gradle.eclipse.mavencentral'
 	id 'com.github.hauner.jarTest'
 	id 'eclipse'
 }
@@ -7,17 +8,25 @@ eclipse.project.natures 'org.eclipse.pde.PluginNature'
 
 sourceSets.test.java.srcDirs = ['src']
 
+eclipseMavenCentral {
+	release eclipseVersion, {
+		[
+				'org.eclipse.core.commands',
+				'org.eclipse.core.jobs',
+				'org.eclipse.core.resources',
+				'org.eclipse.core.runtime',
+				'org.eclipse.equinox.common',
+				'org.eclipse.jface',
+				'org.eclipse.osgi',
+				'org.eclipse.ui.ide',
+				'org.eclipse.ui.workbench',
+		].each { dep 'testImplementation', it }
+		useNativesForRunningPlatform()
+	}
+}
+
 dependencies {
 	testImplementation(
-			'eclipse-deps:org.eclipse.core.commands:+',
-			'eclipse-deps:org.eclipse.core.jobs:+',
-			'eclipse-deps:org.eclipse.core.resources:+',
-			'eclipse-deps:org.eclipse.core.runtime:+',
-			'eclipse-deps:org.eclipse.equinox.common:+',
-			'eclipse-deps:org.eclipse.jface:+',
-			'eclipse-deps:org.eclipse.osgi:+',
-			'eclipse-deps:org.eclipse.ui.ide:+',
-			'eclipse-deps:org.eclipse.ui.workbench:+',
 			'org.osgi:org.osgi.core:4.2.0',
 			project(':com.ibm.wala.core'),
 			project(':com.ibm.wala.ide'),

--- a/com.ibm.wala.ide/build.gradle
+++ b/com.ibm.wala.ide/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+	id 'com.diffplug.gradle.eclipse.mavencentral'
 	id 'eclipse'
 }
 
@@ -6,21 +7,27 @@ eclipse.project.natures 'org.eclipse.pde.PluginNature'
 
 sourceSets.main.java.srcDirs = ['src']
 
-dependencies {
-	api('eclipse-deps:org.eclipse.pde.core:+') {
-		because 'otherwise ECJ fails to compile "JavaScriptEclipseProjectPath.java" and "JavaEclipseProjectPath.java", reporting that org.eclipse.pde.core.plugin.IPluginModelBase cannot be resolved, even though IPluginModelBase is only used by local variables and private methods within "EclipseProjectPath.java"'
+eclipseMavenCentral {
+	release eclipseVersion, {
+		api 'org.eclipse.pde.core'
+		[
+				'org.eclipse.core.commands',
+				'org.eclipse.core.jobs',
+				'org.eclipse.core.resources',
+				'org.eclipse.core.runtime',
+				'org.eclipse.equinox.common',
+				'org.eclipse.jdt.core',
+				'org.eclipse.jface',
+				'org.eclipse.osgi',
+				'org.eclipse.swt',
+				'org.eclipse.ui.workbench',
+		].each it.&implementation
+		useNativesForRunningPlatform()
 	}
+}
+
+dependencies {
 	implementation(
-			'eclipse-deps:org.eclipse.core.commands:+',
-			'eclipse-deps:org.eclipse.core.jobs:+',
-			'eclipse-deps:org.eclipse.core.resources:+',
-			'eclipse-deps:org.eclipse.core.runtime:+',
-			'eclipse-deps:org.eclipse.equinox.common:+',
-			'eclipse-deps:org.eclipse.jdt.core:+',
-			'eclipse-deps:org.eclipse.jface:+',
-			'eclipse-deps:org.eclipse.osgi:+',
-			'eclipse-deps:org.eclipse.swt.${osgi.platform}:+',
-			'eclipse-deps:org.eclipse.ui.workbench:+',
 			project(':com.ibm.wala.core'),
 			project(':com.ibm.wala.util'),
 	)


### PR DESCRIPTION
Many core Eclipse libraries are now cross-published directly to Maven Central. The WST JSDT libraries are not cross-published there, but I've found a source for them in a different public Maven repository. So now we can get everything we need from Maven repositories rather than downloading and converting P2 repositories.

Getting Eclipse libraries from proper Maven repositories should make the first build in a clean WALA tree faster and friendlier. We still need to download the Eclipse libraries, of course. But those downloads can now be concurrent with other Gradle build activity, such as compiling and running tests for non-Eclipse-based pieces of WALA. We also get better download progress reporting, proper Gradle caching, etc.