### PR TITLE
Add document on contributing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,1 @@
+Thank you for contributing to WALA!  Please see [the contribution guidelines](CONTRIBUTING.md) for information on code style and general guidelines for pull requests.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,11 +14,12 @@ For big features, please open an issue so that we can agree on the direction, an
 
 Small pull requests for things like typos, bug fixes, etc are always welcome.
 
-CI checks
----------
+Continous Integration Checks
+----------------------------
 
-Certain checks run on our CI jobs that do not run as part of a standard run of
-`./gradlew build`.  You can run these checks locally with the following command:
+Certain checks run on our continuous integration (CI) jobs that do not run as
+part of a standard run of `./gradlew build`.  You can run these checks locally
+with the following command:
 
 ```
 ./gradlew -PjavaCompiler=ecj linters compileJava compileTestJava
@@ -29,7 +30,7 @@ If this command fails, a CI job will fail as well.
 DOs and DON'Ts
 --------------
 
-* DO format your code using [Google Java Format](https://github.com/google/google-java-format).  You can do so by running `./gradlew goJF`.  A CI job will fail if your code is not formatted in this way.
+* DO format your code using [Google Java Format](https://github.com/google/google-java-format).  You can do so by running `./gradlew googleJavaFormat`.  A CI job will fail if your code is not formatted in this way.
 * DO include tests when adding new features. When fixing bugs, start with adding a test that highlights how the current behavior is broken.
 * DO keep the discussions focused. When a new or related topic comes up it's often better to create new issue than to side track the discussion.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+Contributing to WALA
+====================
+
+WALA welcomes contributions of all kinds and sizes. This includes everything from from simple bug reports to large features.
+
+Workflow
+--------
+
+We love GitHub issues!
+
+For small feature requests, an issue first proposing it for discussion or demo implementation in a PR suffice.
+
+For big features, please open an issue so that we can agree on the direction, and hopefully avoid investing a lot of time on a feature that might need reworking.
+
+Small pull requests for things like typos, bug fixes, etc are always welcome.
+
+CI checks
+---------
+
+Certain checks run on our CI jobs that do not run as part of a standard run of
+`./gradlew build`.  You can run these checks locally with the following command:
+
+```
+./gradlew -PjavaCompiler=ecj linters compileJava compileTestJava
+```
+
+If this command fails, a CI job will fail as well.
+
+DOs and DON'Ts
+--------------
+
+* DO format your code using [Google Java Format](https://github.com/google/google-java-format).  You can do so by running `./gradlew goJF`.  A CI job will fail if your code is not formatted in this way.
+* DO include tests when adding new features. When fixing bugs, start with adding a test that highlights how the current behavior is broken.
+* DO keep the discussions focused. When a new or related topic comes up it's often better to create new issue than to side track the discussion.
+
+* DON'T submit PRs that alter licensing related files or headers. If you believe there's a problem with them, file an issue and we'll be happy to discuss it.
+
+Guiding Principles
+------------------
+
+* We allow anyone to participate in our projects. Tasks can be carried out by anyone that demonstrates the capability to complete them.
+* Always be respectful of one another. Assume the best in others and act with empathy at all times
+* Collaborate closely with individuals maintaining the project or experienced users. Getting ideas out in the open and seeing a proposal before it's a pull request helps reduce redundancy and ensures we're all connected to the decision making process


### PR DESCRIPTION
This is just a quick guide to contributing, including info on what blocking jobs we run on CI.  Mostly cribbed from Uber's [Android template](https://github.com/uber/android-template).