### PR TITLE
Improvements to CallGraph2JSON

### DIFF
--- a/com.ibm.wala.cast.js.rhino/build.gradle
+++ b/com.ibm.wala.cast.js.rhino/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	)
 	testImplementation(
 			'junit:junit:4.13',
+			'com.google.code.gson:gson:2.8.6',
 			testFixtures(project(':com.ibm.wala.cast')),
 			testFixtures(project(':com.ibm.wala.cast.js')),
 	)

--- a/com.ibm.wala.cast.js.rhino/build.gradle
+++ b/com.ibm.wala.cast.js.rhino/build.gradle
@@ -27,6 +27,11 @@ tasks.named('test') {
 	environment 'TRAVIS', 1
 	maxHeapSize = '800M'
 
+	testLogging {
+		exceptionFormat = 'full'
+		events 'passed', 'skipped', 'failed'
+	}
+
 	if (gradle.startParameter.offline)
 		exclude '**/FieldBasedJQueryTest.class'
 

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/AbstractFieldBasedTest.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/AbstractFieldBasedTest.java
@@ -11,6 +11,7 @@ import com.ibm.wala.cast.js.translator.CAstRhinoTranslatorFactory;
 import com.ibm.wala.cast.js.util.CallGraph2JSON;
 import com.ibm.wala.cast.js.util.FieldBasedCGUtil;
 import com.ibm.wala.cast.js.util.FieldBasedCGUtil.BuilderType;
+import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.NullProgressMonitor;
 import com.ibm.wala.util.ProgressMaster;
@@ -63,8 +64,8 @@ public abstract class AbstractFieldBasedTest extends TestJSCallGraphShape {
   }
 
   protected void dumpCG(JSCallGraph cg) {
-    CallGraph2JSON.IGNORE_HARNESS = false;
-    Map<String, Set<String>> edges = CallGraph2JSON.extractEdges(cg);
+    CallGraph2JSON cg2JSON = new CallGraph2JSON(false);
+    Map<String, Set<String>> edges = cg2JSON.extractEdges(cg);
     for (Map.Entry<String, Set<String>> entry : edges.entrySet())
       for (String callee : entry.getValue()) System.out.println(entry.getKey() + " -> " + callee);
   }

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/AbstractFieldBasedTest.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/AbstractFieldBasedTest.java
@@ -11,7 +11,6 @@ import com.ibm.wala.cast.js.translator.CAstRhinoTranslatorFactory;
 import com.ibm.wala.cast.js.util.CallGraph2JSON;
 import com.ibm.wala.cast.js.util.FieldBasedCGUtil;
 import com.ibm.wala.cast.js.util.FieldBasedCGUtil.BuilderType;
-import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.NullProgressMonitor;
 import com.ibm.wala.util.ProgressMaster;

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/AbstractFieldBasedTest.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/AbstractFieldBasedTest.java
@@ -9,6 +9,7 @@ import com.ibm.wala.cast.js.ipa.callgraph.JSCallGraph;
 import com.ibm.wala.cast.js.test.TestJSCallGraphShape;
 import com.ibm.wala.cast.js.translator.CAstRhinoTranslatorFactory;
 import com.ibm.wala.cast.js.util.CallGraph2JSON;
+import com.ibm.wala.cast.js.util.CallGraph2JSON.EdgeFilter;
 import com.ibm.wala.cast.js.util.FieldBasedCGUtil;
 import com.ibm.wala.cast.js.util.FieldBasedCGUtil.BuilderType;
 import com.ibm.wala.util.CancelException;
@@ -63,7 +64,7 @@ public abstract class AbstractFieldBasedTest extends TestJSCallGraphShape {
   }
 
   protected void dumpCG(JSCallGraph cg) {
-    CallGraph2JSON cg2JSON = new CallGraph2JSON(false);
+    CallGraph2JSON cg2JSON = new CallGraph2JSON(EdgeFilter.INCLUDE_ALL);
     Map<String, Set<String>> edges = cg2JSON.extractEdges(cg);
     for (Map.Entry<String, Set<String>> entry : edges.entrySet())
       for (String callee : entry.getValue()) System.out.println(entry.getKey() + " -> " + callee);

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/AbstractFieldBasedTest.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/AbstractFieldBasedTest.java
@@ -1,7 +1,7 @@
 package com.ibm.wala.cast.js.rhino.callgraph.fieldbased.test;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assume.*;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assume.assumeThat;
 
 import com.ibm.wala.cast.ir.translator.TranslatorToCAst.Error;
 import com.ibm.wala.cast.js.html.DefaultSourceExtractor;
@@ -9,7 +9,6 @@ import com.ibm.wala.cast.js.ipa.callgraph.JSCallGraph;
 import com.ibm.wala.cast.js.test.TestJSCallGraphShape;
 import com.ibm.wala.cast.js.translator.CAstRhinoTranslatorFactory;
 import com.ibm.wala.cast.js.util.CallGraph2JSON;
-import com.ibm.wala.cast.js.util.CallGraph2JSON.EdgeFilter;
 import com.ibm.wala.cast.js.util.FieldBasedCGUtil;
 import com.ibm.wala.cast.js.util.FieldBasedCGUtil.BuilderType;
 import com.ibm.wala.util.CancelException;
@@ -64,7 +63,7 @@ public abstract class AbstractFieldBasedTest extends TestJSCallGraphShape {
   }
 
   protected void dumpCG(JSCallGraph cg) {
-    CallGraph2JSON cg2JSON = new CallGraph2JSON(EdgeFilter.INCLUDE_ALL);
+    CallGraph2JSON cg2JSON = new CallGraph2JSON(false);
     Map<String, Set<String>> edges = cg2JSON.extractEdges(cg);
     for (Map.Entry<String, Set<String>> entry : edges.entrySet())
       for (String callee : entry.getValue()) System.out.println(entry.getKey() + " -> " + callee);

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestCallGraph2JSON.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestCallGraph2JSON.java
@@ -52,11 +52,9 @@ public class TestCallGraph2JSON {
     CallGraph cg = buildCallGraph(script);
     CallGraph2JSON cg2JSON = new CallGraph2JSON(false);
     Map<String, String[]> parsed = getParsedJSONCG(cg, cg2JSON);
-    String[] targets = getTargetsStartingWith(parsed, "native_call.js@2");
-    if (targets == null) {
-      throw new RuntimeException(cg2JSON.serialize(cg));
-    }
-    assertArrayEquals(new String[] {"Array_prototype_pop (Native)"}, targets);
+    assertArrayEquals(
+        new String[] {"Array_prototype_pop (Native)"},
+        getTargetsStartingWith(parsed, "native_call.js@2"));
   }
 
   @Test
@@ -87,10 +85,10 @@ public class TestCallGraph2JSON {
     Map<String, String[]> parsed = getParsedJSONCG(cg, cg2JSON);
     assertArrayEquals(
         new String[] {"Array_prototype_map (Native)"},
-        getTargetsStartingWith(parsed, "native_callback.js@2:21-56"));
+        getTargetsStartingWith(parsed, "native_callback.js@2"));
     assertThat(
         Arrays.asList(getTargetsStartingWith(parsed, "Function_prototype_call (Native)")),
-        hasItemStartingWith("native_callback.js@2"));
+        hasItemStartingWith("native_callback.js@3"));
   }
 
   private static Map<String, String[]> getParsedJSONCG(CallGraph cg, CallGraph2JSON cg2JSON) {
@@ -125,7 +123,7 @@ public class TestCallGraph2JSON {
    * We need this method since column offsets can differ across platforms, so we can't do an exact
    * position match
    */
-  private static IsCollectionContaining<String> hasItemStartingWith(String item) {
-    return new IsCollectionContaining<>(startsWith(item));
+  private static IsCollectionContaining<String> hasItemStartingWith(String prefix) {
+    return new IsCollectionContaining<>(startsWith(prefix));
   }
 }

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestCallGraph2JSON.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestCallGraph2JSON.java
@@ -13,7 +13,6 @@ import com.ibm.wala.util.WalaException;
 import java.lang.reflect.Type;
 import java.net.URL;
 import java.util.Map;
-import java.util.Map.Entry;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestCallGraph2JSON.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestCallGraph2JSON.java
@@ -5,6 +5,7 @@ import com.google.gson.reflect.TypeToken;
 import com.ibm.wala.cast.js.html.DefaultSourceExtractor;
 import com.ibm.wala.cast.js.translator.CAstRhinoTranslatorFactory;
 import com.ibm.wala.cast.js.util.CallGraph2JSON;
+import com.ibm.wala.cast.js.util.CallGraph2JSON.EdgeFilter;
 import com.ibm.wala.cast.js.util.FieldBasedCGUtil;
 import com.ibm.wala.cast.js.util.FieldBasedCGUtil.BuilderType;
 import com.ibm.wala.ipa.callgraph.CallGraph;
@@ -30,7 +31,7 @@ public class TestCallGraph2JSON {
   public void testBasic() throws WalaException, CancelException {
     String script = "tests/fieldbased/simple.js";
     CallGraph cg = buildCallGraph(script);
-    CallGraph2JSON cg2JSON = new CallGraph2JSON(true);
+    CallGraph2JSON cg2JSON = new CallGraph2JSON(EdgeFilter.IGNORE_HARNESS_COMPLETELY);
     Map<String, String[]> parsed = getParsedJSONCG(cg, cg2JSON);
     Assert.assertEquals(5, parsed.keySet().size());
     parsed.values().stream()
@@ -38,6 +39,17 @@ public class TestCallGraph2JSON {
             callees -> {
               Assert.assertEquals(1, callees.length);
             });
+  }
+
+  @Test
+  public void testNative() throws WalaException, CancelException {
+    String script = "tests/fieldbased/native_call.js";
+    CallGraph cg = buildCallGraph(script);
+    CallGraph2JSON cg2JSON = new CallGraph2JSON(EdgeFilter.IGNORE_CALLS_WITHIN_HARNESS);
+    Map<String, String[]> parsed = getParsedJSONCG(cg, cg2JSON);
+    Assert.assertEquals(1, parsed.keySet().size());
+    String[] targets = parsed.values().iterator().next();
+    Assert.assertArrayEquals(new String[] {"Array_prototype_pop (Native)"}, targets);
   }
 
   private static Map<String, String[]> getParsedJSONCG(CallGraph cg, CallGraph2JSON cg2JSON) {

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestCallGraph2JSON.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestCallGraph2JSON.java
@@ -1,5 +1,9 @@
 package com.ibm.wala.cast.js.test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.junit.Assert.assertArrayEquals;
+
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.ibm.wala.cast.js.html.DefaultSourceExtractor;
@@ -12,6 +16,7 @@ import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.WalaException;
 import java.lang.reflect.Type;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.Map;
 import org.junit.Assert;
 import org.junit.Before;
@@ -47,7 +52,7 @@ public class TestCallGraph2JSON {
     CallGraph2JSON cg2JSON = new CallGraph2JSON(false);
     Map<String, String[]> parsed = getParsedJSONCG(cg, cg2JSON);
     String[] targets = parsed.get("native_call.js@2:21-28");
-    Assert.assertArrayEquals(new String[] {"Array_prototype_pop (Native)"}, targets);
+    assertArrayEquals(new String[] {"Array_prototype_pop (Native)"}, targets);
   }
 
   @Test
@@ -56,8 +61,18 @@ public class TestCallGraph2JSON {
     CallGraph cg = buildCallGraph(script);
     CallGraph2JSON cg2JSON = new CallGraph2JSON(false);
     Map<String, String[]> parsed = getParsedJSONCG(cg, cg2JSON);
-    String[] targets = parsed.get("native_call.js@2:21-28");
-    Assert.assertArrayEquals(new String[] {"Array_prototype_pop (Native)"}, targets);
+    assertArrayEquals(
+        new String[] {"Function_prototype_call (Native)"},
+        parsed.get("reflective_calls.js@10:63-78"));
+    assertArrayEquals(
+        new String[] {"Function_prototype_apply (Native)"},
+        parsed.get("reflective_calls.js@11:82-99"));
+    assertThat(
+        Arrays.asList(parsed.get("Function_prototype_call (Native)")),
+        hasItem("reflective_calls.js@1:0-24"));
+    assertThat(
+        Arrays.asList(parsed.get("Function_prototype_apply (Native)")),
+        hasItem("reflective_calls.js@5:26-44"));
   }
 
   @Test
@@ -66,13 +81,16 @@ public class TestCallGraph2JSON {
     CallGraph cg = buildCallGraph(script);
     CallGraph2JSON cg2JSON = new CallGraph2JSON(false);
     Map<String, String[]> parsed = getParsedJSONCG(cg, cg2JSON);
-    String[] targets = parsed.get("native_call.js@2:21-28");
-    Assert.assertArrayEquals(new String[] {"Array_prototype_pop (Native)"}, targets);
+    assertArrayEquals(
+        new String[] {"Array_prototype_map (Native)"}, parsed.get("native_callback.js@2:21-56"));
+    assertThat(
+        Arrays.asList(parsed.get("Function_prototype_call (Native)")),
+        hasItem("native_callback.js@2:27-55"));
   }
 
   private static Map<String, String[]> getParsedJSONCG(CallGraph cg, CallGraph2JSON cg2JSON) {
     String json = cg2JSON.serialize(cg);
-    System.err.println(json);
+    // System.err.println(json);
     Gson gson = new Gson();
     Type mapType = new TypeToken<Map<String, String[]>>() {}.getType();
     return gson.fromJson(json, mapType);
@@ -81,7 +99,7 @@ public class TestCallGraph2JSON {
   private CallGraph buildCallGraph(String script) throws WalaException, CancelException {
     URL scriptURL = TestCallGraph2JSON.class.getClassLoader().getResource(script);
     return util.buildCG(
-            scriptURL, BuilderType.PESSIMISTIC, null, false, DefaultSourceExtractor::new)
+            scriptURL, BuilderType.OPTIMISTIC_WORKLIST, null, false, DefaultSourceExtractor::new)
         .fst;
   }
 }

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestCallGraph2JSON.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestCallGraph2JSON.java
@@ -1,0 +1,58 @@
+package com.ibm.wala.cast.js.test;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.ibm.wala.cast.js.html.DefaultSourceExtractor;
+import com.ibm.wala.cast.js.translator.CAstRhinoTranslatorFactory;
+import com.ibm.wala.cast.js.util.CallGraph2JSON;
+import com.ibm.wala.cast.js.util.FieldBasedCGUtil;
+import com.ibm.wala.cast.js.util.FieldBasedCGUtil.BuilderType;
+import com.ibm.wala.ipa.callgraph.CallGraph;
+import com.ibm.wala.util.CancelException;
+import com.ibm.wala.util.WalaException;
+import java.lang.reflect.Type;
+import java.net.URL;
+import java.util.Map;
+import java.util.Map.Entry;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestCallGraph2JSON {
+
+  private FieldBasedCGUtil util;
+
+  @Before
+  public void setUp() throws Exception {
+    util = new FieldBasedCGUtil(new CAstRhinoTranslatorFactory());
+  }
+
+  @Test
+  public void testBasic() throws WalaException, CancelException {
+    String script = "tests/fieldbased/simple.js";
+    CallGraph cg = buildCallGraph(script);
+    CallGraph2JSON cg2JSON = new CallGraph2JSON(true);
+    Map<String, String[]> parsed = getParsedJSONCG(cg, cg2JSON);
+    Assert.assertEquals(5, parsed.keySet().size());
+    parsed.values().stream()
+        .forEach(
+            callees -> {
+              Assert.assertEquals(1, callees.length);
+            });
+  }
+
+  private Map<String, String[]> getParsedJSONCG(CallGraph cg, CallGraph2JSON cg2JSON) {
+    String json = cg2JSON.serialize(cg);
+    System.err.println(json);
+    Gson gson = new Gson();
+    Type mapType = new TypeToken<Map<String, String[]>>() {}.getType();
+    return gson.fromJson(json, mapType);
+  }
+
+  private CallGraph buildCallGraph(String script) throws WalaException, CancelException {
+    URL scriptURL = TestCallGraph2JSON.class.getClassLoader().getResource(script);
+    return util.buildCG(
+            scriptURL, BuilderType.PESSIMISTIC, null, false, DefaultSourceExtractor::new)
+        .fst;
+  }
+}

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestCallGraph2JSON.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestCallGraph2JSON.java
@@ -52,6 +52,9 @@ public class TestCallGraph2JSON {
     CallGraph2JSON cg2JSON = new CallGraph2JSON(false);
     Map<String, String[]> parsed = getParsedJSONCG(cg, cg2JSON);
     String[] targets = parsed.get("native_call.js@2:21-28");
+    if (targets == null) {
+      throw new RuntimeException(cg2JSON.serialize(cg));
+    }
     assertArrayEquals(new String[] {"Array_prototype_pop (Native)"}, targets);
   }
 

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestCallGraph2JSON.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestCallGraph2JSON.java
@@ -5,7 +5,6 @@ import com.google.gson.reflect.TypeToken;
 import com.ibm.wala.cast.js.html.DefaultSourceExtractor;
 import com.ibm.wala.cast.js.translator.CAstRhinoTranslatorFactory;
 import com.ibm.wala.cast.js.util.CallGraph2JSON;
-import com.ibm.wala.cast.js.util.CallGraph2JSON.EdgeFilter;
 import com.ibm.wala.cast.js.util.FieldBasedCGUtil;
 import com.ibm.wala.cast.js.util.FieldBasedCGUtil.BuilderType;
 import com.ibm.wala.ipa.callgraph.CallGraph;
@@ -31,7 +30,7 @@ public class TestCallGraph2JSON {
   public void testBasic() throws WalaException, CancelException {
     String script = "tests/fieldbased/simple.js";
     CallGraph cg = buildCallGraph(script);
-    CallGraph2JSON cg2JSON = new CallGraph2JSON(EdgeFilter.IGNORE_HARNESS_COMPLETELY);
+    CallGraph2JSON cg2JSON = new CallGraph2JSON(true);
     Map<String, String[]> parsed = getParsedJSONCG(cg, cg2JSON);
     Assert.assertEquals(5, parsed.keySet().size());
     parsed.values().stream()
@@ -45,10 +44,29 @@ public class TestCallGraph2JSON {
   public void testNative() throws WalaException, CancelException {
     String script = "tests/fieldbased/native_call.js";
     CallGraph cg = buildCallGraph(script);
-    CallGraph2JSON cg2JSON = new CallGraph2JSON(EdgeFilter.IGNORE_CALLS_WITHIN_HARNESS);
+    CallGraph2JSON cg2JSON = new CallGraph2JSON(false);
     Map<String, String[]> parsed = getParsedJSONCG(cg, cg2JSON);
-    Assert.assertEquals(1, parsed.keySet().size());
-    String[] targets = parsed.values().iterator().next();
+    String[] targets = parsed.get("native_call.js@2:21-28");
+    Assert.assertArrayEquals(new String[] {"Array_prototype_pop (Native)"}, targets);
+  }
+
+  @Test
+  public void testReflectiveCalls() throws WalaException, CancelException {
+    String script = "tests/fieldbased/reflective_calls.js";
+    CallGraph cg = buildCallGraph(script);
+    CallGraph2JSON cg2JSON = new CallGraph2JSON(false);
+    Map<String, String[]> parsed = getParsedJSONCG(cg, cg2JSON);
+    String[] targets = parsed.get("native_call.js@2:21-28");
+    Assert.assertArrayEquals(new String[] {"Array_prototype_pop (Native)"}, targets);
+  }
+
+  @Test
+  public void testNativeCallback() throws WalaException, CancelException {
+    String script = "tests/fieldbased/native_callback.js";
+    CallGraph cg = buildCallGraph(script);
+    CallGraph2JSON cg2JSON = new CallGraph2JSON(false);
+    Map<String, String[]> parsed = getParsedJSONCG(cg, cg2JSON);
+    String[] targets = parsed.get("native_call.js@2:21-28");
     Assert.assertArrayEquals(new String[] {"Array_prototype_pop (Native)"}, targets);
   }
 

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestCallGraph2JSON.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestCallGraph2JSON.java
@@ -40,7 +40,7 @@ public class TestCallGraph2JSON {
             });
   }
 
-  private Map<String, String[]> getParsedJSONCG(CallGraph cg, CallGraph2JSON cg2JSON) {
+  private static Map<String, String[]> getParsedJSONCG(CallGraph cg, CallGraph2JSON cg2JSON) {
     String json = cg2JSON.serialize(cg);
     System.err.println(json);
     Gson gson = new Gson();

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/FieldBasedCallGraphBuilder.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/FieldBasedCallGraphBuilder.java
@@ -259,7 +259,6 @@ public abstract class FieldBasedCallGraphBuilder {
     // need to create nodes for reflective targets of call, and then add them
     // as callees of the synthetic method
     OrdinalSet<FuncVertex> reflectiveTargets = getReflectiveTargets(flowgraph, callVertex, monitor);
-    System.err.println("adding callees " + reflectiveTargets + " for " + caller);
     // there should only be one call site in the synthetic method
     //    CallSiteReference reflectiveCallSite =
     // cache.getIRFactory().makeIR(functionPrototypeCallNode.getMethod(), Everywhere.EVERYWHERE,

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/FlowGraph.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/FlowGraph.java
@@ -214,7 +214,6 @@ public class FlowGraph implements Iterable<Vertex> {
                     if (!dataflow.containsNode(prototype)) {
                       dataflow.addNode(prototype);
                     }
-                    System.err.println("adding " + p + " --> " + prototype);
                     dataflow.addEdge(p, prototype);
                   }
                 }

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/CallGraph2JSON.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/CallGraph2JSON.java
@@ -55,27 +55,15 @@ import java.util.Set;
  */
 public class CallGraph2JSON {
 
-  /** options for which edges to filter from the output JSON */
-  public static enum EdgeFilter {
-    /** ignore any calls to, from, or within WALA's harness containing models of natives methods */
-    IGNORE_HARNESS_COMPLETELY,
-    /**
-     * ignore calls within WALA's native method harness, but include calls to native methods from
-     * scripts and from native methods to scripts (callbacks)
-     */
-    IGNORE_CALLS_WITHIN_HARNESS,
-    /** include all calls in the call graph (including the harness) */
-    INCLUDE_ALL
-  }
-
-  private final EdgeFilter edgeFilter;
+  /** ignore any calls to, from, or within WALA's harness containing models of natives methods */
+  private final boolean ignoreHarness;
 
   public CallGraph2JSON() {
-    this(EdgeFilter.IGNORE_HARNESS_COMPLETELY);
+    this(true);
   }
 
-  public CallGraph2JSON(EdgeFilter edgeFilter) {
-    this.edgeFilter = edgeFilter;
+  public CallGraph2JSON(boolean ignoreHarness) {
+    this.ignoreHarness = ignoreHarness;
   }
 
   public String serialize(CallGraph cg) {
@@ -90,7 +78,7 @@ public class CallGraph2JSON {
         continue;
       }
       AstMethod method = (AstMethod) nd.getMethod();
-      if (edgeFilter.equals(EdgeFilter.IGNORE_HARNESS_COMPLETELY) && isHarnessMethod(method)) {
+      if (ignoreHarness && isHarnessMethod(method)) {
         continue;
       }
       for (CallSiteReference callsite : Iterator2Iterable.make(nd.iterateCallSites())) {
@@ -113,10 +101,7 @@ public class CallGraph2JSON {
             getJSONRep(caller, ppPos(caller.getSourcePosition(callsite.getProgramCounter()))));
     for (IMethod target : targets) {
       target = getCallTargetMethod(target);
-      if (!isValidFunctionFromSource(target)
-          || (edgeFilter.equals(EdgeFilter.IGNORE_CALLS_WITHIN_HARNESS)
-              && isHarnessMethod(caller)
-              && isHarnessMethod(target))) {
+      if (!isValidFunctionFromSource(target) || (ignoreHarness && isHarnessMethod(target))) {
         continue;
       }
       targetNames.add(getJSONRep(target, ppPos(((AstMethod) target).getSourcePosition())));

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/CallGraph2JSON.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/CallGraph2JSON.java
@@ -123,9 +123,6 @@ public class CallGraph2JSON {
     if (isHarnessMethod(method) || isFunctionPrototypeCallOrApply(method)) {
       // just use the method name; position is meaningless
       String typeName = method.getDeclaringClass().getName().toString();
-      if (typeName.lastIndexOf('/') == -1) {
-        throw new RuntimeException(typeName + " is weird on Windows");
-      }
       return typeName.substring(typeName.lastIndexOf('/') + 1) + " (Native)";
     } else {
       return srcPos;

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/CallGraph2JSON.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/CallGraph2JSON.java
@@ -54,14 +54,25 @@ import java.util.Set;
  * @author mschaefer
  */
 public class CallGraph2JSON {
-  public static boolean IGNORE_HARNESS = true;
 
-  public static String serialize(CallGraph cg) {
+  /**
+   * Ignore native methods in WALA models
+   */
+  private final boolean ignoreHarness;
+
+  public CallGraph2JSON() {
+    this(true);
+  }
+
+  public CallGraph2JSON(boolean ignoreHarness) {
+    this.ignoreHarness = ignoreHarness;
+  }
+  public String serialize(CallGraph cg) {
     Map<String, Set<String>> edges = extractEdges(cg);
     return toJSON(edges);
   }
 
-  public static Map<String, Set<String>> extractEdges(CallGraph cg) {
+  public Map<String, Set<String>> extractEdges(CallGraph cg) {
     Map<String, Set<String>> edges = HashMapFactory.make();
     for (CGNode nd : cg) {
       if (!isRealFunction(nd.getMethod())) continue;
@@ -76,7 +87,7 @@ public class CallGraph2JSON {
     return edges;
   }
 
-  public static void serializeCallSite(
+  public void serializeCallSite(
       AstMethod method,
       CallSiteReference callsite,
       Set<IMethod> targets,
@@ -99,14 +110,14 @@ public class CallGraph2JSON {
     return method;
   }
 
-  public static boolean isRealFunction(IMethod method) {
+  public boolean isRealFunction(IMethod method) {
     if (method instanceof AstMethod) {
       String methodName = method.getDeclaringClass().getName().toString();
 
       // exclude synthetic DOM modelling functions
       if (methodName.contains("/make_node")) return false;
 
-      if (IGNORE_HARNESS) {
+      if (ignoreHarness) {
         for (String bootstrapFile : JavaScriptLoader.bootstrapFileNames)
           if (methodName.startsWith('L' + bootstrapFile + '/')) return false;
       }

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/CallGraph2JSON.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/CallGraph2JSON.java
@@ -123,6 +123,9 @@ public class CallGraph2JSON {
     if (isHarnessMethod(method) || isFunctionPrototypeCallOrApply(method)) {
       // just use the method name; position is meaningless
       String typeName = method.getDeclaringClass().getName().toString();
+      if (typeName.lastIndexOf('/') == -1) {
+        throw new RuntimeException(typeName + " is weird on Windows");
+      }
       return typeName.substring(typeName.lastIndexOf('/') + 1) + " (Native)";
     } else {
       return srcPos;

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/CallGraph2JSON.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/CallGraph2JSON.java
@@ -119,7 +119,7 @@ public class CallGraph2JSON {
               && isHarnessMethod(target))) {
         continue;
       }
-      targetNames.add(getJSONRep(target,ppPos(((AstMethod) target).getSourcePosition())));
+      targetNames.add(getJSONRep(target, ppPos(((AstMethod) target).getSourcePosition())));
     }
   }
 

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/CallGraph2JSON.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/CallGraph2JSON.java
@@ -55,9 +55,7 @@ import java.util.Set;
  */
 public class CallGraph2JSON {
 
-  /**
-   * Ignore native methods in WALA models
-   */
+  /** Ignore native methods in WALA models */
   private final boolean ignoreHarness;
 
   public CallGraph2JSON() {
@@ -67,6 +65,7 @@ public class CallGraph2JSON {
   public CallGraph2JSON(boolean ignoreHarness) {
     this.ignoreHarness = ignoreHarness;
   }
+
   public String serialize(CallGraph cg) {
     Map<String, Set<String>> edges = extractEdges(cg);
     return toJSON(edges);

--- a/com.ibm.wala.cast.js/src/test/resources/tests/fieldbased/native_call.js
+++ b/com.ibm.wala.cast.js/src/test/resources/tests/fieldbased/native_call.js
@@ -1,0 +1,2 @@
+var x = [1];
+var y = x.pop();

--- a/com.ibm.wala.cast.js/src/test/resources/tests/fieldbased/native_callback.js
+++ b/com.ibm.wala.cast.js/src/test/resources/tests/fieldbased/native_callback.js
@@ -1,2 +1,4 @@
 var x = [1];
-var y = x.map(function (z) { return z+1; });
+var y = x.map(
+  function (z) { return z+1; }
+);

--- a/com.ibm.wala.cast.js/src/test/resources/tests/fieldbased/native_callback.js
+++ b/com.ibm.wala.cast.js/src/test/resources/tests/fieldbased/native_callback.js
@@ -1,0 +1,2 @@
+var x = [1];
+var y = x.map(function (z) { return z+1; });

--- a/com.ibm.wala.cast.js/src/testFixtures/java/com/ibm/wala/cast/js/test/ExtractingToPredictableFileNames.java
+++ b/com.ibm.wala.cast.js/src/testFixtures/java/com/ibm/wala/cast/js/test/ExtractingToPredictableFileNames.java
@@ -24,7 +24,7 @@ public class ExtractingToPredictableFileNames implements AutoCloseable {
 
   /**
    * Reconfigures {@link JSSourceExtractor} to not use temporary file names, and reconfigures {@link
-   * DomLessSourceExtractor} to place HTML files in the <tt>build</tt> subdirectory of the current
+   * DomLessSourceExtractor} to place HTML files in the {@code build} subdirectory of the current
    * working directory.
    */
   public ExtractingToPredictableFileNames() {


### PR DESCRIPTION
This PR includes various improvements to `CallGraph2JSON` for serializing call graphs built with the field-based call graph builder.  It also adds some tests for `CallGraph2JSON`.  Opportunistically clean up some related code (like removing prints, removing mutable static fields, and fixing a Javadoc warning).

I may land this without review as its on the critical path for a research project.  But, if any issues are spotted I can fix in a follow-up PR.