### PR TITLE
Convert pre-commit script to bash

### DIFF
--- a/config/hooks/pre-commit
+++ b/config/hooks/pre-commit
@@ -17,7 +17,7 @@ REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
 # trailing newlines.  Forego `mapfile -t` for compatibility with Bash 3.x as found on macOS.
 # Recommended by <https://github.com/koalaman/shellcheck/wiki/SC2207>.
 files=()
-while IFS='' read -r line; do array+=("$line"); done \
+while IFS='' read -r line; do files+=("$line"); done \
   < <(git diff --cached --name-only --diff-filter=ACMR | grep -Ei '\.java$')
 
 join() {

--- a/config/hooks/pre-commit
+++ b/config/hooks/pre-commit
@@ -3,8 +3,11 @@
 REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
 
 # Set $files to an array of lines output by the "git diff ...| grep ..." pipeline, excluding the
-# trailing newlines.  Recommended by <https://github.com/koalaman/shellcheck/wiki/SC2207>.
-mapfile -t files < <(git diff --cached --name-only --diff-filter=ACMR | grep -Ei '\.java$')
+# trailing newlines.  Forego `mapfile -t` for compatibility with Bash 3.x as found on macOS.
+# Recommended by <https://github.com/koalaman/shellcheck/wiki/SC2207>.
+files=()
+while IFS='' read -r line; do array+=("$line"); done \
+  < <(git diff --cached --name-only --diff-filter=ACMR | grep -Ei '\.java$')
 
 join() {
   local IFS="$1"

--- a/config/hooks/pre-commit
+++ b/config/hooks/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
 

--- a/config/hooks/pre-commit
+++ b/config/hooks/pre-commit
@@ -1,11 +1,17 @@
-#!/bin/sh -e
+#!/bin/bash -ex
 
 REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
 
-files=$( (git diff --cached --name-only --diff-filter=ACMR | grep -Ei '\.java$') || true)
-if [ -n "$files" ]; then
-  comma_files=$(echo "$files" | paste -s -d , -)
+mapfile -t files < <(git diff --cached --name-only --diff-filter=ACMR | grep -Ei '\.java$')
+
+join() {
+  local IFS="$1"
+  shift
+  echo "$*"
+}
+
+if [ "${#files[@]}" -gt 0 ]; then
+  comma_files=$(join , "${files[@]}")
   "${REPO_ROOT_DIR}/gradlew" goJF -DgoogleJavaFormat.include="$comma_files" >/dev/null 2>&1
-  # shellcheck disable=SC2046
-  git add $(echo "$files" | paste -s -d ' ' -)
+  git add "${files[@]}"
 fi

--- a/config/hooks/pre-commit
+++ b/config/hooks/pre-commit
@@ -2,6 +2,8 @@
 
 REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
 
+# Set $files to an array of lines output by the "git diff ...| grep ..." pipeline, excluding the
+# trailing newlines.  Recommended by <https://github.com/koalaman/shellcheck/wiki/SC2207>.
 mapfile -t files < <(git diff --cached --name-only --diff-filter=ACMR | grep -Ei '\.java$')
 
 join() {

--- a/config/hooks/pre-commit
+++ b/config/hooks/pre-commit
@@ -1,5 +1,16 @@
 #!/bin/bash -e
 
+# Do our best to make sure we are running in bash *without* posix compatibility
+# enabled.  This is needed to detect old and buggy versions of our
+# pre-commit-stub script
+if [ -z "${BASH}" ] || [ -n "${POSIXLY_CORRECT}" ]; then
+  echo "Your git pre-commit script is outdated.";
+  echo "Please re-run \`./gradlew installGitHooks\` to get the latest script,";
+  echo "or run \`rm .git/hooks/pre-commit\` to disable the pre-commit hook.";
+  echo "Aborting commit";
+  exit 1
+fi
+
 REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
 
 # Set $files to an array of lines output by the "git diff ...| grep ..." pipeline, excluding the

--- a/config/hooks/pre-commit-stub
+++ b/config/hooks/pre-commit-stub
@@ -10,5 +10,5 @@ PRE_COMMIT_SCRIPT="${REPO_ROOT_DIR}/config/hooks/pre-commit"
 
 if [ -f "$PRE_COMMIT_SCRIPT" ]; then
   # shellcheck source=pre-commit
-  . "$PRE_COMMIT_SCRIPT"
+  "$PRE_COMMIT_SCRIPT"
 fi


### PR DESCRIPTION
Restore @liblit's aborted improvements to the pre-commit script from #599.  Those changes were aborted as they would cause a hard-to-understand error in the existing `pre-commit-stub` script.  Here we detect the bad condition and emit a more understandable error asking the user to update their script.