### PR TITLE
Only run linter tasks on the Linux Travis CI job

### DIFF
--- a/travis/script-gradle
+++ b/travis/script-gradle
@@ -26,12 +26,16 @@ then
   # only test WALA core on JDK 11 for now
   run_gradle :com.ibm.wala.core:test
 else
-  run_gradle \
-    -PjavaCompiler=ecj \
-    linters \
-    compileJava \
-    compileTestJava \
-    ${documentation:+$SUBMODULE_PREFIX$documentation}
+  # linters only need to run on one operating system
+  if [ "${TRAVIS_OS_NAME:-}" = linux ]
+  then
+    run_gradle \
+      -PjavaCompiler=ecj \
+      linters \
+      compileJava \
+      compileTestJava \
+      ${documentation:+$SUBMODULE_PREFIX$documentation}
+  fi
   run_gradle "$SUBMODULE_PREFIX"build
 fi
 


### PR DESCRIPTION
We don't need to run these lint checks on both Linux and Mac.  The Mac JDK 8 job seems to be the slowest one right now, so this should speed it up slightly.