### PR TITLE
Avoid hard-coded paths to source files

### DIFF
--- a/com.ibm.wala.cast.java.ecj/build.gradle
+++ b/com.ibm.wala.cast.java.ecj/build.gradle
@@ -28,7 +28,9 @@ mainClassName = 'com.ibm.wala.cast.java.ecj.util.SourceDirCallGraph'
 
 run {
 	// this is for testing purposes
-	args = ['-sourceDir', file("$rootDir/com.ibm.wala.cast.java.test.data/src"), '-mainClass', 'LArray1']
+	final def javaTestData = ':com.ibm.wala.cast.java.test.data'
+	evaluationDependsOn javaTestData
+	args = ['-sourceDir', project(javaTestData).sourceSets.test.java.srcDirs.find(), '-mainClass', 'LArray1']
 }
 
 apply from: rootProject.file("gradle-mvn-push.gradle")

--- a/com.ibm.wala.cast.java.test.data/build.gradle
+++ b/com.ibm.wala.cast.java.test.data/build.gradle
@@ -13,7 +13,7 @@ sourceSets.test.java.srcDirs = ['src']
 final def downloadJLex = tasks.register('downloadJLex', VerifiedDownload) {
 	src 'https://www.cs.princeton.edu/~appel/modern/java/JLex/current/Main.java'
 	checksum 'fe0cff5db3e2f0f5d67a153cf6c783af'
-	dest 'src/JLex/Main.java'
+	dest "${sourceSets.test.java.srcDirs.find()}/JLex/Main.java"
 }
 
 tasks.register('cleanDownloadJLex', Delete) {

--- a/com.ibm.wala.cast.js.nodejs/build.gradle
+++ b/com.ibm.wala.cast.js.nodejs/build.gradle
@@ -18,6 +18,9 @@ final def downloadNodeJS = tasks.register('downloadNodeJS', VerifiedDownload) {
 	checksum '33c5ba7a5d45644e70d268d8ad3e57df'
 }
 
+final def resourcesDir = sourceSets.main.resources.srcDirs.find()
+final def coreModulesDir = file("$resourcesDir/core-modules")
+
 tasks.register('unpackNodeJSLib', Copy) {
 	dependsOn downloadNodeJS
 	from(zipTree(downloadNodeJS.get().dest)) {
@@ -27,12 +30,12 @@ tasks.register('unpackNodeJSLib', Copy) {
 		}
 	}
 
-	into 'dat/core-modules'
+	into coreModulesDir
 	includeEmptyDirs false
 }
 
 tasks.register('cleanUnpackNodeJSLib', Delete) {
-	delete fileTree(dir: 'dat/core-modules', include: '*.js')
+	delete fileTree(dir: coreModulesDir, include: '*.js')
 }
 
 tasks.named('processResources') {

--- a/com.ibm.wala.cast.js.test.data/build.gradle
+++ b/com.ibm.wala.cast.js.test.data/build.gradle
@@ -16,7 +16,7 @@ tasks.register('unpackAjaxslt', Sync) {
 			relativePath new RelativePath(!directory, newSegments)
 		}
 	}
-	into 'examples-src/ajaxslt'
+	into "${sourceSets.test.resources.srcDirs.find()}/ajaxslt"
 }
 
 tasks.named('clean') {

--- a/com.ibm.wala.cast.test/xlator_test/build.gradle
+++ b/com.ibm.wala.cast.test/xlator_test/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 library {
-	privateHeaders.from '../build/headers'
+	privateHeaders.from project(':com.ibm.wala.cast.test').tasks.getByName('compileTestJava').options.headerOutputDirectory
 	source.from '../harness-src/c/smoke.cpp'
 
 	dependencies {


### PR DESCRIPTION
Treat each subproject's Gradle `sourceSet` configurations as authoritative regarding what is where.  Derive other Gradle paths from those, rather than hard-coding paths relative to subproject roots.

This change may seem to be more pedantic than practically useful. However, it lays the ground work for a larger upcoming reorganization of source locations.