### PR TITLE
Check for LambdaMetafactory <init> calls in LambdaMethodTargetSelector

### DIFF
--- a/com.ibm.wala.core.testdata/src/lambda/CallMetaFactory.java
+++ b/com.ibm.wala.core.testdata/src/lambda/CallMetaFactory.java
@@ -4,8 +4,8 @@ import java.lang.invoke.LambdaMetafactory;
 
 public class CallMetaFactory {
 
-  public static void main(String[] args) {
+  public static void main(String[] args) throws IllegalAccessException, InstantiationException {
     // shouldn't crash on this
-    LambdaMetafactory m = new LambdaMetafactory();
+    LambdaMetafactory m = LambdaMetafactory.class.newInstance();
   }
 }

--- a/com.ibm.wala.core.testdata/src/lambda/CallMetaFactory.java
+++ b/com.ibm.wala.core.testdata/src/lambda/CallMetaFactory.java
@@ -1,0 +1,11 @@
+package lambda;
+
+import java.lang.invoke.LambdaMetafactory;
+
+public class CallMetaFactory {
+
+  public static void main(String[] args) {
+    // shouldn't crash on this
+    LambdaMetafactory m = new LambdaMetafactory();
+  }
+}

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/LambdaTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/LambdaTest.java
@@ -229,4 +229,22 @@ public class LambdaTest extends WalaTestCase {
     checkCalledFromOneSite.accept("C4");
     checkCalledFromOneSite.accept("C5");
   }
+
+  @Test
+  public void testLambaMetafactoryCall()
+      throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
+
+    AnalysisScope scope =
+        CallGraphTestUtil.makeJ2SEAnalysisScope(
+            TestConstants.WALA_TESTDATA, CallGraphTestUtil.REGRESSION_EXCLUSIONS);
+    ClassHierarchy cha = ClassHierarchyFactory.make(scope);
+    Iterable<Entrypoint> entrypoints =
+        com.ibm.wala.ipa.callgraph.impl.Util.makeMainEntrypoints(
+            scope, cha, "Llambda/CallMetaFactory");
+    AnalysisOptions options = CallGraphTestUtil.makeAnalysisOptions(scope, entrypoints);
+
+    // shouldn't crash
+    CallGraph cg =
+        CallGraphTestUtil.buildZeroCFA(options, new AnalysisCacheImpl(), cha, scope, false);
+  }
 }

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/LambdaMethodTargetSelector.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/LambdaMethodTargetSelector.java
@@ -136,7 +136,9 @@ public class LambdaMethodTargetSelector implements MethodTargetSelector {
 
   private static boolean isNonClinitLambdaMetafactoryMethod(
       IClassHierarchy cha, MethodReference target) {
-    return !target.getName().equals(MethodReference.clinitName)
+    Atom name = target.getName();
+    return !name.equals(MethodReference.clinitName)
+        && !name.equals(MethodReference.initAtom)
         && Objects.equals(
             cha.lookupClass(TypeReference.LambdaMetaFactory),
             cha.lookupClass(target.getDeclaringClass()));

--- a/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/LambdaMethodTargetSelector.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/ipa/summaries/LambdaMethodTargetSelector.java
@@ -20,6 +20,7 @@ import com.ibm.wala.ipa.callgraph.MethodTargetSelector;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.ipa.summaries.LambdaSummaryClass.UnresolvedLambdaBodyException;
 import com.ibm.wala.shrikeCT.BootstrapMethodsReader.BootstrapMethod;
+import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.ssa.SSAInstructionFactory;
 import com.ibm.wala.ssa.SSAInvokeDynamicInstruction;
 import com.ibm.wala.types.MethodReference;
@@ -62,8 +63,15 @@ public class LambdaMethodTargetSelector implements MethodTargetSelector {
     IClassHierarchy cha = caller.getClassHierarchy();
     MethodReference target = site.getDeclaredTarget();
     if (isNonClinitLambdaMetafactoryMethod(cha, target)) {
-      SSAInvokeDynamicInstruction invoke =
-          (SSAInvokeDynamicInstruction) caller.getIR().getCalls(site)[0];
+      SSAAbstractInvokeInstruction call = caller.getIR().getCalls(site)[0];
+      if (!(call instanceof SSAInvokeDynamicInstruction)) {
+        System.err.println("unexpected non-invokedynamic instruction!");
+        System.err.println("instruction type: " + call.getClass());
+        System.err.println("call site: " + site);
+        System.err.println("caller: " + caller);
+        throw new RuntimeException("unexpected non-invokedynamic instruction!");
+      }
+      SSAInvokeDynamicInstruction invoke = (SSAInvokeDynamicInstruction) call;
 
       try {
         return methodSummaries.computeIfAbsent(


### PR DESCRIPTION
Fixes #285 

Previously, a direct call to the constructor of `LambdaMetafactory` would be incorrectly treated as coming from an `invokedynamic`, causing a crash.