### PR TITLE
Set resource path *before* deriving other paths from it

### DIFF
--- a/com.ibm.wala.cast.js.nodejs/build.gradle
+++ b/com.ibm.wala.cast.js.nodejs/build.gradle
@@ -18,6 +18,11 @@ final def downloadNodeJS = tasks.register('downloadNodeJS', VerifiedDownload) {
 	checksum '33c5ba7a5d45644e70d268d8ad3e57df'
 }
 
+sourceSets.main {
+	java.srcDirs = ['src']
+	resources.srcDirs = ['dat']
+}
+
 final def resourcesDir = sourceSets.main.resources.srcDirs.find()
 final def coreModulesDir = file("$resourcesDir/core-modules")
 
@@ -44,9 +49,4 @@ tasks.named('processResources') {
 
 tasks.named('clean') {
 	dependsOn 'cleanUnpackNodeJSLib'
-}
-
-sourceSets.main {
-	java.srcDirs = ['src']
-	resources.srcDirs = ['dat']
 }


### PR DESCRIPTION
All tests pass either way, but this way puts some downloaded files in the right place for an existing `.gitignore` to do what it should.