### PR TITLE
Run ECJ compiler as part of Gradle `check` tasks

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,15 +11,6 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        java-compiler:
-          - default
-          - ecj
-        exclude:
-          # testing ECJ compilation on any one OS is sufficient
-          - os: macos-latest
-            java-compiler: ecj
-          - os: windows-latest
-            java-compiler: ecj
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -49,12 +40,13 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - name: Compile Java using Gradle and ECJ
-        run: ./gradlew --continue --no-build-cache --no-daemon -PjavaCompiler=${{ matrix.java-compiler }} compileJava compileTestJava compileTestFixturesJava compileTestSubjectsJava
-        if: matrix.java-compiler == 'ecj'
-      - name: Build and test using Gradle and default JDK compiler
+      - name: Build and test using Gradle
         run: ./gradlew --continue --no-build-cache --no-daemon linters javadoc build
-        if: matrix.java-compiler != 'ecj'
+        # testing ECJ compilation on any one OS is sufficient; we choose Linux arbitrarily
+        if: runner.os == 'Linux'
+      - name: Build and test using Gradle but without ECJ
+        run: ./gradlew --continue --no-build-cache --no-daemon linters javadoc build -PskipJavaUsingEcjTasks
+        if: runner.os != 'Linux'
       - name: Check for Git cleanliness after build and test
         run: ./check-git-cleanliness.sh
         # not running in Borne or POSIX shell on Windows

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ part of a standard run of `./gradlew build`.  You can run these checks locally
 with the following command:
 
 ```
-./gradlew -PjavaCompiler=ecj linters compileJava compileTestJava compileTestFixturesJava compileTestSubjectsJava
+./gradlew linters
 ```
 
 If this command fails, a CI job will fail as well.

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ plugins {
 	id 'com.diffplug.eclipse.mavencentral' version '3.22.0' apply false
 	id 'com.github.ben-manes.versions' version '0.28.0'
 	id 'com.github.sherter.google-java-format' version '0.8'
-	id 'de.set.ecj' version '1.4.1' apply false
 	id 'de.undercouch.download'
 //	id 'nebula.lint' version '14.2.5'
 }
@@ -37,7 +36,7 @@ version VERSION_NAME
 ext.eclipseVersion = '4.7.2'
 ext.eclipseWstJsdtVersion = '1.0.201.v2010012803'
 
-subprojects { subproject ->
+subprojects { Project subproject ->
 	// skip generic Java setup for the few projects that have no Java code whatsoever
 	switch (subproject.name) {
 		case 'cast':
@@ -97,36 +96,16 @@ subprojects { subproject ->
 		}
 	}
 
-	// Stash the original Java compiler toolchain in case needed.  This is actually only used by
-	// :com.ibm.wala.cast:compileTestJava, which requires JNI support that ECJ does not offer.
-	tasks.withType(JavaCompile).configureEach {
-		it.ext.originalToolChain = it.toolChain
-		options.encoding = 'UTF-8'
+	final ecjCompileTaskProviders = sourceSets.collect { sourceSet ->
+		JavaCompileUsingEcj.withSourceSet(subproject, sourceSet)
 	}
 
-	// Use ECJ instead of default Java compiler if "javaCompiler" project property is set to either
-	// "ecj" or "eclipse" (case-insensitive).  For example, use "-PjavaCompiler=ecj" on Gradle
-	// command line or add "javaCompiler=ecj" to the "gradle.properties" file.
-	final javaCompilerProperty = subproject.findProperty('javaCompiler')?.toLowerCase()
-	switch (javaCompilerProperty) {
-		case 'ecj':
-		case 'eclipse':
-			apply plugin: 'de.set.ecj'
-			ext.javaCompiler = 'ecj'
-			// the toolVersion here is the version of the org.eclipse.jdt:ecj artifact
-			// on Maven Central: https://search.maven.org/artifact/org.eclipse.jdt/ecj
-			ecj.toolVersion = '3.21.0'
-			tasks.withType(JavaCompile).configureEach {
-				options.compilerArgs << '-properties' << "$projectDir/.settings/org.eclipse.jdt.core.prefs"
-			}
-			break
-		case 'default':
-		case '':
-		case null:
-			ext.javaCompiler = 'default'
-			break
-		default:
-			throw new InvalidUserDataException("unrecognized Java compiler \"$javaCompilerProperty\"")
+	project.tasks.named('check').configure {
+		dependsOn ecjCompileTaskProviders
+	}
+
+	tasks.withType(JavaCompile).configureEach {
+		options.encoding = 'UTF-8'
 	}
 
 	// Special hack for WALA as an included build.  Composite

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,7 +1,11 @@
 repositories {
+	maven {
+		url 'https://plugins.gradle.org/m2/'
+	}
 	mavenCentral()
 }
 
 dependencies {
 	implementation 'de.undercouch:gradle-download-task:4.0.4'
+	implementation 'gradle.plugin.de.set.gradle:gradle-eclipse-compiler-plugin:1.4.1'
 }

--- a/buildSrc/src/main/groovy/java-compile-using-ecj.groovy
+++ b/buildSrc/src/main/groovy/java-compile-using-ecj.groovy
@@ -1,0 +1,69 @@
+import de.set.gradle.ecj.EclipseCompilerBasePlugin
+import de.set.gradle.ecj.EclipseCompilerExtension
+import de.set.gradle.ecj.EclipseCompilerToolChain
+import org.gradle.api.Project
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.compile.JavaCompile
+
+import javax.inject.Inject
+
+/**
+ * Compiles some Java {@link SourceSet} using ECJ in addition to the standard compilation task.
+ */
+@CacheableTask
+class JavaCompileUsingEcj extends JavaCompile {
+
+	@Inject
+	JavaCompileUsingEcj() {
+		// Use ECJ tool chain rather than the standard Java compilation tool chain.
+		if (!project.hasProperty('eclipseCompilerToolChain')) {
+			final extension =
+					project.extensions.create(EclipseCompilerBasePlugin.ECJ_EXTENSION, EclipseCompilerExtension)
+			extension.tap {
+				toolGroupId = 'org.eclipse.jdt'
+				toolArtifactId = 'ecj'
+				toolVersion = '3.21.0'
+			}
+			project.configurations {
+				ecj
+			}
+			project.dependencies {
+				ecj "$extension.toolGroupId:$extension.toolArtifactId:$extension.toolVersion"
+			}
+
+			project.ext.eclipseCompilerToolChain = EclipseCompilerToolChain.create project
+		}
+		toolChain = project.eclipseCompilerToolChain
+
+		// Add Eclipse JDT configuration, especially for warnings/errors.
+		options.compilerArgs << '-properties' << project.layout.projectDirectory.file('.settings/org.eclipse.jdt.core.prefs').asFile
+
+		// ECJ doesn't support the "-h" flag for setting the JNI header output directory.
+		options.headerOutputDirectory.set null
+
+		// Allow skipping all ECJ compilation tasks by setting a project property.
+		onlyIf { !project.hasProperty('skipJavaUsingEcjTasks') }
+	}
+
+	final void setSourceSet(SourceSet sourceSet) {
+		// Imitate most of the behavior of the standard compilation task for the given sourceSet.
+		final standardCompileTaskName = sourceSet.getCompileTaskName('java')
+		final standardCompileTask = project.tasks.named(standardCompileTaskName, JavaCompile).get()
+		classpath = standardCompileTask.classpath
+		source = standardCompileTask.source
+
+		// However, put generated class files in a different build directory to avoid conflict.
+		final destinationSubdir = "ecjClasses/${sourceSet.java.name}/${sourceSet.name}"
+		destinationDirectory.set project.layout.buildDirectory.dir(destinationSubdir)
+	}
+
+	final static Provider<JavaCompileUsingEcj> withSourceSet(Project project, SourceSet sourceSet) {
+		final ecjCompileTaskName = sourceSet.getCompileTaskName('javaUsingEcj')
+		final ecjCompileTaskProvider = project.tasks.register(ecjCompileTaskName, JavaCompileUsingEcj) { it ->
+			it.sourceSet = sourceSet
+		}
+		return ecjCompileTaskProvider
+	}
+}

--- a/com.ibm.wala.cast/build.gradle
+++ b/com.ibm.wala.cast/build.gradle
@@ -36,12 +36,6 @@ tasks.named('javadoc', Javadoc) {
 
 tasks.named('compileTestJava') {
 	options.headerOutputDirectory.set file('build/headers')
-
-	// ECJ does not implement the "-h" flag required when the
-	// headerOutputDirectory option is used, so we must switch
-	// back to the default Java compiler for this one task.
-	toolChain = it.ext.originalToolChain
-	options.compilerArgs = []
 }
 
 final getProjectLibraryDirectory(project_name, link_task_name) {

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -19,11 +19,14 @@ sourceSets {
 
 final Provider<JavaCompile> compileTestSubjectsJava = tasks.named('compileTestSubjectsJava', JavaCompile)
 
-if (javaCompiler == 'ecj') {
-	compileTestSubjectsJava.configure {
-		options.compilerArgs << '-err:none'
-		options.compilerArgs << '-warn:none'
-	}
+final ecjCompileJavaTestSubjects = JavaCompileUsingEcj.withSourceSet(project, sourceSets.testSubjects)
+ecjCompileJavaTestSubjects.configure {
+	options.compilerArgs << '-err:none'
+	options.compilerArgs << '-warn:none'
+}
+
+tasks.named('check') {
+	dependsOn ecjCompileJavaTestSubjects
 }
 
 dependencies {

--- a/travis/script-gradle
+++ b/travis/script-gradle
@@ -6,12 +6,12 @@ run_gradle() {
 
 case "$(javac -version 2>&1)" in
   (javac\ 1.8.*)
-     # linters only need to run on one operating system
-     if [ "${TRAVIS_OS_NAME:-}" = linux ]; then
-       run_gradle -PjavaCompiler=ecj linters compileJava compileTestJava compileTestFixturesJava compileTestSubjectsJava javadoc
-     fi
-     run_gradle build publishToMavenLocal
-     ;;
+    # ECJ compilation only needs to run on one operating system; we choose Linux arbitrarily
+    if [ "${TRAVIS_OS_NAME:-}" != linux ]; then
+      skip_ecj=-PskipJavaUsingEcjTasks
+    fi
+    run_gradle ${skip_ecj:-} linters javadoc build publishToMavenLocal
+    ;;
   (*)
     run_gradle :com.ibm.wala.core:test
     ;;


### PR DESCRIPTION
We still use the default Java compiler for builds, tests, published jar archives, etc.  But now we *also* compile all Java using ECJ as part of the standard `check` validation tasks.

Set the `skipJavaUsingEcjTasks` project property if you want to skip ECJ compilation for some reason. For example, `./gradlew -PskipJavaUsingEcjTasks ...`.

Fixes #736.