### PR TITLE
Rejuvenate log levels

### DIFF
--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/FlatInstantiator.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/FlatInstantiator.java
@@ -474,7 +474,7 @@ public class FlatInstantiator implements IInstantiator {
 
   /** Used internally to avoid endless recursion on getTypes(). */
   private Set<TypeReference> getTypes(final TypeReference T, final Set<TypeReference> seen) {
-    logger.debug("getTypes({}, {})", T, seen);
+    logger.trace("getTypes({}, {})", T, seen);
     final Set<TypeReference> ret = new HashSet<>();
     ret.add(T);
 

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/AbstractAndroidModel.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/AbstractAndroidModel.java
@@ -410,7 +410,7 @@ public abstract class AbstractAndroidModel {
     if ((this.currentSection.compareTo(AndroidEntryPoint.ExecutionOrder.MIDDLE_OF_LOOP) <= 0)
         && (section.compareTo(AndroidEntryPoint.ExecutionOrder.MULTIPLE_TIMES_IN_LOOP) >= 0)) {
       PC = enterMULTIPLE_TIMES_IN_LOOP(PC);
-      logger.info("ENTER: MULTIPLE_TIMES_IN_LOOP");
+      logger.debug("ENTER: MULTIPLE_TIMES_IN_LOOP");
       this.currentSection = AndroidEntryPoint.ExecutionOrder.MULTIPLE_TIMES_IN_LOOP;
     }
 

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/LoopAndroidModel.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/LoopAndroidModel.java
@@ -203,7 +203,7 @@ public class LoopAndroidModel extends SingleStartAndroidModel {
    */
   @Override
   protected int leaveAT_LAST(int PC) {
-    logger.info("Leaving Model with PC = {}", PC);
+    logger.trace("Leaving Model with PC = {}", PC);
     return PC;
   }
 }

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentContextSelector.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentContextSelector.java
@@ -135,7 +135,7 @@ public class IntentContextSelector implements ContextSelector {
           } else if (param.getConcreteType().getName().equals(AndroidTypes.IntentName)) {
             if (!intents.contains(param)) {
               logger.error("Unable to resolve Intent called from {}", caller.getMethod());
-              logger.error("Search Key: {} hash: {}", param, param.hashCode());
+              logger.info("Search Key: {} hash: {}", param, param.hashCode());
               break;
             } else {
               intent = intents.find(param);
@@ -310,7 +310,7 @@ public class IntentContextSelector implements ContextSelector {
       final InstanceKey self = actualParameters[0];
       final Intent intent = intents.find(self);
 
-      logger.warn("Re-Setting the target of Intent {} in {} by {}", intent, site, caller);
+      logger.info("Re-Setting the target of Intent {} in {} by {}", intent, site, caller);
 
       intent.setExplicit();
       intents.unbind(self);

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidEntryPointManager.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidEntryPointManager.java
@@ -477,7 +477,7 @@ public final /* singleton */ class AndroidEntryPointManager implements Serializa
       throw new IllegalArgumentException("The given Intent is null");
     }
 
-    logger.info("Register Intent {}", intent);
+    logger.trace("Register Intent {}", intent);
     // Looks a bit weired but works as Intents are only matched based on their action and uri
     overrideIntents.put(intent, intent);
   }
@@ -610,7 +610,7 @@ public final /* singleton */ class AndroidEntryPointManager implements Serializa
       throw new IllegalArgumentException("The Intent given as 'to' is null");
     }
 
-    logger.info("Override Intent {} to {}", from, to);
+    logger.trace("Override Intent {} to {}", from, to);
     overrideIntents.put(from, to);
   }
 
@@ -646,7 +646,7 @@ public final /* singleton */ class AndroidEntryPointManager implements Serializa
         }
       }
       ret = overrideIntents.get(ret); // Once again to get Info set in register
-      logger.info("Resolved {} to {}", intent, ret);
+      logger.debug("Resolved {} to {}", intent, ret);
       return ret;
     } else {
       logger.info("No information on {} hash: {}", intent, intent.hashCode());

--- a/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
+++ b/com.ibm.wala.dalvik/src/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
@@ -447,7 +447,7 @@ public class AndroidManifestXMLReader {
         }
 
         attributesHistory.get(relevant).push(attr);
-        logger.debug("Pushing '{}' for {} in {}", attr, relevant, self);
+        logger.trace("Pushing '{}' for {} in {}", attr, relevant, self);
         // if there is no such value in saxAttrs it returns null
       }
     }
@@ -459,7 +459,7 @@ public class AndroidManifestXMLReader {
     public void popAttributes() {
       for (Attr relevant : self.getRelevantAttributes()) {
         try {
-          logger.debug(
+          logger.trace(
               "Popping {} of value {} in {}",
               relevant,
               attributesHistory.get(relevant).peek(),
@@ -702,10 +702,10 @@ public class AndroidManifestXMLReader {
       }
       final Intent intent = AndroidSettingFactory.intent(pack, name, null);
 
-      logger.info("\tRegister: {}", intent);
+      logger.trace("\tRegister: {}", intent);
       AndroidEntryPointManager.MANAGER.registerIntent(intent);
       for (Intent ovr : overrideTargets) {
-        logger.info("\tOverride: {} --> {}", ovr, intent);
+        logger.trace("\tOverride: {} --> {}", ovr, intent);
         if (ovr.equals(intent)) {
           AndroidEntryPointManager.MANAGER.registerIntent(intent);
         } else {


### PR DESCRIPTION
We appreciate your previous feedback and it's very helpful! We added Slf4j support and enhanced our tool after that. Here's a reissue of https://github.com/wala/WALA/pull/461 with a new version of our tool.  Again, we'd appreciate any feedback and are willing to make further changes if you wish to incorporate our PR into your project.

Settings
---
We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

- Never lower the logging level of logging statements within catch blocks.
- Never lower the logging level of logging statements within if statements.
- Never lower the logging level of logging statements containing certain (important) keywords.
- Never raise the logging level of logging statements without particular keywords in their messages.
- Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
- Consistent log level transformations between overriding methods.

The greatest number of commits from HEAD evaluated: 1000.
The head at the time of analysis was: b73a0b2c60c60e5419c95caa7ced503dd7114289
