### PR TITLE
Assorted Javadoc and Javadoc+Gradle fixups

### DIFF
--- a/buildSrc/src/main/groovy/package-list.groovy
+++ b/buildSrc/src/main/groovy/package-list.groovy
@@ -1,5 +1,6 @@
 import org.gradle.api.tasks.*
 
+import java.nio.file.Path
 
 ////////////////////////////////////////////////////////////////////////
 //
@@ -9,23 +10,35 @@ import org.gradle.api.tasks.*
 @CacheableTask
 class CreatePackageList extends org.gradle.api.DefaultTask {
 
-	@PathSensitive(PathSensitivity.RELATIVE)
-	@Input Object sourceSet
+	@OutputFile
+	final File packageList = new File("$temporaryDir/package-list")
 
-	@OutputFile File packageList = new File("$temporaryDir/package-list")
+	private SortedSet<Path> sourceFileSubdirectories
+
+	@Input final getSourceFileSubdirectories() {
+		// serializable representation of subdirs suitable for cache indexing
+		return sourceFileSubdirectories*.toString()
+	}
+
+	@SuppressWarnings("unused")
+	final sourceSet(final SourceSet sourceSet) {
+		// gather source subdirs relative to each source root
+		sourceFileSubdirectories = new TreeSet<>(
+				sourceSet.java.sourceCollections.collect { collection ->
+					final sourceRoot = collection.tree.dir.toPath()
+					collection.collect { source ->
+						final javaSourceFilePath = source.toPath()
+						final parentPath = javaSourceFilePath.parent
+						sourceRoot.relativize(parentPath)
+					}
+				}.flatten()
+		)
+	}
 
 	@TaskAction
-	def create() {
-		sourceSet.sourceCollections.collect { collection ->
-			def sourceRoot = collection.tree.dir.toPath()
-			collection.collect { source ->
-				def javaSourceFilePath = source.toPath()
-				def parentPath = javaSourceFilePath.parent
-				def relativePath = sourceRoot.relativize(parentPath)
-				relativePath.toString().replace(File.separator, '.')
-			}
-		}.flatten().sort().unique().each {
-			packageList << "$it\n"
-		}
+	final def create() {
+		// relative subbdirs as dot-delimited qualified Java package names, one per line
+		packageList.text = getSourceFileSubdirectories()
+				*.replace(File.separator, '.').join('\n') + '\n'
 	}
 }

--- a/com.ibm.wala.cast.js/build.gradle
+++ b/com.ibm.wala.cast.js/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 }
 
 tasks.register('createPackageList', CreatePackageList) {
-	sourceSet sourceSets.main.java
+	sourceSet sourceSets.main
 }
 
 tasks.named('javadoc') {

--- a/com.ibm.wala.core/src/com/ibm/wala/util/io/FileProvider.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/util/io/FileProvider.java
@@ -176,7 +176,7 @@ public class FileProvider {
    * Properly creates the String file name of a {@link URL}. This works around a bug in the Sun
    * implementation of {@link URL#getFile()}, which doesn't properly handle file paths with spaces
    * (see <a href=
-   * "http://sourceforge.net/tracker/index.php?func=detail&aid=1565842&group_id=176742&atid=878458"
+   * "http://sourceforge.net/tracker/index.php?func=detail&amp;aid=1565842&amp;group_id=176742&amp;atid=878458"
    * >bug report</a>). For now, fails with an assertion if the url is malformed.
    *
    * @return the path name for the url

--- a/com.ibm.wala.dalvik/build.gradle
+++ b/com.ibm.wala.dalvik/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 }
 
 tasks.register('createPackageList', CreatePackageList) {
-	sourceSet sourceSets.main.java
+	sourceSet sourceSets.main
 }
 
 tasks.named('javadoc') {

--- a/com.ibm.wala.util/build.gradle
+++ b/com.ibm.wala.util/build.gradle
@@ -13,7 +13,10 @@ tasks.named('javadoc') {
 	doFirst {
 		classpath += files project(coreName).compileJava
 	}
-	options.links 'https://docs.oracle.com/javase/8/docs/api/'
+
+	options.links sourceCompatibility >= JavaVersion.VERSION_11
+			? "https://docs.oracle.com/en/java/javase/$sourceCompatibility/docs/api/"
+			: "https://docs.oracle.com/javase/$sourceCompatibility/docs/api/"
 }
 
 apply from: rootProject.file("gradle-mvn-push.gradle")


### PR DESCRIPTION
Properly escape ampersands in Javadoc.

Match Java SE Javadoc to version of Java in use.

In a custom Gradle task used to help build Javadoc documentation, don’t apply `@PathSensitive` to non-file inputs.