### PR TITLE
Don't save a CallGraph we never use in the future

### DIFF
--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/LambdaTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/LambdaTest.java
@@ -244,6 +244,9 @@ public class LambdaTest extends WalaTestCase {
     AnalysisOptions options = CallGraphTestUtil.makeAnalysisOptions(scope, entrypoints);
 
     // shouldn't crash
-    CallGraphTestUtil.buildZeroCFA(options, new AnalysisCacheImpl(), cha, scope, false);
+    CallGraph cg =
+        CallGraphTestUtil.buildZeroCFA(options, new AnalysisCacheImpl(), cha, scope, false);
+    // exceedingly unlikely to fail, but ensures that optimizer won't remove buildZeroCFA call
+    Assert.assertTrue(cg.getNumberOfNodes() > 0);
   }
 }

--- a/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/LambdaTest.java
+++ b/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/callGraph/LambdaTest.java
@@ -244,7 +244,6 @@ public class LambdaTest extends WalaTestCase {
     AnalysisOptions options = CallGraphTestUtil.makeAnalysisOptions(scope, entrypoints);
 
     // shouldn't crash
-    CallGraph cg =
-        CallGraphTestUtil.buildZeroCFA(options, new AnalysisCacheImpl(), cha, scope, false);
+    CallGraphTestUtil.buildZeroCFA(options, new AnalysisCacheImpl(), cha, scope, false);
   }
 }


### PR DESCRIPTION
We still build the call graph, which "shouldn't crash" per the existing comment.  But there's no need to save it in an otherwise-unused local variable.