### PR TITLE
If one GitHub CI job fails, let others continue

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,6 +17,7 @@ jobs:
           # testing ECJ compilation on any one OS is sufficient
           - os: macos-latest
             java-compiler: ecj
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out WALA sources


### PR DESCRIPTION
By default, GitHub Actions cancels the rest of a workflow if any job in that workflow fails.  I think I'd rather let the other jobs continue, as we already have with Travis CI.