### PR TITLE
Support for constructing field-based call graphs for all scripts in a directory

### DIFF
--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/FieldBasedCGUtil.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/FieldBasedCGUtil.java
@@ -141,6 +141,10 @@ public class FieldBasedCGUtil {
     return buildCG(loaders, scripts, builderType, monitor, supportFullPointerAnalysis);
   }
 
+  /**
+   * Construct a field-based call graph using all the {@code .js} files appearing in scriptDir or
+   * any of its sub-directories
+   */
   public Pair<JSCallGraph, PointerAnalysis<ObjectVertex>> buildScriptDirCG(
       Path scriptDir,
       BuilderType builderType,
@@ -153,6 +157,8 @@ public class FieldBasedCGUtil {
             .filter(p -> p.toString().toLowerCase().endsWith(".js"))
             .collect(Collectors.toList());
     List<Module> scripts = new ArrayList<>();
+    // we can't do this loop as a map() operation on the previous stream because toURL() throws
+    // a checked exception
     for (Path p : jsFiles) {
       scripts.add(new SourceURLModule(p.toUri().toURL()));
     }

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/FieldBasedCGUtil.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/FieldBasedCGUtil.java
@@ -41,10 +41,15 @@ import com.ibm.wala.util.WalaException;
 import com.ibm.wala.util.collections.Pair;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 /**
  * Utility class for building call graphs.
@@ -134,6 +139,26 @@ public class FieldBasedCGUtil {
     Module[] scripts =
         new Module[] {new SourceURLModule(url), JSCallGraphUtil.getPrologueFile("prologue.js")};
     return buildCG(loaders, scripts, builderType, monitor, supportFullPointerAnalysis);
+  }
+
+  public Pair<JSCallGraph, PointerAnalysis<ObjectVertex>> buildScriptDirCG(
+      Path scriptDir,
+      BuilderType builderType,
+      IProgressMonitor monitor,
+      boolean supportFullPointerAnalysis)
+      throws WalaException, CancelException, IOException {
+    JavaScriptLoaderFactory loaders = new JavaScriptLoaderFactory(translatorFactory);
+    List<Path> jsFiles =
+        Files.walk(scriptDir)
+            .filter(p -> p.toString().toLowerCase().endsWith(".js"))
+            .collect(Collectors.toList());
+    List<Module> scripts = new ArrayList<>();
+    for (Path p : jsFiles) {
+      scripts.add(new SourceURLModule(p.toUri().toURL()));
+    }
+    scripts.add(JSCallGraphUtil.getPrologueFile("prologue.js"));
+    return buildCG(
+        loaders, scripts.toArray(new Module[0]), builderType, monitor, supportFullPointerAnalysis);
   }
 
   public Pair<JSCallGraph, PointerAnalysis<ObjectVertex>> buildTestCG(


### PR DESCRIPTION
We already support this for other JS call graph builders; add a relevant API method.