### PR TITLE
Run ECJ compiler as part of Gradle `check` tasks

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,15 +11,6 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        java-compiler:
-          - default
-          - ecj
-        exclude:
-          # testing ECJ compilation on any one OS is sufficient
-          - os: macos-latest
-            java-compiler: ecj
-          - os: windows-latest
-            java-compiler: ecj
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -49,12 +40,13 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - name: Compile Java using Gradle and ECJ
-        run: ./gradlew --continue --no-build-cache --no-daemon -PjavaCompiler=${{ matrix.java-compiler }} compileJava compileTestJava compileTestFixturesJava compileTestSubjectsJava
-        if: matrix.java-compiler == 'ecj'
-      - name: Build and test using Gradle and default JDK compiler
+      - name: Build and test using Gradle
         run: ./gradlew --continue --no-build-cache --no-daemon javadoc build
-        if: matrix.java-compiler != 'ecj'
+        # testing ECJ compilation on any one OS is sufficient; we choose Linux arbitrarily
+        if: runner.os == 'Linux'
+      - name: Build and test using Gradle but without ECJ
+        run: ./gradlew --continue --no-build-cache --no-daemon javadoc build -PskipJavaUsingEcjTasks
+        if: runner.os != 'Linux'
       - name: Check for Git cleanliness after build and test
         run: ./check-git-cleanliness.sh
         # not running in Borne or POSIX shell on Windows

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ plugins {
 	id 'com.diffplug.eclipse.mavencentral' version '3.22.0' apply false
 	id 'com.github.ben-manes.versions' version '0.28.0'
 	id 'com.github.sherter.google-java-format' version '0.8'
-	id 'de.set.ecj' version '1.4.1' apply false
 	id 'de.undercouch.download'
 //	id 'nebula.lint' version '14.2.5'
 }
@@ -97,36 +96,16 @@ subprojects { subproject ->
 		}
 	}
 
-	// Stash the original Java compiler toolchain in case needed.  This is actually only used by
-	// :com.ibm.wala.cast:compileTestJava, which requires JNI support that ECJ does not offer.
-	tasks.withType(JavaCompile).configureEach {
-		it.ext.originalToolChain = it.toolChain
-		options.encoding = 'UTF-8'
+	final ecjCompileTaskProviders = sourceSets.collect { sourceSet ->
+		JavaCompileUsingEcj.withSourceSet(subproject, sourceSet)
 	}
 
-	// Use ECJ instead of default Java compiler if "javaCompiler" project property is set to either
-	// "ecj" or "eclipse" (case-insensitive).  For example, use "-PjavaCompiler=ecj" on Gradle
-	// command line or add "javaCompiler=ecj" to the "gradle.properties" file.
-	final javaCompilerProperty = subproject.findProperty('javaCompiler')?.toLowerCase()
-	switch (javaCompilerProperty) {
-		case 'ecj':
-		case 'eclipse':
-			apply plugin: 'de.set.ecj'
-			ext.javaCompiler = 'ecj'
-			// the toolVersion here is the version of the org.eclipse.jdt:ecj artifact
-			// on Maven Central: https://search.maven.org/artifact/org.eclipse.jdt/ecj
-			ecj.toolVersion = '3.21.0'
-			tasks.withType(JavaCompile).configureEach {
-				options.compilerArgs << '-properties' << "$projectDir/.settings/org.eclipse.jdt.core.prefs"
-			}
-			break
-		case 'default':
-		case '':
-		case null:
-			ext.javaCompiler = 'default'
-			break
-		default:
-			throw new InvalidUserDataException("unrecognized Java compiler \"$javaCompilerProperty\"")
+	project.tasks.named('check').configure {
+		dependsOn ecjCompileTaskProviders
+	}
+
+	tasks.withType(JavaCompile).configureEach {
+		options.encoding = 'UTF-8'
 	}
 
 	// Special hack for WALA as an included build.  Composite

--- a/buildSrc/src/main/groovy/java-compile-using-ecj.groovy
+++ b/buildSrc/src/main/groovy/java-compile-using-ecj.groovy
@@ -1,0 +1,49 @@
+import com.ibm.wala.gradle.EclipseJavaCompilerToolChain
+import org.gradle.api.Project
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.compile.JavaCompile
+
+/**
+ * Compiles some Java {@link SourceSet} using ECJ, but otherwise imitating the standard {@link JavaCompile} task.
+ */
+@CacheableTask
+class JavaCompileUsingEcj extends JavaCompile {
+
+	JavaCompileUsingEcj() {
+		// Use ECJ tool chain rather than the standard Java compilation tool chain.
+		if (!project.hasProperty('eclipseJavaCompilerToolChain')) {
+			project.ext.eclipseJavaCompilerToolChain = new EclipseJavaCompilerToolChain(project)
+		}
+		assert project.hasProperty('eclipseJavaCompilerToolChain')
+		toolChain = project.eclipseJavaCompilerToolChain
+
+		// Add Eclipse JDT configuration, especially for warnings/errors.
+		options.compilerArgs << '-properties' << project.layout.projectDirectory.file('.settings/org.eclipse.jdt.core.prefs').asFile
+
+		// ECJ doesn't support the "-h" flag for setting the JNI header output directory.
+		options.headerOutputDirectory.set null
+
+		// Allow skipping all ECJ compilation tasks by setting a project property.
+		onlyIf { !project.hasProperty('skipJavaUsingEcjTasks') }
+	}
+
+	final void setSourceSet(SourceSet sourceSet) {
+		// Imitate most of the behavior of the standard compilation task for the given sourceSet.
+		final standardCompileTaskName = sourceSet.getCompileTaskName('java')
+		final standardCompileTask = project.tasks.named(standardCompileTaskName, JavaCompile).get()
+		classpath = standardCompileTask.classpath
+		source = standardCompileTask.source
+
+		// However, put generated class files in a different build directory to avoid conflict.
+		final destinationSubdir = "ecjClasses/${sourceSet.java.name}/${sourceSet.name}"
+		destinationDirectory.set project.layout.buildDirectory.dir(destinationSubdir)
+	}
+
+	final static Provider<JavaCompileUsingEcj> withSourceSet(Project project, SourceSet sourceSet) {
+		return project.tasks.register(sourceSet.getCompileTaskName('javaUsingEcj'), JavaCompileUsingEcj) { it ->
+			it.sourceSet = sourceSet
+		}
+	}
+}

--- a/buildSrc/src/main/java/com/ibm/wala/gradle/EclipseJavaCompiler.java
+++ b/buildSrc/src/main/java/com/ibm/wala/gradle/EclipseJavaCompiler.java
@@ -1,0 +1,69 @@
+package com.ibm.wala.gradle;
+
+import java.io.File;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.internal.tasks.compile.CompilationFailedException;
+import org.gradle.api.internal.tasks.compile.JavaCompileSpec;
+import org.gradle.api.internal.tasks.compile.JavaCompilerArgumentsBuilder;
+import org.gradle.api.tasks.WorkResult;
+import org.gradle.internal.process.ArgWriter;
+import org.gradle.language.base.internal.compile.Compiler;
+import org.gradle.process.ExecResult;
+import org.gradle.process.internal.ExecException;
+
+/**
+ * Eclipse Compiler for Java (ECJ) encapsulated as a {@link Compiler} for use by Gradle.
+ *
+ * <p>Inspired by, and derived from, <a
+ * href="https://github.com/TwoStone/gradle-eclipse-compiler-plugin">TwoStone's
+ * gradle-eclipse-compiler-plugin</a>.
+ */
+class EclipseJavaCompiler implements Compiler<JavaCompileSpec> {
+
+  private final Project project;
+  private final Configuration ecjConfiguration;
+
+  /**
+   * Creates a {@link Compiler} that uses ECJ.
+   *
+   * <p>The given project is used for dependency resolution, in order to find the jar archive
+   * containing the ECJ implementation. It is also used to run that ECJ compiler.
+   *
+   * @param project the project that will use this compiler
+   */
+  EclipseJavaCompiler(Project project) {
+    this.project = project;
+    ecjConfiguration =
+        project
+            .getConfigurations()
+            .detachedConfiguration(project.getDependencies().create("org.eclipse.jdt:ecj:3.21.0"));
+  }
+
+  @Override
+  public WorkResult execute(JavaCompileSpec javaCompileSpec) {
+
+    final ExecResult result =
+        project.javaexec(
+            exec -> {
+              exec.setWorkingDir(javaCompileSpec.getWorkingDir());
+              exec.setClasspath(ecjConfiguration);
+              exec.args(
+                  ArgWriter.argsFileGenerator(
+                          new File(javaCompileSpec.getTempDir(), "java-compiler-args.txt"),
+                          ArgWriter.unixStyleFactory())
+                      .transform(
+                          new JavaCompilerArgumentsBuilder(javaCompileSpec)
+                              .includeSourceFiles(true)
+                              .build()));
+            });
+
+    try {
+      result.assertNormalExitValue();
+    } catch (ExecException e) {
+      throw new CompilationFailedException(e);
+    }
+
+    return () -> true;
+  }
+}

--- a/buildSrc/src/main/java/com/ibm/wala/gradle/EclipseJavaCompilerFactory.java
+++ b/buildSrc/src/main/java/com/ibm/wala/gradle/EclipseJavaCompilerFactory.java
@@ -1,0 +1,36 @@
+package com.ibm.wala.gradle;
+
+import org.gradle.api.Project;
+import org.gradle.api.internal.tasks.compile.JavaCompileSpec;
+import org.gradle.api.internal.tasks.compile.JavaCompilerFactory;
+import org.gradle.api.internal.tasks.compile.NormalizingJavaCompiler;
+import org.gradle.language.base.internal.compile.CompileSpec;
+import org.gradle.language.base.internal.compile.Compiler;
+
+/** Factory for creating {@link EclipseJavaCompiler} instances. */
+class EclipseJavaCompilerFactory implements JavaCompilerFactory {
+
+  private final Project project;
+
+  /**
+   * Creates an ECJ compiler factory for the given project.
+   *
+   * <p>The given project is used for dependency resolution, in order to find the jar archive
+   * containing the ECJ implementation. It is also used to run that ECJ compiler.
+   *
+   * @param project the project that will use compilers that this factory creates
+   */
+  EclipseJavaCompilerFactory(Project project) {
+    this.project = project;
+  }
+
+  @Override
+  public Compiler<JavaCompileSpec> create(Class<? extends CompileSpec> type) {
+    return new NormalizingJavaCompiler(new EclipseJavaCompiler(project));
+  }
+
+  @Override
+  public Compiler<JavaCompileSpec> createForJointCompilation(Class<? extends CompileSpec> type) {
+    return create(type);
+  }
+}

--- a/buildSrc/src/main/java/com/ibm/wala/gradle/EclipseJavaCompilerToolChain.java
+++ b/buildSrc/src/main/java/com/ibm/wala/gradle/EclipseJavaCompilerToolChain.java
@@ -1,0 +1,35 @@
+package com.ibm.wala.gradle;
+
+import org.gradle.api.JavaVersion;
+import org.gradle.api.Project;
+import org.gradle.api.internal.tasks.AbstractJavaToolChain;
+
+/**
+ * {@link org.gradle.jvm.toolchain.JavaToolChain} that uses the Eclipse Compiler for Java for
+ * compilation.
+ *
+ * <p>Inspired by, and derived from, <a
+ * href="https://github.com/TwoStone/gradle-eclipse-compiler-plugin">TwoStone's
+ * gradle-eclipse-compiler-plugin</a>.
+ */
+public class EclipseJavaCompilerToolChain extends AbstractJavaToolChain {
+
+  /**
+   * Creates an ECJ tool chain for the given project.
+   *
+
+   */
+  public EclipseJavaCompilerToolChain(Project project) {
+    super(new EclipseJavaCompilerFactory(project), null);
+  }
+
+  @Override
+  public JavaVersion getJavaVersion() {
+    return JavaVersion.current();
+  }
+
+  @Override
+  public String getName() {
+    return "ecj";
+  }
+}

--- a/com.ibm.wala.cast/build.gradle
+++ b/com.ibm.wala.cast/build.gradle
@@ -36,12 +36,6 @@ tasks.named('javadoc', Javadoc) {
 
 tasks.named('compileTestJava') {
 	options.headerOutputDirectory.set file('build/headers')
-
-	// ECJ does not implement the "-h" flag required when the
-	// headerOutputDirectory option is used, so we must switch
-	// back to the default Java compiler for this one task.
-	toolChain = it.ext.originalToolChain
-	options.compilerArgs = []
 }
 
 final getProjectLibraryDirectory(project_name, link_task_name) {

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -19,11 +19,14 @@ sourceSets {
 
 final Provider<JavaCompile> compileTestSubjectsJava = tasks.named('compileTestSubjectsJava', JavaCompile)
 
-if (javaCompiler == 'ecj') {
-	compileTestSubjectsJava.configure {
-		options.compilerArgs << '-err:none'
-		options.compilerArgs << '-warn:none'
-	}
+final ecjCompileJavaTestSubjects = JavaCompileUsingEcj.withSourceSet(project, sourceSets.testSubjects)
+ecjCompileJavaTestSubjects.configure {
+	options.compilerArgs << '-err:none'
+	options.compilerArgs << '-warn:none'
+}
+
+tasks.named('check') {
+	dependsOn ecjCompileJavaTestSubjects
 }
 
 dependencies {


### PR DESCRIPTION
We still use the default Java compiler for builds, tests, published jar archives, etc.  But now we *also* compile all Java using ECJ as part of the standard `check` validation tasks.

Set the `skipJavaUsingEcjTasks` project property if you want to skip ECJ compilation for some reason.  For example, `./gradlew -PskipJavaUsingEcjTasks ...`.

Our encapsulation of ECJ as a Gradle-compatible Java compilation tool chain is inspired by, and derived from, @TwoStone's [gradle-eclipse-compiler-plugin](https://github.com/TwoStone/gradle-eclipse-compiler-plugin). Existing pull request #744 used that plugin to provide the required ECJ tool chain, but in a way that was somewhat hackish as it deviated from the usage style that gradle-eclipse-compiler-plugin was designed for. [I reached out to @TwoStone to see whether he'd like to support our use case directly](https://github.com/TwoStone/gradle-eclipse-compiler-plugin/issues/10), but have not heard back. I therefore decided to create my own ECJ-for-Gradle implementation, which is part of this pull request.

Fixes #736.