### PR TITLE
Add method info to CallGraph2JSON output

### DIFF
--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/AbstractFieldBasedTest.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/AbstractFieldBasedTest.java
@@ -64,8 +64,13 @@ public abstract class AbstractFieldBasedTest extends TestJSCallGraphShape {
 
   protected void dumpCG(JSCallGraph cg) {
     CallGraph2JSON cg2JSON = new CallGraph2JSON(false);
-    Map<String, Set<String>> edges = cg2JSON.extractEdges(cg);
-    for (Map.Entry<String, Set<String>> entry : edges.entrySet())
-      for (String callee : entry.getValue()) System.out.println(entry.getKey() + " -> " + callee);
+    Map<String, Map<String, Set<String>>> edges = cg2JSON.extractEdges(cg);
+    for (Map<String, Set<String>> sitesInMethod : edges.values()) {
+      for (Map.Entry<String, Set<String>> entry : sitesInMethod.entrySet()) {
+        for (String callee : entry.getValue()) {
+          System.out.println(entry.getKey() + " -> " + callee);
+        }
+      }
+    }
   }
 }

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestCallGraph2JSON.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestCallGraph2JSON.java
@@ -3,6 +3,7 @@ package com.ibm.wala.cast.js.test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -14,12 +15,12 @@ import com.ibm.wala.cast.js.util.FieldBasedCGUtil.BuilderType;
 import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.WalaException;
+import com.ibm.wala.util.collections.HashMapFactory;
 import java.lang.reflect.Type;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Map;
 import org.hamcrest.core.IsCollectionContaining;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -37,12 +38,14 @@ public class TestCallGraph2JSON {
     String script = "tests/fieldbased/simple.js";
     CallGraph cg = buildCallGraph(script);
     CallGraph2JSON cg2JSON = new CallGraph2JSON(true);
-    Map<String, String[]> parsed = getParsedJSONCG(cg, cg2JSON);
-    Assert.assertEquals(5, parsed.keySet().size());
-    parsed.values().stream()
+    Map<String, Map<String, String[]>> parsedJSONCG = getParsedJSONCG(cg, cg2JSON);
+    assertEquals(3, parsedJSONCG.keySet().size());
+    Map<String, String[]> flattened = flattenParsedCG(parsedJSONCG);
+    assertEquals(5, flattened.keySet().size());
+    flattened.values().stream()
         .forEach(
             callees -> {
-              Assert.assertEquals(1, callees.length);
+              assertEquals(1, callees.length);
             });
   }
 
@@ -51,7 +54,7 @@ public class TestCallGraph2JSON {
     String script = "tests/fieldbased/native_call.js";
     CallGraph cg = buildCallGraph(script);
     CallGraph2JSON cg2JSON = new CallGraph2JSON(false);
-    Map<String, String[]> parsed = getParsedJSONCG(cg, cg2JSON);
+    Map<String, String[]> parsed = getFlattenedJSONCG(cg, cg2JSON);
     assertArrayEquals(
         new String[] {"Array_prototype_pop (Native)"},
         getTargetsStartingWith(parsed, "native_call.js@2"));
@@ -62,7 +65,7 @@ public class TestCallGraph2JSON {
     String script = "tests/fieldbased/reflective_calls.js";
     CallGraph cg = buildCallGraph(script);
     CallGraph2JSON cg2JSON = new CallGraph2JSON(false);
-    Map<String, String[]> parsed = getParsedJSONCG(cg, cg2JSON);
+    Map<String, String[]> parsed = getFlattenedJSONCG(cg, cg2JSON);
     assertArrayEquals(
         new String[] {"Function_prototype_call (Native)"},
         getTargetsStartingWith(parsed, "reflective_calls.js@10"));
@@ -82,7 +85,7 @@ public class TestCallGraph2JSON {
     String script = "tests/fieldbased/native_callback.js";
     CallGraph cg = buildCallGraph(script);
     CallGraph2JSON cg2JSON = new CallGraph2JSON(false);
-    Map<String, String[]> parsed = getParsedJSONCG(cg, cg2JSON);
+    Map<String, String[]> parsed = getFlattenedJSONCG(cg, cg2JSON);
     assertArrayEquals(
         new String[] {"Array_prototype_map (Native)"},
         getTargetsStartingWith(parsed, "native_callback.js@2"));
@@ -91,11 +94,29 @@ public class TestCallGraph2JSON {
         hasItemStartingWith("native_callback.js@3"));
   }
 
-  private static Map<String, String[]> getParsedJSONCG(CallGraph cg, CallGraph2JSON cg2JSON) {
+  /**
+   * returns a parsed version of the JSON of the call graph, but flattened to just be a map from
+   * call sites to targets (stripping out the outermost level of containing methods)
+   */
+  private static Map<String, String[]> getFlattenedJSONCG(CallGraph cg, CallGraph2JSON cg2JSON) {
+    Map<String, Map<String, String[]>> parsed = getParsedJSONCG(cg, cg2JSON);
+    return flattenParsedCG(parsed);
+  }
+
+  private static Map<String, String[]> flattenParsedCG(Map<String, Map<String, String[]>> parsed) {
+    Map<String, String[]> result = HashMapFactory.make();
+    for (Map<String, String[]> siteInfo : parsed.values()) {
+      result.putAll(siteInfo);
+    }
+    return result;
+  }
+
+  private static Map<String, Map<String, String[]>> getParsedJSONCG(
+      CallGraph cg, CallGraph2JSON cg2JSON) {
     String json = cg2JSON.serialize(cg);
     // System.err.println(json);
     Gson gson = new Gson();
-    Type mapType = new TypeToken<Map<String, String[]>>() {}.getType();
+    Type mapType = new TypeToken<Map<String, Map<String, String[]>>>() {}.getType();
     return gson.fromJson(json, mapType);
   }
 

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestCallGraph2JSON.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestCallGraph2JSON.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Type;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Set;
 import org.hamcrest.core.IsCollectionContaining;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,7 +40,16 @@ public class TestCallGraph2JSON {
     CallGraph cg = buildCallGraph(script);
     CallGraph2JSON cg2JSON = new CallGraph2JSON(true);
     Map<String, Map<String, String[]>> parsedJSONCG = getParsedJSONCG(cg, cg2JSON);
-    assertEquals(3, parsedJSONCG.keySet().size());
+    Set<String> methods = parsedJSONCG.keySet();
+    assertEquals(3, methods.size());
+    for (String m : methods) {
+      if (m.startsWith("simple.js@3")) {
+        Map<String, String[]> callSites = parsedJSONCG.get(m);
+        assertThat(
+            Arrays.asList(getTargetsStartingWith(callSites, "simple.js@4")),
+            hasItemStartingWith("simple.js@7"));
+      }
+    }
     Map<String, String[]> flattened = flattenParsedCG(parsedJSONCG);
     assertEquals(5, flattened.keySet().size());
     flattened.values().stream()

--- a/com.ibm.wala.cast.js/build.gradle
+++ b/com.ibm.wala.cast.js/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 			'commons-io:commons-io:2.7',
 			'junit:junit:4.13',
 			'net.htmlparser.jericho:jericho-html:3.2',
+			'com.google.code.gson:gson:2.8.6',
 			project(':com.ibm.wala.core'),
 			project(':com.ibm.wala.shrike'),
 			project(':com.ibm.wala.util'),

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/CallGraph2JSON.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/CallGraph2JSON.java
@@ -74,8 +74,12 @@ public class CallGraph2JSON {
     return toJSON(edges);
   }
 
+  /**
+   * Extract the edges of the given callgraph as a map over strings that is easy to serialize. The
+   * map keys are locations of methods. The map values are themselves maps, from call site locations
+   * within a method to the (locations of) potential target methods for the call sites.
+   */
   public Map<String, Map<String, Set<String>>> extractEdges(CallGraph cg) {
-    // map from method location -> (map from call site -> targets)
     Map<String, Map<String, Set<String>>> edges = HashMapFactory.make();
     for (CGNode nd : cg) {
       if (!isValidFunctionFromSource(nd.getMethod())) {
@@ -191,6 +195,10 @@ public class CallGraph2JSON {
     return file + '@' + line + ':' + start_offset + '-' + end_offset;
   }
 
+  /**
+   * Converts a call graph map produced by {@link #extractEdges(CallGraph)} to JSON, eliding call
+   * sites with no targets.
+   */
   public static String toJSON(Map<String, Map<String, Set<String>>> map) {
     // strip out call sites with no targets
     Map<String, Map<String, Set<String>>> filtered = new HashMap<>();

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/CallGraph2JSON.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/CallGraph2JSON.java
@@ -11,6 +11,7 @@
 package com.ibm.wala.cast.js.util;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.ibm.wala.cast.js.loader.JavaScriptLoader;
 import com.ibm.wala.cast.js.types.JavaScriptMethods;
 import com.ibm.wala.cast.loader.AstMethod;
@@ -202,7 +203,7 @@ public class CallGraph2JSON {
         filtered.put(methodLoc, filteredSites);
       }
     }
-    Gson gson = new Gson();
+    Gson gson = new GsonBuilder().setPrettyPrinting().create();
     return gson.toJson(filtered);
   }
 }

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/CallGraph2JSON.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/CallGraph2JSON.java
@@ -202,9 +202,11 @@ public class CallGraph2JSON {
   public static String toJSON(Map<String, Map<String, Set<String>>> map) {
     // strip out call sites with no targets
     Map<String, Map<String, Set<String>>> filtered = new HashMap<>();
-    for (String methodLoc : map.keySet()) {
+    for (Map.Entry<String, Map<String, Set<String>>> entry : map.entrySet()) {
+      String methodLoc = entry.getKey();
+      Map<String, Set<String>> callSites = entry.getValue();
       Map<String, Set<String>> filteredSites =
-          map.get(methodLoc).entrySet().stream()
+          callSites.entrySet().stream()
               .filter(e -> !e.getValue().isEmpty())
               .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
       if (!filteredSites.isEmpty()) {


### PR DESCRIPTION
We now output JSON in a format that includes information on the containing method for each call site, which makes determining things like method reachability from an entrypoint much easier.  Also, use Gson for serializing JSON rather than coding that ourselves.