### PR TITLE
Fix recent regressions in SlowTest filtering

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,9 @@ subprojects { subproject ->
 		exclude '**/*AndroidLibs*.class'
 
 		if (project.hasProperty('excludeSlowTests')) {
+			dependencies {
+				testRuntime project(':com.ibm.wala.testutil')
+			}
 			useJUnit {
 				excludeCategories 'com.ibm.wala.tests.util.SlowTests'
 			}

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ subprojects { subproject ->
 
 		if (project.hasProperty('excludeSlowTests')) {
 			useJUnit {
-				excludeCategories 'com.ibm.wala.core.tests.util.SlowTests'
+				excludeCategories 'com.ibm.wala.tests.util.SlowTests'
 			}
 		}
 


### PR DESCRIPTION
Gradle JUnit `SlowTest` filtering broke recently; these changes fix it.