### PR TITLE
Remove obsolete extra-cleaning task

### DIFF
--- a/com.ibm.wala.dalvik/build.gradle
+++ b/com.ibm.wala.dalvik/build.gradle
@@ -156,10 +156,6 @@ tasks.register('extractSampleCup') {
 	}
 }
 
-tasks.named('clean') {
-	dependsOn 'cleanDownloadSampleCup'
-}
-
 tasks.register('downloadSampleLex', VerifiedDownload) {
 	src 'https://www.cs.princeton.edu/~appel/modern/java/JLex/current/sample.lex'
 	dest "$resourceDir/sample.lex"


### PR DESCRIPTION
The downloaded/unpacked material that the `cleanDownloadSampleCup` task used to remove is now stored under a "build" subdirectory. It will be removed by the standard `clean` task with no extra effort from us.

Fixes #691.