### PR TITLE
Add IntelliJ IDEA project task metadata

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -10,4 +10,7 @@
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
+  <component name="TaskProjectConfiguration">
+    <server type="GitHub" url="https://github.com" />
+  </component>
 </project>


### PR DESCRIPTION
This info lets IntelliJ IDEA associate this project with GitHub for purposes of IntelliJ IDEA's tasks & contexts feature. For example, you can tell the IDE that you are working on a specific GitHub issue.