### PR TITLE
Re-enable Google Java Format checking on CI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -239,7 +239,7 @@ tasks.register('installGitHooks', Copy) {
 }
 
 // run all known linters
-tasks.register('check') {
+final check = tasks.register('check') {
 	group = 'verification'
 	dependsOn(
 			// 'lintGradle',
@@ -250,6 +250,10 @@ tasks.register('check') {
 		// Please fix if you know how!  <https://github.com/wala/WALA/issues/608>
 		dependsOn 'verifyGoogleJavaFormat'
 	}
+}
+
+tasks.register('build') {
+	dependsOn check
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
 
 plugins {
 	id 'com.diffplug.eclipse.mavencentral' version '3.22.0' apply false
+    id 'com.dorongold.task-tree' version '1.5'
 	id 'com.github.ben-manes.versions' version '0.28.0'
 	id 'com.github.sherter.google-java-format' version '0.8'
 	id 'de.undercouch.download'

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ buildscript {
 
 plugins {
 	id 'com.diffplug.eclipse.mavencentral' version '3.22.0' apply false
-    id 'com.dorongold.task-tree' version '1.5'
 	id 'com.github.ben-manes.versions' version '0.28.0'
 	id 'com.github.sherter.google-java-format' version '0.8'
 	id 'de.undercouch.download'

--- a/buildSrc/src/main/java/com/ibm/wala/gradle/EclipseJavaCompilerToolChain.java
+++ b/buildSrc/src/main/java/com/ibm/wala/gradle/EclipseJavaCompilerToolChain.java
@@ -14,11 +14,7 @@ import org.gradle.api.internal.tasks.AbstractJavaToolChain;
  */
 public class EclipseJavaCompilerToolChain extends AbstractJavaToolChain {
 
-  /**
-   * Creates an ECJ tool chain for the given project.
-   *
-
-   */
+  /** Creates an ECJ tool chain for the given project. */
   public EclipseJavaCompilerToolChain(Project project) {
     super(new EclipseJavaCompilerFactory(project), null);
   }

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/vis/JsPaPanel.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/vis/JsPaPanel.java
@@ -34,8 +34,9 @@ public class JsPaPanel extends PaPanel {
 
   private static final long serialVersionUID = 1L;
 
-  private final MutableMapping<List<ObjectPropertyCatalogKey>> instanceKeyIdToObjectPropertyCatalogKey =
-      MutableMapping.<List<ObjectPropertyCatalogKey>>make();
+  private final MutableMapping<List<ObjectPropertyCatalogKey>>
+      instanceKeyIdToObjectPropertyCatalogKey =
+          MutableMapping.<List<ObjectPropertyCatalogKey>>make();
   private final List<AstGlobalPointerKey> globalsPointerKeys = new ArrayList<>();
 
   public JsPaPanel(CallGraph cg, PointerAnalysis<InstanceKey> pa) {

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/util/ssa/SSAValueManager.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/util/ssa/SSAValueManager.java
@@ -126,7 +126,8 @@ public class SSAValueManager {
   }
 
   /** The main data-structure of the management */
-  private final Map<VariableKey, List<Managed<? extends SSAValue>>> seenTypes = HashMapFactory.make();
+  private final Map<VariableKey, List<Managed<? extends SSAValue>>> seenTypes =
+      HashMapFactory.make();
 
   private final List<SSAValue> unmanaged = new ArrayList<>();
 

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/util/ssa/SSAValueManager.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/util/ssa/SSAValueManager.java
@@ -126,8 +126,7 @@ public class SSAValueManager {
   }
 
   /** The main data-structure of the management */
-  private final Map<VariableKey, List<Managed<? extends SSAValue>>> seenTypes =
-      HashMapFactory.make();
+  private final Map<VariableKey, List<Managed<? extends SSAValue>>> seenTypes = HashMapFactory.make();
 
   private final List<SSAValue> unmanaged = new ArrayList<>();
 

--- a/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/exceptionpruning/ExceptionAnalysis2EdgeFilterTest.java
+++ b/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/exceptionpruning/ExceptionAnalysis2EdgeFilterTest.java
@@ -55,7 +55,8 @@ import org.junit.rules.ErrorCollector;
  * @author Stephan Gocht {@code <stephan@gobro.de>}
  */
 public class ExceptionAnalysis2EdgeFilterTest {
-  private static final ClassLoader CLASS_LOADER = ExceptionAnalysis2EdgeFilterTest.class.getClassLoader();
+  private static final ClassLoader CLASS_LOADER =
+      ExceptionAnalysis2EdgeFilterTest.class.getClassLoader();
   public static String REGRESSION_EXCLUSIONS = "Java60RegressionExclusions.txt";
 
   private static ClassHierarchy cha;

--- a/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexIField.java
+++ b/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexIField.java
@@ -77,6 +77,7 @@ public class DexIField implements IField {
    * canonical FieldReference corresponding to this method, construct in the getReference method.
    */
   private FieldReference fieldReference;
+
   private final FieldReference myFieldRef;
 
   private final Atom name;

--- a/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModelClass.java
+++ b/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModelClass.java
@@ -176,7 +176,8 @@ public final /* singleton */ class AndroidModelClass extends SyntheticClass {
   //
   private IMethod macroModel = null;
   //    private IMethod allActivitiesModel = null;
-  private final Map<Selector, IMethod> methods = HashMapFactory.make(); // does not contain macroModel
+  private final Map<Selector, IMethod> methods =
+      HashMapFactory.make(); // does not contain macroModel
 
   public boolean containsMethod(Selector selector) {
     return (((macroModel != null) && macroModel.getSelector().equals(selector))

--- a/travis/script-gradle
+++ b/travis/script-gradle
@@ -6,9 +6,9 @@ run_gradle() {
 
 case "$(javac -version 2>&1)" in
   (javac\ 1.8.*)
-     # ECJ compilation checks only need to run on one operating system
+     # ECJ compilation checks and top-level checks only need to run on one operating system
      if [ "${TRAVIS_OS_NAME:-}" = linux ]; then
-       run_gradle javadoc build publishToMavenLocal
+       run_gradle javadoc :check build publishToMavenLocal
      else
        run_gradle javadoc build publishToMavenLocal -PskipJavaUsingEcjTasks
      fi

--- a/travis/script-gradle
+++ b/travis/script-gradle
@@ -6,9 +6,9 @@ run_gradle() {
 
 case "$(javac -version 2>&1)" in
   (javac\ 1.8.*)
-     # ECJ compilation checks and top-level checks only need to run on one operating system
+     # ECJ compilation checks checks only need to run on one operating system
      if [ "${TRAVIS_OS_NAME:-}" = linux ]; then
-       run_gradle javadoc :check build publishToMavenLocal
+       run_gradle javadoc build publishToMavenLocal
      else
        run_gradle javadoc build publishToMavenLocal -PskipJavaUsingEcjTasks
      fi

--- a/travis/script-gradle
+++ b/travis/script-gradle
@@ -6,7 +6,7 @@ run_gradle() {
 
 case "$(javac -version 2>&1)" in
   (javac\ 1.8.*)
-     # ECJ compilation checks checks only need to run on one operating system
+     # ECJ compilation checks only need to run on one operating system
      if [ "${TRAVIS_OS_NAME:-}" = linux ]; then
        run_gradle javadoc build publishToMavenLocal
      else


### PR DESCRIPTION
It seems the `verifyGoogleJavaFormat` task was not running on CI.  I think it is because at the top level, the `build` task does not depend on `check`.  This PR re-enables the check and also fixes some formatting issues that have crept in.