### PR TITLE
Remove an unnecessary runtime dependency

### DIFF
--- a/com.ibm.wala.ide.tests/META-INF/MANIFEST.MF
+++ b/com.ibm.wala.ide.tests/META-INF/MANIFEST.MF
@@ -5,7 +5,6 @@ Bundle-SymbolicName: com.ibm.wala.ide.tests;singleton:=true
 Bundle-Version: 1.5.5.qualifier
 Bundle-Vendor: %providerName
 Require-Bundle: com.ibm.wala.ide,
- com.ibm.wala.ide.jdt;bundle-version="1.5.5.qualifier",
  org.eclipse.core.runtime,
  org.eclipse.core.resources,
  org.eclipse.jdt.core,

--- a/com.ibm.wala.ide.tests/build.gradle
+++ b/com.ibm.wala.ide.tests/build.gradle
@@ -30,5 +30,4 @@ dependencies {
 			project(':com.ibm.wala.ide'),
 			project(':com.ibm.wala.util'),
 	)
-	testRuntimeOnly project(':com.ibm.wala.ide.jdt')
 }


### PR DESCRIPTION
`com.ibm.wala.ide.tests` has had a runtime dependency on `com.ibm.wala.ide.jdt` at least as far back as 530d74929fa2b00594f26c4f6b3dea8a6544c0c8, in the early days of building WALA with Gradle. I don’t know where I got the impression that this dependency was needed; perhaps from Maven before that?  In any case, this dependency is apparently not needed after all:  all automated CI tests still pass with this dependency removed.

@msridar [described](https://github.com/wala/WALA/issues/636#issuecomment-569527600) this dependency as one that “seems like a mistake or bad.” Removing it now seems safe, and fixes #638 as easily as anyone could hope for.