### PR TITLE
Add JUnit4 entrypoint support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,6 +135,7 @@ allprojects {
 		options.addBooleanOption('Xdoclint:all,-missing', true)
 		options.encoding = 'UTF-8'
 		options.quiet()
+        options.tags += "apiNote:a:API Note:"
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -135,7 +135,7 @@ allprojects {
 		options.addBooleanOption('Xdoclint:all,-missing', true)
 		options.encoding = 'UTF-8'
 		options.quiet()
-        options.tags += "apiNote:a:API Note:"
+		options.tags += "apiNote:a:API Note:"
 	}
 }
 

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/util/scope/JUnitEntryPoints.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/util/scope/JUnitEntryPoints.java
@@ -84,7 +84,7 @@ public class JUnitEntryPoints {
           Set<IMethod> setUpTearDowns;
           try {
             setUpTearDowns = getSetUpTearDownMethods(klass);
-          } catch (ClassHierarchyException e) {
+          } catch (Exception e) {
             throw new IllegalArgumentException("Can't find test method entry points using class hierarchy: " + cha, e);
           }
           for (IMethod m : setUpTearDowns) {

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/util/scope/JUnitEntryPoints.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/util/scope/JUnitEntryPoints.java
@@ -10,12 +10,6 @@
  */
 package com.ibm.wala.util.scope;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.logging.Logger;
-
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IClassLoader;
 import com.ibm.wala.classLoader.IMethod;
@@ -29,6 +23,11 @@ import com.ibm.wala.types.TypeName;
 import com.ibm.wala.types.annotations.Annotation;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.strings.Atom;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Logger;
 
 /**
  * This class represents entry points ({@link Entrypoint})s of JUnit test methods. JUnit test
@@ -39,14 +38,24 @@ public class JUnitEntryPoints {
 
   private static final Logger logger = Logger.getLogger(JUnitEntryPoints.class.getName());
 
-  /**
-   * Names of annotations that denote JUnit4/5 test methods.
-   */
-  private static final Set<String> TEST_ENTRY_POINT_ANNOTATION_NAMES = new HashSet<>(
-      Arrays.asList("org.junit.After", "org.junit.AfterClass", "org.junit.Before", "org.junit.BeforeClass", "org.junit.ClassRule",
-        "org.junit.Rule", "org.junit.Test", "org.junit.runners.Parameterized.Parameters", "org.junit.jupiter.api.AfterAll",
-        "org.junit.jupiter.api.AfterEach", "org.junit.jupiter.api.BeforeAll", "org.junit.jupiter.api.BeforeEach",
-        "org.junit.jupiter.api.RepeatedTest", "org.junit.jupiter.api.Test"));
+  /** Names of annotations that denote JUnit4/5 test methods. */
+  private static final Set<String> TEST_ENTRY_POINT_ANNOTATION_NAMES =
+      new HashSet<>(
+          Arrays.asList(
+              "org.junit.After",
+              "org.junit.AfterClass",
+              "org.junit.Before",
+              "org.junit.BeforeClass",
+              "org.junit.ClassRule",
+              "org.junit.Rule",
+              "org.junit.Test",
+              "org.junit.runners.Parameterized.Parameters",
+              "org.junit.jupiter.api.AfterAll",
+              "org.junit.jupiter.api.AfterEach",
+              "org.junit.jupiter.api.BeforeAll",
+              "org.junit.jupiter.api.BeforeEach",
+              "org.junit.jupiter.api.RepeatedTest",
+              "org.junit.jupiter.api.Test"));
 
   /**
    * Construct JUnit entrypoints for all the JUnit test methods in the given scope.
@@ -83,7 +92,8 @@ public class JUnitEntryPoints {
           try {
             setUpTearDowns = getSetUpTearDownMethods(klass);
           } catch (Exception e) {
-            throw new IllegalArgumentException("Can't find test method entry points using class hierarchy: " + cha, e);
+            throw new IllegalArgumentException(
+                "Can't find test method entry points using class hierarchy: " + cha, e);
           }
           for (IMethod m : setUpTearDowns) {
             result.add(new DefaultEntrypoint(m, cha));
@@ -94,8 +104,7 @@ public class JUnitEntryPoints {
           // Since JUnit4 test classes are POJOs, look through each method.
           for (com.ibm.wala.classLoader.IMethod method : klass.getDeclaredMethods()) {
             // if method has an annotation
-            if (!(method instanceof ShrikeCTMethod))
-              continue;
+            if (!(method instanceof ShrikeCTMethod)) continue;
             for (Annotation annotation : ((ShrikeCTMethod) method).getAnnotations())
               if (isTestEntryPoint(annotation.getType().getName())) {
                 result.add(new DefaultEntrypoint(method, cha));
@@ -107,13 +116,11 @@ public class JUnitEntryPoints {
           if (isTestClass) {
             IMethod classInitializer = klass.getClassInitializer();
 
-            if (classInitializer != null)
-              result.add(new DefaultEntrypoint(classInitializer, cha));
+            if (classInitializer != null) result.add(new DefaultEntrypoint(classInitializer, cha));
 
             IMethod ctor = klass.getMethod(MethodReference.initSelector);
 
-            if (ctor != null)
-              result.add(new DefaultEntrypoint(ctor, cha));
+            if (ctor != null) result.add(new DefaultEntrypoint(ctor, cha));
           }
         }
       }

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/util/scope/JUnitEntryPoints.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/util/scope/JUnitEntryPoints.java
@@ -23,6 +23,7 @@ import com.ibm.wala.types.TypeName;
 import com.ibm.wala.types.annotations.Annotation;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.strings.Atom;
+import com.ibm.wala.util.strings.StringStuff;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -129,16 +130,12 @@ public class JUnitEntryPoints {
   }
 
   private static boolean isTestEntryPoint(TypeName typeName) {
-    String javaName = walaTypeNameToJavaName(typeName);
-    return TEST_ENTRY_POINT_ANNOTATION_NAMES.contains(javaName);
-  }
-
-  private static String walaTypeNameToJavaName(TypeName typeName) {
-    String fullyQualifiedName = typeName.getPackage() + "." + typeName.getClassName();
-
     // WALA uses $ to refers to inner classes. We have to replace "$" by "."
     // to make it a valid class name in Java source code.
-    return fullyQualifiedName.replace("$", ".").replace("/", ".");
+    String javaName =
+        StringStuff.jvmToReadableType(typeName.getPackage() + "." + typeName.getClassName());
+
+    return TEST_ENTRY_POINT_ANNOTATION_NAMES.contains(javaName);
   }
 
   /**

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/util/scope/JUnitEntryPoints.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/util/scope/JUnitEntryPoints.java
@@ -44,11 +44,13 @@ public class JUnitEntryPoints {
   private static final Logger logger = Logger.getLogger(JUnitEntryPoints.class.getName());
 
   /**
-   * Names of annotations that denote JUnit4 test methods.
+   * Names of annotations that denote JUnit4/5 test methods.
    */
   private static final Set<String> TEST_ENTRY_POINT_ANNOTATION_NAMES = new HashSet<>(
       Arrays.asList("org.junit.After", "org.junit.AfterClass", "org.junit.Before", "org.junit.BeforeClass", "org.junit.ClassRule",
-          "org.junit.Rule", "org.junit.Test", "org.junit.runners.Parameterized.Parameters"));
+          "org.junit.Rule", "org.junit.Test", "org.junit.runners.Parameterized.Parameters", "org.junit.jupiter.api.AfterAll",
+          "org.junit.jupiter.api.AfterEach", "org.junit.jupiter.api.BeforeAll", "org.junit.jupiter.api.BeforeEach",
+          "org.junit.jupiter.api.RepeatedTest", "org.junit.jupiter.api.Test"));
 
   /**
    * Construct JUnit entrypoints for all the JUnit test methods in the given scope.

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/util/scope/JUnitEntryPoints.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/util/scope/JUnitEntryPoints.java
@@ -48,9 +48,9 @@ public class JUnitEntryPoints {
    */
   private static final Set<String> TEST_ENTRY_POINT_ANNOTATION_NAMES = new HashSet<>(
       Arrays.asList("org.junit.After", "org.junit.AfterClass", "org.junit.Before", "org.junit.BeforeClass", "org.junit.ClassRule",
-          "org.junit.Rule", "org.junit.Test", "org.junit.runners.Parameterized.Parameters", "org.junit.jupiter.api.AfterAll",
-          "org.junit.jupiter.api.AfterEach", "org.junit.jupiter.api.BeforeAll", "org.junit.jupiter.api.BeforeEach",
-          "org.junit.jupiter.api.RepeatedTest", "org.junit.jupiter.api.Test"));
+        "org.junit.Rule", "org.junit.Test", "org.junit.runners.Parameterized.Parameters", "org.junit.jupiter.api.AfterAll",
+        "org.junit.jupiter.api.AfterEach", "org.junit.jupiter.api.BeforeAll", "org.junit.jupiter.api.BeforeEach",
+        "org.junit.jupiter.api.RepeatedTest", "org.junit.jupiter.api.Test"));
 
   /**
    * Construct JUnit entrypoints for all the JUnit test methods in the given scope.

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/util/scope/JUnitEntryPoints.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/util/scope/JUnitEntryPoints.java
@@ -46,7 +46,7 @@ public class JUnitEntryPoints {
   /**
    * Names of annotations that denote JUnit4 test methods.
    */
-  private static final Set<String> testEntryPointAnnotationNames = new HashSet<>(
+  private static final Set<String> TEST_ENTRY_POINT_ANNOTATION_NAMES = new HashSet<>(
       Arrays.asList("org.junit.After", "org.junit.AfterClass", "org.junit.Before", "org.junit.BeforeClass", "org.junit.ClassRule",
           "org.junit.Rule", "org.junit.Test", "org.junit.runners.Parameterized.Parameters"));
 
@@ -125,7 +125,7 @@ public class JUnitEntryPoints {
 
   private static boolean isTestEntryPoint(TypeName typeName) {
     String javaName = walaTypeNameToJavaName(typeName);
-    return testEntryPointAnnotationNames.contains(javaName);
+    return TEST_ENTRY_POINT_ANNOTATION_NAMES.contains(javaName);
   }
 
   private static String walaTypeNameToJavaName(TypeName typeName) {

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/util/scope/JUnitEntryPoints.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/util/scope/JUnitEntryPoints.java
@@ -13,7 +13,6 @@ package com.ibm.wala.util.scope;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -30,9 +29,6 @@ import com.ibm.wala.types.TypeName;
 import com.ibm.wala.types.annotations.Annotation;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.strings.Atom;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * This class represents entry points ({@link Entrypoint})s of JUnit test methods. JUnit test


### PR DESCRIPTION
Enhancement to add JUnit4 entrypoint support. AFAIK, WALA previously only supported JUnit3.

I did not include regression tests in this PR as I am not very familiar with entrypoint testing in WALA. I am happy to add some if you think that they can be useful.