### PR TITLE
Override the isA() method of CallStringContextPair 

### DIFF
--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/core/tests/callGraph/CallGraphTestUtil.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/core/tests/callGraph/CallGraphTestUtil.java
@@ -19,9 +19,11 @@ import com.ibm.wala.ipa.callgraph.Entrypoint;
 import com.ibm.wala.ipa.callgraph.IAnalysisCacheView;
 import com.ibm.wala.ipa.callgraph.impl.Util;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis;
 import com.ibm.wala.ipa.callgraph.propagation.SSAPropagationCallGraphBuilder;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.util.CancelException;
+import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.util.config.AnalysisScopeReader;
 import com.ibm.wala.util.io.FileProvider;
 import com.ibm.wala.util.perf.StopwatchGC;
@@ -189,5 +191,28 @@ public class CallGraphTestUtil {
       System.err.println(S.report());
     }
     return cg;
+  }
+
+  public static Pair<CallGraph, PointerAnalysis<InstanceKey>> buildNCFA(
+      int n,
+      AnalysisOptions options,
+      IAnalysisCacheView cache,
+      IClassHierarchy cha,
+      AnalysisScope scope)
+      throws IllegalArgumentException, CancelException {
+    StopwatchGC S = null;
+    if (CHECK_FOOTPRINT) {
+      S = new StopwatchGC("build N-CFA graph");
+      S.start();
+    }
+
+    CallGraphBuilder<InstanceKey> builder = Util.makeNCFABuilder(n, options, cache, cha, scope);
+    CallGraph cg = builder.makeCallGraph(options, null);
+
+    if (CHECK_FOOTPRINT) {
+      S.stop();
+      System.err.println(S.report());
+    }
+    return Pair.make(cg, builder.getPointerAnalysis());
   }
 }

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/core/tests/util/TestConstants.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/core/tests/util/TestConstants.java
@@ -88,6 +88,8 @@ public interface TestConstants {
 
   public static final String REFLECT23_MAIN = "Lreflection/Reflect23";
 
+  public static final String REFLECT24_MAIN = "Lreflection/Reflect24";
+
   public static final String REFLECTGETMETHODCONTEXT_MAIN = "Lreflection/GetMethodContext";
 
   public static final String SLICE1_MAIN = "Lslice/Slice1";

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/CallStringContextSelector.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/CallStringContextSelector.java
@@ -85,6 +85,11 @@ public abstract class CallStringContextSelector implements ContextSelector {
     public CallString getCallString() {
       return cs;
     }
+
+    @Override
+    public boolean isA(Class<? extends Context> type) {
+      return base.isA(type) || type.isInstance(this);
+    }
   }
 
   protected final ContextSelector base;

--- a/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/callGraph/ReflectionTest.java
+++ b/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/callGraph/ReflectionTest.java
@@ -46,6 +46,7 @@ import com.ibm.wala.util.warnings.Warnings;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -781,7 +782,10 @@ public class ReflectionTest extends WalaTestCase {
     Assert.assertTrue(nodes.size() == 1);
 
     // get the pts corresponding to the 0th parameter of the Reflect24#doNothing() method
-    CGNode cgNode = nodes.stream().findFirst().get();
+    Optional<CGNode> firstMatched = nodes.stream().findFirst();
+    Assert.assertTrue(firstMatched.isPresent());
+    CGNode cgNode = firstMatched.get();
+
     LocalPointerKey localPointerKey = new LocalPointerKey(cgNode, cgNode.getIR().getParameter(0));
     OrdinalSet<InstanceKey> pts = pointerAnalysis.getPointsToSet(localPointerKey);
     Assert.assertTrue(pts.size() == 1);

--- a/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/callGraph/ReflectionTest.java
+++ b/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/callGraph/ReflectionTest.java
@@ -24,6 +24,9 @@ import com.ibm.wala.ipa.callgraph.ContextKey;
 import com.ibm.wala.ipa.callgraph.Entrypoint;
 import com.ibm.wala.ipa.callgraph.impl.Everywhere;
 import com.ibm.wala.ipa.callgraph.propagation.ConstantKey;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.LocalPointerKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis;
 import com.ibm.wala.ipa.callgraph.propagation.ReceiverInstanceContext;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.ipa.cha.ClassHierarchyFactory;
@@ -36,6 +39,8 @@ import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.WalaException;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.collections.Iterator2Iterable;
+import com.ibm.wala.util.collections.Pair;
+import com.ibm.wala.util.intset.OrdinalSet;
 import com.ibm.wala.util.warnings.Warning;
 import com.ibm.wala.util.warnings.Warnings;
 import java.io.IOException;
@@ -736,6 +741,56 @@ public class ReflectionTest extends WalaTestCase {
     MethodReference mr = MethodReference.findOrCreate(tr, "u", "(Ljava/lang/Integer;)V");
     Set<CGNode> nodes = cg.getNodes(mr);
     Assert.assertFalse(nodes.isEmpty());
+  }
+
+  /**
+   * Test that when analyzing Reflect24.
+   *
+   * <p>Through the pointer analysis in the CallGraph construction process, it can be inferred that
+   * the type pointed to by the 0th parameter of the {@code com.ibm.wala.test.People#doNothing()}
+   * method is {@code Helper}
+   *
+   * <p>This is to test the support for Object.getClass().
+   */
+  @Test
+  public void testReflect24()
+      throws WalaException, IllegalArgumentException, CancelException, IOException {
+    AnalysisScope scope = findOrCreateAnalysisScope();
+    IClassHierarchy cha = findOrCreateCHA(scope);
+    Iterable<Entrypoint> entrypoints =
+        com.ibm.wala.ipa.callgraph.impl.Util.makeMainEntrypoints(
+            scope, cha, TestConstants.REFLECT24_MAIN);
+
+    AnalysisOptions options = CallGraphTestUtil.makeAnalysisOptions(scope, entrypoints);
+    Pair<CallGraph, PointerAnalysis<InstanceKey>> pair =
+        CallGraphTestUtil.buildNCFA(1, options, new AnalysisCacheImpl(), cha, scope);
+
+    CallGraph cg = pair.fst;
+    PointerAnalysis<InstanceKey> pointerAnalysis = pair.snd;
+
+    TypeReference helperTr =
+        TypeReference.findOrCreate(ClassLoaderReference.Application, "Lreflection/Helper");
+    IClass helperClass = cha.lookupClass(helperTr);
+    Assert.assertNotNull(helperClass);
+
+    TypeReference reflect24Tr =
+        TypeReference.findOrCreate(ClassLoaderReference.Application, "Lreflection/Reflect24");
+    MethodReference mr =
+        MethodReference.findOrCreate(reflect24Tr, "doNothing", "(Ljava/lang/Class;)V");
+    Set<CGNode> nodes = cg.getNodes(mr);
+    Assert.assertTrue(nodes.size() == 1);
+
+    // get the pts corresponding to the 0th parameter of the Reflect24#doNothing() method
+    CGNode cgNode = nodes.stream().findFirst().get();
+    LocalPointerKey localPointerKey = new LocalPointerKey(cgNode, cgNode.getIR().getParameter(0));
+    OrdinalSet<InstanceKey> pts = pointerAnalysis.getPointsToSet(localPointerKey);
+    Assert.assertTrue(pts.size() == 1);
+
+    for (InstanceKey mappedObject : pts) {
+      // the type corresponding to the 0th parameter should be Helper
+      Assert.assertTrue(mappedObject instanceof ConstantKey);
+      Assert.assertTrue(((ConstantKey<?>) mappedObject).getValue().equals(helperClass));
+    }
   }
 
   /**

--- a/com.ibm.wala.core/src/testSubjects/java/reflection/Reflect24.java
+++ b/com.ibm.wala.core/src/testSubjects/java/reflection/Reflect24.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2013 IBM Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ */
+package reflection;
+
+/**
+ * Test of Object.getClass();
+ *
+ * @author genli
+ */
+public class Reflect24 {
+
+  public static void main(String[] args) {
+    Helper helper = new Helper();
+    doNothing(helper.getClass());
+  }
+
+  static void doNothing(Class<?> clazz) {}
+}


### PR DESCRIPTION
Override `com.ibm.wala.ipa.callgraph.propagation.cfa.CallStringContextSelector.CallStringContextPair#isA()` to prevent possible problems when dealing with reflection and other situations.

For example: in the case of N-CFA, `com.ibm.wala.analysis.reflection.GetClassContextInterpeter#understand()` will not match `JavaTypeContext`

I think this bug is relatively simple, so I did not add related test cases. If necessary, please contact me.
