### PR TITLE
Reimplement publishing using `maven-publish` plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,6 @@ plugins {
 	id 'de.set.ecj' version '1.4.1' apply false
 	id 'de.undercouch.download'
 	id 'nebula.lint' version '14.2.5'
-	id 'nebula.source-jar' version '16.0.0' apply false
 }
 
 repositories {
@@ -52,7 +51,8 @@ subprojects { subproject ->
 	apply plugin: 'eclipse'
 	apply plugin: 'java-library'
 	apply plugin: 'java-test-fixtures'
-	apply plugin: 'nebula.source-jar'
+	apply plugin: 'maven-publish'
+	apply plugin: 'signing'
 
 	version rootProject.version
 

--- a/com.ibm.wala.cast.java.ecj/gradle.properties
+++ b/com.ibm.wala.cast.java.ecj/gradle.properties
@@ -1,3 +1,1 @@
 POM_NAME=WALA CAst Java ECJ
-POM_ARTIFACT_ID=com.ibm.wala.cast.java.ecj
-POM_PACKAGING=jar

--- a/com.ibm.wala.cast.java/build.gradle
+++ b/com.ibm.wala.cast.java/build.gradle
@@ -18,25 +18,4 @@ dependencies {
 	)
 }
 
-tasks.register('testFixturesSourcesJar', Jar) {
-	classifier = 'test-fixtures-sources'
-	from sourceSets.testFixtures.allSource
-}
-
-tasks.named('testFixturesJavadoc') {
-	destinationDir = file("$docsDir/testFixturesJavadoc")
-}
-
-tasks.register('testFixturesJavadocJar', Jar) {
-	classifier = 'test-fixtures-javadoc'
-	from testFixturesJavadoc.destinationDir
-	dependsOn testFixturesJavadoc
-}
-
-artifacts.archives(
-		testFixturesJar,
-		testFixturesJavadocJar,
-		testFixturesSourcesJar,
-)
-
 apply from: rootProject.file("gradle-mvn-push.gradle")

--- a/com.ibm.wala.cast.java/gradle.properties
+++ b/com.ibm.wala.cast.java/gradle.properties
@@ -1,3 +1,1 @@
 POM_NAME=WALA CAst Java
-POM_ARTIFACT_ID=com.ibm.wala.cast.java
-POM_PACKAGING=jar

--- a/com.ibm.wala.cast.js.rhino/gradle.properties
+++ b/com.ibm.wala.cast.js.rhino/gradle.properties
@@ -1,3 +1,1 @@
 POM_NAME=WALA CAst JavaScript Rhino
-POM_ARTIFACT_ID=com.ibm.wala.cast.js.rhino
-POM_PACKAGING=jar

--- a/com.ibm.wala.cast.js/gradle.properties
+++ b/com.ibm.wala.cast.js/gradle.properties
@@ -1,3 +1,1 @@
 POM_NAME=WALA CAst JavaScript
-POM_ARTIFACT_ID=com.ibm.wala.cast.js
-POM_PACKAGING=jar

--- a/com.ibm.wala.cast/gradle.properties
+++ b/com.ibm.wala.cast/gradle.properties
@@ -1,3 +1,1 @@
 POM_NAME=WALA Cast
-POM_ARTIFACT_ID=com.ibm.wala.cast
-POM_PACKAGING=jar

--- a/com.ibm.wala.core/gradle.properties
+++ b/com.ibm.wala.core/gradle.properties
@@ -1,3 +1,1 @@
 POM_NAME=WALA Core
-POM_ARTIFACT_ID=com.ibm.wala.core
-POM_PACKAGING=jar

--- a/com.ibm.wala.dalvik/gradle.properties
+++ b/com.ibm.wala.dalvik/gradle.properties
@@ -1,3 +1,1 @@
 POM_NAME=WALA Dalvik
-POM_ARTIFACT_ID=com.ibm.wala.dalvik
-POM_PACKAGING=jar

--- a/com.ibm.wala.scandroid/gradle.properties
+++ b/com.ibm.wala.scandroid/gradle.properties
@@ -1,3 +1,1 @@
 POM_NAME=WALA Scandroid
-POM_ARTIFACT_ID=com.ibm.wala.scandroid
-POM_PACKAGING=jar

--- a/com.ibm.wala.shrike/gradle.properties
+++ b/com.ibm.wala.shrike/gradle.properties
@@ -1,3 +1,1 @@
 POM_NAME=WALA Shrike
-POM_ARTIFACT_ID=com.ibm.wala.shrike
-POM_PACKAGING=jar

--- a/com.ibm.wala.util/gradle.properties
+++ b/com.ibm.wala.util/gradle.properties
@@ -1,3 +1,1 @@
 POM_NAME=WALA Util
-POM_ARTIFACT_ID=com.ibm.wala.util
-POM_PACKAGING=jar

--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -138,7 +138,7 @@ signing {
 	required = true
 }
 
-// Only sign the archives if we are uploading a snapshot or release.
+// Only sign release uploads; snapshots and local installations are unsigned.
 tasks.withType(Sign) {
 	onlyIf {
 		!isSnapshot &&

--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -122,11 +122,6 @@ publishing {
 				password = properties.get('SONATYPE_NEXUS_PASSWORD')
 			}
 		}
-
-		maven {
-			name = 'projectBuild'
-			url = "file://$rootProject.buildDir/maven-repository"
-		}
 	}
 }
 

--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -125,12 +125,12 @@ publishing {
 	repositories {
 		maven {
 			url = (isSnapshot
-					? properties.getOrDefault('SNAPSHOT_REPOSITORY_URL', 'https://oss.sonatype.org/content/repositories/snapshots/')
-					: properties.getOrDefault('RELEASE_REPOSITORY_URL', 'https://oss.sonatype.org/service/local/staging/deploy/maven2/')
+					? project.properties.getOrDefault('SNAPSHOT_REPOSITORY_URL', 'https://oss.sonatype.org/content/repositories/snapshots/')
+					: project.properties.getOrDefault('RELEASE_REPOSITORY_URL', 'https://oss.sonatype.org/service/local/staging/deploy/maven2/')
 			)
 			credentials {
-				username = properties.get('SONATYPE_NEXUS_USERNAME')
-				password = properties.get('SONATYPE_NEXUS_PASSWORD')
+				username = project.properties.get('SONATYPE_NEXUS_USERNAME')
+				password = project.properties.get('SONATYPE_NEXUS_PASSWORD')
 			}
 		}
 

--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
-final def isSnapshot = version.contains('SNAPSHOT')
+final isSnapshot = version.contains('SNAPSHOT')
 
 publishing {
 	publications {

--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -133,6 +133,11 @@ publishing {
 				password = properties.get('SONATYPE_NEXUS_PASSWORD')
 			}
 		}
+
+		maven {
+			name = 'fakeRemote'
+			url = "file://$rootProject.buildDir/maven-fake-remote-repository"
+		}
 	}
 }
 

--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -3,10 +3,6 @@ apply plugin: 'signing'
 
 final isSnapshot = version.contains('SNAPSHOT')
 
-final isRemoteRepository(taskGraph) {
-	return taskGraph.hasTask("$project.path:publishRemotePublicationToMavenRepository")
-}
-
 final skipTestFixtures() {
 	components.java.withVariantsFromConfiguration(configurations.testFixturesApiElements) {
 		skip()

--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -3,24 +3,101 @@ apply plugin: 'signing'
 
 final isSnapshot = version.contains('SNAPSHOT')
 
+final isRemoteRepository(taskGraph) {
+	return taskGraph.hasTask("$project.path:publishRemotePublicationToMavenRepository")
+}
+
+final skipTestFixtures() {
+	components.java.withVariantsFromConfiguration(configurations.testFixturesApiElements) {
+		skip()
+	}
+	components.java.withVariantsFromConfiguration(configurations.testFixturesRuntimeElements) {
+		skip()
+	}
+}
+
+final sharedPublicationConfiguration(publication) {
+	publication.from components.java
+	publication.pom {
+		name = POM_NAME
+		description = 'T. J. Watson Libraries for Analysis'
+		inceptionYear = '2006'
+		url = 'https://github.com/wala/WALA'
+
+		ciManagement {
+			system = 'Travis CI'
+			url = 'https://travis-ci.org/wala/WALA'
+		}
+
+		developers {
+			[
+					// Current WALA maintainers, alphabetical by ID
+					juliandolby: 'Julian Dolby',
+					liblit     : 'Ben Liblit',
+					msridhar   : 'Manu Sridharan',
+					sjfink     : 'Stephen Fink',
+			].each { entry ->
+				developer {
+					id = entry.key
+					name = entry.value
+					url = "https://github.com/$entry.key"
+				}
+			}
+		}
+
+		issueManagement {
+			system = 'GitHub'
+			url = "${publication.pom.url.get()}/issues"
+		}
+
+		licenses {
+			license {
+				name = 'Eclipse Public License v2.0'
+				url = "${publication.pom.url.get()}/blob/master/LICENSE"
+			}
+		}
+
+		mailingLists {
+			[
+					'commits',
+					'wala',
+			].each { topic ->
+				mailingList {
+					name = "wala-$topic"
+					archive = "https://sourceforge.net/p/wala/mailman/wala-$topic"
+					subscribe = "https://sourceforge.net/projects/wala/lists/wala-$topic"
+					unsubscribe = "https://sourceforge.net/projects/wala/lists/wala-$topic/unsubscribe"
+					post = "wala-$topic@lists.sourceforge.net"
+				}
+			}
+		}
+
+		scm {
+			url = publication.pom.url
+			connection = 'scm:git:git://github.com/wala/WALA.git'
+			developerConnection = 'scm:git:ssh://git@github.com/wala/WALA.git'
+		}
+	}
+}
+
 publishing {
 	publications {
-		wala(MavenPublication) {
-			from components.java
-			suppressPomMetadataWarningsFor 'testFixturesApiElements'
-			suppressPomMetadataWarningsFor 'testFixturesRuntimeElements'
 
-			// Special handling for test fixtures.
+		// Everything we want to publish to remote repositories.  That includes code, sources, and
+		// Javadoc for main sourceSet, but not tests or test fixtures.
+		remote(MavenPublication) {
+			sharedPublicationConfiguration it
+			skipTestFixtures()
+		}
+
+		// Everything we want to publish to local installations.  That includes code, sources, and
+		// Javadoc for the both main and test-fixtures sourceSets, but not tests.
+		local(MavenPublication) {
+			sharedPublicationConfiguration it
+
 			if (sourceSets.testFixtures.allSource.isEmpty()) {
 				// Test-fixtures jar would be empty except for the manifest, so skip it.
-				[
-						configurations.testFixturesApiElements,
-						configurations.testFixturesRuntimeElements,
-				].each {
-					components.java.withVariantsFromConfiguration(it) {
-						skip()
-					}
-				}
+				skipTestFixtures()
 			} else {
 				// Test-fixtures jar will have real contents, so add Javadoc and sources
 				tasks.named('testFixturesJavadoc') {
@@ -38,75 +115,9 @@ publishing {
 					from sourceSets.testFixtures.allSource
 				}
 
-				publishing {
-					publications {
-						wala(MavenPublication) {
-							artifact testFixturesJavadocJar
-							artifact testFixturesSourcesJar
-						}
-					}
-				}
-			}
-
-			pom {
-				name = POM_NAME
-				description = 'T. J. Watson Libraries for Analysis'
-				inceptionYear = '2006'
-				url = 'https://github.com/wala/WALA'
-
-				ciManagement {
-					system = 'Travis CI'
-					url = 'https://travis-ci.org/wala/WALA'
-				}
-
-				developers {
-					[
-							// Current WALA maintainers, alphabetical by ID
-							juliandolby: 'Julian Dolby',
-							liblit     : 'Ben Liblit',
-							msridhar   : 'Manu Sridharan',
-							sjfink     : 'Stephen Fink',
-					].each { entry ->
-						developer {
-							id = entry.key
-							name = entry.value
-							url = "https://github.com/$entry.key"
-						}
-					}
-				}
-
-				issueManagement {
-					system = 'GitHub'
-					url = "${pom.url.get()}/issues"
-				}
-
-				licenses {
-					license {
-						name = 'Eclipse Public License v2.0'
-						url = "${pom.url.get()}/blob/master/LICENSE"
-					}
-				}
-
-				mailingLists {
-					[
-							'commits',
-							'wala',
-					].each { topic ->
-						mailingList {
-							name = "wala-$topic"
-							archive = "https://sourceforge.net/p/wala/mailman/wala-$topic"
-							subscribe = "https://sourceforge.net/projects/wala/lists/wala-$topic"
-							unsubscribe = "https://sourceforge.net/projects/wala/lists/wala-$topic/unsubscribe"
-							post = "wala-$topic@lists.sourceforge.net"
-						}
-					}
-				}
-
-				scm {
-					url = pom.url
-					connection = 'scm:git:git://github.com/wala/WALA.git'
-					developerConnection = 'scm:git:ssh://git@github.com/wala/WALA.git'
-				}
+				artifact testFixturesJar
+				artifact testFixturesJavadocJar
+				artifact testFixturesSourcesJar
 			}
 		}
 	}
@@ -127,24 +138,39 @@ publishing {
 
 signing {
 	// Use external gpg cmd.  This makes it easy to use gpg-agent,
-	// to avoid being prompted for a password once per artifact
+	// to avoid being prompted for a password once per artifact.
 	useGpgCmd()
-	sign publishing.publications.wala
+
+	// If anything about signing is misconfigured, fail loudly rather than quietly continuing with
+	// unsigned artifacts.
 	required = true
+
+	// Only sign publications sent to remote repositories; local install installatios are unsigned.
+	sign publishing.publications.remote
 }
 
-// Only sign release uploads; snapshots and local installations are unsigned.
+// Only sign releases; snapshots are unsigned.
 tasks.withType(Sign) {
 	onlyIf {
-		!isSnapshot &&
-				[
-						'publishWalaPublicationToProjectBuildRepository',
-						'publishWalaPublicationToSnapshotRepository',
-				].any { gradle.taskGraph.hasTask("$project.path:$it") }
+		!isSnapshot
 	}
 }
 
 java {
 	withJavadocJar()
 	withSourcesJar()
+}
+
+// Remote publication set goes to remote repositories, so we don't publicly publish test fixtures.
+tasks.withType(PublishToMavenRepository) {
+	onlyIf {
+		publication == publishing.publications.remote
+	}
+}
+
+// Local publication set goes to local installations, so we can reuse test fixtures locally.
+tasks.withType(PublishToMavenLocal) {
+	onlyIf {
+		publication == publishing.publications.local
+	}
 }

--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -1,228 +1,155 @@
-/*
- * Copyright (C) Chris Banes
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-// This script is derived from the version here:
-// https://github.com/uber/android-template/blob/master/gradle/gradle-mvn-push.gradle
-
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
-def isReleaseBuild() {
-  return VERSION_NAME.contains("SNAPSHOT") == false
+final def isSnapshot = version.contains('SNAPSHOT')
+
+publishing {
+	publications {
+		wala(MavenPublication) {
+			from components.java
+			suppressPomMetadataWarningsFor 'testFixturesApiElements'
+			suppressPomMetadataWarningsFor 'testFixturesRuntimeElements'
+
+			// Special handling for test fixtures.
+			if (sourceSets.testFixtures.allSource.isEmpty()) {
+				// Test-fixtures jar would be empty except for the manifest, so skip it.
+				[
+						configurations.testFixturesApiElements,
+						configurations.testFixturesRuntimeElements,
+				].each {
+					components.java.withVariantsFromConfiguration(it) {
+						skip()
+					}
+				}
+			} else {
+				// Test-fixtures jar will have real contents, so add Javadoc and sources
+				tasks.named('testFixturesJavadoc') {
+					destinationDir = file("$docsDir/testFixturesJavadoc")
+				}
+
+				tasks.register('testFixturesJavadocJar', Jar) {
+					classifier = 'test-fixtures-javadoc'
+					from testFixturesJavadoc.destinationDir
+					dependsOn testFixturesJavadoc
+				}
+
+				tasks.register('testFixturesSourcesJar', Jar) {
+					classifier = 'test-fixtures-sources'
+					from sourceSets.testFixtures.allSource
+				}
+
+				publishing {
+					publications {
+						wala(MavenPublication) {
+							artifact testFixturesJavadocJar
+							artifact testFixturesSourcesJar
+						}
+					}
+				}
+			}
+
+			pom {
+				name = POM_NAME
+				description = 'T. J. Watson Libraries for Analysis'
+				inceptionYear = '2006'
+				url = 'https://github.com/wala/WALA'
+
+				ciManagement {
+					system = 'Travis CI'
+					url = 'https://travis-ci.org/wala/WALA'
+				}
+
+				developers {
+					[
+							// Current WALA maintainers, alphabetical by ID
+							juliandolby: 'Julian Dolby',
+							liblit     : 'Ben Liblit',
+							msridhar   : 'Manu Sridharan',
+							sjfink     : 'Stephen Fink',
+					].each { entry ->
+						developer {
+							id = entry.key
+							name = entry.value
+							url = "https://github.com/$entry.key"
+						}
+					}
+				}
+
+				issueManagement {
+					system = 'GitHub'
+					url = "${pom.url.get()}/issues"
+				}
+
+				licenses {
+					license {
+						name = 'Eclipse Public License v2.0'
+						url = "${pom.url.get()}/blob/master/LICENSE"
+					}
+				}
+
+				mailingLists {
+					[
+							'commits',
+							'wala',
+					].each { topic ->
+						mailingList {
+							name = "wala-$topic"
+							archive = "https://sourceforge.net/p/wala/mailman/wala-$topic"
+							subscribe = "https://sourceforge.net/projects/wala/lists/wala-$topic"
+							unsubscribe = "https://sourceforge.net/projects/wala/lists/wala-$topic/unsubscribe"
+							post = "wala-$topic@lists.sourceforge.net"
+						}
+					}
+				}
+
+				scm {
+					url = pom.url
+					connection = 'scm:git:git://github.com/wala/WALA.git'
+					developerConnection = 'scm:git:ssh://git@github.com/wala/WALA.git'
+				}
+			}
+		}
+	}
+
+	repositories {
+		maven {
+			url = (isSnapshot
+					? properties.getOrDefault('SNAPSHOT_REPOSITORY_URL', 'https://oss.sonatype.org/content/repositories/snapshots/')
+					: properties.getOrDefault('RELEASE_REPOSITORY_URL', 'https://oss.sonatype.org/service/local/staging/deploy/maven2/')
+			)
+			credentials {
+				username = properties.get('SONATYPE_NEXUS_USERNAME')
+				password = properties.get('SONATYPE_NEXUS_PASSWORD')
+			}
+		}
+
+		maven {
+			name = 'projectBuild'
+			url = "file://$rootProject.buildDir/maven-repository"
+		}
+	}
 }
 
-def getReleaseRepositoryUrl() {
-  return hasProperty('RELEASE_REPOSITORY_URL') ? RELEASE_REPOSITORY_URL
-          : "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+signing {
+	// Use external gpg cmd.  This makes it easy to use gpg-agent,
+	// to avoid being prompted for a password once per artifact
+	useGpgCmd()
+	sign publishing.publications.wala
+	required = true
 }
 
-def getSnapshotRepositoryUrl() {
-  return hasProperty('SNAPSHOT_REPOSITORY_URL') ? SNAPSHOT_REPOSITORY_URL
-          : "https://oss.sonatype.org/content/repositories/snapshots/"
+// Only sign the archives if we are uploading a snapshot or release.
+tasks.withType(Sign) {
+	onlyIf {
+		!isSnapshot &&
+				[
+						'publishWalaPublicationToProjectBuildRepository',
+						'publishWalaPublicationToSnapshotRepository',
+				].any { gradle.taskGraph.hasTask("$project.path:$it") }
+	}
 }
 
-def getRepositoryUsername() {
-  return hasProperty('SONATYPE_NEXUS_USERNAME') ? SONATYPE_NEXUS_USERNAME : ""
-}
-
-def getRepositoryPassword() {
-  return hasProperty('SONATYPE_NEXUS_PASSWORD') ? SONATYPE_NEXUS_PASSWORD : ""
-}
-
-def needsSigning() {
-  return isReleaseBuild() && gradle.taskGraph.allTasks.any { it.name == 'uploadArchives' }
-}
-
-afterEvaluate { project ->
-  uploadArchives {
-    repositories {
-      mavenDeployer {
-        beforeDeployment { MavenDeployment deployment -> if (needsSigning()) signing.signPom(deployment) }
-
-        pom.groupId = GROUP
-        pom.artifactId = POM_ARTIFACT_ID
-        pom.version = VERSION_NAME
-
-        repository(url: getReleaseRepositoryUrl()) {
-          authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-        }
-        snapshotRepository(url: getSnapshotRepositoryUrl()) {
-          authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-        }
-
-        pom.project {
-          name POM_NAME
-          packaging POM_PACKAGING
-          description POM_DESCRIPTION
-          url POM_URL
-
-          scm {
-            url POM_SCM_URL
-            connection POM_SCM_CONNECTION
-            developerConnection POM_SCM_DEV_CONNECTION
-          }
-
-          licenses {
-            license {
-              name POM_LICENCE_NAME
-              url POM_LICENCE_URL
-              distribution POM_LICENCE_DIST
-            }
-          }
-
-          developers {
-            developer {
-              id POM_DEVELOPER_ID
-              name POM_DEVELOPER_NAME
-            }
-          }
-        }
-      }
-    }
-  }
-
-  signing {
-    // Use external gpg cmd.  This makes it easy to use gpg-agent,
-    // to avoid being prompted for a password once per artifact
-    useGpgCmd()
-    sign configurations.archives
-  }
-
-  // only sign the archives if we are uploading a release build
-  tasks.withType(Sign) {
-    onlyIf { needsSigning() }
-  }
-
-  if (project.getPlugins().hasPlugin('com.android.application') ||
-          project.getPlugins().hasPlugin('com.android.library')) {
-    task install(type: Upload, dependsOn: assemble) {
-      repositories.mavenInstaller {
-        configuration = configurations.archives
-
-        pom.groupId = GROUP
-        pom.artifactId = POM_ARTIFACT_ID
-        pom.version = VERSION_NAME
-
-        pom.project {
-          name POM_NAME
-          packaging POM_PACKAGING
-          description POM_DESCRIPTION
-          url POM_URL
-
-          scm {
-            url POM_SCM_URL
-            connection POM_SCM_CONNECTION
-            developerConnection POM_SCM_DEV_CONNECTION
-          }
-
-          licenses {
-            license {
-              name POM_LICENCE_NAME
-              url POM_LICENCE_URL
-              distribution POM_LICENCE_DIST
-            }
-          }
-
-          developers {
-            developer {
-              id POM_DEVELOPER_ID
-              name POM_DEVELOPER_NAME
-            }
-          }
-        }
-      }
-    }
-
-    task androidJavadocs(type: Javadoc) {
-      if (!project.plugins.hasPlugin('kotlin-android')) {
-        source = android.sourceSets.main.java.srcDirs
-      }
-      classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-      exclude '**/internal/*'
-
-      if (JavaVersion.current().isJava8Compatible()) {
-        options.addStringOption('Xdoclint:none', '-quiet')
-      }
-    }
-
-    task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
-      classifier = 'javadoc'
-      from androidJavadocs.destinationDir
-    }
-
-    task androidSourcesJar(type: Jar) {
-      classifier = 'sources'
-      from android.sourceSets.main.java.sourceFiles
-    }
-  } else {
-    install {
-      repositories.mavenInstaller {
-        pom.groupId = GROUP
-        pom.artifactId = POM_ARTIFACT_ID
-        pom.version = VERSION_NAME
-
-        pom.project {
-          name POM_NAME
-          packaging POM_PACKAGING
-          description POM_DESCRIPTION
-          url POM_URL
-
-          scm {
-            url POM_SCM_URL
-            connection POM_SCM_CONNECTION
-            developerConnection POM_SCM_DEV_CONNECTION
-          }
-
-          licenses {
-            license {
-              name POM_LICENCE_NAME
-              url POM_LICENCE_URL
-              distribution POM_LICENCE_DIST
-            }
-          }
-
-          developers {
-            developer {
-              id POM_DEVELOPER_ID
-              name POM_DEVELOPER_NAME
-            }
-          }
-        }
-      }
-    }
-
-    task sourcesJar(type: Jar, dependsOn: classes) {
-      classifier = 'sources'
-      from sourceSets.main.allSource
-    }
-
-    task javadocJar(type: Jar, dependsOn: javadoc) {
-      classifier = 'javadoc'
-      from javadoc.destinationDir
-    }
-  }
-
-  artifacts {
-    if (project.getPlugins().hasPlugin('com.android.application') ||
-            project.getPlugins().hasPlugin('com.android.library')) {
-      archives androidSourcesJar
-      archives androidJavadocsJar
-    } else {
-      archives sourcesJar
-      archives javadocJar
-    }
-  }
+java {
+	withJavadocJar()
+	withSourcesJar()
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,19 +1,4 @@
 org.gradle.caching=true
 org.gradle.parallel=true
 
-GROUP=com.ibm.wala
 VERSION_NAME=1.5.5-SNAPSHOT
-
-POM_DESCRIPTION=T. J. Watson Libraries for Analysis
-
-POM_URL=https://github.com/wala/WALA
-POM_SCM_URL=https://github.com/wala/WALA
-POM_SCM_CONNECTION=scm:git:git://github.com/wala/WALA.git
-POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/wala/WALA.git
-
-POM_LICENCE_NAME=Eclipse Public License
-POM_LICENCE_URL=https://www.eclipse.org/legal/epl-v10.html
-POM_LICENCE_DIST=repo
-
-POM_DEVELOPER_ID=msridhar
-POM_DEVELOPER_NAME=Manu Sridharan

--- a/travis-after-success.sh
+++ b/travis-after-success.sh
@@ -27,7 +27,7 @@ elif [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
   echo "Skipping snapshot deployment; running cron job."
 else
   echo "Deploying snapshot..."
-  ./gradlew clean uploadArchives
+  ./gradlew clean publishAllPublicationsToMavenRepository
   echo "Snapshot deployed!"
 
   echo "Uploading javadoc..."

--- a/travis/before-install-maven
+++ b/travis/before-install-maven
@@ -1,6 +1,6 @@
 #!/bin/sh -eux
 
-./gradlew prepareMavenBuild install -x javadoc
+./gradlew prepareMavenBuild publishToMavenLocal -x javadoc
 
 if [ ! -d "$M2_HOME/bin" ]; then
   curl https://archive.apache.org/dist/maven/maven-3/3.5.0/binaries/apache-maven-3.5.0-bin.tar.gz | tar zxf - -C "$HOME"

--- a/travis/script-gradle
+++ b/travis/script-gradle
@@ -36,7 +36,7 @@ else
       compileTestJava \
       ${documentation:+$SUBMODULE_PREFIX$documentation}
   fi
-  run_gradle "$SUBMODULE_PREFIX"build
+  run_gradle "$SUBMODULE_PREFIX"build publishAllPublicationsToProjectBuildRepository
 fi
 
 ./check-git-cleanliness.sh

--- a/travis/script-gradle
+++ b/travis/script-gradle
@@ -36,7 +36,7 @@ else
       compileTestJava \
       ${documentation:+$SUBMODULE_PREFIX$documentation}
   fi
-  run_gradle "$SUBMODULE_PREFIX"build publishAllPublicationsToProjectBuildRepository
+  run_gradle "$SUBMODULE_PREFIX"build publishToMavenLocal
 fi
 
 ./check-git-cleanliness.sh

--- a/travis/script-gradle
+++ b/travis/script-gradle
@@ -36,7 +36,7 @@ else
       compileTestJava \
       ${documentation:+$SUBMODULE_PREFIX$documentation}
   fi
-  run_gradle "$SUBMODULE_PREFIX"build publishToMavenLocal
+  run_gradle "$SUBMODULE_PREFIX"build "$SUBMODULE_PREFIX"publishToMavenLocal
 fi
 
 ./check-git-cleanliness.sh


### PR DESCRIPTION
# Description of Changes

## Jar Archives for Test Fixtures

Previously we published three jars for each subproject: sources, Javadoc, and class files. We still publish those, and now also publish sources, Javadoc, and class files for each subproject’s test fixtures. We also publish various checksum files. All jar archives and the POM files should be signed (via command-line GnuPG) when publishing a release.

## Task Name Changes

Names of tasks used for publishing have changed. Run `./gradlew tasks --group=publishing` for a list of all publishing-related tasks. Tasks likely to be of most interest are:

* `publishAllPublicationsToProjectBuildRepository`: populates a Maven repository in `build/maven-repository`. This is a good way to see what would be published without actually affecting the world outside the build tree.

* `publishToMavenLocal`: populates a Maven repository in `~/.m2`. This is the typical way to install WALA locally for use by other dependent projects.

* `publishAllPublicationsToMavenRepository`: uploads a WALA release or development snapshot to an external server. Releases are signed, but snapshots are not.

## Continuous Integration

We now publish to a local Maven repository as part of CI testing. This seems useful to help us notice if a change breaks publishing. Even better would be to *validate* the published repository contents, which we don’t currently do.

## Additional Metadata

Published POM files now contain more metadata than before. POM metadata previously included SCM links, just one developer/maintainer, and some license info which was actually inconsistent with the `LICENSE` file. Now we provide SCM links, *all* official WALA maintainers, consistent license information, project inception year, issue-management info, mailing-list info, and continuous-integration info.

# Reviewing Advice

## General Guidance

I have tested this to the best of my abilities, but it would still benefit from careful review by others. Consider checking out this pull request’s Git branch and examining the published artifacts for yourself. Use `./gradlew publishToMavenLocal` to populate a Maven repository in `~/.m2`. Or use `./gradlew publishAllPublicationsToProjectBuildRepository` to populate a Maven repository in `build/maven-repository`: a good way to see what would be published without actually affecting the world outside the build tree.

## Specific Areas of Concern

The parts I am least confident about involve uploading snapshots and releases to remote Maven repositories, and also signing of (non-snapshot) releases. I am not sure whether I even would know how to do these things myself using the old implementation.

Please take a particularly careful look at this logic for selecting the remote Maven repository URL:

https://github.com/wala/WALA/blob/054ab8ced73880664fc1c6abaa4ad50c71996c1d/gradle-mvn-push.gradle#L116-L118

Please also check this logic for fetching the username and password to upload to those remote repositories:

https://github.com/wala/WALA/blob/054ab8ced73880664fc1c6abaa4ad50c71996c1d/gradle-mvn-push.gradle#L120-L123

I based these on what was here before, but mistakes can happen, and none of this uploading logic has been tested in this new implementation.
