### PR TITLE
Multiple minor warning/linter fixes

### DIFF
--- a/.idea/inspectionProfiles/No_Back_Sliding.xml
+++ b/.idea/inspectionProfiles/No_Back_Sliding.xml
@@ -210,6 +210,9 @@
     <inspection_tool class="InnerClassMayBeStatic" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Java Sources as Test Subjects" level="WARNING" enabled="false" />
     </inspection_tool>
+    <inspection_tool class="InstantiationOfUtilityClass" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="Java Sources as Test Subjects" level="WARNING" enabled="false" />
+    </inspection_tool>
     <inspection_tool class="JSAssignmentUsedAsCondition" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Eclipse Build Artifacts" level="WARNING" enabled="false" />
       <scope name="JavaScript Test Subjects" level="WARNING" enabled="false" />
@@ -234,10 +237,12 @@
       <scope name="Eclipse Build Artifacts" level="INFORMATION" enabled="false" />
       <scope name="JavaScript Prologue" level="INFORMATION" enabled="false" />
     </inspection_tool>
-    <inspection_tool class="JSConstructorReturnsPrimitive" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JSDeprecatedSymbols" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <scope name="Eclipse Build Artifacts" level="WEAK WARNING" enabled="false" />
       <scope name="JavaScript Test Subjects" level="WEAK WARNING" enabled="false" />
+    </inspection_tool>
+    <inspection_tool class="JSDuplicatedDeclaration" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="JavaScript Test Subjects" level="WARNING" enabled="false" />
     </inspection_tool>
     <inspection_tool class="JSEqualityComparisonWithCoercion" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="JSIncompatibleTypesComparison" enabled="true" level="ERROR" enabled_by_default="true">
@@ -394,6 +399,9 @@
     <inspection_tool class="RedundantArrayCreation" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="RedundantBackticksAroundRawStringLiteral" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="RedundantCast" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantOperationOnEmptyContainer" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="Java Sources as Test Subjects" level="WARNING" enabled="false" />
+    </inspection_tool>
     <inspection_tool class="RedundantSuppression" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="RedundantThrows" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="RedundantTypeArguments" enabled="false" level="WARNING" enabled_by_default="false" />
@@ -507,6 +515,12 @@
       <scope name="Java Sources as Test Subjects" level="WARNING" enabled="false" />
     </inspection_tool>
     <inspection_tool class="TypeParameterExtendsObject" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="TypeScriptValidateJSTypes" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <scope name="JavaScript Test Subjects" level="WEAK WARNING" enabled="false" />
+    </inspection_tool>
+    <inspection_tool class="TypeScriptValidateTypes" enabled="true" level="ERROR" enabled_by_default="true">
+      <scope name="JavaScript Test Subjects" level="ERROR" enabled="false" />
+    </inspection_tool>
     <inspection_tool class="UNCHECKED_WARNING" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UnnecessaryBoxing" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Java Sources as Test Subjects" level="WARNING" enabled="false" />
@@ -547,9 +561,6 @@
       <scope name="JavaScript Test Subjects" level="WARNING" enabled="false" />
     </inspection_tool>
     <inspection_tool class="UnstableApiUsage" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="UnterminatedStatementJS" enabled="false" level="WARNING" enabled_by_default="false">
-      <option name="ignoreSemicolonAtEndOfBlock" value="true" />
-    </inspection_tool>
     <inspection_tool class="UnusedAssignment" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="REPORT_PREFIX_EXPRESSIONS" value="false" />
       <option name="REPORT_POSTFIX_EXPRESSIONS" value="true" />

--- a/.idea/runConfigurations/Compile_using_ECJ.xml
+++ b/.idea/runConfigurations/Compile_using_ECJ.xml
@@ -4,16 +4,16 @@
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="-PjavaCompiler=ecj" />
+      <option name="scriptParameters" value="" />
       <option name="taskDescriptions">
         <list />
       </option>
       <option name="taskNames">
         <list>
-          <option value="compileJava" />
-          <option value="compileTestJava" />
-	  <option value="compileTestFixturesJava" />
-	  <option value="compileTestSubjectsJava" />
+          <option value="compileJavaUsingEcj" />
+          <option value="compileTestFixturesJavaUsingEcj" />
+          <option value="compileTestJavaUsingEcj" />
+          <option value="compileTestSubjectsJavaUsingEcj" />
         </list>
       </option>
       <option name="vmOptions" value="" />

--- a/com.ibm.wala.cast.java.ecj/build.gradle
+++ b/com.ibm.wala.cast.java.ecj/build.gradle
@@ -26,7 +26,9 @@ dependencies {
 	)
 }
 
-mainClassName = 'com.ibm.wala.cast.java.ecj.util.SourceDirCallGraph'
+application {
+	mainClassName = 'com.ibm.wala.cast.java.ecj.util.SourceDirCallGraph'
+}
 
 tasks.named('run') {
 	// this is for testing purposes

--- a/com.ibm.wala.cast.js.rhino/src/main/java/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
+++ b/com.ibm.wala.cast.js.rhino/src/main/java/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
@@ -943,19 +943,19 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
       }
 
       // TODO: fix the correlation-tracking rewriters, and kill the old for..in translation
-      if (useNewForIn) {
-        // set up
-        String tempName = "for in loop temp";
-        CAstNode[] loopHeader =
-            new CAstNode[] {
-              Ast.makeNode(
-                  CAstNode.DECL_STMT,
-                  Ast.makeConstant(new CAstSymbolImpl(tempName, JSAstTranslator.Any)),
-                  readName(arg, null, "$$undefined")),
-              Ast.makeNode(
-                  CAstNode.ASSIGN, Ast.makeNode(CAstNode.VAR, Ast.makeConstant(tempName)), object)
-            };
 
+      // set up
+      String tempName = "for in loop temp";
+      CAstNode[] loopHeader =
+          new CAstNode[] {
+            Ast.makeNode(
+                CAstNode.DECL_STMT,
+                Ast.makeConstant(new CAstSymbolImpl(tempName, JSAstTranslator.Any)),
+                readName(arg, null, "$$undefined")),
+            Ast.makeNode(
+                CAstNode.ASSIGN, Ast.makeNode(CAstNode.VAR, Ast.makeConstant(tempName)), object)
+          };
+      if (useNewForIn) {
         assert var instanceof Name || var instanceof VariableDeclaration || var instanceof LetNode
             : var.getClass() + " " + var;
         if (var instanceof Name) {
@@ -1023,19 +1023,7 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
                                 readName(arg, null, name))),
                         body),
                     breakLabel));
-        arg.cfg().map(node, loop);
       } else {
-        String tempName = "for in loop temp";
-        CAstNode[] loopHeader =
-            new CAstNode[] {
-              Ast.makeNode(
-                  CAstNode.DECL_STMT,
-                  Ast.makeConstant(new CAstSymbolImpl(tempName, JSAstTranslator.Any)),
-                  readName(arg, null, "$$undefined")),
-              Ast.makeNode(
-                  CAstNode.ASSIGN, Ast.makeNode(CAstNode.VAR, Ast.makeConstant(tempName)), object)
-            };
-
         CAstNode initNode;
         assert var instanceof Name || var instanceof VariableDeclaration || var instanceof LetNode
             : var.getClass() + " " + var + " " + var.getLineno() + ":" + var.getPosition();
@@ -1112,8 +1100,8 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
                                     readName(arg, null, name))),
                         body),
                     breakLabel));
-        arg.cfg().map(node, loop);
       }
+      arg.cfg().map(node, loop);
 
       arg.cfg().map(get, get);
       CAstNode ctch = arg.getCatchTarget();

--- a/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
+++ b/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
@@ -642,12 +642,12 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
 
     @Override
     public String getFollowingComment(int instructionOffset) throws IOException {
-      return getComment(instructionOffset, (p) -> codePositions.tailSet(p));
+      return getComment(instructionOffset, codePositions::tailSet);
     }
 
     @Override
     public String getLeadingComment(int instructionOffset) throws IOException {
-      return getComment(instructionOffset, (p) -> codePositions.headSet(p));
+      return getComment(instructionOffset, codePositions::headSet);
     }
   }
 

--- a/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/util/CAstPattern.java
+++ b/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/util/CAstPattern.java
@@ -323,8 +323,10 @@ public class CAstPattern {
         if (s != null && name != null) s.add(name, tree);
 
         if (children == null || children.length == 0) {
-          if (DEBUG_MATCH && tree.getChildCount() != 0) {
-            System.err.println("match failed (c)");
+          if (DEBUG_MATCH) {
+            if (tree.getChildCount() != 0) {
+              System.err.println("match failed (c)");
+            }
           }
           return tree.getChildCount() == 0;
         } else {

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationSystem.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationSystem.java
@@ -618,6 +618,7 @@ public class PropagationSystem extends DefaultFixedPointSolver<PointsToSetVariab
       final int[] topFive = new int[5];
       value.foreach(
           x -> {
+            //noinspection SuspiciousSystemArraycopy
             System.arraycopy(topFive, 1, topFive, 0, 4);
             topFive[4] = x;
           });

--- a/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModel.java
+++ b/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModel.java
@@ -272,21 +272,14 @@ public class AndroidModel /* makes SummarizedMethod */ implements IClassHierarch
             IClassHierarchy cha = getClassHierarchy();
             TypeReference tRef = super.getParameterType(i);
 
-            if (tRef.isClassType()) {
-              if (cha.lookupClass(tRef) != null) {
-                return tRef;
-              } else {
-                for (IClass c : cha) {
-                  if (c.getName().toString().equals(tRef.getName().toString())) {
-                    return c.getReference();
-                  }
+            if (tRef.isClassType() && cha.lookupClass(tRef) == null) {
+              for (IClass c : cha) {
+                if (c.getName().toString().equals(tRef.getName().toString())) {
+                  return c.getReference();
                 }
               }
-              return tRef;
-              // throw new IllegalStateException("Error looking up " + tRef);
-            } else {
-              return tRef;
             }
+            return tRef;
           }
         };
 


### PR DESCRIPTION
Easy:
- 90a11e2: Correct IntelliJ IDEA warning about unused assignment
- 7e11d4f: Disable some inspections on test code
- 0ba4127: Suppress a warning about overlapping array copy
- baa99cd: Update run configuration for new ECJ strategy
- bb5a582: Use method references instead of lambdas where possible

A bit more subtle:
- 8a8362d: Hoist common actions out of if/else branches
- 3432d71: Restructure a conditional that includes dead code

Tricky, so please check carefully:
- c4e98d0: Simplify a complex knot of conditionals