### PR TITLE
Log stdout and stderr from ECJ run

### DIFF
--- a/com.ibm.wala.cast.java.ecj/build.gradle
+++ b/com.ibm.wala.cast.java.ecj/build.gradle
@@ -31,6 +31,15 @@ run {
 	final def javaTestData = ':com.ibm.wala.cast.java.test.data'
 	evaluationDependsOn javaTestData
 	args = ['-sourceDir', project(javaTestData).sourceSets.test.java.srcDirs.find(), '-mainClass', 'LArray1']
+
+	// log output to file, although we don't validate it
+	final def outFile = file("$temporaryDir/stdout-and-stderr.log")
+	outputs.file outFile
+	doFirst {
+		final def fileStream = outFile.newOutputStream()
+		standardOutput fileStream
+		errorOutput fileStream
+	}
 }
 
 apply from: rootProject.file("gradle-mvn-push.gradle")


### PR DESCRIPTION
The `run` task here really serves as a test.  We don’t validate the output; the test merely consists of completing the run successfully. So now we log this `run` task’s `stdout` and `stderr` to a file, and set
that file as the task’s output.  Without this, Gradle thinks that the `run` task must be rerun every time we run the test suite.  In general, Gradle caching and incremental rebuilds work best if it knows where each task’s output is stored.