### PR TITLE
Suppress a false-positive JUnit warning

### DIFF
--- a/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/shrike/FloatingPointsTest.java
+++ b/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/shrike/FloatingPointsTest.java
@@ -22,6 +22,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+@SuppressWarnings("UnconstructableJUnitTestCase")
 public class FloatingPointsTest extends WalaTestCase {
   private final String klass = "shrike/FloatingPoints";
 


### PR DESCRIPTION
IntelliJ IDEA thinks that this class is "unrunnable by most JUnit test runners, including IDEA's" because it does not expose a public constructor that takes either no arguments or one String argument. However, this class does indeed offer a public nullary constructor, and running it in IntelliJ IDEA works just fine.