### PR TITLE
Use properties and providers for lazier task configuration

### DIFF
--- a/buildSrc/src/main/groovy/package-list.groovy
+++ b/buildSrc/src/main/groovy/package-list.groovy
@@ -1,3 +1,4 @@
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.tasks.*
 
 import java.nio.file.Path
@@ -10,12 +11,14 @@ import java.nio.file.Path
 @CacheableTask
 class CreatePackageList extends org.gradle.api.DefaultTask {
 
-	@OutputFile
-	final File packageList = new File("$temporaryDir/package-list")
+	@OutputDirectory
+	final DirectoryProperty packageListDirectory =
+			project.objects.directoryProperty().convention(project.layout.buildDirectory.dir(name))
 
 	private SortedSet<Path> sourceFileSubdirectories
 
-	@Input final getSourceFileSubdirectories() {
+	@Input
+	final getSourceFileSubdirectories() {
 		// serializable representation of subdirs suitable for cache indexing
 		return sourceFileSubdirectories*.toString()
 	}
@@ -38,7 +41,7 @@ class CreatePackageList extends org.gradle.api.DefaultTask {
 	@TaskAction
 	final def create() {
 		// relative subbdirs as dot-delimited qualified Java package names, one per line
-		packageList.text = getSourceFileSubdirectories()
-				*.replace(File.separator, '.').join('\n') + '\n'
+		packageListDirectory.get().file('package-list').asFile.text =
+				getSourceFileSubdirectories()*.replace(File.separator, '.').join('\n') + '\n'
 	}
 }

--- a/com.ibm.wala.cast.js.nodejs/build.gradle
+++ b/com.ibm.wala.cast.js.nodejs/build.gradle
@@ -22,8 +22,7 @@ final def downloadNodeJS = tasks.register('downloadNodeJS', VerifiedDownload) {
 }
 
 tasks.register('unpackNodeJSLib', Copy) {
-	dependsOn downloadNodeJS
-	from(zipTree(downloadNodeJS.get().dest)) {
+	from(downloadNodeJS.map { zipTree it.dest }) {
 		include 'nodejs-node-0a604e9/lib/*.js'
 		eachFile {
 			relativePath RelativePath.parse(!directory, relativePath.lastName)

--- a/com.ibm.wala.cast.js/build.gradle
+++ b/com.ibm.wala.cast.js/build.gradle
@@ -27,12 +27,7 @@ tasks.register('createPackageList', CreatePackageList) {
 }
 
 tasks.named('javadoc') {
-	def rhinoName = ':com.ibm.wala.cast.js.rhino'
-	dependsOn "$rhinoName:compileJava"
-
-	doFirst {
-		classpath += files project(rhinoName).compileJava
-	}
+	classpath += files project(':com.ibm.wala.cast.js.rhino').tasks.named('compileJava', JavaCompile)
 }
 
 tasks.named('test') {
@@ -48,8 +43,7 @@ final def downloadAjaxslt = tasks.register('downloadAjaxslt', VerifiedDownload) 
 }
 
 final unpackAjaxslt = tasks.register('unpackAjaxslt', Sync) {
-	dependsOn downloadAjaxslt
-	from(tarTree(downloadAjaxslt.get().dest)) {
+	from(downloadAjaxslt.map { tarTree it.dest }) {
 		eachFile {
 			def newSegments = relativePath.segments[1 .. -1] as String[]
 			relativePath new RelativePath(!directory, newSegments)

--- a/com.ibm.wala.cast/build.gradle
+++ b/com.ibm.wala.cast/build.gradle
@@ -18,15 +18,19 @@ dependencies {
 	)
 }
 
-tasks.named('javadoc') {
-	def jsName = ':com.ibm.wala.cast.js'
-	dependsOn "$jsName:compileJava"
-	dependsOn "$jsName:createPackageList"
+tasks.named('javadoc', Javadoc) {
+	final jsTasks = project(':com.ibm.wala.cast.js').tasks
+	classpath += files jsTasks.named('compileJava', JavaCompile)
+	final jsCreatePackageList = jsTasks.named('createPackageList', CreatePackageList)
+	final packageListDirectory = jsCreatePackageList.flatMap { it.packageListDirectory }
+	it.inputs.dir packageListDirectory
 
 	doFirst {
-		def js = project(jsName)
-		classpath += files js.compileJava
-		options.linksOffline js.javadoc.outputDirectory.path, js.createPackageList.packageList.parent
+		final jsJavadoc = jsTasks.named('javadoc', Javadoc)
+		options.linksOffline(
+				jsJavadoc.get().destinationDir.path,
+				packageListDirectory.get().toString()
+		)
 	}
 }
 

--- a/com.ibm.wala.cast/smoke_main/build.gradle
+++ b/com.ibm.wala.cast/smoke_main/build.gradle
@@ -12,18 +12,20 @@ application {
 
 	addCastLibrary(project, it)
 
-	binaries.whenElementFinalized { binary ->
+	binaries.whenElementFinalized(CppExecutable) { binary ->
 		binary.linkTask.get().configure { linkTask ->
 			final def libxlator_test = getNativeLibraryOutput(project(':com.ibm.wala.cast:xlator_test').tasks.getByName(linkTask.name))
 			addRpath(linkTask, libxlator_test)
 
 			if (binary.debuggable && !binary.optimized) {
 				tasks.register('checkSmoke_main', Exec) {
-					dependsOn linkTask
 
 					// main executable to run for test
-					def executableBinary = binary.executableFile.get()
-					executable executableBinary
+					final linkedFile = linkTask.linkedFile
+					inputs.file linkedFile
+					doFirst {
+						executable linkedFile.get().asFile
+					}
 
 					// xlator Java bytecode + implementation of native methods
 					def pathElements = ['../build/classes/java/test', libxlator_test.parent]

--- a/com.ibm.wala.cast/xlator_test/build.gradle
+++ b/com.ibm.wala.cast/xlator_test/build.gradle
@@ -3,7 +3,9 @@ plugins {
 }
 
 library {
-	privateHeaders.from project(':com.ibm.wala.cast').tasks.getByName('compileTestJava').options.headerOutputDirectory
+	privateHeaders.from project(':com.ibm.wala.cast').tasks.named('compileTestJava').map {
+		it.options.headerOutputDirectory
+	}
 
 	dependencies {
 		implementation project(':com.ibm.wala.cast:cast')

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 			'junit:junit:4.13',
 			'org.hamcrest:hamcrest-core:2.2',
 	)
-	testRuntime(
+	testRuntimeOnly(
 			files(compileTestSubjectsJava.outputs.files.first())
 	)
 }

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -45,12 +45,7 @@ dependencies {
 }
 
 tasks.named('javadoc') {
-	def dalvik = ':com.ibm.wala.dalvik'
-	dependsOn "$dalvik:compileJava"
-
-	doFirst {
-		classpath += files project(dalvik).compileJava
-	}
+	classpath += files project(':com.ibm.wala.dalvik').tasks.named('compileJava', JavaCompile)
 }
 
 
@@ -68,12 +63,12 @@ final def downloadKawa = tasks.register('downloadKawa', VerifiedDownload) {
 }
 
 tasks.register('extractKawa') {
-	inputs.files downloadKawa.get()
+	inputs.files downloadKawa
 	outputs.file 'kawa.jar'
 
 	doLast {
 		copy {
-			from(zipTree(downloadKawa.get().dest)) {
+			from(downloadKawa.map { zipTree it.dest }) {
 				include "kawa-${downloadKawa.get().version}/lib/${outputs.files.singleFile.name}"
 				eachFile {
 					relativePath RelativePath.parse(!directory, relativePath.lastName)
@@ -274,8 +269,7 @@ final def downloadOcamlJava = tasks.register('downloadOcamlJava', VerifiedDownlo
 }
 
 final def unpackOcamlJava = tasks.register('unpackOcamlJava', Sync) {
-	dependsOn downloadOcamlJava
-	from tarTree(downloadOcamlJava.get().dest)
+	from downloadOcamlJava.map { tarTree it.dest }
 	into temporaryDir
 }
 
@@ -286,21 +280,29 @@ final prepareGenerateHelloHashJar = tasks.register('prepareGenerateHelloHashJar'
 }
 
 tasks.register('generateHelloHashJar', JavaExec) {
-	dependsOn prepareGenerateHelloHashJar
-	final ocamlSource = prepareGenerateHelloHashJar.get().copiedOcamlSource
+	final ocamlSource = prepareGenerateHelloHashJar.map { it.copiedOcamlSource }
 	inputs.file ocamlSource
 
 	def jarTarget = file("$temporaryDir/hello_hash.jar")
 	outputs.file jarTarget
 	outputs.cacheIf { true }
 
-	dependsOn unpackOcamlJava
-	def ocamlJavaJar = new File("${unpackOcamlJava.get().destinationDir}/${downloadOcamlJava.get().basename}/lib/ocamljava.jar")
+	final downloadOcamlJavaBasename = downloadOcamlJava.map { it.basename }
+	it.inputs.property 'downloadOcamlJavaBasename', downloadOcamlJavaBasename
+
+	final ocamlJavaJar = unpackOcamlJava.map {
+		file "$it.destinationDir/${downloadOcamlJavaBasename.get()}/lib/ocamljava.jar"
+	}
 	inputs.file ocamlJavaJar
 	classpath ocamlJavaJar
 
 	main 'ocaml.compilers.ocamljavaMain'
-	args ocamlSource, '-o', jarTarget
+	args '-o', jarTarget
+	argumentProviders.add(new CommandLineArgumentProvider() {
+		Iterable<String> asArguments() {
+			return [ocamlSource.get().toString()]
+		}
+	})
 }
 
 

--- a/com.ibm.wala.dalvik/build.gradle
+++ b/com.ibm.wala.dalvik/build.gradle
@@ -2,17 +2,6 @@
 // incompatible with Java 9 or later: <https://issuetracker.google.com/issues/67495440>.
 final enableDalvikTests = JavaVersion.current() <= JavaVersion.VERSION_1_8
 
-tasks.register('createPackageList', CreatePackageList) {
-	sourceSet sourceSets.main
-}
-
-tasks.named('javadoc') {
-	dependsOn 'createPackageList'
-	doFirst {
-		options.linksOffline outputDirectory.path, createPackageList.packageList.parent
-	}
-}
-
 tasks.named('test') {
 	enabled = enableDalvikTests
 }
@@ -24,8 +13,7 @@ final def downloadDroidBench = tasks.register('downloadDroidBench', VerifiedDown
 }
 
 tasks.register('unpackDroidBench', Sync) {
-	dependsOn downloadDroidBench
-	from(zipTree(downloadDroidBench.get().dest)) {
+	from(downloadDroidBench.map { zipTree it.dest }) {
 		eachFile {
 			relativePath new RelativePath(!directory, relativePath.segments[1..-1] as String[])
 		}
@@ -61,16 +49,18 @@ final def downloadAndroidSdk = tasks.register('downloadAndroidSdk', VerifiedDown
 
 final def installAndroidSdk = tasks.register('installAndroidSdk', Sync) {
 	enabled = enableDalvikTests
-	dependsOn downloadAndroidSdk
-	from zipTree(downloadAndroidSdk.get().dest)
+	from downloadAndroidSdk.map { zipTree it.dest }
 	into temporaryDir
 
 	def buildToolsVersion = '28.0.3'
 	ext {
-		components = [
+		version = [
 				'build-tools': buildToolsVersion,
-				'platforms': "android-${buildToolsVersion.tokenize('.')[0]}"
+				'platforms'  : "android-${buildToolsVersion.tokenize('.')[0]}"
 		]
+		component = {
+			file "${outputs.files.singleFile}/$it/${version[it]}"
+		}
 	}
 
 	doLast {
@@ -100,15 +90,11 @@ final def installAndroidSdk = tasks.register('installAndroidSdk', Sync) {
 			// Gradle under Java 1.8.
 			environment('JAVA_HOME', System.properties.'java.home')
 
-			def componentArgs = components.collect { "$it.key$semicolon$it.value" }.join ' '
+			def componentArgs = version.collect { "$it.key$semicolon$it.value" }.join ' '
 			commandLine shell, shellFlags, "$yes | $temporaryDir/tools/bin/sdkmanager $componentArgs >$discard"
 		}
 	}
 	outputs.cacheIf { true }
-}
-
-tasks.named('compileTestJava') {
-	dependsOn 'installAndroidSdk'
 }
 
 eclipse {
@@ -158,7 +144,7 @@ dependencies {
 			'junit:junit:4.13',
 			'org.osgi:org.osgi.core:6.0.0',
 			'org.smali:dexlib2:2.4.0',
-			files("${files(installAndroidSdk).singleFile}/build-tools/${installAndroidSdk.get().components['build-tools']}/lib/dx.jar"),
+			files(installAndroidSdk.map { "${it.component('build-tools')}/lib/dx.jar" }),
 			project(':com.ibm.wala.core'),
 			project(':com.ibm.wala.dalvik'),
 			project(':com.ibm.wala.shrike'),
@@ -167,7 +153,7 @@ dependencies {
 	)
 	testRuntimeOnly(
 			// directory containing "android.jar", which various tests want to find as a resource
-			files("${files(installAndroidSdk).singleFile}/platforms/${installAndroidSdk.get().components['platforms']}"),
+			files(installAndroidSdk.map { it.component('platforms') }),
 	)
 }
 

--- a/com.ibm.wala.util/build.gradle
+++ b/com.ibm.wala.util/build.gradle
@@ -5,13 +5,7 @@ plugins {
 eclipse.project.natures 'org.eclipse.pde.PluginNature'
 
 tasks.named('javadoc') {
-	def coreName = ':com.ibm.wala.core'
-	dependsOn "$coreName:compileJava"
-
-	doFirst {
-		classpath += files project(coreName).compileJava
-	}
-
+	classpath += files project(':com.ibm.wala.core').tasks.named('compileJava', JavaCompile)
 	final def linksPrefix = sourceCompatibility >= JavaVersion.VERSION_11 ? 'en/java/' : ''
 	options.links "https://docs.oracle.com/${linksPrefix}javase/$sourceCompatibility.majorVersion/docs/api/"
 }

--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -96,14 +96,13 @@ publishing {
 				skipTestFixtures()
 			} else {
 				// Test-fixtures jar will have real contents, so add Javadoc and sources
-				tasks.named('testFixturesJavadoc') {
+				final testFixturesJavadoc = tasks.named('testFixturesJavadoc') {
 					destinationDir = file("$docsDir/testFixturesJavadoc")
 				}
 
 				tasks.register('testFixturesJavadocJar', Jar) {
 					classifier = 'test-fixtures-javadoc'
-					from testFixturesJavadoc.destinationDir
-					dependsOn testFixturesJavadoc
+					from testFixturesJavadoc.map { it.destinationDir }
 				}
 
 				tasks.register('testFixturesSourcesJar', Jar) {


### PR DESCRIPTION
The goal is to make builds faster by only configuring tasks that are actually needed.  The naive approach to establishing task dependencies effectively looks like:

1. Configure task *A*.

2. Fetch information about task *A*’s outputs.

3. Use that information to configure task *B*’s inputs.

4. If task *B* is ever needed, task *A* (upon which *B* depends) has already been configured, so we’re good to go.

The preferred approach, using properties, providers, and [lazy task configuration](https://docs.gradle.org/current/userguide/lazy_configuration.html), is more like:

1. Fetch a closure that will compute task *A*’s outputs when needed.

2. Set task *B*’s outputs to this closure, or some other closure computed from that closure.

3. If task *B* is ever needed, task *A* (upon which *B* depends) will be configured on demand, because the aforementioned closures include information on which task they are derived from.

This lets us avoid configuring task *A* unless it’s actually needed. This also establishes the dependency of *B* upon *A* as channelled through these closures, rather than needing an explicit `dependsOn` directive.

This commit improves our use of the second strategy, though there are still plenty more cases of the first strategy remaining to work on. In practice, the impact on our build times is likely small, as most
eagerly-configured tasks arise from standard plugins that we cannot fix on our own.