### PR TITLE
Upgrade to Gradle 6.0.1

### DIFF
--- a/com.ibm.wala.cast.js.html.nu_validator/build.gradle
+++ b/com.ibm.wala.cast.js.html.nu_validator/build.gradle
@@ -13,9 +13,9 @@ dependencies {
 	testImplementation(
 			project(':com.ibm.wala.cast.test'),
 			project(':com.ibm.wala.cast.js.test'),
-			project(':com.ibm.wala.core.tests'),
 			project(configuration: 'testArchives', path: ':com.ibm.wala.cast.js.rhino.test'),
 			project(configuration: 'testArchives', path: ':com.ibm.wala.cast.js.test'),
+			project(configuration: 'testArchives', path: ':com.ibm.wala.core.tests'),
 	)
 }
 

--- a/com.ibm.wala.cast.js.nodejs.test/build.gradle
+++ b/com.ibm.wala.cast.js.nodejs.test/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 	testImplementation(
 			'junit:junit:4.12',
 			project(':com.ibm.wala.cast.js.nodejs'),
-			project(':com.ibm.wala.core'),
+			project(configuration: 'testArchives', path: ':com.ibm.wala.core.tests'),
 	)
 }
 

--- a/com.ibm.wala.cast.test/build.gradle
+++ b/com.ibm.wala.cast.test/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 			project(':com.ibm.wala.cast'),
 			project(':com.ibm.wala.core'),
 			project(':com.ibm.wala.util'),
+			project(configuration: 'testArchives', path: ':com.ibm.wala.core.tests'),
 	)
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This required some test classpath tweaks, presumably due to changes in how Gradle 6.x handles dependency resolution.

Gradle 6.0 also added built-in support for publishing Javadoc and source archives, which is something for which we currently rely on third-party plugins and scripts. Unfortunately, Gradle’s built-in support only works with the `maven-publish` and `ivy-publish` plugins. We [switched to using `maven` instead of `maven-publish`](https://github.com/liblit/WALA/commit/53e64de8cc6bc8ab9773168aff8fabd4b66efd5a) some time ago because we “couldn't get proper artifacts built with the `maven-publish` plugin”. So for now Gradle’s built-in support will remain unused by us. I have [a branch that partially enables this](https://github.com/liblit/WALA/tree/use-Gradle-6-built-in-javadoc-and-sources-publishing) in case someone else wants to poke around further, but it won’t do anything interesting unless we switch back from `maven` to `maven-publish`.