### PR TITLE
Suppress ECJ errors on Java test subjects

### DIFF
--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -21,8 +21,16 @@ final Provider<JavaCompile> compileTestSubjectsJava = tasks.named('compileTestSu
 
 final ecjCompileJavaTestSubjects = JavaCompileUsingEcj.withSourceSet(project, sourceSets.testSubjects)
 ecjCompileJavaTestSubjects.configure {
-	options.compilerArgs << '-err:none'
 	options.compilerArgs << '-warn:none'
+	[
+			'serial',
+			'unchecked',
+			'unusedLocal',
+			'unusedParam',
+			'unusedThrown',
+	].each {
+		options.compilerArgs << "-err:-$it"
+	}
 }
 
 tasks.named('check') {


### PR DESCRIPTION
Previously we were suppressing these by adding `-err:none` to the ECJ command line. But that's not actually a valid ECJ flag. It did suppress the error diagnostics, but also produced a warning about the invalid flag. Now we suppress the specific error diagnostics that the Java test subjects trigger, and we do it using valid ECJ flags.