### PR TITLE
Gradle task improvements for building test resources

### DIFF
--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -93,9 +93,7 @@ class CompileKawaJar extends Jar {
 
 	@Nested
 	final def compile = project.task("compileKawaInto${name.capitalize()}", type: JavaExec) {
-		dependsOn project.extractKawa
-		final def kawaJar = project.extractKawa.outputs.files.singleFile
-		classpath kawaJar
+		classpath project.tasks.named('extractKawa')
 		main 'kawa.repl'
 
 		args '-d', temporaryDir

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -66,7 +66,7 @@ final def downloadKawa = tasks.register('downloadKawa', VerifiedDownload) {
 
 tasks.register('extractKawa') {
 	inputs.files downloadKawa
-	outputs.file 'kawa.jar'
+	outputs.file layout.buildDirectory.file("$name/kawa.jar")
 
 	doLast {
 		copy {
@@ -80,10 +80,6 @@ tasks.register('extractKawa') {
 			includeEmptyDirs false
 		}
 	}
-}
-
-tasks.named('clean') {
-	dependsOn 'cleanExtractKawa'
 }
 
 

--- a/com.ibm.wala.dalvik/build.gradle
+++ b/com.ibm.wala.dalvik/build.gradle
@@ -101,8 +101,6 @@ eclipse {
 	synchronizationTasks 'installAndroidSdk'
 }
 
-final def resourceDir = sourceSets.test.resources.srcDirs.find()
-
 tasks.register('extractSampleCup') {
 	inputs.file configurations.sampleCup.singleFile
 	outputs.file layout.buildDirectory.file("$name/sample.cup")
@@ -119,12 +117,8 @@ tasks.register('extractSampleCup') {
 
 tasks.register('downloadSampleLex', VerifiedDownload) {
 	src 'https://www.cs.princeton.edu/~appel/modern/java/JLex/current/sample.lex'
-	dest "$resourceDir/sample.lex"
+	dest layout.buildDirectory.file("$name/sample.lex")
 	checksum 'ae887758b2657981d023a72a165da830'
-}
-
-tasks.named('clean') {
-	dependsOn 'cleanDownloadSampleLex'
 }
 
 configurations {

--- a/com.ibm.wala.dalvik/build.gradle
+++ b/com.ibm.wala.dalvik/build.gradle
@@ -105,7 +105,7 @@ final def resourceDir = sourceSets.test.resources.srcDirs.find()
 
 tasks.register('extractSampleCup') {
 	inputs.file configurations.sampleCup.singleFile
-	outputs.file "$resourceDir/sample.cup"
+	outputs.file layout.buildDirectory.file("$name/sample.cup")
 
 	doLast {
 		copy {

--- a/com.ibm.wala.dalvik/src/test/resources/.gitignore
+++ b/com.ibm.wala.dalvik/src/test/resources/.gitignore
@@ -1,2 +1,1 @@
-/sample.cup
 /sample.lex

--- a/com.ibm.wala.dalvik/src/test/resources/.gitignore
+++ b/com.ibm.wala.dalvik/src/test/resources/.gitignore
@@ -1,1 +1,0 @@
-/sample.lex

--- a/com.ibm.wala.ide.jdt.test/src/test/resources/.gitignore
+++ b/com.ibm.wala.ide.jdt.test/src/test/resources/.gitignore
@@ -1,1 +1,0 @@
-/test_project.zip


### PR DESCRIPTION
Improve use of implicit dependencies in Gradle tasks for building material used in tests.

Build more test-related resources under various `com.ibm.wala.*/build` directories rather than under `com.ibm.wala.*/src` or directly in `com.ibm.wala.*` subdirectories.