### PR TITLE
Add Gradle versions plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ plugins {
 	id 'de.undercouch.download'
 	id 'nebula.lint' version '14.2.5'
 	id 'nebula.source-jar' version '14.1.1' apply false
+	id 'com.github.ben-manes.versions' version '0.27.0'
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -9,13 +9,13 @@ buildscript {
 
 plugins {
 	id 'com.diffplug.gradle.eclipse.mavencentral' version '3.18.1' apply false
+	id 'com.github.ben-manes.versions' version '0.27.0'
 	id 'com.github.hauner.jarTest' version '1.0.1' apply false
 	id 'com.github.sherter.google-java-format' version '0.8'
 	id 'de.set.ecj' version '1.4.1' apply false
 	id 'de.undercouch.download'
 	id 'nebula.lint' version '14.2.5'
 	id 'nebula.source-jar' version '14.1.1' apply false
-	id 'com.github.ben-manes.versions' version '0.27.0'
 }
 
 repositories {


### PR DESCRIPTION
See [the docs](https://github.com/ben-manes/gradle-versions-plugin/blob/master/README.md).  Now we can run `./gradlew dependencyUpdates` to see which dependencies are out of date.  This is a complement to dependabot, which doesn't work perfectly.  (E.g., there are still a bunch of references to JUnit 4.12, even though we already updated to 4.13 based on the dependabot PR.)  The plugin is customizable so eventually we could ignore certain deps, certain types of releases, etc.