### PR TITLE
Travis CI p2.asmaven cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ cache:
   - "$HOME/.gradle/wrapper"
   - "$HOME/.m2"
   - "$HOME/apache-maven-3.5.0"
-  - "$TRAVIS_BUILD_DIR/build/p2asmaven"
   - "$TRAVIS_BUILD_DIR/com.ibm.wala.core.testdata/ocaml/ocamljava-2.0-alpha1/lib"
 env:
   global:

--- a/travis/before-install-gradle
+++ b/travis/before-install-gradle
@@ -1,10 +1,1 @@
 #!/bin/sh -emux
-
-# Initial p2AsMaven downloads are mostly silent, and can sometimes be
-# quite slow.  If 10 minutes go by with no output, then Travis CI
-# decides the entire job is hung.
-
-while sleep 8m; do echo 'waiting for Eclipse P2 downloads to finish'; done &
-trap 'kill %' EXIT
-
-./gradlew --dry-run

--- a/travis/before-install-maven
+++ b/travis/before-install-maven
@@ -1,7 +1,5 @@
 #!/bin/sh -eux
 
-"$(dirname "$0")"/before-install-gradle
-
 ./gradlew prepareMavenBuild
 
 git clone --depth=1 https://github.com/secure-software-engineering/DroidBench.git /tmp/DroidBench


### PR DESCRIPTION
Remove some Travis CI tweaks and hacks that are no longer relevant now that we stopped using the `p2.asmaven` plugin.