### PR TITLE
improve detection of invokedynamic for Java lambdas

### DIFF
--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/summaries/LambdaMethodTargetSelector.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/summaries/LambdaMethodTargetSelector.java
@@ -20,6 +20,7 @@ import com.ibm.wala.ipa.callgraph.MethodTargetSelector;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.ipa.summaries.LambdaSummaryClass.UnresolvedLambdaBodyException;
 import com.ibm.wala.shrikeCT.BootstrapMethodsReader.BootstrapMethod;
+import com.ibm.wala.ssa.IR;
 import com.ibm.wala.ssa.SSAAbstractInvokeInstruction;
 import com.ibm.wala.ssa.SSAInstructionFactory;
 import com.ibm.wala.ssa.SSAInvokeDynamicInstruction;
@@ -28,7 +29,6 @@ import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.strings.Atom;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * Generates synthetic summaries to model the behavior of Java 8 lambdas. See
@@ -58,36 +58,45 @@ public class LambdaMethodTargetSelector implements MethodTargetSelector {
     this.base = base;
   }
 
+  /**
+   * Return a synthetic method target for invokedynamic calls corresponding to Java lambdas
+   *
+   * @param caller the GCNode in the call graph containing the call
+   * @param site the call site reference of the call site
+   * @param receiver the type of the target object or null
+   * @return a synthetic method if the call is an invokedynamic for Java lambdas; the callee target
+   *     from the base selector otherwise
+   */
   @Override
   public IMethod getCalleeTarget(CGNode caller, CallSiteReference site, IClass receiver) {
-    IClassHierarchy cha = caller.getClassHierarchy();
-    MethodReference target = site.getDeclaredTarget();
-    if (isNonClinitLambdaMetafactoryMethod(cha, target)) {
-      SSAAbstractInvokeInstruction call = caller.getIR().getCalls(site)[0];
-      if (!(call instanceof SSAInvokeDynamicInstruction)) {
-        System.err.println("unexpected non-invokedynamic instruction!");
-        System.err.println("instruction type: " + call.getClass());
-        System.err.println("call site: " + site);
-        System.err.println("caller: " + caller);
-        throw new RuntimeException("unexpected non-invokedynamic instruction!");
+    IR ir = caller.getIR();
+    if (ir.getCallInstructionIndices(site) != null) {
+      SSAAbstractInvokeInstruction call = ir.getCalls(site)[0];
+      if (call instanceof SSAInvokeDynamicInstruction) {
+        SSAInvokeDynamicInstruction invoke = (SSAInvokeDynamicInstruction) call;
+        BootstrapMethod bootstrap = invoke.getBootstrap();
+        if (bootstrap.isBootstrapForJavaLambdas()) {
+          IClassHierarchy cha = caller.getClassHierarchy();
+          // our summary generation relies on being able to resolve the Lambdametafactory class
+          if (cha.lookupClass(TypeReference.LambdaMetaFactory) != null) {
+            MethodReference target = site.getDeclaredTarget();
+            try {
+              return methodSummaries.computeIfAbsent(
+                  invoke.getBootstrap(),
+                  (b) -> {
+                    MethodSummary summary = getLambdaFactorySummary(caller, site, target, invoke);
+                    return new SummarizedMethod(
+                        summary.getMethod(), summary, cha.lookupClass(target.getDeclaringClass()));
+                  });
+            } catch (UnresolvedLambdaBodyException e) {
+              // give up on modeling the lambda
+              return null;
+            }
+          }
+        }
       }
-      SSAInvokeDynamicInstruction invoke = (SSAInvokeDynamicInstruction) call;
-
-      try {
-        return methodSummaries.computeIfAbsent(
-            invoke.getBootstrap(),
-            (b) -> {
-              MethodSummary summary = getLambdaFactorySummary(caller, site, target, invoke);
-              return new SummarizedMethod(
-                  summary.getMethod(), summary, cha.lookupClass(target.getDeclaringClass()));
-            });
-      } catch (UnresolvedLambdaBodyException e) {
-        // give up on modeling the lambda
-        return null;
-      }
-    } else {
-      return base.getCalleeTarget(caller, site, receiver);
     }
+    return base.getCalleeTarget(caller, site, receiver);
   }
 
   /**
@@ -140,16 +149,5 @@ public class LambdaMethodTargetSelector implements MethodTargetSelector {
     // return the anonymous class instance
     summary.addStatement(insts.ReturnInstruction(index++, v, false));
     return summary;
-  }
-
-  private static boolean isNonClinitLambdaMetafactoryMethod(
-      IClassHierarchy cha, MethodReference target) {
-    Atom name = target.getName();
-    return !name.equals(MethodReference.clinitName)
-        && !name.equals(MethodReference.initAtom)
-        && cha.lookupClass(TypeReference.LambdaMetaFactory) != null
-        && Objects.equals(
-            cha.lookupClass(TypeReference.LambdaMetaFactory),
-            cha.lookupClass(target.getDeclaringClass()));
   }
 }

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/summaries/LambdaMethodTargetSelector.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/summaries/LambdaMethodTargetSelector.java
@@ -82,7 +82,7 @@ public class LambdaMethodTargetSelector implements MethodTargetSelector {
             MethodReference target = site.getDeclaredTarget();
             try {
               return methodSummaries.computeIfAbsent(
-                  invoke.getBootstrap(),
+                  bootstrap,
                   (b) -> {
                     MethodSummary summary = getLambdaFactorySummary(caller, site, target, invoke);
                     return new SummarizedMethod(

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ssa/SSAInvokeDynamicInstruction.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ssa/SSAInvokeDynamicInstruction.java
@@ -47,4 +47,17 @@ public class SSAInvokeDynamicInstruction extends SSAInvokeInstruction {
   public BootstrapMethod getBootstrap() {
     return bootstrap;
   }
+
+  /**
+   * Mark the instruction as an invokedynamic. The String will also contain the invocation type of
+   * the boostrap method
+   *
+   * @param symbolTable the symbol table
+   * @return result of {@link SSAAbstractInvokeInstruction#toString(SymbolTable)} with
+   *     "[invokedynamic] " pre-pended
+   */
+  @Override
+  public String toString(SymbolTable symbolTable) {
+    return "[invokedynamic] " + super.toString(symbolTable);
+  }
 }

--- a/com.ibm.wala.core/src/testSubjects/java/lambda/CallMetaFactory.java
+++ b/com.ibm.wala.core/src/testSubjects/java/lambda/CallMetaFactory.java
@@ -1,11 +1,16 @@
 package lambda;
 
+import java.lang.invoke.LambdaConversionException;
 import java.lang.invoke.LambdaMetafactory;
 
 public class CallMetaFactory {
 
-  public static void main(String[] args) throws IllegalAccessException, InstantiationException {
+  public static void main(String[] args)
+      throws IllegalAccessException, InstantiationException, LambdaConversionException {
     // shouldn't crash on this
     LambdaMetafactory m = LambdaMetafactory.class.newInstance();
+
+    // shouldn't crash on this either
+    LambdaMetafactory.altMetafactory(null, null, null);
   }
 }

--- a/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrikeCT/BootstrapMethodsReader.java
+++ b/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrikeCT/BootstrapMethodsReader.java
@@ -12,6 +12,7 @@
 package com.ibm.wala.shrikeCT;
 
 import com.ibm.wala.shrikeCT.ClassReader.AttrIterator;
+import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.invoke.MethodType;
@@ -20,6 +21,12 @@ import java.lang.reflect.Method;
 public class BootstrapMethodsReader extends AttributeReader {
 
   public interface BootstrapMethod {
+
+    static final String LAMBDA_METAFACTORY_CLASS = "java/lang/invoke/LambdaMetafactory";
+    static final String BOOTSTRAP_METHOD_NAME = "metafactory";
+    static final String BOOTSTRAP_METHOD_TYPE =
+        "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;";
+
     byte invokeType();
 
     String methodClass();
@@ -39,6 +46,19 @@ public class BootstrapMethodsReader extends AttributeReader {
     ConstantPoolParser getCP();
 
     int getIndexInClassFile();
+
+    /**
+     * Is this the bootstrap method used for compiling Java lambdas?
+     *
+     * @return {@code true} if the method is {@link
+     *     java.lang.invoke.LambdaMetafactory#metafactory(Lookup, String, MethodType, MethodType,
+     *     MethodHandle, MethodType)}
+     */
+    default boolean isBootstrapForJavaLambdas() {
+      return methodClass().equals(LAMBDA_METAFACTORY_CLASS)
+          && methodName().equals(BOOTSTRAP_METHOD_NAME)
+          && methodType().equals(BOOTSTRAP_METHOD_TYPE);
+    }
   }
 
   private BootstrapMethod entries[];


### PR DESCRIPTION
Fixes #717

To determine whether an `invokedynamic` instruction is for Java lambdas, we now directly check if the bootstrap method is the one used in compiling such lambdas.  There is an additional test line in `CallMetafactory` capturing the behavior observed in #717