### PR TITLE
Travis CI jobs no longer need realpath or xvfb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 version: ~> 1.0
 language: java
-addons:
-  apt:
-    packages:
-    - xvfb
 before_install:
   - export M2_HOME=$HOME/apache-maven-3.5.0
   - "travis/before-install-$BUILD_SYSTEM"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: java
 addons:
   apt:
     packages:
-    - realpath
     - xvfb
 before_install:
   - export M2_HOME=$HOME/apache-maven-3.5.0

--- a/travis/script-gradle
+++ b/travis/script-gradle
@@ -1,12 +1,7 @@
 #!/bin/sh -eux
 
-case "$TRAVIS_OS_NAME" in
-  (linux) headless=xvfb-run ;;
-  (osx) headless= ;;
-esac
-
 run_gradle() {
-  $headless ./gradlew --continue --no-build-cache --stacktrace "$@"
+  ./gradlew --continue --no-build-cache --stacktrace "$@"
 }
 
 case "$(javac -version 2>&1)" in

--- a/travis/script-maven
+++ b/travis/script-maven
@@ -1,3 +1,3 @@
 #!/bin/sh -ex
 
-xvfb-run mvn clean install -B -q -Dmaven.javadoc.skip=true
+mvn clean install -B -q -Dmaven.javadoc.skip=true


### PR DESCRIPTION
Each of these was needed at some point, but all of our Travis CI jobs pass now without them.