### PR TITLE
Appease IntelliJ IDEA with different RelativePath API

### DIFF
--- a/com.ibm.wala.cast.js.nodejs/build.gradle
+++ b/com.ibm.wala.cast.js.nodejs/build.gradle
@@ -29,7 +29,7 @@ tasks.register('unpackNodeJSLib', Copy) {
 	from(zipTree(downloadNodeJS.get().dest)) {
 		include 'nodejs-node-0a604e9/lib/*.js'
 		eachFile {
-			relativePath new RelativePath(!directory, relativePath.lastName)
+			relativePath RelativePath.parse(!directory, relativePath.lastName)
 		}
 	}
 


### PR DESCRIPTION
IntelliJ IDEA was incorrectly identifying the `RelativePath` constructor as a private one, even though we were actually using a different, public constructor. Using an equivalent `RelativePath.parse` factory method removes a spurious IntelliJ IDEA warning.

Prior commit d20ddc7b924a49c77e0d5f93d33ec12f1c5c88db addressed one instance of this problem. This commit applies the analogous fix elsewhere.