### PR TITLE
Add IntelliJ IDEA run configuration that builds nearly all tests

### DIFF
--- a/.idea/runConfigurations/Build_excluding_slow_tests.xml
+++ b/.idea/runConfigurations/Build_excluding_slow_tests.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Build excluding slow tests" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="-PexcludeSlowTests" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="linters" />
+          <option value="javadoc" />
+          <option value="build" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <GradleScriptDebugEnabled>true</GradleScriptDebugEnabled>
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
This IntelliJ IDEA run configuration uses the Gradle `build` task to run nearly all tests, excluding those tagged as slow. It also runs all Gradle-configured linters and builds Javadoc documentation. This configuration is intended to be a fairly thorough check that everything is in order, while still not taking an unreasonably long time to finish.