### PR TITLE
Un-deprecate CGNode.addTarget()

### DIFF
--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/FieldBasedCallGraphBuilder.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/FieldBasedCallGraphBuilder.java
@@ -150,7 +150,6 @@ public abstract class FieldBasedCallGraphBuilder {
     return extract(interpreter, flowgraph, eps, monitor);
   }
 
-  @SuppressWarnings("deprecation")
   public JSCallGraph extract(
       SSAContextInterpreter interpreter,
       FlowGraph flowgraph,
@@ -286,7 +285,6 @@ public abstract class FieldBasedCallGraphBuilder {
 
   Everywhere targetContext = Everywhere.EVERYWHERE;
 
-  @SuppressWarnings("deprecation")
   private static boolean addCGEdgeWithContext(
       final JSCallGraph cg,
       CallSiteReference site,

--- a/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/CrossLanguageCallGraph.java
+++ b/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/CrossLanguageCallGraph.java
@@ -64,7 +64,6 @@ public class CrossLanguageCallGraph extends AstCallGraph {
 
   private final Map<Atom, IMethod> languageRoots = HashMapFactory.make();
 
-  @SuppressWarnings("deprecation")
   public AbstractRootMethod getLanguageRoot(Atom language) {
     if (!languageRoots.containsKey(language)) {
       AbstractRootMethod languageRoot = roots.get(language, this);

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/CGNode.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/CGNode.java
@@ -38,13 +38,11 @@ public interface CGNode extends INodeWithNumber, ContextItem, IClassHierarchyDwe
   public Context getContext();
 
   /**
-   * This is for use only by call graph builders ... not by the general public. Clients should not
-   * use this.
+   * NOTE: This is for use only by call graph builders, not by any other client of this interface.
    *
    * <p>Record that a particular call site might resolve to a call to a particular target node.
    * Returns true if this is a new target
    */
-  @Deprecated
   public boolean addTarget(CallSiteReference site, CGNode target);
 
   /** @return the "default" IR for this node used by the governing call graph */

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/cha/CHACallGraph.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/cha/CHACallGraph.java
@@ -115,7 +115,6 @@ public class CHACallGraph extends BasicCallGraph<CHAContextInterpreter> {
     setInterpreter(new ContextInsensitiveCHAContextInterpreter());
   }
 
-  @SuppressWarnings("deprecation")
   public void init(Iterable<Entrypoint> entrypoints) throws CancelException {
     super.init();
 
@@ -218,7 +217,6 @@ public class CHACallGraph extends BasicCallGraph<CHAContextInterpreter> {
   private int clinitPC = 0;
 
   @Override
-  @SuppressWarnings("deprecation")
   public CGNode findOrCreateNode(IMethod method, Context C) throws CancelException {
     assert C.equals(Everywhere.EVERYWHERE);
     assert !method.isAbstract();

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/impl/BasicCallGraph.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/impl/BasicCallGraph.java
@@ -81,7 +81,6 @@ public abstract class BasicCallGraph<T> extends AbstractNumberedGraph<CGNode> im
     super();
   }
 
-  @SuppressWarnings("deprecation")
   public void init() throws CancelException {
     fakeRoot = makeFakeRootNode();
     Key k = new Key(fakeRoot.getMethod(), fakeRoot.getContext());
@@ -199,10 +198,6 @@ public abstract class BasicCallGraph<T> extends AbstractNumberedGraph<CGNode> im
     public Context getContext() {
       return context;
     }
-
-    @SuppressWarnings("deprecation")
-    @Override
-    public abstract boolean addTarget(CallSiteReference reference, CGNode target);
 
     @Override
     public IClassHierarchy getClassHierarchy() {

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/SSAPropagationCallGraphBuilder.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/SSAPropagationCallGraphBuilder.java
@@ -1642,7 +1642,6 @@ public abstract class SSAPropagationCallGraphBuilder extends PropagationCallGrap
    * @param uniqueCatchKey if non-null, then this is the unique PointerKey that catches all
    *     exceptions from this call site.
    */
-  @SuppressWarnings("deprecation")
   private void processResolvedCall(
       CGNode caller,
       SSAAbstractInvokeInstruction instruction,

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/AbstractRTABuilder.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/AbstractRTABuilder.java
@@ -284,7 +284,6 @@ public abstract class AbstractRTABuilder extends PropagationCallGraphBuilder {
    *
    * <p>Side effect: add edge to the call graph.
    */
-  @SuppressWarnings("deprecation")
   void processResolvedCall(CGNode caller, CallSiteReference site, CGNode target) {
 
     if (DEBUG) {


### PR DESCRIPTION
Several call graph builders rely on this API, and we have no alternative.  So the method should not be marked as deprecated.  Added "NOTE" in all caps to the javadoc to further discourage use of the method outside of call graph builders.