### PR TITLE
Upgrade GitHub checkout action

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,9 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out WALA sources
-        uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
+        uses: actions/checkout@v2
       - name: Cache Goomph
         uses: actions/cache@v1
         with:


### PR DESCRIPTION
I have been seeing some persistent `fatal: reference is not a tree` failures during the initial checkout stage of our GitHub actions. Skimming reports by others suggests that [`actions/checkout@v2` does better in the situations that trigger this under `@v1`](https://github.com/actions/checkout/issues/23).