### PR TITLE
Don't use Gradle tasks' temporaryDir for retained files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -197,7 +197,7 @@ if (isWindows) {
 		group 'verification'
 
 		inputs.files fileTree('.').exclude('**/build').include('**/*.sh')
-		outputs.file "$temporaryDir/log"
+		outputs.file project.layout.buildDirectory.file('shellcheck.log')
 
 		doFirst {
 			// quietly succeed if "shellcheck" is not available

--- a/com.ibm.wala.cast.java.ecj/build.gradle
+++ b/com.ibm.wala.cast.java.ecj/build.gradle
@@ -37,10 +37,10 @@ tasks.named('run') {
 	args = ['-sourceDir', project(javaTestData).sourceSets.test.java.srcDirs.find(), '-mainClass', 'LArray1']
 
 	// log output to file, although we don't validate it
-	final outFile = file("$temporaryDir/stdout-and-stderr.log")
+	final outFile = project.layout.buildDirectory.file 'SourceDirCallGraph.log'
 	outputs.file outFile
 	doFirst {
-		final fileStream = outFile.newOutputStream()
+		final fileStream = outFile.get().asFile.newOutputStream()
 		standardOutput fileStream
 		errorOutput fileStream
 	}

--- a/com.ibm.wala.cast.js.nodejs/build.gradle
+++ b/com.ibm.wala.cast.js.nodejs/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
 final downloadNodeJS = tasks.register('downloadNodeJS', VerifiedDownload) {
 	src 'https://nodejs.org/dist/v0.12.4/node-v0.12.4.tar.gz'
-	dest "$temporaryDir/nodejs.tar.gz"
+	dest project.layout.buildDirectory.file('nodejs.tar.gz')
 	algorithm 'SHA-1'
 	checksum '147ff79947752399b870fcf3f1fc37102100b545'
 }

--- a/com.ibm.wala.cast.js/build.gradle
+++ b/com.ibm.wala.cast.js/build.gradle
@@ -38,7 +38,7 @@ final downloadAjaxslt = tasks.register('downloadAjaxslt', VerifiedDownload) {
 	def version = '0.8.1'
 	def versionedArchive = "ajaxslt-${version}.tar.gz"
 	src "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/ajaxslt/$versionedArchive"
-	dest "$temporaryDir/$versionedArchive"
+	dest project.layout.buildDirectory.file(versionedArchive)
 	checksum 'c995abe3310a401bb4db7f28a6409756'
 }
 
@@ -49,7 +49,7 @@ final unpackAjaxslt = tasks.register('unpackAjaxslt', Sync) {
 			relativePath new RelativePath(!directory, newSegments)
 		}
 	}
-	into temporaryDir
+	into project.layout.buildDirectory.dir(name)
 }
 
 tasks.named('processTestResources', Copy) {

--- a/com.ibm.wala.cast/smoke_main/build.gradle
+++ b/com.ibm.wala.cast/smoke_main/build.gradle
@@ -49,10 +49,10 @@ application {
 					} as CommandLineArgumentProvider)
 
 					// log output to file, although we don't validate it
-					final outFile = file("$temporaryDir/stdout-and-stderr.log")
+					final outFile = project.layout.buildDirectory.file("${name}.log")
 					outputs.file outFile
 					doFirst {
-						final fileStream = new FileOutputStream(outFile)
+						final fileStream = outFile.get().asFile.newOutputStream()
 						standardOutput fileStream
 						errorOutput fileStream
 					}

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -71,7 +71,7 @@ final downloadKawa = tasks.register('downloadKawa', VerifiedDownload) {
 	ext.version = '3.0'
 	final archive = "kawa-${version}.zip"
 	src "https://ftp.gnu.org/pub/gnu/kawa/$archive"
-	dest "$temporaryDir/$archive"
+	dest project.layout.buildDirectory.file(archive)
 	checksum '2713e6dfb939274ba3b1d36daea68436'
 }
 
@@ -108,8 +108,9 @@ class CompileKawaScheme extends JavaExec {
 		classpath project.tasks.named('extractKawa')
 		main 'kawa.repl'
 
-		args '-d', temporaryDir
-		outputs.dir temporaryDir
+		final outputDir = project.layout.buildDirectory.dir(name)
+		args '-d', outputDir.get().asFile
+		outputs.dir outputDir
 
 		logging.captureStandardError LogLevel.INFO
 		args '--main', '-C'
@@ -128,13 +129,13 @@ final kawaChessCommitHash = 'f1d2dcc707a1ef19dc159e2eaee5aecc8a41d7a8'
 
 final downloadKawaChess = tasks.register('downloadKawaChess', VerifiedDownload) {
 	src "https://github.com/ttu-fpclub/kawa-chess/archive/${kawaChessCommitHash}.zip"
-	dest "$temporaryDir/kawa-chess.zip"
+	dest project.layout.buildDirectory.file('kawa-chess.zip')
 	checksum 'cf29613d2be5f476a475ee28b4df9d9e'
 }
 
 final unpackKawaChess = tasks.register('unpackKawaChess') {
 	inputs.files downloadKawaChess
-	outputs.dir "$temporaryDir/kawa-chess-$kawaChessCommitHash"
+	outputs.dir project.layout.buildDirectory.file("kawa-chess-$kawaChessCommitHash")
 
 	doLast {
 		copy {
@@ -184,7 +185,7 @@ final downloadBcel = tasks.register('downloadBcel', VerifiedDownload) {
 	ext.basename = 'bcel-5.2'
 	final archive = "${basename}.tar.gz"
 	src "http://archive.apache.org/dist/jakarta/bcel/binaries/$archive"
-	dest "$temporaryDir/$archive"
+	dest project.layout.buildDirectory.file(archive)
 	checksum '19bffd7f217b0eae415f1ef87af2f0bc'
 	useETag false
 }
@@ -246,19 +247,20 @@ final downloadOcamlJava = tasks.register('downloadOcamlJava', VerifiedDownload) 
 	ext.basename = "ocamljava-$version"
 	def archive = "${basename}.tar.gz"
 	src "http://www.ocamljava.org/downloads/download.php?version=$version-bin"
-	dest "$temporaryDir/$archive"
+	dest project.layout.buildDirectory.file(archive)
 	checksum '45feec6e3889f5073a39c2c4c84878d1'
 }
 
 final unpackOcamlJava = tasks.register('unpackOcamlJava', Sync) {
 	from downloadOcamlJava.map { tarTree it.dest }
-	into temporaryDir
+	into project.layout.buildDirectory.dir(name)
 }
 
 final prepareGenerateHelloHashJar = tasks.register('prepareGenerateHelloHashJar', Copy) {
 	from 'ocaml/hello_hash.ml'
-	into temporaryDir
-	ext.copiedOcamlSource = file("$temporaryDir/$source.singleFile.name")
+	final outputDir = project.layout.buildDirectory.dir(name)
+	into outputDir
+	ext.copiedOcamlSource = file("$outputDir/$source.singleFile.name")
 }
 
 final generateHelloHashJar = tasks.register('generateHelloHashJar', JavaExec) {

--- a/com.ibm.wala.dalvik/build.gradle
+++ b/com.ibm.wala.dalvik/build.gradle
@@ -8,7 +8,7 @@ tasks.named('test') {
 
 final downloadDroidBench = tasks.register('downloadDroidBench', VerifiedDownload) {
 	src 'https://codeload.github.com/secure-software-engineering/DroidBench/zip/DroidBench_2.0'
-	dest "$temporaryDir/DroidBench_2.0.zip"
+	dest project.layout.buildDirectory.file('DroidBench_2.0.zip')
 	checksum '16726a48329835140e14f18470a1b4a3'
 }
 
@@ -43,7 +43,7 @@ final downloadAndroidSdk = tasks.register('downloadAndroidSdk', VerifiedDownload
 	}
 	def archive = "sdk-tools-$sdkOs-3859397.zip"
 	src "https://dl.google.com/android/repository/$archive"
-	dest "$temporaryDir/$archive"
+	dest project.layout.buildDirectory.file(archive)
 	algorithm 'SHA-256'
 }
 


### PR DESCRIPTION
A task's `temporaryDir` is supposed to be for short-lived files that need not outlive that task.  In theory, Gradle could delete these temporary directories at any time, even though it currently does not.

A good example of something that would be sensible to store in `temporaryDir` would be a file that contains additional command-line flags to be given to an external command.  That file need not be retained after the task that runs the command finishes.

By contrast, files that constitute a task's outputs should not go in `temporaryDir`.  There's no guarantee that `temporaryDir` files will be retained after each task finishes.