### PR TITLE
More work on moving built artifacts into `build` subdirectories

### DIFF
--- a/com.ibm.wala.cast/smoke_main/build.gradle
+++ b/com.ibm.wala.cast/smoke_main/build.gradle
@@ -44,11 +44,9 @@ application {
 					}
 
 					// all combined as a colon-delimited path list
-					argumentProviders.add(new CommandLineArgumentProvider() {
-						Iterable<String> asArguments() {
-							return [pathElements.get().join(':')]
-						}
-					})
+					argumentProviders.add({ ->
+						[pathElements.get().join(':')]
+					} as CommandLineArgumentProvider)
 
 					// log output to file, although we don't validate it
 					final def outFile = file("$temporaryDir/stdout-and-stderr.log")

--- a/com.ibm.wala.core/.gitignore
+++ b/com.ibm.wala.core/.gitignore
@@ -1,2 +1,1 @@
-/*.jar
 /report

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -107,7 +107,7 @@ class CompileKawaJar extends Jar {
 		compile.dependsOn dependsOn
 		from compile
 		archiveVersion.set null
-		destinationDirectory.set project.projectDir
+		destinationDirectory.set project.layout.buildDirectory.dir(name)
 	}
 
 	@SuppressWarnings("unused")
@@ -156,10 +156,6 @@ tasks.register('buildChessJar', CompileKawaJar) {
 	baseName 'kawachess'
 }
 
-tasks.named('clean') {
-	dependsOn 'cleanBuildChessJar'
-}
-
 
 ////////////////////////////////////////////////////////////////////////
 //
@@ -171,10 +167,6 @@ tasks.register('buildKawaTestJar', CompileKawaJar) {
 	args schemeFile
 	inputs.files schemeFile
 	baseName 'kawatest'
-}
-
-tasks.named('clean') {
-	dependsOn 'cleanBuildKawaTestJar'
 }
 
 

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -234,12 +234,8 @@ tasks.register('downloadJavaCup', VerifiedDownload) {
 tasks.register('collectJLex', Jar) {
 	from project(':com.ibm.wala.cast.java.test.data').compileTestJava
 	include 'JLex/'
-	archiveFileName.set 'JLex.jar'
-	destinationDirectory.set projectDir
-}
-
-tasks.named('clean') {
-	dependsOn 'cleanCollectJLex'
+	archiveFileName = 'JLex.jar'
+	destinationDirectory = layout.buildDirectory.dir name
 }
 
 

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -193,26 +193,23 @@ final def downloadBcel = tasks.register('downloadBcel', VerifiedDownload) {
 }
 
 tasks.register('extractBcel') {
-	final def basename = downloadBcel.get().basename
+	final basename = downloadBcel.map { it.basename }
+	final jarFile = basename.flatMap { layout.buildDirectory.file "$name/${it}.jar" }
 	inputs.files downloadBcel
-	outputs.file "${basename}.jar"
+	outputs.file jarFile
 
 	doLast {
 		copy {
 			from(tarTree(inputs.files.singleFile)) {
-				include "$basename/${basename}.jar"
+				include "${basename.get()}/${basename.get()}.jar"
 				eachFile {
 					relativePath RelativePath.parse(!directory, relativePath.lastName)
 				}
 			}
-			into projectDir
+			into jarFile.get().asFile.parent
 			includeEmptyDirs false
 		}
 	}
-}
-
-tasks.named('clean') {
-	dependsOn 'cleanExtractBcel'
 }
 
 

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -313,16 +313,12 @@ tasks.register('collectTestDataA', Jar) {
 	from compileTestSubjectsJava
 	from 'classes'
 	includeEmptyDirs false
-	destinationDirectory.set projectDir
+	destinationDirectory = layout.buildDirectory.dir name
 	exclude(
 			'**/CodeDeleted.class',
 			'**/SortingExample.class',
 			'**/A.class',
 	)
-}
-
-tasks.named('clean') {
-	dependsOn 'cleanCollectTestDataA'
 }
 
 

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -221,12 +221,8 @@ tasks.register('extractBcel') {
 tasks.register('downloadJavaCup', VerifiedDownload) {
 	def archive = 'java-cup-11a.jar'
 	src "http://www2.cs.tum.edu/projects/cup/$archive"
-	dest "$projectDir/$archive"
+	dest layout.buildDirectory.file("$name/$archive")
 	checksum '2bda8c40abd0cbc295d3038643d6e4ec'
-}
-
-tasks.named('clean') {
-	dependsOn 'cleanDownloadJavaCup'
 }
 
 

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -294,11 +294,9 @@ final generateHelloHashJar = tasks.register('generateHelloHashJar', JavaExec) {
 
 	main 'ocaml.compilers.ocamljavaMain'
 	args '-o', jarTarget
-	argumentProviders.add(new CommandLineArgumentProvider() {
-		Iterable<String> asArguments() {
-			return [ocamlSource.get().toString()]
-		}
-	})
+	argumentProviders.add({ ->
+		[ocamlSource.get().toString()]
+	} as CommandLineArgumentProvider)
 }
 
 

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -299,11 +299,7 @@ tasks.register('collectTestData', Jar) {
 	from compileTestSubjectsJava
 	from 'classes'
 	includeEmptyDirs false
-	destinationDirectory.set projectDir
-}
-
-tasks.named('clean') {
-	dependsOn 'cleanCollectTestData'
+	destinationDirectory = layout.buildDirectory.dir name
 }
 
 

--- a/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/cha/AnalysisScopeTest.java
+++ b/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/cha/AnalysisScopeTest.java
@@ -25,9 +25,8 @@ public class AnalysisScopeTest {
             TestConstants.WALA_TESTDATA,
             (new FileProvider()).getFile("J2SEClassHierarchyExclusions.txt"),
             AnalysisScopeTest.class.getClassLoader());
-    // assumes com.ibm.wala.core.tests is the current working directory
-    Path bcelJarPath =
-        Paths.get(System.getProperty("user.dir"), "..", "com.ibm.wala.core", "bcel-5.2.jar");
+    // assumes com.ibm.wala.core is the current working directory
+    Path bcelJarPath = Paths.get("build", "extractBcel", "bcel-5.2.jar");
     scope.addInputStreamForJarToScope(
         ClassLoaderReference.Application, new FileInputStream(bcelJarPath.toString()));
     ClassHierarchy cha = ClassHierarchyFactory.make(scope);


### PR DESCRIPTION
Taken together, these changes mean that `com.ibm.wala.core` finally puts *all* of its generated files into `com.ibm.wala.core/build`, rather than in `com.ibm.wala.core` or other subdirectories thereof.