### PR TITLE
More verbose output for wala.core tests

### DIFF
--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -376,6 +376,7 @@ tasks.named('test') {
 	classpath += files project(':com.ibm.wala.core').sourceSets.test.java.outputDir
 	testLogging {
 		exceptionFormat = 'full'
+		events 'passed', 'skipped', 'failed', 'started'
 	}
 	// temporarily turn off some tests on JDK 11+
 	if (JavaVersion.current() >= JavaVersion.VERSION_11) {

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -376,7 +376,7 @@ tasks.named('test') {
 	classpath += files project(':com.ibm.wala.core').sourceSets.test.java.outputDir
 	testLogging {
 		exceptionFormat = 'full'
-		events 'passed', 'skipped', 'failed', 'started'
+		events 'passed', 'skipped', 'failed'
 	}
 	// temporarily turn off some tests on JDK 11+
 	if (JavaVersion.current() >= JavaVersion.VERSION_11) {

--- a/travis/script-gradle
+++ b/travis/script-gradle
@@ -17,7 +17,7 @@ case "$SUBMODULE_PREFIX" in
 esac
 
 run_gradle() {
-  $headless ./gradlew --info --continue --no-build-cache --stacktrace "$@"
+  $headless ./gradlew --continue --no-build-cache --stacktrace "$@"
 }
 
 # TRAVIS_JDK_VERSION is unset on Mac with JDK 8

--- a/travis/script-gradle
+++ b/travis/script-gradle
@@ -17,7 +17,7 @@ case "$SUBMODULE_PREFIX" in
 esac
 
 run_gradle() {
-  $headless ./gradlew --continue --no-build-cache --stacktrace "$@"
+  travis_wait 15 $headless ./gradlew --continue --no-build-cache --stacktrace "$@"
 }
 
 # TRAVIS_JDK_VERSION is unset on Mac with JDK 8

--- a/travis/script-gradle
+++ b/travis/script-gradle
@@ -17,7 +17,7 @@ case "$SUBMODULE_PREFIX" in
 esac
 
 run_gradle() {
-  travis_wait 15 $headless ./gradlew --continue --no-build-cache --stacktrace "$@"
+  $headless ./gradlew --continue --no-build-cache --stacktrace "$@"
 }
 
 # TRAVIS_JDK_VERSION is unset on Mac with JDK 8

--- a/travis/script-gradle
+++ b/travis/script-gradle
@@ -17,7 +17,7 @@ case "$SUBMODULE_PREFIX" in
 esac
 
 run_gradle() {
-  $headless ./gradlew --continue --no-build-cache --stacktrace "$@"
+  $headless ./gradlew --info --continue --no-build-cache --stacktrace "$@"
 }
 
 # TRAVIS_JDK_VERSION is unset on Mac with JDK 8


### PR DESCRIPTION
This should fix the timeouts we have been seeing on Travis. Not sure why they started, but I don’t see a fundamental underlying performance problem that arose recently