### PR TITLE
Ignore “.idea/jarRepositories.xml”

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,5 +1,6 @@
 *.iml
 /compiler.xml
+/jarRepositories.xml
 /libraries/*.xml
 /modules.xml
 /shelf/


### PR DESCRIPTION
IntelliJ IDEA 2019.3 stores this file as part of the project’s metadata. However, for a Gradle-based project such as WALA, this file is automatically derived from the Gradle build scripts.