### PR TITLE
Use Android jars in-place, rather than copying

### DIFF
--- a/com.ibm.wala.dalvik/.gitignore
+++ b/com.ibm.wala.dalvik/.gitignore
@@ -1,5 +1,4 @@
 /dalvik.jar
-/lib/
 /parser.java
 /report
 /sym.java

--- a/com.ibm.wala.dalvik/build.gradle
+++ b/com.ibm.wala.dalvik/build.gradle
@@ -116,22 +116,12 @@ final def installAndroidSdk = tasks.register('installAndroidSdk', Sync) {
 	outputs.cacheIf { true }
 }
 
-final def copyDxJar = tasks.register('copyDxJar', Sync) {
-	dependsOn installAndroidSdk
-	from "${files(installAndroidSdk).singleFile}/build-tools/${installAndroidSdk.get().components['build-tools']}/lib/dx.jar"
-	into 'lib'
-}
-
-tasks.named('clean') {
-	dependsOn 'cleanCopyDxJar'
-}
-
 tasks.named('compileTestJava') {
-	dependsOn 'copyDxJar'
+	dependsOn 'installAndroidSdk'
 }
 
 eclipse {
-	synchronizationTasks 'copyDxJar'
+	synchronizationTasks 'installAndroidSdk'
 }
 
 tasks.register('copyAndroidJar', Sync) {
@@ -176,7 +166,7 @@ dependencies {
 			'junit:junit:4.13',
 			'org.osgi:org.osgi.core:6.0.0',
 			'org.smali:dexlib2:2.4.0',
-			files("${copyDxJar.get().destinationDir}/dx.jar"),
+			files("${files(installAndroidSdk).singleFile}/build-tools/${installAndroidSdk.get().components['build-tools']}/lib/dx.jar"),
 			project(':com.ibm.wala.core'),
 			project(':com.ibm.wala.dalvik'),
 			project(':com.ibm.wala.shrike'),

--- a/com.ibm.wala.dalvik/build.gradle
+++ b/com.ibm.wala.dalvik/build.gradle
@@ -1,13 +1,3 @@
-dependencies {
-	implementation(
-			'org.slf4j:slf4j-api:1.7.30',
-			'org.smali:dexlib2:2.4.0',
-			project(':com.ibm.wala.core'),
-			project(':com.ibm.wala.shrike'),
-			project(':com.ibm.wala.util'),
-	)
-}
-
 // Dalvik tests require additional libraries installed by the Android SDK Manager, but the latter is
 // incompatible with Java 9 or later: <https://issuetracker.google.com/issues/67495440>.
 final enableDalvikTests = JavaVersion.current() <= JavaVersion.VERSION_1_8
@@ -155,6 +145,13 @@ configurations {
 }
 
 dependencies {
+	implementation(
+			'org.slf4j:slf4j-api:1.7.30',
+			'org.smali:dexlib2:2.4.0',
+			project(':com.ibm.wala.core'),
+			project(':com.ibm.wala.shrike'),
+			project(':com.ibm.wala.util'),
+	)
 	sampleCup 'java_cup:java_cup:0.9e:sources'
 	testImplementation(
 			'junit:junit:4.13',

--- a/com.ibm.wala.dalvik/build.gradle
+++ b/com.ibm.wala.dalvik/build.gradle
@@ -124,12 +124,6 @@ eclipse {
 	synchronizationTasks 'installAndroidSdk'
 }
 
-tasks.register('copyAndroidJar', Sync) {
-	dependsOn installAndroidSdk
-	from "${installAndroidSdk.get().destinationDir}/platforms/${installAndroidSdk.get().components['platforms']}/android.jar"
-	into temporaryDir
-}
-
 final def resourceDir = sourceSets.test.resources.srcDirs.find()
 
 tasks.register('extractSampleCup') {
@@ -173,13 +167,15 @@ dependencies {
 			project(':com.ibm.wala.util'),
 			testFixtures(project(':com.ibm.wala.core')),
 	)
-	testRuntimeOnly files("${copyAndroidJar.destinationDir}/android.jar")
+	testRuntimeOnly(
+			// directory containing "android.jar", which various tests want to find as a resource
+			files("${files(installAndroidSdk).singleFile}/platforms/${installAndroidSdk.get().components['platforms']}"),
+	)
 }
 
 tasks.named('processTestResources') {
 	def testdata = project(':com.ibm.wala.core')
 
-	from copyAndroidJar
 	from downloadSampleLex
 	from extractSampleCup
 	from testdata.collectTestDataA

--- a/com.ibm.wala.dalvik/build.gradle
+++ b/com.ibm.wala.dalvik/build.gradle
@@ -16,6 +16,7 @@ tasks.named('javadoc') {
 tasks.named('test') {
 	enabled = enableDalvikTests
 }
+
 final def downloadDroidBench = tasks.register('downloadDroidBench', VerifiedDownload) {
 	src 'https://codeload.github.com/secure-software-engineering/DroidBench/zip/DroidBench_2.0'
 	dest "$temporaryDir/DroidBench_2.0.zip"


### PR DESCRIPTION
Previously we were copying several jars out of the Android SDK into other locations. That's no longer necessary, for various reasons. Instead we can just use these jar files where they sit within the installed Android SDK tree.