### PR TITLE
Absorb `linters` task into `check`

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -53,7 +53,7 @@ jobs:
         run: ./gradlew --continue --no-build-cache --no-daemon -PjavaCompiler=${{ matrix.java-compiler }} compileJava compileTestJava compileTestFixturesJava compileTestSubjectsJava
         if: matrix.java-compiler == 'ecj'
       - name: Build and test using Gradle and default JDK compiler
-        run: ./gradlew --continue --no-build-cache --no-daemon linters javadoc build
+        run: ./gradlew --continue --no-build-cache --no-daemon javadoc build
         if: matrix.java-compiler != 'ecj'
       - name: Check for Git cleanliness after build and test
         run: ./check-git-cleanliness.sh

--- a/.idea/runConfigurations/Build_excluding_slow_tests.xml
+++ b/.idea/runConfigurations/Build_excluding_slow_tests.xml
@@ -10,7 +10,6 @@
       </option>
       <option name="taskNames">
         <list>
-          <option value="linters" />
           <option value="javadoc" />
           <option value="build" />
         </list>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ part of a standard run of `./gradlew build`.  You can run these checks locally
 with the following command:
 
 ```
-./gradlew -PjavaCompiler=ecj linters compileJava compileTestJava compileTestFixturesJava compileTestSubjectsJava
+./gradlew -PjavaCompiler=ecj compileJava compileTestJava compileTestFixturesJava compileTestSubjectsJava
 ```
 
 If this command fails, a CI job will fail as well.

--- a/build.gradle
+++ b/build.gradle
@@ -215,7 +215,7 @@ if (isWindows) {
 	// create a real "shellCheck" task that actually runs the "shellcheck" linter, if available
 	tasks.register('shellCheck', Exec) {
 		description 'Check all shell scripts using shellcheck, if available'
-		group 'lint'
+		group 'verification'
 
 		inputs.files fileTree('.').exclude('**/build').include('**/*.sh')
 		outputs.file "$temporaryDir/log"
@@ -239,11 +239,16 @@ if (isWindows) {
 
 // Java formatting
 googleJavaFormat {
+	group 'verification'
 	toolVersion = '1.7'
 	// exclude since various tests make assertions based on
 	// source positions in the test inputs.  to auto-format
 	// we also need to update the test assertions
 	exclude 'com.ibm.wala.cast.java.test.data/**/*.java'
+}
+
+tasks.named('verifyGoogleJavaFormat') {
+	group 'verification'
 }
 
 // install Java reformatter as git pre-commit hook
@@ -255,8 +260,8 @@ tasks.register('installGitHooks', Copy) {
 }
 
 // run all known linters
-tasks.register('linters') {
-	group = 'lint'
+tasks.register('check') {
+	group = 'verification'
 	dependsOn(
 			// 'lintGradle',
 			'shellCheck',

--- a/travis/script-gradle
+++ b/travis/script-gradle
@@ -6,11 +6,11 @@ run_gradle() {
 
 case "$(javac -version 2>&1)" in
   (javac\ 1.8.*)
-     # linters only need to run on one operating system
+     # ECJ compilation checks only need to run on one operating system
      if [ "${TRAVIS_OS_NAME:-}" = linux ]; then
-       run_gradle -PjavaCompiler=ecj linters compileJava compileTestJava compileTestFixturesJava compileTestSubjectsJava javadoc
+       run_gradle -PjavaCompiler=ecj compileJava compileTestJava compileTestFixturesJava compileTestSubjectsJava
      fi
-     run_gradle build publishToMavenLocal
+     run_gradle javadoc build publishToMavenLocal
      ;;
   (*)
     run_gradle :com.ibm.wala.core:test


### PR DESCRIPTION
Previously some verification steps happened as part of `./gradlew check` and therefore also under `./gradlew build`, while others only happened as part of `./gradlew linters`.  Now we are retiring the `linters` task and moving all of its dependent verification tasks to be dependencies of `check` instead.

Fixes #740.