### PR TITLE
Upgrade download plugin to latest v4.0.2 release

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -3,5 +3,5 @@ repositories {
 }
 
 dependencies {
-	implementation 'de.undercouch:gradle-download-task:4.0.0'
+	implementation 'de.undercouch:gradle-download-task:4.0.2'
 }


### PR DESCRIPTION
This release restores download progress reporting, fixing #597.