### PR TITLE
Don't crash for new Function() called with empty string

### DIFF
--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/TestFieldBasedCG.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/TestFieldBasedCG.java
@@ -160,6 +160,12 @@ public class TestFieldBasedCG extends AbstractFieldBasedTest {
         "tests/fieldbased/callbacks2.js", assertionsForCallbacks2, BuilderType.OPTIMISTIC_WORKLIST);
   }
 
+  @Test
+  public void testNewFnEmptyNoCrash() throws WalaException, Error, CancelException {
+    runTest(
+        "tests/fieldbased/new_fn_empty.js", new Object[][] {}, BuilderType.OPTIMISTIC_WORKLIST);
+  }
+
   // @Test
   public void testBug2979() throws WalaException, Error, CancelException {
     System.err.println(

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/TestFieldBasedCG.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/TestFieldBasedCG.java
@@ -162,8 +162,7 @@ public class TestFieldBasedCG extends AbstractFieldBasedTest {
 
   @Test
   public void testNewFnEmptyNoCrash() throws WalaException, Error, CancelException {
-    runTest(
-        "tests/fieldbased/new_fn_empty.js", new Object[][] {}, BuilderType.OPTIMISTIC_WORKLIST);
+    runTest("tests/fieldbased/new_fn_empty.js", new Object[][] {}, BuilderType.OPTIMISTIC_WORKLIST);
   }
 
   // @Test

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/JSMethodInstructionVisitor.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/JSMethodInstructionVisitor.java
@@ -55,9 +55,14 @@ public class JSMethodInstructionVisitor extends JSAbstractInstructionVisitor {
       if (fndef instanceof AstGlobalRead) {
         AstGlobalRead agr = (AstGlobalRead) fndef;
         if (agr.getGlobalName().equals("global Function")) {
-          if (invk.getNumberOfPositionalParameters() != 2) return false;
+          if (invk.getNumberOfPositionalParameters() != 2) {
+            return false;
+          }
           // this may be a genuine use of "new Function()", not a declaration/expression
-          if (!symtab.isStringConstant(invk.getUse(1))) return false;
+          if (!symtab.isStringConstant(invk.getUse(1))
+              || symtab.getStringValue(invk.getUse(1)).equals("")) {
+            return false;
+          }
           return true;
         }
       }

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/ipa/summaries/JavaScriptConstructorFunctions.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/ipa/summaries/JavaScriptConstructorFunctions.java
@@ -465,7 +465,8 @@ public class JavaScriptConstructorFunctions {
       case 0:
         return makeFunctionConstructor(cls, cls);
       case 1:
-        if (ST.isStringConstant(callStmt.getUse(1))) {
+        if (ST.isStringConstant(callStmt.getUse(1))
+            && !ST.getStringValue(callStmt.getUse(1)).equals("")) {
           TypeReference ref =
               TypeReference.findOrCreate(
                   JavaScriptTypes.jsLoader,

--- a/com.ibm.wala.cast.js/src/test/resources/tests/fieldbased/new_fn_empty.js
+++ b/com.ibm.wala.cast.js/src/test/resources/tests/fieldbased/new_fn_empty.js
@@ -1,0 +1,1 @@
+new Function('');


### PR DESCRIPTION
Fixes a crash in the field-based call graph builder