### PR TITLE
Only download and unpack NodeJS as part of processing test resources

### DIFF
--- a/com.ibm.wala.cast.js.nodejs/build.gradle
+++ b/com.ibm.wala.cast.js.nodejs/build.gradle
@@ -30,11 +30,11 @@ tasks.register('unpackNodeJSLib', Copy) {
 		}
 	}
 
-	into "${tasks.named('processResources', Copy).get().destinationDir}/core-modules"
+	into "${tasks.named('processTestResources', Copy).get().destinationDir}/core-modules"
 	includeEmptyDirs false
 }
 
-tasks.named('processResources') {
+tasks.named('processTestResources') {
 	dependsOn 'unpackNodeJSLib'
 }
 


### PR DESCRIPTION
We only need to download and unpack NodeJS to run `com.ibm.wala.cast.js.nodejs` tests.  It should not get packaged as part of the main resources.