### PR TITLE
Unpack DroidBench under `build`, not under `/tmp`

### DIFF
--- a/com.ibm.wala.dalvik/build.gradle
+++ b/com.ibm.wala.dalvik/build.gradle
@@ -31,7 +31,7 @@ tasks.register('unpackDroidBench', Sync) {
 		}
 	}
 
-	into '/tmp/DroidBench'
+	into layout.buildDirectory.dir('DroidBench')
 	includeEmptyDirs false
 }
 

--- a/com.ibm.wala.dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/DroidBenchCGTest.java
+++ b/com.ibm.wala.dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/DroidBenchCGTest.java
@@ -165,7 +165,7 @@ public abstract class DroidBenchCGTest extends DalvikCallGraphTestBase {
   public static String getDroidBenchRoot() {
     String f = walaProperties.getProperty("droidbench.root");
     if (f == null || !new File(f).exists()) {
-      f = "/tmp/DroidBench";
+      f = "build/DroidBench";
     }
 
     System.err.println("Use " + f + " as droid bench root");


### PR DESCRIPTION
We shouldn't assume that the current build tree is the only thing running that might be interested in `/tmp/DroidBench`.  Better to keep everything we need in our own `build` subdirectories and avoid cross-build-tree interference.