### PR TITLE
Final all the things!

### DIFF
--- a/.idea/inspectionProfiles/No_Back_Sliding.xml
+++ b/.idea/inspectionProfiles/No_Back_Sliding.xml
@@ -122,6 +122,9 @@
       <scope name="JavaScript Test Subjects" level="WARNING" enabled="false" />
     </inspection_tool>
     <inspection_tool class="FieldCanBeLocal" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="FieldMayBeFinal" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="Java Sources as Test Subjects" level="WARNING" enabled="false" />
+    </inspection_tool>
     <inspection_tool class="FinalPrivateMethod" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="FinalStaticMethod" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="ForCanBeForeach" enabled="true" level="WARNING" enabled_by_default="true">

--- a/com.ibm.wala.cast.java.ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
+++ b/com.ibm.wala.cast.java.ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
@@ -982,17 +982,17 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
 
     MethodDeclaration fDecl; // TAGALONG serious tagalong...
 
-    private String[] fParameterNames; // INCLUDING this
+    private final String[] fParameterNames; // INCLUDING this
 
-    private ArrayList<CAstType> fParameterTypes;
+    private final ArrayList<CAstType> fParameterTypes;
 
-    private MethodContext fContext; // possibly TAGALONG, maybe not
+    private final MethodContext fContext; // possibly TAGALONG, maybe not
 
-    private ITypeBinding fType; // TAGALONG
+    private final ITypeBinding fType; // TAGALONG
 
     protected ITypeBinding fReturnType;
 
-    private int fModifiers;
+    private final int fModifiers;
 
     private final Set<CAstAnnotation> annotations;
 

--- a/com.ibm.wala.cast.java.ecj/src/test/java/com/ibm/wala/cast/java/test/ECJJava17IRTest.java
+++ b/com.ibm.wala.cast.java.ecj/src/test/java/com/ibm/wala/cast/java/test/ECJJava17IRTest.java
@@ -73,7 +73,7 @@ public class ECJJava17IRTest extends IRTests {
             TypeReference.findOrCreate(
                 SOURCE, TypeName.findOrCreateClassName(packageName, "BinaryLiterals$State"));
 
-        private Pair<MethodReference, int[]> constants[] =
+        private final Pair<MethodReference, int[]>[] constants =
             new Pair[] {
               Pair.make(
                   MethodReference.findOrCreate(testClass, MethodReference.clinitSelector),

--- a/com.ibm.wala.cast.java.ecj/src/test/java/com/ibm/wala/cast/java/test/ECJSyncDuplicatorTest.java
+++ b/com.ibm.wala.cast.java.ecj/src/test/java/com/ibm/wala/cast/java/test/ECJSyncDuplicatorTest.java
@@ -43,7 +43,7 @@ import org.eclipse.jdt.core.dom.CompilationUnit;
 
 public class ECJSyncDuplicatorTest extends SyncDuplicatorTests {
 
-  private static CallSiteReference guard =
+  private static final CallSiteReference guard =
       CallSiteReference.make(
           0,
           MethodReference.findOrCreate(

--- a/com.ibm.wala.cast.java/src/main/java/com/ibm/wala/cast/java/examples/ast/SynchronizedBlockDuplicator.java
+++ b/com.ibm.wala.cast.java/src/main/java/com/ibm/wala/cast/java/examples/ast/SynchronizedBlockDuplicator.java
@@ -43,16 +43,16 @@ public class SynchronizedBlockDuplicator
    */
   static class UnwindKey implements CAstRewriter.CopyKey<UnwindKey> {
     /** are we on the true or false branch? */
-    private boolean testDirection;
+    private final boolean testDirection;
 
     /** the AST node representing the synchronized block */
-    private CAstNode syncNode;
+    private final CAstNode syncNode;
 
     /**
      * key associated with the {@link com.ibm.wala.cast.tree.rewrite.CAstRewriter.RewriteContext
      * context} of the parent AST node of the synchronized block
      */
-    private UnwindKey rest;
+    private final UnwindKey rest;
 
     private UnwindKey(boolean testDirection, CAstNode syncNode, UnwindKey rest) {
       this.rest = rest;

--- a/com.ibm.wala.cast.js.html.nu_validator/src/main/java/com/ibm/wala/cast/js/html/nu_validator/NuValidatorHtmlParser.java
+++ b/com.ibm.wala.cast.js.html.nu_validator/src/main/java/com/ibm/wala/cast/js/html/nu_validator/NuValidatorHtmlParser.java
@@ -54,7 +54,7 @@ public class NuValidatorHtmlParser implements IHtmlParser {
     parser.setContentHandler(
         new ContentHandler() {
           private Locator locator;
-          private Stack<ITag> tags = new Stack<>();
+          private final Stack<ITag> tags = new Stack<>();
 
           private int countLines(char[] ch, int start, int length) {
             LineNumberReader r =

--- a/com.ibm.wala.cast.js.nodejs/src/main/java/com/ibm/wala/cast/js/nodejs/NodejsRequireTargetSelector.java
+++ b/com.ibm.wala.cast.js.nodejs/src/main/java/com/ibm/wala/cast/js/nodejs/NodejsRequireTargetSelector.java
@@ -54,11 +54,11 @@ import org.json.JSONObject;
  */
 public class NodejsRequireTargetSelector implements MethodTargetSelector {
 
-  private File rootDir;
-  private MethodTargetSelector base;
+  private final File rootDir;
+  private final MethodTargetSelector base;
   private PropagationCallGraphBuilder builder;
 
-  private HashMap<String, IMethod> previouslyRequired = HashMapFactory.make();
+  private final HashMap<String, IMethod> previouslyRequired = HashMapFactory.make();
 
   public NodejsRequireTargetSelector(File rootDir, MethodTargetSelector base) {
     this.rootDir = rootDir;

--- a/com.ibm.wala.cast.js.rhino/src/main/java/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
+++ b/com.ibm.wala.cast.js.rhino/src/main/java/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
@@ -2684,7 +2684,7 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
   public CAstEntity translateToCAst()
       throws Error, IOException, com.ibm.wala.cast.ir.translator.TranslatorToCAst.Error {
     class CAstErrorReporter implements ErrorReporter {
-      private Set<Warning> w = HashSetFactory.make();
+      private final Set<Warning> w = HashSetFactory.make();
 
       @Override
       public void error(

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/FlowGraphBuilder.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/FlowGraphBuilder.java
@@ -122,7 +122,7 @@ public class FlowGraphBuilder {
   }
 
   // primitive functions that are treated specially
-  private static String[] primitiveFunctions = {
+  private static final String[] primitiveFunctions = {
     "Object", "Function", "Array", "StringObject", "NumberObject", "BooleanObject", "RegExp"
   };
 

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/ParamVertex.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/ParamVertex.java
@@ -23,8 +23,8 @@ package com.ibm.wala.cast.js.callgraph.fieldbased.flowgraph.vertices;
  * @author mschaefer
  */
 public class ParamVertex extends Vertex {
-  private FuncVertex func;
-  private int index;
+  private final FuncVertex func;
+  private final int index;
 
   ParamVertex(FuncVertex func, int index) {
     this.func = func;

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/VertexFactory.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/VertexFactory.java
@@ -137,7 +137,7 @@ public class VertexFactory {
     return value;
   }
 
-  private GlobalVertex global = GlobalVertex.instance();
+  private final GlobalVertex global = GlobalVertex.instance();
 
   public GlobalVertex global() {
     return global;

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/JSCallGraphUtil.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/JSCallGraphUtil.java
@@ -274,8 +274,8 @@ public class JSCallGraphUtil extends com.ibm.wala.cast.ipa.callgraph.CAstCallGra
   }
 
   public static class Bootstrap implements SourceModule {
-    private String name;
-    private InputStream stream;
+    private final String name;
+    private final InputStream stream;
     private final URL url;
 
     public Bootstrap(String name, InputStream stream, URL url) {

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/JSSSAPropagationCallGraphBuilder.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/JSSSAPropagationCallGraphBuilder.java
@@ -558,7 +558,7 @@ public class JSSSAPropagationCallGraphBuilder extends AstSSAPropagationCallGraph
                   return node;
                 }
 
-                private MutableIntSet previous = IntSetUtil.make();
+                private final MutableIntSet previous = IntSetUtil.make();
 
                 @Override
                 public byte evaluate(PointsToSetVariable lhs, PointsToSetVariable ptrs) {
@@ -644,7 +644,7 @@ public class JSSSAPropagationCallGraphBuilder extends AstSSAPropagationCallGraph
         }
       } else {
         class ReceiverForDispatchOp extends UnaryOperator<PointsToSetVariable> {
-          MutableIntSet previous = IntSetUtil.make();
+          final MutableIntSet previous = IntSetUtil.make();
 
           private CGNode getNode() {
             return node;

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionApplyContextSelector.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionApplyContextSelector.java
@@ -45,7 +45,7 @@ public class JavaScriptFunctionApplyContextSelector implements ContextSelector {
   public static final ContextKey APPLY_NON_NULL_ARGS = new ContextKey() {};
 
   private final ContextSelector base;
-  private ContextSelector oneLevel;
+  private final ContextSelector oneLevel;
 
   public JavaScriptFunctionApplyContextSelector(ContextSelector base) {
     this.base = base;

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/CAstRewriterExt.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/CAstRewriterExt.java
@@ -47,9 +47,9 @@ public abstract class CAstRewriterExt extends CAstRewriter<NodePos, NoKey> {
    * @author mschaefer
    */
   protected static class Edge {
-    private CAstNode from;
-    private Object label;
-    private CAstNode to;
+    private final CAstNode from;
+    private final Object label;
+    private final CAstNode to;
 
     public Edge(CAstNode from, Object label, CAstNode to) {
       assert from != null;

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/ChildPos.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/ChildPos.java
@@ -20,9 +20,9 @@ import com.ibm.wala.cast.tree.CAstNode;
  * @author mschaefer
  */
 public class ChildPos extends NodePos {
-  private CAstNode parent;
-  private int index;
-  private NodePos parent_pos;
+  private final CAstNode parent;
+  private final int index;
+  private final NodePos parent_pos;
 
   public ChildPos(CAstNode parent, int index, NodePos parent_pos) {
     this.parent = parent;

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/ClosureExtractor.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/ClosureExtractor.java
@@ -184,7 +184,7 @@ import java.util.Set;
  * @author mschaefer
  */
 public class ClosureExtractor extends CAstRewriterExt {
-  private LinkedList<ExtractionPolicy> policies = new LinkedList<>();
+  private final LinkedList<ExtractionPolicy> policies = new LinkedList<>();
   private final ExtractionPolicyFactory policyFactory;
 
   private static final boolean LOCALISE = true;
@@ -192,7 +192,7 @@ public class ClosureExtractor extends CAstRewriterExt {
   // names for extracted functions are built from this string with a number appended
   private static final String EXTRACTED_FUN_BASENAME = "_forin_body_";
 
-  private NodeLabeller labeller = new NodeLabeller();
+  private final NodeLabeller labeller = new NodeLabeller();
 
   public ClosureExtractor(CAst Ast, ExtractionPolicyFactory policyFactory) {
     super(Ast, true, new RootPos());

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/NodeLabeller.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/NodeLabeller.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
  * @author mschaefer
  */
 public class NodeLabeller {
-  private ArrayList<CAstNode> nodes = new ArrayList<>();
+  private final ArrayList<CAstNode> nodes = new ArrayList<>();
 
   /**
    * Adds a node to the mapping if it is not present yet.

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/ssa/JavaScriptInvoke.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/ssa/JavaScriptInvoke.java
@@ -23,7 +23,7 @@ public class JavaScriptInvoke extends MultiReturnValueInvokeInstruction {
   /** The value numbers of the arguments passed to the call. */
   private final int[] params;
 
-  private int function;
+  private final int function;
 
   public JavaScriptInvoke(
       int iindex,

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/translator/JavaScriptTranslatorToCAst.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/translator/JavaScriptTranslatorToCAst.java
@@ -193,7 +193,7 @@ public interface JavaScriptTranslatorToCAst extends TranslatorToCAst {
      */
     private final Set<T> baseFor = new HashSet<>();
 
-    private int operationIndex;
+    private final int operationIndex;
 
     /** have we discovered a value to be passed as the 'this' parameter? */
     private boolean foundBase = false;

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/vis/JsPaPanel.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/vis/JsPaPanel.java
@@ -34,9 +34,9 @@ public class JsPaPanel extends PaPanel {
 
   private static final long serialVersionUID = 1L;
 
-  private MutableMapping<List<ObjectPropertyCatalogKey>> instanceKeyIdToObjectPropertyCatalogKey =
+  private final MutableMapping<List<ObjectPropertyCatalogKey>> instanceKeyIdToObjectPropertyCatalogKey =
       MutableMapping.<List<ObjectPropertyCatalogKey>>make();
-  private List<AstGlobalPointerKey> globalsPointerKeys = new ArrayList<>();
+  private final List<AstGlobalPointerKey> globalsPointerKeys = new ArrayList<>();
 
   public JsPaPanel(CallGraph cg, PointerAnalysis<InstanceKey> pa) {
     super(cg, pa);
@@ -72,8 +72,8 @@ public class JsPaPanel extends PaPanel {
     return ret;
   }
 
-  private String cgNodesRoot = "CGNodes";
-  private String globalsRoot = "Globals";
+  private final String cgNodesRoot = "CGNodes";
+  private final String globalsRoot = "Globals";
 
   @Override
   protected List<Object> getRootNodes() {

--- a/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/AstSSAPropagationCallGraphBuilder.java
+++ b/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/AstSSAPropagationCallGraphBuilder.java
@@ -771,7 +771,7 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
       }
     }
 
-    private Set<PointerKey> discoveredUpwardFunargs = HashSetFactory.make();
+    private final Set<PointerKey> discoveredUpwardFunargs = HashSetFactory.make();
 
     /**
      * add constraints that assign the final value of name in definingNode to the upward funarg

--- a/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/ssa/SSAConversion.java
+++ b/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/ssa/SSAConversion.java
@@ -60,7 +60,7 @@ public class SSAConversion extends AbstractSSAConversion {
 
   private SSAInformation computedLocalMap;
 
-  private Map<Integer, Integer> assignments = HashMapFactory.make();
+  private final Map<Integer, Integer> assignments = HashMapFactory.make();
 
   //
   // Copy propagation history

--- a/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
+++ b/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
@@ -212,7 +212,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   /** used to generate instructions for array operations; defaults to this */
-  private ArrayOpHandler arrayOpHandler;
+  private final ArrayOpHandler arrayOpHandler;
 
   protected boolean isExceptionLabel(Object label) {
     if (label == null) return false;
@@ -478,19 +478,19 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
 
   /** for keeping position information for the generated SSAInstructions and SSA locals */
   private static class AstDebuggingInformation implements DebuggingInformation {
-    private Position codeBodyPosition;
+    private final Position codeBodyPosition;
 
-    private Position codeBodyNamePosition;
+    private final Position codeBodyNamePosition;
 
-    private String[][] valueNumberNames;
+    private final String[][] valueNumberNames;
 
-    private Position[] instructionPositions;
+    private final Position[] instructionPositions;
 
-    private Position[][] operandPositions;
+    private final Position[][] operandPositions;
 
-    private Position[] parameterPositions;
+    private final Position[] parameterPositions;
 
-    private SortedSet<Position> codePositions;
+    private final SortedSet<Position> codePositions;
 
     AstDebuggingInformation(
         Position codeBodyNamePosition,
@@ -1693,11 +1693,11 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   public abstract static class AbstractSymbol implements Symbol {
     private Object constantValue;
 
-    private boolean isFinalValue;
+    private final boolean isFinalValue;
 
     private final Scope definingScope;
 
-    private Object defaultValue;
+    private final Object defaultValue;
 
     protected AbstractSymbol(Scope definingScope, boolean isFinalValue, Object defaultValue) {
       this.definingScope = definingScope;
@@ -1906,7 +1906,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
 
   protected AbstractScope makeScriptScope(final CAstEntity s, Scope parent) {
     return new AbstractScope(parent) {
-      SymbolTable scriptGlobalSymtab = new SymbolTable(s.getArgumentCount());
+      final SymbolTable scriptGlobalSymtab = new SymbolTable(s.getArgumentCount());
 
       @Override
       public SymbolTable getUnderlyingSymtab() {

--- a/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/tree/CAstQualifier.java
+++ b/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/tree/CAstQualifier.java
@@ -53,9 +53,9 @@ public class CAstQualifier {
 
   private static int sNextBitNum = 0;
 
-  private String fName;
+  private final String fName;
 
-  private long fBit;
+  private final long fBit;
 
   public CAstQualifier(String name) {
     super();

--- a/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/tree/rewrite/AstConstantFolder.java
+++ b/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/tree/rewrite/AstConstantFolder.java
@@ -24,7 +24,7 @@ public class AstConstantFolder {
   }
 
   static class AssignSkipContext extends NonCopyingContext {
-    private Set<CAstNode> skip = HashSetFactory.make();
+    private final Set<CAstNode> skip = HashSetFactory.make();
   }
 
   public CAstEntity fold(CAstEntity ce) {

--- a/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/tree/rewrite/AstLoopUnwinder.java
+++ b/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/tree/rewrite/AstLoopUnwinder.java
@@ -25,8 +25,8 @@ public class AstLoopUnwinder
         CAstRewriter.RewriteContext<AstLoopUnwinder.UnwindKey>, AstLoopUnwinder.UnwindKey> {
 
   public static class UnwindKey implements CAstRewriter.CopyKey<UnwindKey> {
-    private int iteration;
-    private UnwindKey rest;
+    private final int iteration;
+    private final UnwindKey rest;
 
     private UnwindKey(int iteration, UnwindKey rest) {
       this.rest = rest;

--- a/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/util/CAstPattern.java
+++ b/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/util/CAstPattern.java
@@ -28,9 +28,9 @@ import java.util.TreeMap;
 import java.util.regex.Pattern;
 
 public class CAstPattern {
-  private static boolean DEBUG_PARSER = false;
+  private static final boolean DEBUG_PARSER = false;
 
-  private static boolean DEBUG_MATCH = false;
+  private static final boolean DEBUG_MATCH = false;
 
   private static final int CHILD_KIND = -1;
 

--- a/com.ibm.wala.cast/src/test/java/com/ibm/wala/cast/test/TestConstantCollector.java
+++ b/com.ibm.wala.cast/src/test/java/com/ibm/wala/cast/test/TestConstantCollector.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 
 public class TestConstantCollector {
 
-  private CAst ast = new CAstImpl();
+  private final CAst ast = new CAstImpl();
 
   private static CAstEntity fakeEntity(CAstNode root) {
     return new CAstEntity() {
@@ -137,7 +137,7 @@ public class TestConstantCollector {
     };
   }
 
-  private CAstNode root1 =
+  private final CAstNode root1 =
       ast.makeNode(
           CAstNode.BLOCK_STMT,
           ast.makeNode(
@@ -158,7 +158,7 @@ public class TestConstantCollector {
     assert x.size() == 1;
   }
 
-  private CAstNode root2 =
+  private final CAstNode root2 =
       ast.makeNode(
           CAstNode.BLOCK_STMT,
           ast.makeNode(
@@ -177,7 +177,7 @@ public class TestConstantCollector {
     assert x.size() == 2;
   }
 
-  private CAstNode root3 =
+  private final CAstNode root3 =
       ast.makeNode(
           CAstNode.BLOCK_EXPR,
           ast.makeNode(
@@ -201,7 +201,7 @@ public class TestConstantCollector {
     assert matches.size() == 1;
   }
 
-  private CAstNode root4 =
+  private final CAstNode root4 =
       ast.makeNode(
           CAstNode.BLOCK_STMT,
           ast.makeNode(

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/analysis/exceptionanalysis/CGIntraproceduralExceptionAnalysis.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/analysis/exceptionanalysis/CGIntraproceduralExceptionAnalysis.java
@@ -29,9 +29,9 @@ import java.util.Set;
  * @author Stephan Gocht {@code <stephan@gobro.de>}
  */
 public class CGIntraproceduralExceptionAnalysis {
-  private Map<CGNode, IntraproceduralExceptionAnalysis> analysis;
-  private Set<TypeReference> exceptions;
-  private CallGraph callGraph;
+  private final Map<CGNode, IntraproceduralExceptionAnalysis> analysis;
+  private final Set<TypeReference> exceptions;
+  private final CallGraph callGraph;
 
   public CGIntraproceduralExceptionAnalysis(
       CallGraph cg,

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/analysis/exceptionanalysis/ExceptionAnalysis.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/analysis/exceptionanalysis/ExceptionAnalysis.java
@@ -52,12 +52,12 @@ import java.util.Set;
  * @author Stephan Gocht {@code <stephan@gobro.de>}
  */
 public class ExceptionAnalysis {
-  private BitVectorSolver<CGNode> solver;
-  private Exception2BitvectorTransformer transformer;
-  private InterproceduralExceptionFilter<SSAInstruction> filter;
-  private ClassHierarchy cha;
-  private CGIntraproceduralExceptionAnalysis intraResult;
-  private CallGraph cg;
+  private final BitVectorSolver<CGNode> solver;
+  private final Exception2BitvectorTransformer transformer;
+  private final InterproceduralExceptionFilter<SSAInstruction> filter;
+  private final ClassHierarchy cha;
+  private final CGIntraproceduralExceptionAnalysis intraResult;
+  private final CallGraph cg;
   private boolean isSolved = false;
 
   public ExceptionAnalysis(

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/analysis/exceptionanalysis/ExceptionAnalysis2EdgeFilter.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/analysis/exceptionanalysis/ExceptionAnalysis2EdgeFilter.java
@@ -21,8 +21,8 @@ import com.ibm.wala.ssa.SSAInstruction;
  * @author Stephan Gocht {@code <stephan@gobro.de>}
  */
 public class ExceptionAnalysis2EdgeFilter implements EdgeFilter<ISSABasicBlock> {
-  private ExceptionAnalysis analysis;
-  private CGNode node;
+  private final ExceptionAnalysis analysis;
+  private final CGNode node;
 
   public ExceptionAnalysis2EdgeFilter(ExceptionAnalysis analysis, CGNode node) {
     this.analysis = analysis;

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/analysis/exceptionanalysis/ExceptionTransferFunctionProvider.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/analysis/exceptionanalysis/ExceptionTransferFunctionProvider.java
@@ -28,9 +28,9 @@ import java.util.Set;
 
 public class ExceptionTransferFunctionProvider
     implements ITransferFunctionProvider<CGNode, BitVectorVariable> {
-  private Exception2BitvectorTransformer transformer;
-  private CallGraph cg;
-  private CGIntraproceduralExceptionAnalysis intraResult;
+  private final Exception2BitvectorTransformer transformer;
+  private final CallGraph cg;
+  private final CGIntraproceduralExceptionAnalysis intraResult;
 
   public ExceptionTransferFunctionProvider(
       CGIntraproceduralExceptionAnalysis intraResult,

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/analysis/exceptionanalysis/IntraproceduralExceptionAnalysis.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/analysis/exceptionanalysis/IntraproceduralExceptionAnalysis.java
@@ -38,7 +38,7 @@ import java.util.Map;
 import java.util.Set;
 
 public class IntraproceduralExceptionAnalysis {
-  private Set<TypeReference> exceptions;
+  private final Set<TypeReference> exceptions;
   private Set<TypeReference> possiblyCaughtExceptions;
   private PointerAnalysis<InstanceKey> pointerAnalysis;
   private CGNode node;

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/analysis/reflection/java7/MethodHandles.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/analysis/reflection/java7/MethodHandles.java
@@ -62,7 +62,7 @@ public class MethodHandles {
 
   private static final IntSet self = IntSetUtil.make(new int[0]);
 
-  private static ContextKey METHOD_KEY =
+  private static final ContextKey METHOD_KEY =
       new ContextKey() {
         @Override
         public String toString() {
@@ -70,7 +70,7 @@ public class MethodHandles {
         }
       };
 
-  private static ContextKey CLASS_KEY =
+  private static final ContextKey CLASS_KEY =
       new ContextKey() {
         @Override
         public String toString() {
@@ -78,7 +78,7 @@ public class MethodHandles {
         }
       };
 
-  private static ContextKey NAME_KEY =
+  private static final ContextKey NAME_KEY =
       new ContextKey() {
         @Override
         public String toString() {

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/cfg/cdg/ControlDependenceGraph.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/cfg/cdg/ControlDependenceGraph.java
@@ -98,7 +98,7 @@ public class ControlDependenceGraph<T> extends AbstractNumberedGraph<T> {
    */
   private NumberedEdgeManager<T> constructGraphEdges(final Map<T, Set<T>> forwardEdges) {
     return new NumberedEdgeManager<T>() {
-      Map<T, Set<T>> backwardEdges = HashMapFactory.make(forwardEdges.size());
+      final Map<T, Set<T>> backwardEdges = HashMapFactory.make(forwardEdges.size());
 
       {
         for (T name : cfg) {

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/cfg/exc/inter/InterprocNullPointerAnalysis.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/cfg/exc/inter/InterprocNullPointerAnalysis.java
@@ -245,7 +245,7 @@ public final class InterprocNullPointerAnalysis {
    * @author Markus Herhoffer &lt;markus.herhoffer@student.kit.edu&gt;
    */
   private static class CallGraphFilter {
-    private Set<Atom> filter;
+    private final Set<Atom> filter;
 
     /**
      * Filter for CallGraphs

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/classLoader/JarFileModule.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/classLoader/JarFileModule.java
@@ -61,7 +61,7 @@ public class JarFileModule implements Module {
   public Iterator<ModuleEntry> getEntries() {
     return new Iterator<ModuleEntry>() {
 
-      private Enumeration<JarEntry> zipEntryEnumerator = file.entries();
+      private final Enumeration<JarEntry> zipEntryEnumerator = file.entries();
 
       @Override
       public boolean hasNext() {

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/classLoader/LanguageImpl.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/classLoader/LanguageImpl.java
@@ -21,7 +21,7 @@ public abstract class LanguageImpl implements Language {
 
   private Language baseLang;
 
-  private Set<Language> derivedLangs = HashSetFactory.make();
+  private final Set<Language> derivedLangs = HashSetFactory.make();
 
   public LanguageImpl() {}
 

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/examples/analysis/dataflow/ContextSensitiveReachingDefs.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/examples/analysis/dataflow/ContextSensitiveReachingDefs.java
@@ -205,10 +205,10 @@ public class ContextSensitiveReachingDefs {
       implements PartiallyBalancedTabulationProblem<
           BasicBlockInContext<IExplodedBasicBlock>, CGNode, Pair<CGNode, Integer>> {
 
-    private ReachingDefsFlowFunctions flowFunctions = new ReachingDefsFlowFunctions(domain);
+    private final ReachingDefsFlowFunctions flowFunctions = new ReachingDefsFlowFunctions(domain);
 
     /** path edges corresponding to all putstatic instructions, used as seeds for the analysis */
-    private Collection<PathEdge<BasicBlockInContext<IExplodedBasicBlock>>> initialSeeds =
+    private final Collection<PathEdge<BasicBlockInContext<IExplodedBasicBlock>>> initialSeeds =
         collectInitialSeeds();
 
     /**

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/examples/analysis/dataflow/StaticInitializer.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/examples/analysis/dataflow/StaticInitializer.java
@@ -274,10 +274,10 @@ public class StaticInitializer {
       implements PartiallyBalancedTabulationProblem<
           BasicBlockInContext<IExplodedBasicBlock>, CGNode, IClass> {
 
-    private InitializerFlowFunctions flowFunctions = new InitializerFlowFunctions(domain);
+    private final InitializerFlowFunctions flowFunctions = new InitializerFlowFunctions(domain);
 
     /** path edges corresponding to all putstatic instructions, used as seeds for the analysis */
-    private Collection<PathEdge<BasicBlockInContext<IExplodedBasicBlock>>> initialSeeds =
+    private final Collection<PathEdge<BasicBlockInContext<IExplodedBasicBlock>>> initialSeeds =
         collectInitialSeeds();
 
     /**

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/cha/CHACallGraph.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/cha/CHACallGraph.java
@@ -241,7 +241,7 @@ public class CHACallGraph extends BasicCallGraph<CHAContextInterpreter> {
     return n;
   }
 
-  private Stack<CGNode> newNodes = new Stack<>();
+  private final Stack<CGNode> newNodes = new Stack<>();
 
   private void closure() throws CancelException {
     while (!newNodes.isEmpty()) {

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/impl/AbstractRootMethod.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/impl/AbstractRootMethod.java
@@ -54,7 +54,7 @@ public abstract class AbstractRootMethod extends SyntheticMethod {
 
   public final ArrayList<SSAInstruction> statements = new ArrayList<>();
 
-  private Map<ConstantValue, Integer> constant2ValueNumber = HashMapFactory.make();
+  private final Map<ConstantValue, Integer> constant2ValueNumber = HashMapFactory.make();
 
   /**
    * The number of the next local value number available for the fake root method. Note that we

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/impl/FakeRootClass.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/impl/FakeRootClass.java
@@ -41,7 +41,7 @@ public class FakeRootClass extends SyntheticClass {
 
   private Map<Atom, IField> fakeRootStaticFields = null;
 
-  private Set<IMethod> methods = HashSetFactory.make();
+  private final Set<IMethod> methods = HashSetFactory.make();
 
   public FakeRootClass(ClassLoaderReference clr, IClassHierarchy cha) {
     this(fakeRootClass(clr), cha);

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/FallbackContextInterpreter.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/FallbackContextInterpreter.java
@@ -49,7 +49,7 @@ import java.util.Iterator;
  */
 public class FallbackContextInterpreter implements SSAContextInterpreter {
 
-  private SSAContextInterpreter shrikeCI;
+  private final SSAContextInterpreter shrikeCI;
 
   public FallbackContextInterpreter(SSAContextInterpreter shrikeCI) {
     this.shrikeCI = shrikeCI;

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/pruned/CallGraphPruning.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/pruned/CallGraphPruning.java
@@ -30,9 +30,9 @@ public final class CallGraphPruning {
   private LinkedList<CGNode> visited;
   private List<CGNode> marked;
   private int depth;
-  private CallGraph cg;
+  private final CallGraph cg;
 
-  private boolean DEBUG = false;
+  private final boolean DEBUG = false;
 
   /**
    * Searches all nodes in the callgraph that correspond to a method of the application (and not the

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/pruned/PrunedCallGraph.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/pruned/PrunedCallGraph.java
@@ -31,8 +31,8 @@ import java.util.stream.Stream;
 
 public class PrunedCallGraph implements CallGraph {
 
-  private CallGraph cg;
-  private Set<CGNode> keep;
+  private final CallGraph cg;
+  private final Set<CGNode> keep;
   private Map<CGNode, Set<CGNode>> remove = Collections.emptyMap();
 
   /**

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/cfg/exceptionpruning/interprocedural/IgnoreExceptionsInterFilter.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/cfg/exceptionpruning/interprocedural/IgnoreExceptionsInterFilter.java
@@ -15,7 +15,7 @@ import com.ibm.wala.ipa.cfg.exceptionpruning.ExceptionFilter;
 
 public class IgnoreExceptionsInterFilter<Instruction>
     implements InterproceduralExceptionFilter<Instruction> {
-  private ExceptionFilter<Instruction> filter;
+  private final ExceptionFilter<Instruction> filter;
 
   public IgnoreExceptionsInterFilter(ExceptionFilter<Instruction> filter) {
     this.filter = filter;

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/cfg/exceptionpruning/interprocedural/StoringExceptionFilter.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/cfg/exceptionpruning/interprocedural/StoringExceptionFilter.java
@@ -17,7 +17,7 @@ import java.util.Map;
 
 public abstract class StoringExceptionFilter<Instruction>
     implements InterproceduralExceptionFilter<Instruction> {
-  private Map<CGNode, ExceptionFilter<Instruction>> store;
+  private final Map<CGNode, ExceptionFilter<Instruction>> store;
 
   public StoringExceptionFilter() {
     this.store = new LinkedHashMap<>();

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/modref/ModRefFieldAccess.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/modref/ModRefFieldAccess.java
@@ -62,12 +62,12 @@ public final class ModRefFieldAccess {
 
   private final CallGraph cg;
 
-  private Map<CGNode, Map<IClass, Set<IField>>> mods;
-  private Map<CGNode, Map<IClass, Set<IField>>> refs;
-  private Map<CGNode, Map<IClass, Set<IField>>> tmods;
-  private Map<CGNode, Map<IClass, Set<IField>>> trefs;
+  private final Map<CGNode, Map<IClass, Set<IField>>> mods;
+  private final Map<CGNode, Map<IClass, Set<IField>>> refs;
+  private final Map<CGNode, Map<IClass, Set<IField>>> tmods;
+  private final Map<CGNode, Map<IClass, Set<IField>>> trefs;
 
-  private List<CGNode> done;
+  private final List<CGNode> done;
 
   private ModRefFieldAccess(CallGraph cg) {
     this.cg = cg;

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/summaries/VolatileMethodSummary.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/summaries/VolatileMethodSummary.java
@@ -78,9 +78,9 @@ public class VolatileMethodSummary {
 
   private static final boolean DEBUG = false;
   private boolean allowReservedPC = false;
-  private MethodSummary summary;
+  private final MethodSummary summary;
   private List<SSAInstruction> instructions = new ArrayList<>();
-  private Map<Integer, Atom> localNames = new HashMap<>();
+  private final Map<Integer, Atom> localNames = new HashMap<>();
   private int currentProgramCounter = 0;
   private boolean locked = false;
 

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/util/ssa/InstructionByIIndexMap.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/util/ssa/InstructionByIIndexMap.java
@@ -20,7 +20,7 @@ import java.util.Set;
 
 public class InstructionByIIndexMap<Instruction extends SSAInstruction, T>
     implements Map<Instruction, T> {
-  private Map<InstructionByIIndexWrapper<Instruction>, T> map;
+  private final Map<InstructionByIIndexWrapper<Instruction>, T> map;
 
   public InstructionByIIndexMap(Map<InstructionByIIndexWrapper<Instruction>, T> map) {
     this.map = map;

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/util/ssa/InstructionByIIndexWrapper.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/util/ssa/InstructionByIIndexWrapper.java
@@ -13,7 +13,7 @@ package com.ibm.wala.util.ssa;
 import com.ibm.wala.ssa.SSAInstruction;
 
 public class InstructionByIIndexWrapper<T extends SSAInstruction> {
-  private T instruction;
+  private final T instruction;
 
   @Override
   public int hashCode() {

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/util/ssa/SSAValueManager.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/util/ssa/SSAValueManager.java
@@ -90,9 +90,9 @@ public class SSAValueManager {
   /** for managing cascaded code blocks */
   private int currentScope = 0;
   /** Description only used for toString() */
-  private String description;
+  private final String description;
 
-  private MethodReference forMethod;
+  private final MethodReference forMethod;
 
   /** User-Defined debugging info */
   public String breadCrumb = "";
@@ -126,9 +126,9 @@ public class SSAValueManager {
   }
 
   /** The main data-structure of the management */
-  private Map<VariableKey, List<Managed<? extends SSAValue>>> seenTypes = HashMapFactory.make();
+  private final Map<VariableKey, List<Managed<? extends SSAValue>>> seenTypes = HashMapFactory.make();
 
-  private List<SSAValue> unmanaged = new ArrayList<>();
+  private final List<SSAValue> unmanaged = new ArrayList<>();
 
   public SSAValueManager(ParameterAccessor acc) {
     this.nextLocal = acc.getFirstAfter();

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/viz/viewer/IrViewer.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/viz/viewer/IrViewer.java
@@ -31,9 +31,9 @@ import javax.swing.event.ListSelectionListener;
 
 public class IrViewer extends JPanel {
   private static final long serialVersionUID = -5668847442988389016L;
-  private JTextField methodName;
-  private DefaultListModel<String> irLineList = new DefaultListModel<>();
-  private JList<String> irLines;
+  private final JTextField methodName;
+  private final DefaultListModel<String> irLineList = new DefaultListModel<>();
+  private final JList<String> irLines;
 
   // mapping from ir viewer list line to source code line number.
   private Map<Integer, Integer> lineToPosition = null;

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/viz/viewer/PaPanel.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/viz/viewer/PaPanel.java
@@ -61,11 +61,11 @@ public class PaPanel extends JSplitPane {
 
   private IrAndSourceViewer irViewer;
 
-  private MutableMapping<List<LocalPointerKey>> cgNodeIdToLocalPointers =
+  private final MutableMapping<List<LocalPointerKey>> cgNodeIdToLocalPointers =
       MutableMapping.<List<LocalPointerKey>>make();
-  private MutableMapping<List<ReturnValueKey>> cgNodeIdToReturnValue =
+  private final MutableMapping<List<ReturnValueKey>> cgNodeIdToReturnValue =
       MutableMapping.<List<ReturnValueKey>>make();
-  private MutableMapping<List<InstanceFieldPointerKey>> instanceKeyIdToInstanceFieldPointers =
+  private final MutableMapping<List<InstanceFieldPointerKey>> instanceKeyIdToInstanceFieldPointers =
       MutableMapping.<List<InstanceFieldPointerKey>>make();
 
   public PaPanel(CallGraph cg, PointerAnalysis<InstanceKey> pa) {

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/viz/viewer/SourceViewer.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/viz/viewer/SourceViewer.java
@@ -24,9 +24,9 @@ import javax.swing.JTextField;
 public class SourceViewer extends JPanel {
   private static final long serialVersionUID = -1688405955293925453L;
   private URL sourceURL;
-  private JTextField sourceCodeLocation;
-  private DefaultListModel<String> sourceCodeLinesList = new DefaultListModel<>();
-  private JList<String> sourceCodeLines;
+  private final JTextField sourceCodeLocation;
+  private final DefaultListModel<String> sourceCodeLinesList = new DefaultListModel<>();
+  private final JList<String> sourceCodeLines;
 
   public SourceViewer() {
     super(new BorderLayout());

--- a/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/arraybounds/ArrayboundsAnalysisTest.java
+++ b/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/arraybounds/ArrayboundsAnalysisTest.java
@@ -43,7 +43,7 @@ import org.junit.rules.ErrorCollector;
  * @author Stephan Gocht {@code <stephan@gobro.de>}
  */
 public class ArrayboundsAnalysisTest {
-  private static ClassLoader CLASS_LOADER = ArrayboundsAnalysisTest.class.getClassLoader();
+  private static final ClassLoader CLASS_LOADER = ArrayboundsAnalysisTest.class.getClassLoader();
 
   private static final String DETECTABLE_TESTDATA = "Larraybounds/Detectable";
   private static final int DETECTABLE_NUMBER_OF_ARRAY_ACCESS = 34;

--- a/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/arraybounds/PruneArrayOutOfBoundExceptionEdge.java
+++ b/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/arraybounds/PruneArrayOutOfBoundExceptionEdge.java
@@ -59,7 +59,7 @@ import org.junit.rules.ErrorCollector;
  * @author Stephan Gocht {@code <stephan@gobro.de>}
  */
 public class PruneArrayOutOfBoundExceptionEdge {
-  private static ClassLoader CLASS_LOADER =
+  private static final ClassLoader CLASS_LOADER =
       PruneArrayOutOfBoundExceptionEdge.class.getClassLoader();
 
   private static final String DETECTABLE_TESTDATA = "Larraybounds/Detectable";

--- a/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/exceptionpruning/ExceptionAnalysis2EdgeFilterTest.java
+++ b/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/exceptionpruning/ExceptionAnalysis2EdgeFilterTest.java
@@ -55,7 +55,7 @@ import org.junit.rules.ErrorCollector;
  * @author Stephan Gocht {@code <stephan@gobro.de>}
  */
 public class ExceptionAnalysis2EdgeFilterTest {
-  private static ClassLoader CLASS_LOADER = ExceptionAnalysis2EdgeFilterTest.class.getClassLoader();
+  private static final ClassLoader CLASS_LOADER = ExceptionAnalysis2EdgeFilterTest.class.getClassLoader();
   public static String REGRESSION_EXCLUSIONS = "Java60RegressionExclusions.txt";
 
   private static ClassHierarchy cha;

--- a/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/exceptionpruning/ExceptionAnalysisTest.java
+++ b/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/exceptionpruning/ExceptionAnalysisTest.java
@@ -48,7 +48,7 @@ import org.junit.rules.ErrorCollector;
  * @author Stephan Gocht {@code <stephan@gobro.de>}
  */
 public class ExceptionAnalysisTest {
-  private static ClassLoader CLASS_LOADER = ExceptionAnalysisTest.class.getClassLoader();
+  private static final ClassLoader CLASS_LOADER = ExceptionAnalysisTest.class.getClassLoader();
   public static String REGRESSION_EXCLUSIONS = "Java60RegressionExclusions.txt";
 
   private static ClassHierarchy cha;

--- a/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/ir/DeterministicIRTest.java
+++ b/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/ir/DeterministicIRTest.java
@@ -39,7 +39,7 @@ import org.junit.Test;
  */
 public abstract class DeterministicIRTest extends WalaTestCase {
 
-  private IClassHierarchy cha;
+  private final IClassHierarchy cha;
 
   private final AnalysisOptions options = new AnalysisOptions();
 

--- a/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/shrike/FloatingPointsTest.java
+++ b/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/shrike/FloatingPointsTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 public class FloatingPointsTest extends WalaTestCase {
   private final String klass = "shrike/FloatingPoints";
 
-  private String testJarLocation;
+  private final String testJarLocation;
   private OfflineInstrumenter instrumenter;
   private Path instrumentedJarLocation;
   private List<ClassInstrumenter> classInstrumenters;

--- a/com.ibm.wala.core/src/testFixtures/java/com/ibm/wala/core/tests/shrike/DynamicCallGraphTestBase.java
+++ b/com.ibm.wala.core/src/testFixtures/java/com/ibm/wala/core/tests/shrike/DynamicCallGraphTestBase.java
@@ -48,9 +48,9 @@ public abstract class DynamicCallGraphTestBase extends WalaTestCase {
 
   private boolean instrumentedJarBuilt = false;
 
-  private java.nio.file.Path instrumentedJarLocation;
+  private final java.nio.file.Path instrumentedJarLocation;
 
-  private java.nio.file.Path cgLocation;
+  private final java.nio.file.Path cgLocation;
 
   protected DynamicCallGraphTestBase() {
     try {

--- a/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/analysis/typeInference/DalvikTypeInference.java
+++ b/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/analysis/typeInference/DalvikTypeInference.java
@@ -14,7 +14,7 @@ public class DalvikTypeInference extends TypeInference {
     return new DalvikTypeVariable[size];
   }
 
-  private static AbstractOperator<TypeVariable> dalvikPhiOp = new DalvikPhiOperator();
+  private static final AbstractOperator<TypeVariable> dalvikPhiOp = new DalvikPhiOperator();
 
   protected DalvikTypeInference(IR ir, boolean doPrimitives) {
     super(ir, doPrimitives);

--- a/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexIField.java
+++ b/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexIField.java
@@ -76,9 +76,10 @@ public class DexIField implements IField {
   /**
    * canonical FieldReference corresponding to this method, construct in the getReference method.
    */
-  private FieldReference fieldReference, myFieldRef;
+  private FieldReference fieldReference;
+  private final FieldReference myFieldRef;
 
-  private Atom name;
+  private final Atom name;
 
   public DexIField(Field encodedField, DexIClass klass) {
     // public DexIField(EncodedField encodedField) {

--- a/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/WDexClassLoaderImpl.java
+++ b/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/WDexClassLoaderImpl.java
@@ -68,7 +68,7 @@ import java.util.Set;
 
 /** ClassLoader for Java &amp; Dalvik. */
 public class WDexClassLoaderImpl extends ClassLoaderImpl {
-  private IClassLoader lParent;
+  private final IClassLoader lParent;
 
   private final SetOfClasses exclusions;
 

--- a/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModel.java
+++ b/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModel.java
@@ -130,7 +130,7 @@ public class AndroidModel /* makes SummarizedMethod */ implements IClassHierarch
   protected AnalysisOptions options;
   protected IAnalysisCacheView cache;
   private AbstractAndroidModel labelSpecial;
-  private IInstantiationBehavior instanceBehavior;
+  private final IInstantiationBehavior instanceBehavior;
   private SSAValueManager paramManager;
   private ParameterAccessor modelAcc;
   private ReuseParameters reuseParameters;

--- a/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModelClass.java
+++ b/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModelClass.java
@@ -87,13 +87,13 @@ import org.slf4j.LoggerFactory;
  *     loader? Currently: Primordial
  */
 public final /* singleton */ class AndroidModelClass extends SyntheticClass {
-  private static Logger logger = LoggerFactory.getLogger(AndroidModelClass.class);
+  private static final Logger logger = LoggerFactory.getLogger(AndroidModelClass.class);
 
   public static final TypeReference ANDROID_MODEL_CLASS =
       TypeReference.findOrCreate(
           ClassLoaderReference.Primordial,
           TypeName.string2TypeName("Lcom/ibm/wala/AndroidModelClass"));
-  private IClassHierarchy cha;
+  private final IClassHierarchy cha;
 
   public static AndroidModelClass getInstance(IClassHierarchy cha) {
     IClass android = cha.lookupClass(ANDROID_MODEL_CLASS);
@@ -176,7 +176,7 @@ public final /* singleton */ class AndroidModelClass extends SyntheticClass {
   //
   private IMethod macroModel = null;
   //    private IMethod allActivitiesModel = null;
-  private Map<Selector, IMethod> methods = HashMapFactory.make(); // does not contain macroModel
+  private final Map<Selector, IMethod> methods = HashMapFactory.make(); // does not contain macroModel
 
   public boolean containsMethod(Selector selector) {
     return (((macroModel != null) && macroModel.getSelector().equals(selector))
@@ -243,7 +243,7 @@ public final /* singleton */ class AndroidModelClass extends SyntheticClass {
   //  Contents of the class: Fields
   //  We have none...
   //
-  private Map<Atom, IField> fields = new HashMap<>();
+  private final Map<Atom, IField> fields = new HashMap<>();
 
   @Override
   public IField getField(Atom name) {

--- a/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/AndroidModelParameterManager.java
+++ b/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/AndroidModelParameterManager.java
@@ -113,7 +113,7 @@ public class AndroidModelParameterManager {
   }
 
   /** The main data-structure of the management */
-  private Map<TypeReference, List<ManagedParameter>> seenTypes = new HashMap<>();
+  private final Map<TypeReference, List<ManagedParameter>> seenTypes = new HashMap<>();
 
   /**
    * Setting the behaviour may be handy in the later model.

--- a/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/impl/AndroidEntryPoint.java
+++ b/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/impl/AndroidEntryPoint.java
@@ -221,7 +221,7 @@ public class AndroidEntryPoint extends DexEntryPoint {
     /** This value getts used by the detection heuristic - It is not recommended for manual use. */
     public static final ExecutionOrder DEFAULT = MIDDLE_OF_LOOP;
 
-    private int value;
+    private final int value;
     /**
      * Unrecommended way to generate the Order based on an Integer.
      *

--- a/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/impl/DexEntryPoint.java
+++ b/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/impl/DexEntryPoint.java
@@ -48,7 +48,7 @@ import com.ibm.wala.types.TypeReference;
 
 public class DexEntryPoint extends DefaultEntrypoint implements IClassHierarchyDweller {
   /* BEGIN Custom change */
-  private IClassHierarchy cha;
+  private final IClassHierarchy cha;
   /* END Custom change */
   public DexEntryPoint(IMethod method, IClassHierarchy cha) {
     super(method, cha);

--- a/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidEntryPointManager.java
+++ b/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidEntryPointManager.java
@@ -678,7 +678,7 @@ public final /* singleton */ class AndroidEntryPointManager implements Serializa
     return false;
   }
 
-  private transient Map<CallSiteReference, Intent> seenIntentCalls = HashMapFactory.make();
+  private final transient Map<CallSiteReference, Intent> seenIntentCalls = HashMapFactory.make();
   /**
    * DO NOT CALL! - This is for IntentContextSelector.
    *

--- a/com.ibm.wala.ide.jdt.test/src/test/java/com/ibm/wala/cast/java/test/TypeInferenceAssertion.java
+++ b/com.ibm.wala.ide.jdt.test/src/test/java/com/ibm/wala/cast/java/test/TypeInferenceAssertion.java
@@ -23,7 +23,7 @@ import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.util.collections.Iterator2Iterable;
 
 final class TypeInferenceAssertion implements IRAssertion {
-  private String typeName;
+  private final String typeName;
 
   public TypeInferenceAssertion(String packageName) {
     this.typeName = packageName;

--- a/com.ibm.wala.ide.jdt/src/main/java/com/ibm/wala/ide/util/JavaEclipseProjectPath.java
+++ b/com.ibm.wala.ide.jdt/src/main/java/com/ibm/wala/ide/util/JavaEclipseProjectPath.java
@@ -33,7 +33,7 @@ public class JavaEclipseProjectPath extends EclipseProjectPath<IClasspathEntry, 
   public enum JavaSourceLoader implements ILoader {
     SOURCE(JavaSourceAnalysisScope.SOURCE);
 
-    private ClassLoaderReference ref;
+    private final ClassLoaderReference ref;
 
     JavaSourceLoader(ClassLoaderReference ref) {
       this.ref = ref;

--- a/com.ibm.wala.ide.jsdt/src/main/java/com/ibm/wala/ide/util/JavaScriptEclipseProjectPath.java
+++ b/com.ibm.wala.ide.jsdt/src/main/java/com/ibm/wala/ide/util/JavaScriptEclipseProjectPath.java
@@ -37,7 +37,7 @@ public class JavaScriptEclipseProjectPath
   public enum JSLoader implements ILoader {
     JAVASCRIPT(JavaScriptTypes.jsLoader);
 
-    private ClassLoaderReference ref;
+    private final ClassLoaderReference ref;
 
     JSLoader(ClassLoaderReference ref) {
       this.ref = ref;

--- a/com.ibm.wala.ide/src/main/java/com/ibm/wala/ide/classloader/EclipseSourceFileModule.java
+++ b/com.ibm.wala.ide/src/main/java/com/ibm/wala/ide/classloader/EclipseSourceFileModule.java
@@ -17,7 +17,7 @@ import org.eclipse.core.resources.IFile;
 /** A module which is a wrapper around a .java file */
 public class EclipseSourceFileModule extends SourceFileModule {
 
-  private IFile f;
+  private final IFile f;
 
   public static EclipseSourceFileModule createEclipseSourceFileModule(IFile f) {
     if (f == null) {

--- a/com.ibm.wala.ide/src/main/java/com/ibm/wala/ide/ui/ViewIFDSLocalAction.java
+++ b/com.ibm.wala.ide/src/main/java/com/ibm/wala/ide/ui/ViewIFDSLocalAction.java
@@ -99,7 +99,7 @@ public class ViewIFDSLocalAction<T, P, F> extends Action {
   }
 
   private static class Labels<T, P, F> implements NodeDecorator<T> {
-    private TabulationResult<T, P, F> result;
+    private final TabulationResult<T, P, F> result;
 
     Labels(TabulationResult<T, P, F> result) {
       this.result = result;

--- a/com.ibm.wala.ide/src/main/java/com/ibm/wala/ide/util/EclipseProjectPath.java
+++ b/com.ibm.wala.ide/src/main/java/com/ibm/wala/ide/util/EclipseProjectPath.java
@@ -80,7 +80,7 @@ public abstract class EclipseProjectPath<E, P> {
     EXTENSION(ClassLoaderReference.Extension),
     PRIMORDIAL(ClassLoaderReference.Primordial);
 
-    private ClassLoaderReference ref;
+    private final ClassLoaderReference ref;
 
     Loader(ClassLoaderReference ref) {
       this.ref = ref;

--- a/com.ibm.wala.scandroid/src/main/java/org/scandroid/domain/FieldElement.java
+++ b/com.ibm.wala.scandroid/src/main/java/org/scandroid/domain/FieldElement.java
@@ -51,8 +51,8 @@ import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.types.FieldReference;
 
 public class FieldElement extends CodeElement {
-  private FieldReference fieldRef;
-  private InstanceKey object;
+  private final FieldReference fieldRef;
+  private final InstanceKey object;
   //    private TypeReference object;
 
   public FieldElement(InstanceKey object, FieldReference fieldRef) {

--- a/com.ibm.wala.scandroid/src/main/java/org/scandroid/domain/IFDSTaintDomain.java
+++ b/com.ibm.wala.scandroid/src/main/java/org/scandroid/domain/IFDSTaintDomain.java
@@ -61,10 +61,10 @@ import java.util.stream.Stream;
 
 public class IFDSTaintDomain<E extends ISSABasicBlock>
     implements TabulationDomain<DomainElement, BasicBlockInContext<E>> {
-  private Map<DomainElement, Integer> table = new HashMap<>();
-  private ArrayList<DomainElement> objects = new ArrayList<>();
+  private final Map<DomainElement, Integer> table = new HashMap<>();
+  private final ArrayList<DomainElement> objects = new ArrayList<>();
 
-  private Map<CodeElement, Set<DomainElement>> elementIndex = new HashMap<>();
+  private final Map<CodeElement, Set<DomainElement>> elementIndex = new HashMap<>();
 
   Set<DomainElement> emptySet = new HashSet<>();
 

--- a/com.ibm.wala.scandroid/src/main/java/org/scandroid/domain/InstanceKeyElement.java
+++ b/com.ibm.wala.scandroid/src/main/java/org/scandroid/domain/InstanceKeyElement.java
@@ -50,7 +50,7 @@ package org.scandroid.domain;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 
 public class InstanceKeyElement extends CodeElement {
-  private InstanceKey ik;
+  private final InstanceKey ik;
 
   public InstanceKeyElement(InstanceKey ik) {
     this.ik = ik;

--- a/com.ibm.wala.scandroid/src/main/java/org/scandroid/flow/functions/CallNoneToReturnFunction.java
+++ b/com.ibm.wala.scandroid/src/main/java/org/scandroid/flow/functions/CallNoneToReturnFunction.java
@@ -50,7 +50,7 @@ import org.scandroid.flow.types.FlowType;
 
 public final class CallNoneToReturnFunction<E extends ISSABasicBlock>
     implements IUnaryFlowFunction {
-  private IFDSTaintDomain<E> domain;
+  private final IFDSTaintDomain<E> domain;
 
   public CallNoneToReturnFunction(IFDSTaintDomain<E> domain) {
     this.domain = domain;

--- a/com.ibm.wala.scandroid/src/main/java/org/scandroid/flow/functions/CallToReturnFunction.java
+++ b/com.ibm.wala.scandroid/src/main/java/org/scandroid/flow/functions/CallToReturnFunction.java
@@ -50,7 +50,7 @@ import org.scandroid.domain.ReturnElement;
 
 public class CallToReturnFunction<E extends ISSABasicBlock> implements IUnaryFlowFunction {
 
-  private IFDSTaintDomain<E> domain;
+  private final IFDSTaintDomain<E> domain;
 
   public CallToReturnFunction(IFDSTaintDomain<E> domain) {
     this.domain = domain;

--- a/com.ibm.wala.scandroid/src/main/java/org/scandroid/model/AppModelMethod.java
+++ b/com.ibm.wala.scandroid/src/main/java/org/scandroid/model/AppModelMethod.java
@@ -88,18 +88,18 @@ public class AppModelMethod {
 
   private final AnalysisScope scope;
 
-  private Map<ConstantValue, Integer> constant2ValueNumber = HashMapFactory.make();
+  private final Map<ConstantValue, Integer> constant2ValueNumber = HashMapFactory.make();
 
   SSAInstructionFactory insts;
 
   // Maps a Type to variable name
-  private Map<TypeReference, Integer> typeToID = new HashMap<>();
+  private final Map<TypeReference, Integer> typeToID = new HashMap<>();
   // innerclass dependencies
-  private Map<TypeReference, LinkedList<TypeReference>> icDependencies = new HashMap<>();
+  private final Map<TypeReference, LinkedList<TypeReference>> icDependencies = new HashMap<>();
   // all callbacks to consider
-  private List<MethodParams> callBacks = new ArrayList<>();
+  private final List<MethodParams> callBacks = new ArrayList<>();
 
-  private Map<TypeReference, TypeReference> aClassToTR = new HashMap<>();
+  private final Map<TypeReference, TypeReference> aClassToTR = new HashMap<>();
 
   private static class MethodParams {
     public IMethod im;

--- a/com.ibm.wala.scandroid/src/main/java/org/scandroid/prefixtransfer/BlockSearch.java
+++ b/com.ibm.wala.scandroid/src/main/java/org/scandroid/prefixtransfer/BlockSearch.java
@@ -56,7 +56,7 @@ import java.util.Set;
 
 public class BlockSearch {
 
-  private ArrayList<ISSABasicBlock> blockQueue = new ArrayList<>();
+  private final ArrayList<ISSABasicBlock> blockQueue = new ArrayList<>();
   private int location = 0;
 
   private final SSACFG cfg;

--- a/com.ibm.wala.scandroid/src/main/java/org/scandroid/spec/AndroidSpecs.java
+++ b/com.ibm.wala.scandroid/src/main/java/org/scandroid/spec/AndroidSpecs.java
@@ -136,7 +136,7 @@ public class AndroidSpecs implements ISpecs {
   static MethodNamePattern glStatusChanged = new MethodNamePattern(gl, "onGpsStatusChanged");
   static MethodNamePattern nlNmeaRecvd = new MethodNamePattern(nl, "onNmeaReceived");
 
-  private static MethodNamePattern[] defaultCallbacks = {
+  private static final MethodNamePattern[] defaultCallbacks = {
     actCreate,
     actStart,
     actResume,
@@ -167,7 +167,7 @@ public class AndroidSpecs implements ISpecs {
     return defaultCallbacks;
   }
 
-  private static SourceSpec[] sourceSpecs = {
+  private static final SourceSpec[] sourceSpecs = {
     //		new EntryArgSourceSpec( actCreate, null ),
     // doesn't have any parameters
     // new EntryArgSourceSpec( actStart, null ),
@@ -225,7 +225,7 @@ public class AndroidSpecs implements ISpecs {
   }
 
   /** TODO: document! */
-  private static SinkSpec[] sinkSpecs = {
+  private static final SinkSpec[] sinkSpecs = {
     new CallArgSinkSpec(actSetResult, new int[] {2}),
     //		new CallArgSinkSpec(bndTransact, new int[] { 2 }),
 

--- a/com.ibm.wala.scandroid/src/main/java/org/scandroid/synthmethod/SSAtoXMLVisitor.java
+++ b/com.ibm.wala.scandroid/src/main/java/org/scandroid/synthmethod/SSAtoXMLVisitor.java
@@ -79,7 +79,7 @@ public class SSAtoXMLVisitor implements SSAInstruction.IVisitor {
   private int defCounter = 0;
 
   /** Map the known defNum to local def names. */
-  private Map<Integer, String> localDefs = HashMapFactory.make();
+  private final Map<Integer, String> localDefs = HashMapFactory.make();
 
   /** XML document to use for creating elements. */
   private final Document doc;

--- a/com.ibm.wala.scandroid/src/main/java/org/scandroid/util/CGAnalysisContext.java
+++ b/com.ibm.wala.scandroid/src/main/java/org/scandroid/util/CGAnalysisContext.java
@@ -96,7 +96,7 @@ public class CGAnalysisContext<E extends ISSABasicBlock> {
 
   public final AndroidAnalysisContext analysisContext;
 
-  private List<Entrypoint> entrypoints;
+  private final List<Entrypoint> entrypoints;
   public CallGraph cg;
   public PointerAnalysis<InstanceKey> pa;
   public ISupergraph<BasicBlockInContext<E>, CGNode> graph;

--- a/com.ibm.wala.scandroid/src/main/java/org/scandroid/util/CLISCanDroidOptions.java
+++ b/com.ibm.wala.scandroid/src/main/java/org/scandroid/util/CLISCanDroidOptions.java
@@ -69,13 +69,13 @@ public class CLISCanDroidOptions implements ISCanDroidOptions {
   private static final String PARTIAL_CALL_GRAPH = "partial-call-graph";
   private static final String CALL_GRAPH = "call-graph";
 
-  private CommandLineParser parser = new DefaultParser();
+  private final CommandLineParser parser = new DefaultParser();
   private CommandLine line;
-  private URI classpath;
-  private String filename;
-  private URI androidLib;
-  private URI summariesFile;
-  private ReflectionOptions reflectionOptions;
+  private final URI classpath;
+  private final String filename;
+  private final URI androidLib;
+  private final URI summariesFile;
+  private final ReflectionOptions reflectionOptions;
   private static final String USAGE = "[options] <.apk or .jar>";
 
   private final Options options = new Options();

--- a/com.ibm.wala.scandroid/src/main/java/org/scandroid/util/DexDotUtil.java
+++ b/com.ibm.wala.scandroid/src/main/java/org/scandroid/util/DexDotUtil.java
@@ -32,11 +32,11 @@ public class DexDotUtil extends DotUtil {
   //      PS, SVG, PDF, EPS
   //    }
 
-  private static DotOutputType outputType = DotOutputType.PDF;
+  private static final DotOutputType outputType = DotOutputType.PDF;
 
   private static int fontSize = 6;
-  private static String fontColor = "black";
-  private static String fontName = "Arial";
+  private static final String fontColor = "black";
+  private static final String fontName = "Arial";
 
   //    public static void setOutputType(DotOutputType outType) {
   //      outputType = outType;

--- a/com.ibm.wala.scandroid/src/main/java/org/scandroid/util/DexDotUtil.java
+++ b/com.ibm.wala.scandroid/src/main/java/org/scandroid/util/DexDotUtil.java
@@ -191,8 +191,8 @@ public class DexDotUtil extends DotUtil {
       result.append("rankdir=").append(rankdir).append(';');
     }
     String fontsizeStr = "fontsize=" + fontSize;
-    String fontcolorStr = (fontColor != null) ? ",fontcolor=" + fontColor : "";
-    String fontnameStr = (fontName != null) ? ",fontname=" + fontName : "";
+    String fontcolorStr = ",fontcolor=" + fontColor;
+    String fontnameStr = ",fontname=" + fontName;
 
     result.append("center=true;");
     result.append(fontsizeStr);

--- a/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrike/cg/OfflineDynamicCallGraph.java
+++ b/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrike/cg/OfflineDynamicCallGraph.java
@@ -104,7 +104,7 @@ public class OfflineDynamicCallGraph {
 
   private static boolean patchExits = true;
   private static boolean patchCalls = true;
-  private static boolean extractCalls = true;
+  private static final boolean extractCalls = true;
   private static boolean extractDynamicCalls = false;
   private static boolean extractConstructors = true;
 
@@ -112,7 +112,7 @@ public class OfflineDynamicCallGraph {
 
   private static SetOfClasses filter;
 
-  private static ClassHierarchyStore cha = new ClassHierarchyStore();
+  private static final ClassHierarchyStore cha = new ClassHierarchyStore();
 
   public static void main(String[] args)
       throws IOException, ClassNotFoundException, InvalidClassFileException, FailureException {

--- a/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrike/cg/OnlineDynamicCallGraph.java
+++ b/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrike/cg/OnlineDynamicCallGraph.java
@@ -17,9 +17,9 @@ import java.security.ProtectionDomain;
 
 public class OnlineDynamicCallGraph implements ClassFileTransformer {
 
-  private ClassHierarchyStore cha = new ClassHierarchyStore();
+  private final ClassHierarchyStore cha = new ClassHierarchyStore();
 
-  private Writer out = new PrintWriter(System.err);
+  private final Writer out = new PrintWriter(System.err);
 
   public OnlineDynamicCallGraph()
       throws IllegalArgumentException, IOException, InvalidClassFileException {

--- a/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrike/cg/Runtime.java
+++ b/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrike/cg/Runtime.java
@@ -53,9 +53,9 @@ public class Runtime {
   private PrintWriter output;
   private SetOfClasses filter;
   private Policy handleCallback;
-  private ThreadLocal<String> currentSite = new ThreadLocal<>();
+  private final ThreadLocal<String> currentSite = new ThreadLocal<>();
 
-  private ThreadLocal<Stack<String>> callStacks =
+  private final ThreadLocal<Stack<String>> callStacks =
       ThreadLocal.withInitial(
           () -> {
             Stack<String> callStack = new Stack<>();

--- a/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrikeCT/StackMapTableReader.java
+++ b/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrikeCT/StackMapTableReader.java
@@ -10,7 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class StackMapTableReader extends AttributeReader {
-  private List<StackMapFrame> frames;
+  private final List<StackMapFrame> frames;
 
   public List<StackMapFrame> frames() {
     return frames;

--- a/com.ibm.wala.shrike/src/main/java/com/ibm/wala/sourcepos/Debug.java
+++ b/com.ibm.wala.shrike/src/main/java/com/ibm/wala/sourcepos/Debug.java
@@ -51,7 +51,7 @@ public final class Debug {
 
   private static final Map<LogLevel, LogStream> logStreams = new EnumMap<>(LogLevel.class);
 
-  private static Set<LogLevel> allowed = EnumSet.noneOf(LogLevel.class);
+  private static final Set<LogLevel> allowed = EnumSet.noneOf(LogLevel.class);
 
   static {
     allowed.addAll(Arrays.asList(LogLevel.values()));

--- a/com.ibm.wala.shrike/src/main/java/com/ibm/wala/sourcepos/InvalidPositionException.java
+++ b/com.ibm.wala.shrike/src/main/java/com/ibm/wala/sourcepos/InvalidPositionException.java
@@ -36,7 +36,7 @@ class InvalidPositionException extends Exception {
   }
 
   /** the cause for this exception */
-  private Cause cause;
+  private final Cause cause;
 
   /**
    * Constructs an instance of {@code InvalidRangeException} with the specified cause.

--- a/com.ibm.wala.shrike/src/main/java/com/ibm/wala/sourcepos/InvalidRangeException.java
+++ b/com.ibm.wala.shrike/src/main/java/com/ibm/wala/sourcepos/InvalidRangeException.java
@@ -35,7 +35,7 @@ class InvalidRangeException extends Exception {
   }
 
   /** the cause for this exception */
-  private Cause cause;
+  private final Cause cause;
 
   /**
    * Constructs an instance of {@code InvalidRangeException} with the specified cause.

--- a/com.ibm.wala.shrike/src/main/java/com/ibm/wala/sourcepos/Position.java
+++ b/com.ibm.wala.shrike/src/main/java/com/ibm/wala/sourcepos/Position.java
@@ -34,7 +34,7 @@ public final class Position {
   private static final int COLUMN_MASK = 1023;
 
   /** Stores the position as unsigned integer. */
-  private int position;
+  private final int position;
 
   /** Creates the undefined position. */
   Position() {

--- a/com.ibm.wala.shrike/src/main/java/com/ibm/wala/sourcepos/Range.java
+++ b/com.ibm.wala.shrike/src/main/java/com/ibm/wala/sourcepos/Range.java
@@ -26,9 +26,9 @@ package com.ibm.wala.sourcepos;
 public class Range {
 
   /** stores the start position */
-  private Position start;
+  private final Position start;
   /** stores the end position */
-  private Position end;
+  private final Position end;
 
   /** Creates an empty range. */
   Range() {

--- a/com.ibm.wala.util/src/main/java/com/ibm/wala/util/graph/GraphSlicer.java
+++ b/com.ibm.wala.util/src/main/java/com/ibm/wala/util/graph/GraphSlicer.java
@@ -210,9 +210,9 @@ public class GraphSlicer {
     final EdgeManager<E> edgeManager =
         new EdgeManager<E>() {
 
-          private Map<E, Collection<E>> succs = new HashMap<>();
+          private final Map<E, Collection<E>> succs = new HashMap<>();
 
-          private Map<E, Collection<E>> preds = new HashMap<>();
+          private final Map<E, Collection<E>> preds = new HashMap<>();
 
           private Set<E> getConnected(E inst, Function<E, Iterator<? extends E>> fconnected) {
             Set<E> result = new LinkedHashSet<>();

--- a/com.ibm.wala.util/src/main/java/com/ibm/wala/util/graph/impl/SelfLoopAddedEdgeManager.java
+++ b/com.ibm.wala.util/src/main/java/com/ibm/wala/util/graph/impl/SelfLoopAddedEdgeManager.java
@@ -6,7 +6,7 @@ import java.util.Iterator;
 public class SelfLoopAddedEdgeManager<T> implements EdgeManager<T> {
   private class PrependItterator implements Iterator<T> {
     private boolean usedFirst = false;
-    private Iterator<T> original;
+    private final Iterator<T> original;
     private T first;
 
     public PrependItterator(Iterator<T> original, T first) {

--- a/com.ibm.wala.util/src/main/java/com/ibm/wala/util/graph/traverse/FloydWarshall.java
+++ b/com.ibm.wala.util/src/main/java/com/ibm/wala/util/graph/traverse/FloydWarshall.java
@@ -91,7 +91,7 @@ public class FloydWarshall<T> {
 
   public static <T> GetPath<T> allPairsShortestPath(final NumberedGraph<T> G) {
     return new FloydWarshall<T>(G) {
-      int[][] next = new int[G.getNumberOfNodes()][G.getNumberOfNodes()];
+      final int[][] next = new int[G.getNumberOfNodes()][G.getNumberOfNodes()];
 
       @Override
       protected void pathCallback(int i, int j, int k) {
@@ -147,7 +147,7 @@ public class FloydWarshall<T> {
 
   public static <T> GetPaths<T> allPairsShortestPaths(final NumberedGraph<T> G) {
     return new FloydWarshall<T>(G) {
-      MutableIntSet[][] next = new MutableIntSet[G.getNumberOfNodes()][G.getNumberOfNodes()];
+      final MutableIntSet[][] next = new MutableIntSet[G.getNumberOfNodes()][G.getNumberOfNodes()];
 
       @Override
       protected void pathCallback(int i, int j, int k) {

--- a/com.ibm.wala.util/src/main/java/com/ibm/wala/util/intset/OrdinalSet.java
+++ b/com.ibm.wala.util/src/main/java/com/ibm/wala/util/intset/OrdinalSet.java
@@ -61,7 +61,7 @@ public class OrdinalSet<T> implements Iterable<T> {
     } else {
 
       return new Iterator<T>() {
-        IntIterator it = S.intIterator();
+        final IntIterator it = S.intIterator();
 
         @Override
         public boolean hasNext() {

--- a/com.ibm.wala.util/src/main/java/com/ibm/wala/util/processes/JavaLauncher.java
+++ b/com.ibm.wala.util/src/main/java/com/ibm/wala/util/processes/JavaLauncher.java
@@ -87,7 +87,7 @@ public class JavaLauncher extends Launcher {
   private String javaExe;
 
   /** Extra args to pass to the JVM */
-  private List<String> vmArgs = new ArrayList<>();
+  private final List<String> vmArgs = new ArrayList<>();
 
   /** The last process returned by a call to start() on this object. */
   private Process lastProcess;

--- a/com.ibm.wala.util/src/main/java/com/ibm/wala/viz/DotUtil.java
+++ b/com.ibm.wala.util/src/main/java/com/ibm/wala/viz/DotUtil.java
@@ -43,8 +43,8 @@ public class DotUtil {
   private static DotOutputType outputType = DotOutputType.PDF;
 
   private static int fontSize = 6;
-  private static String fontColor = "black";
-  private static String fontName = "Arial";
+  private static final String fontColor = "black";
+  private static final String fontName = "Arial";
 
   public static void setOutputType(DotOutputType outType) {
     outputType = outType;

--- a/com.ibm.wala.util/src/main/java/com/ibm/wala/viz/DotUtil.java
+++ b/com.ibm.wala.util/src/main/java/com/ibm/wala/viz/DotUtil.java
@@ -192,8 +192,8 @@ public class DotUtil {
       result.append("rankdir=").append(rankdir).append(';');
     }
     String fontsizeStr = "fontsize=" + fontSize;
-    String fontcolorStr = (fontColor != null) ? ",fontcolor=" + fontColor : "";
-    String fontnameStr = (fontName != null) ? ",fontname=" + fontName : "";
+    String fontcolorStr = ",fontcolor=" + fontColor;
+    String fontnameStr = ",fontname=" + fontName;
 
     result.append("center=true;");
     result.append(fontsizeStr);


### PR DESCRIPTION
Add 199 Java `final` qualifiers. All affected symbols are `private` or package-protected fields, so we know they aren't changed by any third-party code we can't see.

Remove redundant `null` checks on some `static final` fields can never be `null`.