### PR TITLE
Add infrastructure for identifying slow tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,18 @@ subprojects { subproject ->
 			}
 		}
 
-		maxParallelForks = Integer.MAX_VALUE
+		if (project.hasProperty('trial')) {
+			outputs.upToDateWhen { false }
+			afterTest { descriptor, result ->
+				def csv = new File("$rootProject.buildDir/time-trials.csv")
+				if (!csv.exists()) {
+					csv.append('trial,className,name,resultType,startTime,endTime\n')
+				}
+				csv.append("$trial,$descriptor.className,$descriptor.name,$result.resultType,$result.startTime,$result.endTime\n")
+			}
+		} else {
+			maxParallelForks = Integer.MAX_VALUE
+		}
 	}
 
 	// Stash the original Java compiler toolchain in case needed.  This is actually only used by

--- a/run-time-trials
+++ b/run-time-trials
@@ -1,0 +1,16 @@
+#!/bin/bash -eux
+
+cd "$(dirname "$0")"
+
+# use one parallel invocation to build everything quickly before sequential time trials
+./gradlew testClasses "$@"
+
+gio trash build/time-trials.csv || :
+
+for trial in {1..10}; do
+  # "touch orderly-shutdown" to stop after current trial completes
+  if [ -f orderly-shutdown ]; then
+    break
+  fi
+  ./gradlew test --no-build-cache --no-parallel --project-prop trial=$trial "$@"
+done

--- a/summarize-time-trials
+++ b/summarize-time-trials
@@ -1,0 +1,50 @@
+#!/usr/bin/python3
+
+import numpy
+import pandas
+
+
+def main():
+    # load results, then identify successful and skipped tests
+    frame = pandas.read_csv('build/time-trials.csv')
+    results = frame['resultType']
+    successes = results == 'SUCCESS'
+    skips = results == 'SKIPPED'
+
+    # report failed tests, if any
+    failures = frame[~(successes | skips)]
+    if not failures.empty:
+        print('failed tests:')
+        print(failures)
+        return
+
+    # aggregate multiple trials of each individual test method
+    frame['elapsedTime'] = frame['endTime'] - frame['startTime']
+    grouped = frame[successes].groupby(['className', 'name'])['elapsedTime']
+
+    # print very wide tables in full; assume user can scroll horizontally
+    pandas.set_option('display.width', None)
+    pandas.set_option('display.max_colwidth', -1)
+
+    # summarize distribution of elapsed times, including fine-grained
+    # percentiles at the upper (slowest) end
+    times = grouped.mean()
+    times.sort_values(inplace=True)
+    print('Overall distribution and percentiles of elapsed times:\n')
+    print(times.describe(percentiles=numpy.arange(.8, 1, .01)))
+    print('\n')
+
+    # print slowest individual tests, showing only those in the 95% percentile
+    # or higher (slower)
+    rankedTimes = pandas.DataFrame(times)
+    rankedTimes['percentRank'] = times.rank(pct=True)
+    elapsedTimes = rankedTimes['elapsedTime']
+    rankedTimes['fractionOfTotal'] = elapsedTimes / elapsedTimes.sum()
+    isSlow = rankedTimes['percentRank'] >= .95
+    slowestTests = rankedTimes[isSlow][::-1]
+    print('Slowest individual tests:')
+    print(slowestTests.to_string(formatters={'percentRank': '{:.1%}'.format}))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The `run-time-trials` script repeatedly uses Gradle to rerun all tests.  During these runs, some extra Gradle logic is activated to record the start and end times of each individual test method.

The `summarize-time-trials` script describes the overall distribution of recorded test times, along with the top slowest individual test methods.

This was all useful for deciding which tests to annotate as `SlowTests`. I did that some time ago, but never committed these supporting tools.