### PR TITLE
Switch from dx to d8 for converting jar to dex

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,8 @@ subprojects { subproject ->
 
 	repositories {
 		mavenCentral()
+		// to get r8
+		google()
 	}
 
 	eclipse {

--- a/build.gradle
+++ b/build.gradle
@@ -57,9 +57,8 @@ subprojects { subproject ->
 	version rootProject.version
 
 	repositories {
+		google() // to get r8
 		mavenCentral()
-		// to get r8
-		google()
 	}
 
 	eclipse {

--- a/com.ibm.wala.cast.js.nodejs/build.gradle
+++ b/com.ibm.wala.cast.js.nodejs/build.gradle
@@ -16,14 +16,15 @@ dependencies {
 }
 
 final downloadNodeJS = tasks.register('downloadNodeJS', VerifiedDownload) {
-	src 'https://api.github.com/repos/nodejs/node/zipball/0a604e92e258c5ee2752d763e50721e35053f135'
-	dest "$temporaryDir/nodejs.zip"
-	checksum '33c5ba7a5d45644e70d268d8ad3e57df'
+	src 'https://nodejs.org/dist/v0.12.4/node-v0.12.4.tar.gz'
+	dest "$temporaryDir/nodejs.tar.gz"
+	algorithm 'SHA-1'
+	checksum '147ff79947752399b870fcf3f1fc37102100b545'
 }
 
 tasks.register('unpackNodeJSLib', Copy) {
-	from(downloadNodeJS.map { zipTree it.dest }) {
-		include 'nodejs-node-0a604e9/lib/*.js'
+	from(downloadNodeJS.map { tarTree it.dest }) {
+		include 'node-v0.12.4/lib/*.js'
 		eachFile {
 			relativePath RelativePath.parse(!directory, relativePath.lastName)
 		}

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/classLoader/IBytecodeMethod.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/classLoader/IBytecodeMethod.java
@@ -46,5 +46,5 @@ public interface IBytecodeMethod<I> extends IMethod {
 
   Collection<Annotation>[] getParameterAnnotations();
 
-  Collection<Annotation> getAnnotations(boolean runtimeVisible) throws InvalidClassFileException;
+  Collection<Annotation> getAnnotations(boolean runtimeInvisible) throws InvalidClassFileException;
 }

--- a/com.ibm.wala.core/src/testSubjects/java/annotations/AnnotationWithParams.java
+++ b/com.ibm.wala.core/src/testSubjects/java/annotations/AnnotationWithParams.java
@@ -10,6 +10,10 @@
  */
 package annotations;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
 public @interface AnnotationWithParams {
 
   String strParam() default "strdef";

--- a/com.ibm.wala.core/src/testSubjects/java/annotations/AnnotationWithSingleParam.java
+++ b/com.ibm.wala.core/src/testSubjects/java/annotations/AnnotationWithSingleParam.java
@@ -10,6 +10,10 @@
  */
 package annotations;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
 public @interface AnnotationWithSingleParam {
 
   String value() default "";

--- a/com.ibm.wala.dalvik/build.gradle
+++ b/com.ibm.wala.dalvik/build.gradle
@@ -135,10 +135,10 @@ dependencies {
 	)
 	sampleCup 'java_cup:java_cup:0.9e:sources'
 	testImplementation(
+			'com.android.tools:r8:1.6.84',
 			'junit:junit:4.13',
 			'org.osgi:org.osgi.core:6.0.0',
 			'org.smali:dexlib2:2.4.0',
-			'com.android.tools:r8:1.6.84',
 			project(':com.ibm.wala.core'),
 			project(':com.ibm.wala.dalvik'),
 			project(':com.ibm.wala.shrike'),

--- a/com.ibm.wala.dalvik/build.gradle
+++ b/com.ibm.wala.dalvik/build.gradle
@@ -138,7 +138,7 @@ dependencies {
 			'junit:junit:4.13',
 			'org.osgi:org.osgi.core:6.0.0',
 			'org.smali:dexlib2:2.4.0',
-			files(installAndroidSdk.map { "${it.component('build-tools')}/lib/dx.jar" }),
+			'com.android.tools:r8:1.6.84',
 			project(':com.ibm.wala.core'),
 			project(':com.ibm.wala.dalvik'),
 			project(':com.ibm.wala.shrike'),

--- a/com.ibm.wala.dalvik/src/test/java/com/ibm/wala/dalvik/test/ir/DalvikAnnotationsTest.java
+++ b/com.ibm.wala.dalvik/src/test/java/com/ibm/wala/dalvik/test/ir/DalvikAnnotationsTest.java
@@ -12,6 +12,6 @@ public class DalvikAnnotationsTest extends AnnotationTest {
   }
 
   public DalvikAnnotationsTest() throws ClassHierarchyException, IOException {
-    super(Util.makeCHA());
+    super(Util.makeCHA(), true);
   }
 }


### PR DESCRIPTION
`dx` is deprecated so this modernizes our test code.  Also, using `d8` means we don't need to pull in the Android SDK as a `testCompile` dependence in `com.ibm.wala.dalvik`, since `d8` can be pulled from a Maven repository.  We still require the Android SDK as a `testRuntime` dependence.

Apparently `d8` strips out all bytecode annotations that are not runtime retention (undocumented, but mentioned [here](https://github.com/DexPatcher/dexpatcher-tool/releases/tag/v1.8.0-alpha4)).  So, we change our test code for Dalvik annotations to only look for annotations with runtime retention.  Cleaned up some related code in the process.  