### PR TITLE
Assorted minor Javascript fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,7 +140,7 @@ allprojects {
 }
 
 tasks.register('aggregatedJavadocs', Javadoc) {
-	description = 'Generate javadocs from all child projects as if it was a single project'
+	description = 'Generate javadocs from all child projects as if they were a single project'
 	group = 'Documentation'
 	destinationDir = file("$buildDir/docs/javadoc")
 	title = "$project.name $version API"

--- a/com.ibm.wala.cast.java/build.gradle
+++ b/com.ibm.wala.cast.java/build.gradle
@@ -23,6 +23,10 @@ tasks.register('testFixturesSourcesJar', Jar) {
 	from sourceSets.testFixtures.allSource
 }
 
+tasks.named('testFixturesJavadoc') {
+	destinationDir = file("$docsDir/testFixturesJavadoc")
+}
+
 tasks.register('testFixturesJavadocJar', Jar) {
 	classifier = 'test-fixtures-javadoc'
 	from testFixturesJavadoc.destinationDir


### PR DESCRIPTION
Use correct plural and subjunctive verb mood in an task description.

Avoid directory clash for `main` and `testFixtures` Javadocs. This clash led to two tasks making each other appear perpetually out-of-date.