### PR TITLE
Updates for Gradle 6.3

### DIFF
--- a/buildSrc/src/main/java/com/ibm/wala/gradle/EclipseJavaCompilerFactory.java
+++ b/buildSrc/src/main/java/com/ibm/wala/gradle/EclipseJavaCompilerFactory.java
@@ -28,9 +28,4 @@ class EclipseJavaCompilerFactory implements JavaCompilerFactory {
   public Compiler<JavaCompileSpec> create(Class<? extends CompileSpec> type) {
     return new NormalizingJavaCompiler(new EclipseJavaCompiler(project));
   }
-
-  @Override
-  public Compiler<JavaCompileSpec> createForJointCompilation(Class<? extends CompileSpec> type) {
-    return create(type);
-  }
 }

--- a/com.ibm.wala.cast/build.gradle
+++ b/com.ibm.wala.cast/build.gradle
@@ -34,10 +34,6 @@ tasks.named('javadoc', Javadoc) {
 	}
 }
 
-tasks.named('compileTestJava') {
-	options.headerOutputDirectory.set file('build/headers')
-}
-
 final getProjectLibraryDirectory(project_name, link_task_name) {
 	final library_project = project(project_name)
 	final link_task = library_project.tasks.getByName(link_task_name)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
A [default directory for native-method headers](https://docs.gradle.org/6.3/release-notes.html#customizing-location-of-native-headers-generated-from-java-source) means we no longer need to set our own.

Our ECJ-for-Gradle encapsulation got a bit simpler, since the factory API it is required to implement shrank.