### PR TITLE
Convert cast.java.test to use the main source set

### DIFF
--- a/com.ibm.wala.cast.java.ecj.test/build.gradle
+++ b/com.ibm.wala.cast.java.ecj.test/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 			project(':com.ibm.wala.core'),
 			project(':com.ibm.wala.shrike'),
 			project(':com.ibm.wala.util'),
-			project(configuration: 'testArchives', path: ':com.ibm.wala.cast.java.test'),
+			project(':com.ibm.wala.cast.java.test'),
 	)
 }
 

--- a/com.ibm.wala.cast.java.test/build.gradle
+++ b/com.ibm.wala.cast.java.test/build.gradle
@@ -1,17 +1,15 @@
 plugins {
-	id 'com.github.hauner.jarTest'
 	id 'eclipse'
 }
 
 eclipse.project.natures 'org.eclipse.pde.PluginNature'
 
-sourceSets.test {
+sourceSets.main {
 	java.srcDirs = ['src']
-	resources.srcDirs = ['data']
 }
 
 dependencies {
-	testImplementation(
+	implementation(
 			'junit:junit:4.12',
 			'org.osgi:org.osgi.core:6.0.0',
 			project(':com.ibm.wala.cast'),
@@ -20,8 +18,4 @@ dependencies {
 			project(':com.ibm.wala.shrike'),
 			project(':com.ibm.wala.util'),
 	)
-}
-
-tasks.named('test') {
-	maxHeapSize = '800M'
 }

--- a/com.ibm.wala.cast.java.test/build.properties
+++ b/com.ibm.wala.cast.java.test/build.properties
@@ -1,5 +1,5 @@
 source.. = src/
-output.. = bin/test
+output.. = bin/main
 bin.includes = META-INF/,\
                .,\
                OSGI-INF/

--- a/com.ibm.wala.cast.java.test/pom.xml
+++ b/com.ibm.wala.cast.java.test/pom.xml
@@ -9,34 +9,4 @@
     </parent>
   <artifactId>com.ibm.wala.cast.java.test</artifactId>
   <packaging>eclipse-plugin</packaging>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>test</id>
-            <phase>test</phase>
-            <configuration>
-              <testClassesDirectory>${project.build.outputDirectory}</testClassesDirectory>
-              <argLine>-Xmx800M -ea</argLine>
-              <redirectTestOutputToFile>true</redirectTestOutputToFile>
-            </configuration>
-            <goals>
-              <goal>test</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
-  <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies> 
 </project>

--- a/com.ibm.wala.ide.jdt.test/build.gradle
+++ b/com.ibm.wala.ide.jdt.test/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 			project(':com.ibm.wala.ide.jdt'),
 			project(':com.ibm.wala.shrike'),
 			project(':com.ibm.wala.util'),
-			project(configuration: 'testArchives', path: ':com.ibm.wala.cast.java.test'),
+			project(':com.ibm.wala.cast.java.test'),
 			project(configuration: 'testArchives', path: ':com.ibm.wala.ide.tests'),
 	)
 }


### PR DESCRIPTION
There are actually no tests run in `com.ibm.wala.cast.java.test`.  It just has abstract test classes that get extended in other test modules.  So, use the main source set instead of the test source set, which will enable us to more easily put an artifact on Maven Central (to let us move IDE projects out of the repo, to enable retiring Maven).