### PR TITLE
Lazier task configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ subprojects { subproject ->
 
 	// Stash the original Java compiler toolchain in case needed.  This is actually only used by
 	// :com.ibm.wala.cast:compileTestJava, which requires JNI support that ECJ does not offer.
-	tasks.withType(JavaCompile) {
+	tasks.withType(JavaCompile).configureEach {
 		it.ext.originalToolChain = it.toolChain
 		options.encoding = 'UTF-8'
 	}
@@ -110,7 +110,7 @@ subprojects { subproject ->
 		case 'eclipse':
 			apply plugin: 'de.set.ecj'
 			ext.javaCompiler = 'ecj'
-			tasks.withType(JavaCompile) {
+			tasks.withType(JavaCompile).configureEach {
 				options.compilerArgs << '-properties' << "$projectDir/.settings/org.eclipse.jdt.core.prefs"
 			}
 			break
@@ -169,7 +169,7 @@ tasks.register('aggregatedJavadocs', Javadoc) {
 	options.author true
 
 	subprojects.each { proj ->
-		proj.tasks.withType(Javadoc).each { javadocTask ->
+		proj.tasks.withType(Javadoc).configureEach { javadocTask ->
 			source += javadocTask.source
 			classpath += javadocTask.classpath
 			excludes += javadocTask.excludes

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 	id 'com.github.sherter.google-java-format' version '0.8'
 	id 'de.set.ecj' version '1.4.1' apply false
 	id 'de.undercouch.download'
-	id 'nebula.lint' version '14.2.5'
+//	id 'nebula.lint' version '14.2.5'
 }
 
 repositories {
@@ -185,6 +185,8 @@ tasks.register('aggregatedJavadocs', Javadoc) {
 //
 
 // Gradle build scripts
+// disabled until <https://github.com/gradle/gradle/issues/6246> is fixed
+/*
 allprojects {
 	apply plugin: 'nebula.lint'
 	gradleLint.alwaysRun = false
@@ -197,6 +199,7 @@ allprojects {
 		]
 	}
 }
+*/
 
 // shell scripts, provided they have ".sh" extension
 if (isWindows) {
@@ -249,7 +252,7 @@ tasks.register('installGitHooks', Copy) {
 tasks.register('linters') {
 	group = 'lint'
 	dependsOn(
-			'lintGradle',
+			// 'lintGradle',
 			'shellCheck',
 	)
 	if (!(isWindows && System.getenv('GITHUB_ACTIONS') == 'true')) {

--- a/com.ibm.wala.cast.java.ecj/build.gradle
+++ b/com.ibm.wala.cast.java.ecj/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 
 mainClassName = 'com.ibm.wala.cast.java.ecj.util.SourceDirCallGraph'
 
-run {
+tasks.named('run') {
 	// this is for testing purposes
 	final def javaTestData = ':com.ibm.wala.cast.java.test.data'
 	evaluationDependsOn javaTestData

--- a/com.ibm.wala.cast.js.rhino/build.gradle
+++ b/com.ibm.wala.cast.js.rhino/build.gradle
@@ -28,15 +28,11 @@ tasks.named('test') {
 
 	if (gradle.startParameter.offline)
 		exclude '**/FieldBasedJQueryTest.class'
-}
 
-tasks.register('cleanTestExtras', Delete) {
-	delete 'actual.dump'
-	delete 'expected.dump'
-}
-
-tasks.named('cleanTest') {
-	dependsOn 'cleanTestExtras'
+	outputs.files([
+			'actual.dump',
+			'expected.dump',
+	].collect(layout.buildDirectory.&file))
 }
 
 apply from: rootProject.file("gradle-mvn-push.gradle")

--- a/com.ibm.wala.cast/smoke_main/build.gradle
+++ b/com.ibm.wala.cast/smoke_main/build.gradle
@@ -28,22 +28,27 @@ application {
 					}
 
 					// xlator Java bytecode + implementation of native methods
-					def pathElements = ['../build/classes/java/test', libxlator_test.parent]
+					final pathElements = project.objects.listProperty(File)
+					pathElements.addAll(files('../build/classes/java/test', libxlator_test.parent))
 
 					// "primordial.txt" resource loaded during test
-					def coreResources = project(':com.ibm.wala.core').processResources
-					dependsOn coreResources
-					pathElements << coreResources.destinationDir
+					final coreResources = project(':com.ibm.wala.core').tasks.named('processResources', Copy)
+					pathElements.add(coreResources.map { it.destinationDir })
+					inputs.files coreResources
 
 					// additional supporting Java class files
 					['cast', 'core', 'util'].each {
-						def compileJava = project(":com.ibm.wala.$it").compileJava
-						dependsOn compileJava
-						pathElements << compileJava.destinationDir
+						final compileJava = project(":com.ibm.wala.$it").tasks.named('compileJava', AbstractCompile)
+						pathElements.add(compileJava.map { it.destinationDir })
+						inputs.files compileJava
 					}
 
 					// all combined as a colon-delimited path list
-					args pathElements.join(':')
+					argumentProviders.add(new CommandLineArgumentProvider() {
+						Iterable<String> asArguments() {
+							return [pathElements.get().join(':')]
+						}
+					})
 
 					// log output to file, although we don't validate it
 					final def outFile = file("$temporaryDir/stdout-and-stderr.log")

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -388,14 +388,8 @@ tasks.named('test') {
 		exclude '**/cha/LibraryVersionTest.class'
 		exclude '**/ir/TypeAnnotationTest.class'
 	}
-}
 
-tasks.register('cleanTestExtras', Delete) {
-	delete 'report'
-}
-
-tasks.named('cleanTest') {
-	dependsOn 'cleanTestExtras'
+	outputs.file layout.buildDirectory.file('report')
 }
 
 apply from: rootProject.file("gradle-mvn-push.gradle")

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -17,8 +17,10 @@ sourceSets {
 	testSubjects
 }
 
+final Provider<JavaCompile> compileTestSubjectsJava = tasks.named('compileTestSubjectsJava', JavaCompile)
+
 if (javaCompiler == 'ecj') {
-	tasks.named('compileTestSubjectsJava', JavaCompile) {
+	compileTestSubjectsJava.configure {
 		options.compilerArgs << '-err:none'
 		options.compilerArgs << '-warn:none'
 	}
@@ -40,7 +42,7 @@ dependencies {
 			'org.hamcrest:hamcrest-core:2.2',
 	)
 	testRuntimeOnly(
-			files(compileTestSubjectsJava.outputs.files.first())
+			files(compileTestSubjectsJava.map { it.outputs.files.first() })
 	)
 }
 

--- a/com.ibm.wala.dalvik/build.gradle
+++ b/com.ibm.wala.dalvik/build.gradle
@@ -180,18 +180,12 @@ else
 
 tasks.named('test') {
 	maxHeapSize = '800M'
-}
 
-tasks.register('cleanTestExtras', Delete) {
-	delete(
+	outputs.files([
 			'parser.java',
 			'report',
 			'sym.java',
-	)
-}
-
-tasks.named('cleanTest') {
-	dependsOn 'cleanTestExtras'
+	].collect(layout.buildDirectory.&file))
 }
 
 googleJavaFormat {

--- a/com.ibm.wala.dalvik/build.gradle
+++ b/com.ibm.wala.dalvik/build.gradle
@@ -12,7 +12,7 @@ final def downloadDroidBench = tasks.register('downloadDroidBench', VerifiedDown
 	checksum '16726a48329835140e14f18470a1b4a3'
 }
 
-tasks.register('unpackDroidBench', Sync) {
+final unpackDroidBench = tasks.register('unpackDroidBench', Sync) {
 	from(downloadDroidBench.map { zipTree it.dest }) {
 		eachFile {
 			relativePath new RelativePath(!directory, relativePath.segments[1..-1] as String[])
@@ -175,7 +175,7 @@ if (isWindows)
 	}
 else
 	tasks.named('processTestResources') {
-		dependsOn 'unpackDroidBench'
+		dependsOn unpackDroidBench
 	}
 
 tasks.named('test') {

--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -110,6 +110,10 @@ publishing {
 					from sourceSets.testFixtures.allSource
 				}
 
+				// For eachs subproject with test fixtures, the `artifact` calls below trigger
+				// creation of three tasks during configuration: `testFixturesJar`,
+				// `testFixturesJavadocJar`, and `testFixturesSourcesJar`.  Configuring those lazily
+				// instead will require a fix to <https://github.com/gradle/gradle/issues/6246>.
 				artifact testFixturesJar
 				artifact testFixturesJavadocJar
 				artifact testFixturesSourcesJar
@@ -146,6 +150,10 @@ signing {
 	required = true
 
 	// Only sign publications sent to remote repositories; local install installatios are unsigned.
+	// The `sign` invocation below causes eager creation of three tasks per subproject:
+	// `signRemotePublication` is created immediately and `generateMetadataFileForRemotePublication`
+	// and `generatePomFileForRemotePublication` are created during configuration.  Creating these
+	// lazily instead will require a fix to <https://github.com/gradle/gradle/issues/8796>.
 	sign publishing.publications.remote
 }
 

--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -110,7 +110,7 @@ publishing {
 					from sourceSets.testFixtures.allSource
 				}
 
-				// For eachs subproject with test fixtures, the `artifact` calls below trigger
+				// For each subproject with test fixtures, the `artifact` calls below trigger
 				// creation of three tasks during configuration: `testFixturesJar`,
 				// `testFixturesJavadocJar`, and `testFixturesSourcesJar`.  Configuring those lazily
 				// instead will require a fix to <https://github.com/gradle/gradle/issues/6246>.
@@ -158,7 +158,7 @@ signing {
 }
 
 // Only sign releases; snapshots are unsigned.
-tasks.withType(Sign) {
+tasks.withType(Sign).configureEach {
 	onlyIf {
 		!isSnapshot
 	}
@@ -170,14 +170,14 @@ java {
 }
 
 // Remote publication set goes to remote repositories, so we don't publicly publish test fixtures.
-tasks.withType(PublishToMavenRepository) {
+tasks.withType(PublishToMavenRepository).configureEach {
 	onlyIf {
 		publication == publishing.publications.remote
 	}
 }
 
 // Local publication set goes to local installations, so we can reuse test fixtures locally.
-tasks.withType(PublishToMavenLocal) {
+tasks.withType(PublishToMavenLocal).configureEach {
 	onlyIf {
 		publication == publishing.publications.local
 	}


### PR DESCRIPTION
Continue earlier efforts (#711) to use lazy configuration, task configuration avoidance, and implicit task dependencies.

| Revision | Build Scan | Created Immediately :-1: | Created During Configuration :-1: | Not Created :+1: | Configuration Time :-1: |
|-|-|-:|-:|-:|-:|
| Before (3651dc48ef37c9fd90f1aabe4b91cc252f51781e) | [Link](https://scans.gradle.com/s/ld4n3iirz6be6/performance/configuration) | 46 tasks | 171 tasks | 1,015 tasks | 2.007 sec |
| After (77951632735172717db1f29369b6410598512f8c ) | [Link](https://scans.gradle.com/s/llnnxjcq33pbk/performance/configuration) | 11 tasks | 48 tasks | 1,135 tasks | 1.501 sec |

* :-1:: lower is better
* :+1:: higher is better

The remaining eagerly-created tasks are all outside of our control. A few are created by us, but only because the standard Gradle `cpp-application` and `cpp-library` plugins’ APIs give us no other choice. Most are created within the standard Gradle `maven-publish` or `signing` plugins: for these I have added comments noting the open Gradle issues that would need to be resolved before we can do better.