### PR TITLE
Add task-tree plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
 
 plugins {
 	id 'com.diffplug.eclipse.mavencentral' version '3.22.0' apply false
+	id 'com.dorongold.task-tree' version '1.5'
 	id 'com.github.ben-manes.versions' version '0.28.0'
 	id 'com.github.sherter.google-java-format' version '0.8'
 	id 'de.undercouch.download'


### PR DESCRIPTION
I find this plugin very useful for visualizing task dependencies.  Example run related to #771:

```
$ ./gradlew :build :taskTree

> Task :taskTree

------------------------------------------------------------
Root project
------------------------------------------------------------

:build
\--- :check
     +--- :shellCheck
     \--- :verifyGoogleJavaFormat
```