### PR TITLE
Don't deploy snapshots on cron builds

### DIFF
--- a/travis-after-success.sh
+++ b/travis-after-success.sh
@@ -23,6 +23,8 @@ elif [ "$TRAVIS_BRANCH" != "$BRANCH" ]; then
   echo "Skipping snapshot deployment: wrong branch. Expected '$BRANCH' but was '$TRAVIS_BRANCH'."
 elif [ "$TRAVIS_OS_NAME" != "$OSNAME" ]; then
   echo "Skipping snapshot deployment: wrong OS. Expected '$OSNAME' but was '$TRAVIS_OS_NAME'."
+elif [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+  echo "Skipping snapshot deployment; running cron job."
 else
   echo "Deploying snapshot..."
   ./gradlew clean uploadArchives


### PR DESCRIPTION
Before we would deploy snapshot builds from cron jobs running for individual submodules, which is a waste.