### PR TITLE
Fix several Eclipse-detected resource leaks

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           java-version: 1.8
       - name: Compile Java using Gradle and ECJ
-        run: ./gradlew --continue --no-build-cache --no-daemon -PjavaCompiler=${{ matrix.java-compiler }} compileJava compileTestJava
+        run: ./gradlew --continue --no-build-cache --no-daemon -PjavaCompiler=${{ matrix.java-compiler }} compileJava compileTestJava compileTestFixturesJava compileTestSubjectsJava
         if: matrix.java-compiler == 'ecj'
       - name: Build and test using Gradle and default JDK compiler
         run: ./gradlew --continue --no-build-cache --no-daemon linters javadoc build

--- a/.idea/runConfigurations/Compile_using_ECJ.xml
+++ b/.idea/runConfigurations/Compile_using_ECJ.xml
@@ -12,6 +12,8 @@
         <list>
           <option value="compileJava" />
           <option value="compileTestJava" />
+	  <option value="compileTestFixturesJava" />
+	  <option value="compileTestSubjectsJava" />
         </list>
       </option>
       <option name="vmOptions" value="" />

--- a/.idea/runConfigurations/Compile_using_ECJ.xml
+++ b/.idea/runConfigurations/Compile_using_ECJ.xml
@@ -1,0 +1,22 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Compile using ECJ" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="-PjavaCompiler=ecj" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="compileJava" />
+          <option value="compileTestJava" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <GradleScriptDebugEnabled>true</GradleScriptDebugEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ part of a standard run of `./gradlew build`.  You can run these checks locally
 with the following command:
 
 ```
-./gradlew -PjavaCompiler=ecj linters compileJava compileTestJava
+./gradlew -PjavaCompiler=ecj linters compileJava compileTestJava compileTestFixturesJava compileTestSubjectsJava
 ```
 
 If this command fails, a CI job will fail as well.

--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,7 @@ subprojects { subproject ->
 		case 'eclipse':
 			apply plugin: 'de.set.ecj'
 			ext.javaCompiler = 'ecj'
+			ecj.toolVersion = '3.21.0'
 			tasks.withType(JavaCompile).configureEach {
 				options.compilerArgs << '-properties' << "$projectDir/.settings/org.eclipse.jdt.core.prefs"
 			}

--- a/build.gradle
+++ b/build.gradle
@@ -113,8 +113,8 @@ subprojects { subproject ->
 		case 'eclipse':
 			apply plugin: 'de.set.ecj'
 			ext.javaCompiler = 'ecj'
-			// the toolVersion here is the version of the org.eclipse.jdt:org.eclipse.jdt.core
-			// artifact, which now contains ECJ
+			// the toolVersion here is the version of the org.eclipse.jdt:ecj artifact
+			// on Maven Central: https://search.maven.org/artifact/org.eclipse.jdt/ecj
 			ecj.toolVersion = '3.21.0'
 			tasks.withType(JavaCompile).configureEach {
 				options.compilerArgs << '-properties' << "$projectDir/.settings/org.eclipse.jdt.core.prefs"

--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,8 @@ subprojects { subproject ->
 		case 'eclipse':
 			apply plugin: 'de.set.ecj'
 			ext.javaCompiler = 'ecj'
+			// the toolVersion here is the version of the org.eclipse.jdt:org.eclipse.jdt.core
+			// artifact, which now contains ECJ
 			ecj.toolVersion = '3.21.0'
 			tasks.withType(JavaCompile).configureEach {
 				options.compilerArgs << '-properties' << "$projectDir/.settings/org.eclipse.jdt.core.prefs"

--- a/com.ibm.wala.cast.js.nodejs/src/main/java/com/ibm/wala/cast/js/nodejs/NodejsRequiredCoreModule.java
+++ b/com.ibm.wala.cast.js.nodejs/src/main/java/com/ibm/wala/cast/js/nodejs/NodejsRequiredCoreModule.java
@@ -106,7 +106,9 @@ public class NodejsRequiredCoreModule extends NodejsRequiredSourceModule {
       names.put(name, f);
     }
     File file = names.get(name);
-    TemporaryFile.streamToFile(file, getModule(name));
+    try (InputStream module = getModule(name)) {
+      TemporaryFile.streamToFile(file, module);
+    }
     SourceFileModule sourceFileModule =
         CAstCallGraphUtil.makeSourceModule(file.toURI().toURL(), file.getName());
     return new NodejsRequiredCoreModule(file, sourceFileModule);

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/JSCallGraphUtil.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/JSCallGraphUtil.java
@@ -341,6 +341,7 @@ public class JSCallGraphUtil extends com.ibm.wala.cast.ipa.callgraph.CAstCallGra
     }
   }
 
+  @SuppressWarnings("resource")
   public static Module getPrologueFile(final String name) {
     return new Bootstrap(
         name,

--- a/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/loader/CAstAbstractModuleLoader.java
+++ b/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/loader/CAstAbstractModuleLoader.java
@@ -46,6 +46,7 @@ import com.ibm.wala.util.warnings.Warning;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.util.Collection;
@@ -87,7 +88,9 @@ public abstract class CAstAbstractModuleLoader extends CAstAbstractLoader {
     } else {
       File f = File.createTempFile("module", ".txt");
       f.deleteOnExit();
-      TemporaryFile.streamToFile(f, M.getInputStream());
+      try (InputStream inputStream = M.getInputStream()) {
+        TemporaryFile.streamToFile(f, inputStream);
+      }
       return f;
     }
   }

--- a/com.ibm.wala.ide.jsdt/src/main/java/com/ibm/wala/ide/util/JavaScriptEclipseProjectPath.java
+++ b/com.ibm.wala.ide.jsdt/src/main/java/com/ibm/wala/ide/util/JavaScriptEclipseProjectPath.java
@@ -18,6 +18,7 @@ import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.collections.Pair;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
@@ -72,7 +73,9 @@ public class JavaScriptEclipseProjectPath
     for (Pair<String, Plugin> model : models) {
       URL modelFile = JsdtUtil.getPrologueFile(model.fst, model.snd);
       assert modelFile != null : "cannot find file for " + model;
-      s.add(new JSCallGraphUtil.Bootstrap(model.fst, modelFile.openStream(), modelFile));
+      try (InputStream openStream = modelFile.openStream()) {
+        s.add(new JSCallGraphUtil.Bootstrap(model.fst, openStream, modelFile));
+      }
     }
 
     return path;

--- a/com.ibm.wala.scandroid/src/main/java/org/scandroid/util/AndroidAnalysisContext.java
+++ b/com.ibm.wala.scandroid/src/main/java/org/scandroid/util/AndroidAnalysisContext.java
@@ -290,12 +290,13 @@ public class AndroidAnalysisContext {
 
   private static XMLMethodSummaryReader loadMethodSummaries(
       AnalysisScope scope, InputStream xmlIStream) {
-    try (InputStream s =
-        xmlIStream != null
-            ? xmlIStream
-            : AndroidAnalysisContext.class
-                .getClassLoader()
-                .getResourceAsStream(pathToSpec + File.separator + methodSpec)) {
+    try (@SuppressWarnings("resource")
+        InputStream s =
+            xmlIStream != null
+                ? xmlIStream
+                : AndroidAnalysisContext.class
+                    .getClassLoader()
+                    .getResourceAsStream(pathToSpec + File.separator + methodSpec)) {
       return new XMLMethodSummaryReader(s, scope);
     } catch (IOException e) {
       e.printStackTrace();

--- a/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrike/cg/OfflineDynamicCallGraph.java
+++ b/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrike/cg/OfflineDynamicCallGraph.java
@@ -124,7 +124,9 @@ public class OfflineDynamicCallGraph {
         if ("--runtime".equals(args[i])) {
           runtime = Class.forName(args[i + 1]);
         } else if ("--exclusions".equals(args[i])) {
-          filter = new FileOfClasses(new FileInputStream(args[i + 1]));
+          try (FileInputStream input = new FileInputStream(args[i + 1])) {
+            filter = new FileOfClasses(input);
+          }
         } else if ("--dont-patch-exits".equals(args[i])) {
           patchExits = false;
         } else if ("--patch-calls".equals(args[i])) {

--- a/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrikeBT/tools/OfflineInstrumenterBase.java
+++ b/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrikeBT/tools/OfflineInstrumenterBase.java
@@ -415,7 +415,6 @@ public abstract class OfflineInstrumenterBase {
         throw new IllegalStateException("Output file was not set");
       }
 
-      @SuppressWarnings("resource")
       final FileOutputStream out = new FileOutputStream(outputFile);
       outputJar = new JarOutputStream(out);
     }

--- a/com.ibm.wala.shrike/src/main/java/com/ibm/wala/sourcepos/Debug.java
+++ b/com.ibm.wala.shrike/src/main/java/com/ibm/wala/sourcepos/Debug.java
@@ -199,7 +199,8 @@ public final class Debug {
     LogStream logStream = logStreams.get(level);
     if (OUT_STREAM != null && logStream == null) {
       logStream = new LogStream(OUT_STREAM, level);
-      logStreams.put(level, logStream);
+      @SuppressWarnings({"resource", "unused"})
+      LogStream put = logStreams.put(level, logStream);
     }
 
     return logStream;

--- a/com.ibm.wala.util/src/main/java/com/ibm/wala/util/io/TemporaryFile.java
+++ b/com.ibm.wala.util/src/main/java/com/ibm/wala/util/io/TemporaryFile.java
@@ -35,7 +35,9 @@ public class TemporaryFile {
   }
 
   public static File urlToFile(File F, URL input) throws IOException {
-    return streamToFile(F, input.openStream());
+    try (InputStream openStream = input.openStream()) {
+      return streamToFile(F, openStream);
+    }
   }
 
   public static File streamToFile(File F, InputStream... inputs) throws IOException {

--- a/travis/script-gradle
+++ b/travis/script-gradle
@@ -8,7 +8,7 @@ case "$(javac -version 2>&1)" in
   (javac\ 1.8.*)
      # linters only need to run on one operating system
      if [ "${TRAVIS_OS_NAME:-}" = linux ]; then
-       run_gradle -PjavaCompiler=ecj linters compileJava compileTestJava javadoc
+       run_gradle -PjavaCompiler=ecj linters compileJava compileTestJava compileTestFixturesJava compileTestSubjectsJava javadoc
      fi
      run_gradle build publishToMavenLocal
      ;;


### PR DESCRIPTION
Plug several resource leaks detected by Eclipse. Suppress one such detection that is actually a false positive.

Other Eclipse leak warnings remain, but this is an initial step on the ones that I could fix in the obvious way.