### PR TITLE
Ignore failed deletions during cache cleanup

### DIFF
--- a/travis/before-cache-gradle
+++ b/travis/before-cache-gradle
@@ -1,4 +1,4 @@
-#!/bin/sh -eux
+#!/bin/sh -ux
 
 caches="$HOME/.gradle/caches"
 
@@ -10,3 +10,6 @@ find "$caches" -name cache.properties -delete
 find "$caches" -name workerMain -type d -prune -exec rm -r "{}" \;
 find "$caches" -name '*.bin' -delete
 find "$caches" -name '*.lock' -delete
+
+# Consider script to have succeeded even if some "find ... -delete" commands failed.
+:


### PR DESCRIPTION
This script is failing repeatedly on macOS when run during GitHub Actions CI jobs.  The first "`find ... -delete`" command reports "No such file or directory".  This is probably some transient inconsistency in our view of the file system that holds the per-user Gradle cache.  It should be safe to ignore those errors: if a file we wanted to delete is already gone, then mission accomplished!