### PR TITLE
Correct slow-test filtering in all subprojects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,12 @@ subprojects { subproject ->
 		include '**/Test*.class'
 		exclude '**/*AndroidLibs*.class'
 
+		if (project.hasProperty('excludeSlowTests')) {
+			useJUnit {
+				excludeCategories 'com.ibm.wala.core.tests.util.SlowTests'
+			}
+		}
+
 		maxParallelForks = Integer.MAX_VALUE
 	}
 

--- a/com.ibm.wala.core.tests/build.gradle
+++ b/com.ibm.wala.core.tests/build.gradle
@@ -57,11 +57,6 @@ tasks.named('test') {
 		exclude '**/cha/LibraryVersionTest.class'
 		exclude '**/ir/TypeAnnotationTest.class'
 	}
-	if (project.hasProperty('excludeSlowTests')) {
-		useJUnit {
-			excludeCategories 'com.ibm.wala.core.tests.util.SlowTests'
-		}
-	}
 }
 
 tasks.register('cleanTestExtras', Delete) {


### PR DESCRIPTION
Previously we were only filtering out tests marked as slow in the `com.ibm.wala.core.tests` subproject.  However, `com.ibm.wala.cast.js.test` has some slow tests too.