### PR TITLE
Add ability to serialize flow graph from JS field-based call graph builder to JSON

### DIFF
--- a/com.ibm.wala.cast.js.rhino/build.gradle
+++ b/com.ibm.wala.cast.js.rhino/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	)
 	testImplementation(
 			'junit:junit:4.13',
+			'org.hamcrest:hamcrest:2.2',
 			'com.google.code.gson:gson:2.8.6',
 			testFixtures(project(':com.ibm.wala.cast')),
 			testFixtures(project(':com.ibm.wala.cast.js')),

--- a/com.ibm.wala.cast.js.rhino/src/main/java/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
+++ b/com.ibm.wala.cast.js.rhino/src/main/java/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
@@ -43,6 +43,7 @@ import com.ibm.wala.util.warnings.Warning;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -2767,7 +2768,11 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
     this.Ast = Ast;
     this.scriptName = scriptName;
     this.sourceModule = m;
-    this.sourceReader = new InputStreamReader(sourceModule.getInputStream());
+    try {
+      this.sourceReader = new InputStreamReader(sourceModule.getInputStream(), "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      throw new RuntimeException("UTF-8 not supported??", e);
+    }
     this.doLoopTranslator = new DoLoopTranslator(replicateForDoLoops, Ast);
     this.useNewForIn = useNewForIn;
   }

--- a/com.ibm.wala.cast.js.rhino/src/main/java/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
+++ b/com.ibm.wala.cast.js.rhino/src/main/java/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
@@ -43,7 +43,6 @@ import com.ibm.wala.util.warnings.Warning;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -2768,11 +2767,7 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
     this.Ast = Ast;
     this.scriptName = scriptName;
     this.sourceModule = m;
-    try {
-      this.sourceReader = new InputStreamReader(sourceModule.getInputStream(), "UTF-8");
-    } catch (UnsupportedEncodingException e) {
-      throw new RuntimeException("UTF-8 not supported??", e);
-    }
+    this.sourceReader = new InputStreamReader(sourceModule.getInputStream());
     this.doLoopTranslator = new DoLoopTranslator(replicateForDoLoops, Ast);
     this.useNewForIn = useNewForIn;
   }

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/AbstractFieldBasedTest.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/AbstractFieldBasedTest.java
@@ -45,7 +45,9 @@ public abstract class AbstractFieldBasedTest extends TestJSCallGraphShape {
     for (BuilderType builderType : builderTypes) {
       ProgressMaster monitor = ProgressMaster.make(new NullProgressMonitor(), 45000, true);
       try {
-        cg = util.buildCG(url, builderType, monitor, false, DefaultSourceExtractor.factory).fst;
+        cg =
+            util.buildCG(url, builderType, monitor, false, DefaultSourceExtractor.factory)
+                .getCallGraph();
         System.err.println(cg);
         verifyGraphAssertions(cg, assertions);
       } catch (AssertionError afe) {

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestCallGraph2JSON.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestCallGraph2JSON.java
@@ -138,7 +138,7 @@ public class TestCallGraph2JSON {
     URL scriptURL = TestCallGraph2JSON.class.getClassLoader().getResource(script);
     return util.buildCG(
             scriptURL, BuilderType.OPTIMISTIC_WORKLIST, null, false, DefaultSourceExtractor::new)
-        .fst;
+        .getCallGraph();
   }
 
   /**

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestCallGraph2JSON.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestCallGraph2JSON.java
@@ -21,7 +21,7 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
-import org.hamcrest.core.IsCollectionContaining;
+import org.hamcrest.core.IsIterableContaining;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -158,7 +158,7 @@ public class TestCallGraph2JSON {
    * We need this method since column offsets can differ across platforms, so we can't do an exact
    * position match
    */
-  private static IsCollectionContaining<String> hasItemStartingWith(String prefix) {
-    return new IsCollectionContaining<>(startsWith(prefix));
+  private static IsIterableContaining<String> hasItemStartingWith(String prefix) {
+    return new IsIterableContaining<>(startsWith(prefix));
   }
 }

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestFlowGraphJSON.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestFlowGraphJSON.java
@@ -1,0 +1,37 @@
+package com.ibm.wala.cast.js.test;
+
+import com.ibm.wala.cast.js.callgraph.fieldbased.flowgraph.FlowGraph;
+import com.ibm.wala.cast.js.html.DefaultSourceExtractor;
+import com.ibm.wala.cast.js.translator.CAstRhinoTranslatorFactory;
+import com.ibm.wala.cast.js.util.FieldBasedCGUtil;
+import com.ibm.wala.cast.js.util.FieldBasedCGUtil.BuilderType;
+import com.ibm.wala.util.CancelException;
+import com.ibm.wala.util.WalaException;
+import java.net.URL;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestFlowGraphJSON {
+
+  private FieldBasedCGUtil util;
+
+  @Before
+  public void setUp() throws Exception {
+    util = new FieldBasedCGUtil(new CAstRhinoTranslatorFactory());
+  }
+
+  @Test
+  public void testBasic() throws WalaException, CancelException {
+    String script = "tests/fieldbased/simple.js";
+    FlowGraph fg = buildFlowGraph(script);
+    String json = fg.toJSON();
+    System.err.println(json);
+  }
+
+  private FlowGraph buildFlowGraph(String script) throws WalaException, CancelException {
+    URL scriptURL = TestCallGraph2JSON.class.getClassLoader().getResource(script);
+    return util.buildCG(
+            scriptURL, BuilderType.OPTIMISTIC_WORKLIST, null, false, DefaultSourceExtractor::new)
+        .getFlowGraph();
+  }
+}

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestFlowGraphJSON.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestFlowGraphJSON.java
@@ -12,6 +12,7 @@ import com.ibm.wala.util.WalaException;
 import java.lang.reflect.Type;
 import java.net.URL;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,6 +31,12 @@ public class TestFlowGraphJSON {
   @Test
   public void testNamedIIFE() {
     String[] targets = parsedJSON.get("Func(flowgraph_constraints.js@2:25-41)");
+    Assert.assertNotNull(
+        parsedJSON.keySet().stream()
+            .filter(s -> s.startsWith("Func(flowgraph_constraints.js@2"))
+            .collect(Collectors.toList())
+            .toString(),
+        targets);
     Assert.assertArrayEquals(
         new String[] {
           "Var(flowgraph_constraints.js@2:25-41, [f1])",

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestFlowGraphJSON.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestFlowGraphJSON.java
@@ -1,5 +1,7 @@
 package com.ibm.wala.cast.js.test;
 
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import com.ibm.wala.cast.js.callgraph.fieldbased.flowgraph.FlowGraph;
 import com.ibm.wala.cast.js.html.DefaultSourceExtractor;
 import com.ibm.wala.cast.js.translator.CAstRhinoTranslatorFactory;
@@ -7,31 +9,46 @@ import com.ibm.wala.cast.js.util.FieldBasedCGUtil;
 import com.ibm.wala.cast.js.util.FieldBasedCGUtil.BuilderType;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.WalaException;
+import java.lang.reflect.Type;
 import java.net.URL;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
 public class TestFlowGraphJSON {
 
-  private FieldBasedCGUtil util;
+  private static final String SCRIPT = "tests/fieldbased/flowgraph_constraints.js";
+
+  private Map<String, String[]> parsedJSON;
 
   @Before
   public void setUp() throws Exception {
-    util = new FieldBasedCGUtil(new CAstRhinoTranslatorFactory());
+    parsedJSON = getParsedFlowGraphJSON(SCRIPT);
   }
 
   @Test
-  public void testBasic() throws WalaException, CancelException {
-    String script = "tests/fieldbased/simple.js";
-    FlowGraph fg = buildFlowGraph(script);
+  public void testBasic() throws WalaException, CancelException {}
+
+  //  @Test
+  //  public void testBasic2() throws WalaException, CancelException {
+  //  }
+
+  private static Map<String, String[]> getParsedFlowGraphJSON(String script)
+      throws WalaException, CancelException {
+    URL scriptURL = TestCallGraph2JSON.class.getClassLoader().getResource(script);
+    FieldBasedCGUtil util = new FieldBasedCGUtil(new CAstRhinoTranslatorFactory());
+    FlowGraph fg =
+        util.buildCG(
+                scriptURL,
+                BuilderType.OPTIMISTIC_WORKLIST,
+                null,
+                false,
+                DefaultSourceExtractor::new)
+            .getFlowGraph();
     String json = fg.toJSON();
     System.err.println(json);
-  }
-
-  private FlowGraph buildFlowGraph(String script) throws WalaException, CancelException {
-    URL scriptURL = TestCallGraph2JSON.class.getClassLoader().getResource(script);
-    return util.buildCG(
-            scriptURL, BuilderType.OPTIMISTIC_WORKLIST, null, false, DefaultSourceExtractor::new)
-        .getFlowGraph();
+    Gson gson = new Gson();
+    Type mapType = new TypeToken<Map<String, String[]>>() {}.getType();
+    return gson.fromJson(json, mapType);
   }
 }

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestFlowGraphJSON.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestFlowGraphJSON.java
@@ -8,12 +8,10 @@ import com.ibm.wala.cast.js.translator.CAstRhinoTranslatorFactory;
 import com.ibm.wala.cast.js.util.FieldBasedCGUtil;
 import com.ibm.wala.cast.js.util.FieldBasedCGUtil.BuilderType;
 import com.ibm.wala.util.CancelException;
-import com.ibm.wala.util.PlatformUtil;
 import com.ibm.wala.util.WalaException;
 import java.lang.reflect.Type;
 import java.net.URL;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,27 +29,11 @@ public class TestFlowGraphJSON {
 
   @Test
   public void testNamedIIFE() {
-    boolean onWindows = PlatformUtil.onWindows();
-    String[] targets =
-        onWindows
-            ? parsedJSON.get("Func(flowgraph_constraints.js@2:26-42)")
-            : parsedJSON.get("Func(flowgraph_constraints.js@2:25-41)");
-    Assert.assertNotNull(
-        parsedJSON.keySet().stream()
-            .filter(s -> s.startsWith("Func(flowgraph_constraints.js@2"))
-            .collect(Collectors.toList())
-            .toString(),
-        targets);
+    String[] targets = parsedJSON.get("Func(flowgraph_constraints.js@2)");
     String[] expected =
-        onWindows
-            ? new String[] {
-              "Var(flowgraph_constraints.js@2:26-42, [f1])",
-              "Var(flowgraph_constraints.js@1:1-90, %ssa_val 3)"
-            }
-            : new String[] {
-              "Var(flowgraph_constraints.js@2:25-41, [f1])",
-              "Var(flowgraph_constraints.js@1:0-89, %ssa_val 3)"
-            };
+        new String[] {
+          "Var(flowgraph_constraints.js@2, [f1])", "Var(flowgraph_constraints.js@1, %ssa_val 3)"
+        };
     Assert.assertArrayEquals(expected, targets);
   }
 
@@ -68,6 +50,8 @@ public class TestFlowGraphJSON {
                 DefaultSourceExtractor::new)
             .getFlowGraph();
     String json = fg.toJSON();
+    // Strip out character offsets, as they differ on Windows and make it hard to write assertions.
+    json = json.replaceAll(":[0-9]+-[0-9]+", "");
     System.err.println(json);
     Gson gson = new Gson();
     Type mapType = new TypeToken<Map<String, String[]>>() {}.getType();

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestFlowGraphJSON.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestFlowGraphJSON.java
@@ -12,6 +12,7 @@ import com.ibm.wala.util.WalaException;
 import java.lang.reflect.Type;
 import java.net.URL;
 import java.util.Map;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -27,11 +28,15 @@ public class TestFlowGraphJSON {
   }
 
   @Test
-  public void testBasic() throws WalaException, CancelException {}
-
-  //  @Test
-  //  public void testBasic2() throws WalaException, CancelException {
-  //  }
+  public void testNamedIIFE() {
+    String[] targets = parsedJSON.get("Func(flowgraph_constraints.js@2:25-41)");
+    Assert.assertArrayEquals(
+        new String[] {
+          "Var(flowgraph_constraints.js@2:25-41, [f1])",
+          "Var(flowgraph_constraints.js@1:0-89, %ssa_val 3)"
+        },
+        targets);
+  }
 
   private static Map<String, String[]> getParsedFlowGraphJSON(String script)
       throws WalaException, CancelException {

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestFlowGraphJSON.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestFlowGraphJSON.java
@@ -32,7 +32,7 @@ public class TestFlowGraphJSON {
   public void testNamedIIFE() {
     assertArrayEquals(
         new String[] {
-          "Var(flowgraph_constraints.js@2, [f1])", "Var(flowgraph_constraints.js@1, %ssa_val 13)"
+          "Var(flowgraph_constraints.js@2, [f1])", "Var(flowgraph_constraints.js@1, %ssa_val 18)"
         },
         parsedJSON.get("Func(flowgraph_constraints.js@2)"));
   }
@@ -51,8 +51,15 @@ public class TestFlowGraphJSON {
         },
         parsedJSON.get("Var(flowgraph_constraints.js@12, [x])"));
     assertArrayEquals(
-        new String[] {"Var(flowgraph_constraints.js@12, [y])"},
+        new String[] {
+          "Var(flowgraph_constraints.js@17, [y])", "Var(flowgraph_constraints.js@12, [y])"
+        },
         parsedJSON.get("Ret(Func(flowgraph_constraints.js@8))"));
+    assertArrayEquals(
+        new String[] {
+          "Param(Func(flowgraph_constraints.js@8), 2)", "Args(Func(flowgraph_constraints.js@8))"
+        },
+        parsedJSON.get("Var(flowgraph_constraints.js@17, [x])"));
   }
 
   private static Map<String, String[]> getParsedFlowGraphJSON(String script)

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestFlowGraphJSON.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestFlowGraphJSON.java
@@ -1,5 +1,7 @@
 package com.ibm.wala.cast.js.test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.junit.Assert.assertArrayEquals;
 
 import com.google.gson.Gson;
@@ -13,6 +15,7 @@ import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.WalaException;
 import java.lang.reflect.Type;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,21 +48,20 @@ public class TestFlowGraphJSON {
     assertArrayEquals(
         new String[] {"Ret(Func(flowgraph_constraints.js@8))"},
         parsedJSON.get("Var(flowgraph_constraints.js@8, [p])"));
-    assertArrayEquals(
-        new String[] {
-          "Param(Func(flowgraph_constraints.js@8), 2)", "Args(Func(flowgraph_constraints.js@8))"
-        },
-        parsedJSON.get("Var(flowgraph_constraints.js@12, [x])"));
-    assertArrayEquals(
-        new String[] {
-          "Var(flowgraph_constraints.js@17, [y])", "Var(flowgraph_constraints.js@12, [y])"
-        },
-        parsedJSON.get("Ret(Func(flowgraph_constraints.js@8))"));
-    assertArrayEquals(
-        new String[] {
-          "Param(Func(flowgraph_constraints.js@8), 2)", "Args(Func(flowgraph_constraints.js@8))"
-        },
-        parsedJSON.get("Var(flowgraph_constraints.js@17, [x])"));
+    assertThat(
+        Arrays.asList(parsedJSON.get("Var(flowgraph_constraints.js@12, [x])")),
+        containsInAnyOrder(
+            "Param(Func(flowgraph_constraints.js@8), 2)",
+            "Args(Func(flowgraph_constraints.js@8))"));
+    assertThat(
+        Arrays.asList(parsedJSON.get("Var(flowgraph_constraints.js@17, [x])")),
+        containsInAnyOrder(
+            "Param(Func(flowgraph_constraints.js@8), 2)",
+            "Args(Func(flowgraph_constraints.js@8))"));
+    assertThat(
+        Arrays.asList(parsedJSON.get("Ret(Func(flowgraph_constraints.js@8))")),
+        containsInAnyOrder(
+            "Var(flowgraph_constraints.js@17, [y])", "Var(flowgraph_constraints.js@12, [y])"));
   }
 
   private static Map<String, String[]> getParsedFlowGraphJSON(String script)

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestFlowGraphJSON.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestFlowGraphJSON.java
@@ -1,5 +1,7 @@
 package com.ibm.wala.cast.js.test;
 
+import static org.junit.Assert.assertArrayEquals;
+
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.ibm.wala.cast.js.callgraph.fieldbased.flowgraph.FlowGraph;
@@ -12,7 +14,6 @@ import com.ibm.wala.util.WalaException;
 import java.lang.reflect.Type;
 import java.net.URL;
 import java.util.Map;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -29,12 +30,29 @@ public class TestFlowGraphJSON {
 
   @Test
   public void testNamedIIFE() {
-    String[] targets = parsedJSON.get("Func(flowgraph_constraints.js@2)");
-    String[] expected =
+    assertArrayEquals(
         new String[] {
-          "Var(flowgraph_constraints.js@2, [f1])", "Var(flowgraph_constraints.js@1, %ssa_val 3)"
-        };
-    Assert.assertArrayEquals(expected, targets);
+          "Var(flowgraph_constraints.js@2, [f1])", "Var(flowgraph_constraints.js@1, %ssa_val 13)"
+        },
+        parsedJSON.get("Func(flowgraph_constraints.js@2)"));
+  }
+
+  @Test
+  public void testParamAndReturn() {
+    assertArrayEquals(
+        new String[] {"Var(flowgraph_constraints.js@8, [p])"},
+        parsedJSON.get("Param(Func(flowgraph_constraints.js@8), 2)"));
+    assertArrayEquals(
+        new String[] {"Ret(Func(flowgraph_constraints.js@8))"},
+        parsedJSON.get("Var(flowgraph_constraints.js@8, [p])"));
+    assertArrayEquals(
+        new String[] {
+          "Param(Func(flowgraph_constraints.js@8), 2)", "Args(Func(flowgraph_constraints.js@8))"
+        },
+        parsedJSON.get("Var(flowgraph_constraints.js@12, [x])"));
+    assertArrayEquals(
+        new String[] {"Var(flowgraph_constraints.js@12, [y])"},
+        parsedJSON.get("Ret(Func(flowgraph_constraints.js@8))"));
   }
 
   private static Map<String, String[]> getParsedFlowGraphJSON(String script)
@@ -52,7 +70,7 @@ public class TestFlowGraphJSON {
     String json = fg.toJSON();
     // Strip out character offsets, as they differ on Windows and make it hard to write assertions.
     json = json.replaceAll(":[0-9]+-[0-9]+", "");
-    System.err.println(json);
+    // System.err.println(json);
     Gson gson = new Gson();
     Type mapType = new TypeToken<Map<String, String[]>>() {}.getType();
     return gson.fromJson(json, mapType);

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestFlowGraphJSON.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestFlowGraphJSON.java
@@ -8,6 +8,7 @@ import com.ibm.wala.cast.js.translator.CAstRhinoTranslatorFactory;
 import com.ibm.wala.cast.js.util.FieldBasedCGUtil;
 import com.ibm.wala.cast.js.util.FieldBasedCGUtil.BuilderType;
 import com.ibm.wala.util.CancelException;
+import com.ibm.wala.util.PlatformUtil;
 import com.ibm.wala.util.WalaException;
 import java.lang.reflect.Type;
 import java.net.URL;
@@ -30,19 +31,28 @@ public class TestFlowGraphJSON {
 
   @Test
   public void testNamedIIFE() {
-    String[] targets = parsedJSON.get("Func(flowgraph_constraints.js@2:25-41)");
+    boolean onWindows = PlatformUtil.onWindows();
+    String[] targets =
+        onWindows
+            ? parsedJSON.get("Func(flowgraph_constraints.js@2:26-42)")
+            : parsedJSON.get("Func(flowgraph_constraints.js@2:25-41)");
     Assert.assertNotNull(
         parsedJSON.keySet().stream()
             .filter(s -> s.startsWith("Func(flowgraph_constraints.js@2"))
             .collect(Collectors.toList())
             .toString(),
         targets);
-    Assert.assertArrayEquals(
-        new String[] {
-          "Var(flowgraph_constraints.js@2:25-41, [f1])",
-          "Var(flowgraph_constraints.js@1:0-89, %ssa_val 3)"
-        },
-        targets);
+    String[] expected =
+        onWindows
+            ? new String[] {
+              "Var(flowgraph_constraints.js@2:26-42, [f1])",
+              "Var(flowgraph_constraints.js@1:1-90, %ssa_val 3)"
+            }
+            : new String[] {
+              "Var(flowgraph_constraints.js@2:25-41, [f1])",
+              "Var(flowgraph_constraints.js@1:0-89, %ssa_val 3)"
+            };
+    Assert.assertArrayEquals(expected, targets);
   }
 
   private static Map<String, String[]> getParsedFlowGraphJSON(String script)

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/FieldBasedCallGraphBuilder.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/FieldBasedCallGraphBuilder.java
@@ -110,8 +110,37 @@ public abstract class FieldBasedCallGraphBuilder {
   /** Build a flow graph for the program to be analysed. */
   public abstract FlowGraph buildFlowGraph(IProgressMonitor monitor) throws CancelException;
 
+  /** Full result of call graph computation */
+  public static class CallGraphResult {
+
+    private final JSCallGraph callGraph;
+
+    private final PointerAnalysis<ObjectVertex> pointerAnalysis;
+
+    private final FlowGraph flowGraph;
+
+    public CallGraphResult(
+        JSCallGraph callGraph, PointerAnalysis<ObjectVertex> pointerAnalysis, FlowGraph flowGraph) {
+      this.callGraph = callGraph;
+      this.pointerAnalysis = pointerAnalysis;
+      this.flowGraph = flowGraph;
+    }
+
+    public JSCallGraph getCallGraph() {
+      return callGraph;
+    }
+
+    public PointerAnalysis<ObjectVertex> getPointerAnalysis() {
+      return pointerAnalysis;
+    }
+
+    public FlowGraph getFlowGraph() {
+      return flowGraph;
+    }
+  }
+
   /** Main entry point: builds a flow graph, then extracts a call graph and returns it. */
-  public Pair<JSCallGraph, PointerAnalysis<ObjectVertex>> buildCallGraph(
+  public CallGraphResult buildCallGraph(
       Iterable<? extends Entrypoint> eps, IProgressMonitor monitor) throws CancelException {
     long fgBegin, fgEnd, cgBegin, cgEnd;
 
@@ -136,7 +165,7 @@ public abstract class FieldBasedCallGraphBuilder {
       System.out.println("call graph extraction took " + (cgEnd - cgBegin) / 1000.0 + " seconds");
     }
 
-    return Pair.make(cg, flowGraph.getPointerAnalysis(cg, cache, monitor));
+    return new CallGraphResult(cg, flowGraph.getPointerAnalysis(cg, cache, monitor), flowGraph);
   }
 
   /** Extract a call graph from a given flow graph. */

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/FlowGraph.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/FlowGraph.java
@@ -586,8 +586,8 @@ public class FlowGraph implements Iterable<Vertex> {
   }
 
   /**
-   * Converts flow graph to a JSON representation.  Keys of the JSON object are vertices,
-   * with each vertex mapped to its successors
+   * Converts flow graph to a JSON representation. Keys of the JSON object are vertices, with each
+   * vertex mapped to its successors
    */
   public String toJSON() {
     Map<String, Set<String>> edges = new LinkedHashMap<>();

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/FlowGraph.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/FlowGraph.java
@@ -59,6 +59,7 @@ import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.collections.Iterator2Iterable;
 import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.util.graph.Graph;
+import com.ibm.wala.util.graph.GraphPrint;
 import com.ibm.wala.util.graph.GraphReachability;
 import com.ibm.wala.util.graph.GraphSlicer;
 import com.ibm.wala.util.graph.NumberedGraph;
@@ -579,5 +580,9 @@ public class FlowGraph implements Iterable<Vertex> {
         return null;
       }
     };
+  }
+
+  public String toJSON() {
+    return GraphPrint.graphToJSON(graph);
   }
 }

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/FlowGraph.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/FlowGraph.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.cast.js.callgraph.fieldbased.flowgraph;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.ibm.wala.analysis.pointers.HeapGraph;
 import com.ibm.wala.cast.ipa.callgraph.AstHeapModel;
 import com.ibm.wala.cast.ir.ssa.AstGlobalWrite;
@@ -57,6 +59,7 @@ import com.ibm.wala.util.collections.CompoundIterator;
 import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.collections.Iterator2Iterable;
+import com.ibm.wala.util.collections.MapUtil;
 import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.util.graph.Graph;
 import com.ibm.wala.util.graph.GraphPrint;
@@ -71,6 +74,7 @@ import com.ibm.wala.util.intset.OrdinalSet;
 import com.ibm.wala.util.intset.OrdinalSetMapping;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -583,6 +587,15 @@ public class FlowGraph implements Iterable<Vertex> {
   }
 
   public String toJSON() {
-    return GraphPrint.graphToJSON(graph);
+    Map<String, Set<String>> edges = new LinkedHashMap<>();
+    for (Vertex node : graph) {
+      String nodeStr = node.toString();
+      Set<String> succs = MapUtil.findOrCreateSet(edges, nodeStr);
+      for (Vertex succ : Iterator2Iterable.make(graph.getSuccNodes(node))) {
+        succs.add(succ.toString());
+      }
+    }
+    Gson gson = new GsonBuilder().setPrettyPrinting().create();
+    return gson.toJson(edges);
   }
 }

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/FlowGraph.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/FlowGraph.java
@@ -15,6 +15,7 @@ import com.google.gson.GsonBuilder;
 import com.ibm.wala.analysis.pointers.HeapGraph;
 import com.ibm.wala.cast.ipa.callgraph.AstHeapModel;
 import com.ibm.wala.cast.ir.ssa.AstGlobalWrite;
+import com.ibm.wala.cast.ir.ssa.AstIRFactory;
 import com.ibm.wala.cast.ir.ssa.AstPropertyWrite;
 import com.ibm.wala.cast.js.callgraph.fieldbased.flowgraph.vertices.AbstractVertexVisitor;
 import com.ibm.wala.cast.js.callgraph.fieldbased.flowgraph.vertices.CreationSiteVertex;
@@ -37,6 +38,7 @@ import com.ibm.wala.classLoader.IField;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.classLoader.NewSiteReference;
 import com.ibm.wala.classLoader.ProgramCounter;
+import com.ibm.wala.ipa.callgraph.AnalysisCacheImpl;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.ibm.wala.ipa.callgraph.IAnalysisCacheView;
@@ -590,12 +592,13 @@ public class FlowGraph implements Iterable<Vertex> {
    * vertex mapped to its successors
    */
   public String toJSON() {
+    IAnalysisCacheView cache = new AnalysisCacheImpl(AstIRFactory.makeDefaultFactory());
     Map<String, Set<String>> edges = new LinkedHashMap<>();
     for (Vertex node : graph) {
-      String nodeStr = node.toString();
+      String nodeStr = node.toSourceLevelString(cache);
       Set<String> succs = MapUtil.findOrCreateSet(edges, nodeStr);
       for (Vertex succ : Iterator2Iterable.make(graph.getSuccNodes(node))) {
-        succs.add(succ.toString());
+        succs.add(succ.toSourceLevelString(cache));
       }
     }
     Gson gson = new GsonBuilder().setPrettyPrinting().create();

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/FlowGraph.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/FlowGraph.java
@@ -75,7 +75,6 @@ import com.ibm.wala.util.intset.OrdinalSet;
 import com.ibm.wala.util.intset.OrdinalSetMapping;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -593,7 +592,7 @@ public class FlowGraph implements Iterable<Vertex> {
    */
   public String toJSON() {
     IAnalysisCacheView cache = new AnalysisCacheImpl(AstIRFactory.makeDefaultFactory());
-    Map<String, Set<String>> edges = new LinkedHashMap<>();
+    Map<String, Set<String>> edges = HashMapFactory.make();
     for (Vertex node : graph) {
       String nodeStr = node.toSourceLevelString(cache);
       Set<String> succs = MapUtil.findOrCreateSet(edges, nodeStr);
@@ -601,7 +600,14 @@ public class FlowGraph implements Iterable<Vertex> {
         succs.add(succ.toSourceLevelString(cache));
       }
     }
+    // filter out empty entries
+    Map<String, Set<String>> filtered = HashMapFactory.make();
+    for (Map.Entry<String, Set<String>> entry : edges.entrySet()) {
+      if (!entry.getValue().isEmpty()) {
+        filtered.put(entry.getKey(), entry.getValue());
+      }
+    }
     Gson gson = new GsonBuilder().setPrettyPrinting().create();
-    return gson.toJson(edges);
+    return gson.toJson(filtered);
   }
 }

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/FlowGraph.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/FlowGraph.java
@@ -585,6 +585,10 @@ public class FlowGraph implements Iterable<Vertex> {
     };
   }
 
+  /**
+   * Converts flow graph to a JSON representation.  Keys of the JSON object are vertices,
+   * with each vertex mapped to its successors
+   */
   public String toJSON() {
     Map<String, Set<String>> edges = new LinkedHashMap<>();
     for (Vertex node : graph) {

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/FlowGraph.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/FlowGraph.java
@@ -62,7 +62,6 @@ import com.ibm.wala.util.collections.Iterator2Iterable;
 import com.ibm.wala.util.collections.MapUtil;
 import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.util.graph.Graph;
-import com.ibm.wala.util.graph.GraphPrint;
 import com.ibm.wala.util.graph.GraphReachability;
 import com.ibm.wala.util.graph.GraphSlicer;
 import com.ibm.wala.util.graph.NumberedGraph;

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/ArgVertex.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/ArgVertex.java
@@ -10,6 +10,7 @@
  */
 package com.ibm.wala.cast.js.callgraph.fieldbased.flowgraph.vertices;
 
+import com.ibm.wala.ipa.callgraph.IAnalysisCacheView;
 import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
 
 /**
@@ -36,5 +37,10 @@ public class ArgVertex extends Vertex implements PointerKey {
   @Override
   public String toString() {
     return "Args(" + func + ')';
+  }
+
+  @Override
+  public String toSourceLevelString(IAnalysisCacheView cache) {
+    return "Args(" + func.toSourceLevelString(cache) + ')';
   }
 }

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/CallVertex.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/CallVertex.java
@@ -12,7 +12,6 @@ package com.ibm.wala.cast.js.callgraph.fieldbased.flowgraph.vertices;
 
 import com.ibm.wala.cast.js.ssa.JavaScriptInvoke;
 import com.ibm.wala.cast.js.types.JavaScriptMethods;
-import com.ibm.wala.cast.js.util.CallGraph2JSON;
 import com.ibm.wala.cast.loader.AstMethod;
 import com.ibm.wala.cast.types.AstMethodReference;
 import com.ibm.wala.classLoader.CallSiteReference;
@@ -71,8 +70,6 @@ public class CallVertex extends Vertex {
   public String toSourceLevelString(IAnalysisCacheView cache) {
     IClass concreteType = func.getConcreteType();
     AstMethod method = (AstMethod) concreteType.getMethod(AstMethodReference.fnSelector);
-    return "Callee("
-        + CallGraph2JSON.ppPos(method.getSourcePosition(site.getProgramCounter()))
-        + ")";
+    return "Callee(" + method.getSourcePosition(site.getProgramCounter()).prettyPrint() + ")";
   }
 }

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/CallVertex.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/CallVertex.java
@@ -12,7 +12,12 @@ package com.ibm.wala.cast.js.callgraph.fieldbased.flowgraph.vertices;
 
 import com.ibm.wala.cast.js.ssa.JavaScriptInvoke;
 import com.ibm.wala.cast.js.types.JavaScriptMethods;
+import com.ibm.wala.cast.js.util.CallGraph2JSON;
+import com.ibm.wala.cast.loader.AstMethod;
+import com.ibm.wala.cast.types.AstMethodReference;
 import com.ibm.wala.classLoader.CallSiteReference;
+import com.ibm.wala.classLoader.IClass;
+import com.ibm.wala.ipa.callgraph.IAnalysisCacheView;
 
 /**
  * A call vertex represents the possible callees of a function call or {@code new} expression.
@@ -60,5 +65,14 @@ public class CallVertex extends Vertex {
   @Override
   public String toString() {
     return "Callee(" + func + ", " + site + ')';
+  }
+
+  @Override
+  public String toSourceLevelString(IAnalysisCacheView cache) {
+    IClass concreteType = func.getConcreteType();
+    AstMethod method = (AstMethod) concreteType.getMethod(AstMethodReference.fnSelector);
+    return "Callee("
+        + CallGraph2JSON.ppPos(method.getSourcePosition(site.getProgramCounter()))
+        + ")";
   }
 }

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/FuncVertex.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/FuncVertex.java
@@ -13,11 +13,15 @@ package com.ibm.wala.cast.js.callgraph.fieldbased.flowgraph.vertices;
 import com.ibm.wala.cast.js.ipa.summaries.JavaScriptConstructorFunctions.JavaScriptConstructor;
 import com.ibm.wala.cast.js.types.JavaScriptMethods;
 import com.ibm.wala.cast.js.types.JavaScriptTypes;
+import com.ibm.wala.cast.js.util.CallGraph2JSON;
+import com.ibm.wala.cast.loader.AstMethod;
+import com.ibm.wala.cast.types.AstMethodReference;
 import com.ibm.wala.classLoader.CallSiteReference;
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.NewSiteReference;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.CallGraph;
+import com.ibm.wala.ipa.callgraph.IAnalysisCacheView;
 import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.util.collections.EmptyIterator;
 import com.ibm.wala.util.collections.NonNullSingletonIterator;
@@ -88,5 +92,15 @@ public class FuncVertex extends Vertex implements ObjectVertex {
   @Override
   public IClass getConcreteType() {
     return klass;
+  }
+
+  @Override
+  public String toSourceLevelString(IAnalysisCacheView cache) {
+    AstMethod method = (AstMethod) klass.getMethod(AstMethodReference.fnSelector);
+    if (method != null) {
+      return "Func(" + CallGraph2JSON.ppPos(method.getSourcePosition()) + ")";
+    } else {
+      return toString();
+    }
   }
 }

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/FuncVertex.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/FuncVertex.java
@@ -13,7 +13,6 @@ package com.ibm.wala.cast.js.callgraph.fieldbased.flowgraph.vertices;
 import com.ibm.wala.cast.js.ipa.summaries.JavaScriptConstructorFunctions.JavaScriptConstructor;
 import com.ibm.wala.cast.js.types.JavaScriptMethods;
 import com.ibm.wala.cast.js.types.JavaScriptTypes;
-import com.ibm.wala.cast.js.util.CallGraph2JSON;
 import com.ibm.wala.cast.loader.AstMethod;
 import com.ibm.wala.cast.types.AstMethodReference;
 import com.ibm.wala.classLoader.CallSiteReference;
@@ -98,7 +97,7 @@ public class FuncVertex extends Vertex implements ObjectVertex {
   public String toSourceLevelString(IAnalysisCacheView cache) {
     AstMethod method = (AstMethod) klass.getMethod(AstMethodReference.fnSelector);
     if (method != null) {
-      return "Func(" + CallGraph2JSON.ppPos(method.getSourcePosition()) + ")";
+      return "Func(" + method.getSourcePosition().prettyPrint() + ")";
     } else {
       return toString();
     }

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/ParamVertex.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/ParamVertex.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.cast.js.callgraph.fieldbased.flowgraph.vertices;
 
+import com.ibm.wala.ipa.callgraph.IAnalysisCacheView;
+
 /**
  * A parameter vertex represents a positional parameter of a function. It doesn't necessarily need
  * to correspond to a named parameter.
@@ -47,5 +49,10 @@ public class ParamVertex extends Vertex {
   @Override
   public String toString() {
     return "Param(" + func + ", " + index + ')';
+  }
+
+  @Override
+  public String toSourceLevelString(IAnalysisCacheView cache) {
+    return "Param(" + func.toSourceLevelString(cache) + ", " + index + ')';
   }
 }

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/RetVertex.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/RetVertex.java
@@ -10,6 +10,7 @@
  */
 package com.ibm.wala.cast.js.callgraph.fieldbased.flowgraph.vertices;
 
+import com.ibm.wala.ipa.callgraph.IAnalysisCacheView;
 import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
 
 /**
@@ -36,5 +37,10 @@ public class RetVertex extends Vertex implements PointerKey {
   @Override
   public String toString() {
     return "Ret(" + func + ')';
+  }
+
+  @Override
+  public String toSourceLevelString(IAnalysisCacheView cache) {
+    return "Ret(" + func.toSourceLevelString(cache) + ')';
   }
 }

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/VarVertex.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/VarVertex.java
@@ -10,7 +10,6 @@
  */
 package com.ibm.wala.cast.js.callgraph.fieldbased.flowgraph.vertices;
 
-import com.ibm.wala.cast.js.util.CallGraph2JSON;
 import com.ibm.wala.cast.loader.AstMethod;
 import com.ibm.wala.cast.types.AstMethodReference;
 import com.ibm.wala.classLoader.IClass;
@@ -57,7 +56,7 @@ public final class VarVertex extends Vertex implements PointerKey {
     IClass concreteType = func.getConcreteType();
     AstMethod method = (AstMethod) concreteType.getMethod(AstMethodReference.fnSelector);
     IR ir = cache.getIR(method);
-    String methodPos = CallGraph2JSON.ppPos(method.getSourcePosition());
+    String methodPos = method.getSourcePosition().prettyPrint();
     // we rely on the fact that the CAst IR ignores the index position!
     String[] localNames = ir.getLocalNames(0, valueNumber);
     StringBuilder result = new StringBuilder("Var(" + methodPos + ", ");

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/VarVertex.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/VarVertex.java
@@ -10,7 +10,14 @@
  */
 package com.ibm.wala.cast.js.callgraph.fieldbased.flowgraph.vertices;
 
+import com.ibm.wala.cast.js.util.CallGraph2JSON;
+import com.ibm.wala.cast.loader.AstMethod;
+import com.ibm.wala.cast.types.AstMethodReference;
+import com.ibm.wala.classLoader.IClass;
+import com.ibm.wala.ipa.callgraph.IAnalysisCacheView;
 import com.ibm.wala.ipa.callgraph.propagation.PointerKey;
+import com.ibm.wala.ssa.IR;
+import java.util.Arrays;
 
 /**
  * A variable vertex represents an SSA variable inside a given function.
@@ -42,5 +49,24 @@ public final class VarVertex extends Vertex implements PointerKey {
   @Override
   public String toString() {
     return "Var(" + func + ", " + valueNumber + ')';
+  }
+
+  @Override
+  public String toSourceLevelString(IAnalysisCacheView cache) {
+    // we want to get a variable name rather than a value number
+    IClass concreteType = func.getConcreteType();
+    AstMethod method = (AstMethod) concreteType.getMethod(AstMethodReference.fnSelector);
+    IR ir = cache.getIR(method);
+    String methodPos = CallGraph2JSON.ppPos(method.getSourcePosition());
+    // we rely on the fact that the CAst IR ignores the index position!
+    String[] localNames = ir.getLocalNames(0, valueNumber);
+    StringBuilder result = new StringBuilder("Var(" + methodPos + ", ");
+    if (localNames != null && localNames.length > 0) {
+      result.append(Arrays.toString(localNames));
+    } else {
+      result.append("%ssa_val " + valueNumber);
+    }
+    result.append(")");
+    return result.toString();
   }
 }

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/VarVertex.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/VarVertex.java
@@ -59,11 +59,11 @@ public final class VarVertex extends Vertex implements PointerKey {
     String methodPos = method.getSourcePosition().prettyPrint();
     // we rely on the fact that the CAst IR ignores the index position!
     String[] localNames = ir.getLocalNames(0, valueNumber);
-    StringBuilder result = new StringBuilder("Var(" + methodPos + ", ");
+    StringBuilder result = new StringBuilder("Var(").append(methodPos).append(", ");
     if (localNames != null && localNames.length > 0) {
       result.append(Arrays.toString(localNames));
     } else {
-      result.append("%ssa_val " + valueNumber);
+      result.append("%ssa_val ").append(valueNumber);
     }
     result.append(")");
     return result.toString();

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/Vertex.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/Vertex.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.cast.js.callgraph.fieldbased.flowgraph.vertices;
 
+import com.ibm.wala.ipa.callgraph.IAnalysisCacheView;
+
 /**
  * Class representing a flow graph vertex. Vertices should never be instantiated directly, but
  * rather generated through a {@link VertexFactory}.
@@ -18,4 +20,13 @@ package com.ibm.wala.cast.js.callgraph.fieldbased.flowgraph.vertices;
  */
 public abstract class Vertex {
   public abstract <T> T accept(VertexVisitor<T> visitor);
+
+  /**
+   * If possible, returns a String representation of {@code this} that refers to source-level
+   * entities rather thatn WALA-internal ones (e.g., source-level variable names rather than SSA
+   * value numbers). By default, just returns the results of {@link #toString()}
+   */
+  public String toSourceLevelString(@SuppressWarnings("unused") IAnalysisCacheView cache) {
+    return toString();
+  }
 }

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/client/JavaScriptAnalysisEngine.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/client/JavaScriptAnalysisEngine.java
@@ -13,12 +13,12 @@ package com.ibm.wala.cast.js.client;
 import com.ibm.wala.cast.ipa.callgraph.CAstAnalysisScope;
 import com.ibm.wala.cast.ir.ssa.AstIRFactory;
 import com.ibm.wala.cast.js.callgraph.fieldbased.FieldBasedCallGraphBuilder;
+import com.ibm.wala.cast.js.callgraph.fieldbased.FieldBasedCallGraphBuilder.CallGraphResult;
 import com.ibm.wala.cast.js.callgraph.fieldbased.OptimisticCallgraphBuilder;
 import com.ibm.wala.cast.js.callgraph.fieldbased.PessimisticCallGraphBuilder;
 import com.ibm.wala.cast.js.callgraph.fieldbased.flowgraph.vertices.ObjectVertex;
 import com.ibm.wala.cast.js.client.impl.ZeroCFABuilderFactory;
 import com.ibm.wala.cast.js.ipa.callgraph.JSAnalysisOptions;
-import com.ibm.wala.cast.js.ipa.callgraph.JSCallGraph;
 import com.ibm.wala.cast.js.ipa.callgraph.JSCallGraphUtil;
 import com.ibm.wala.cast.js.ipa.callgraph.JSZeroOrOneXCFABuilder;
 import com.ibm.wala.cast.js.ipa.callgraph.JavaScriptEntryPoints;
@@ -45,7 +45,6 @@ import com.ibm.wala.ipa.cha.SeqClassHierarchyFactory;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.MonitorUtil.IProgressMonitor;
 import com.ibm.wala.util.collections.HashSetFactory;
-import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.util.debug.Assertions;
 import java.util.Collections;
 import java.util.Set;
@@ -162,15 +161,15 @@ public abstract class JavaScriptAnalysisEngine<I extends InstanceKey>
         @Override
         public CallGraph makeCallGraph(AnalysisOptions options, IProgressMonitor monitor)
             throws IllegalArgumentException, CallGraphBuilderCancelException {
-          Pair<JSCallGraph, PointerAnalysis<ObjectVertex>> dat;
+          CallGraphResult result;
           try {
-            dat = builder.buildCallGraph(options.getEntrypoints(), monitor);
+            result = builder.buildCallGraph(options.getEntrypoints(), monitor);
           } catch (CancelException e) {
             throw CallGraphBuilderCancelException.createCallGraphBuilderCancelException(
                 e, null, null);
           }
-          ptr = dat.snd;
-          return dat.fst;
+          ptr = result.getPointerAnalysis();
+          return result.getCallGraph();
         }
 
         @Override

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/CallGraph2JSON.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/CallGraph2JSON.java
@@ -15,7 +15,6 @@ import com.google.gson.GsonBuilder;
 import com.ibm.wala.cast.js.loader.JavaScriptLoader;
 import com.ibm.wala.cast.js.types.JavaScriptMethods;
 import com.ibm.wala.cast.loader.AstMethod;
-import com.ibm.wala.cast.tree.CAstSourcePositionMap.Position;
 import com.ibm.wala.cast.types.AstMethodReference;
 import com.ibm.wala.classLoader.CallSiteReference;
 import com.ibm.wala.classLoader.IMethod;
@@ -135,7 +134,7 @@ public class CallGraph2JSON {
       result = getNativeMethodName(method);
     } else {
       AstMethod astMethod = (AstMethod) method;
-      result = ppPos(astMethod.getSourcePosition());
+      result = astMethod.getSourcePosition().prettyPrint();
     }
     if (exposeContexts) {
       result += getContextString(context);
@@ -168,7 +167,7 @@ public class CallGraph2JSON {
       result = getNativeMethodName(method);
     } else {
       AstMethod astMethod = (AstMethod) method;
-      result = ppPos(astMethod.getSourcePosition(site.getProgramCounter()));
+      result = astMethod.getSourcePosition(site.getProgramCounter()).prettyPrint();
     }
     if (exposeContexts) {
       result += getContextString(context);
@@ -214,22 +213,6 @@ public class CallGraph2JSON {
       }
     }
     return false;
-  }
-
-  /**
-   * Pretty print a source position
-   *
-   * @param pos the position
-   * @return pretty-printed string representation
-   */
-  public static String ppPos(Position pos) {
-    String file = pos.getURL().getFile();
-    file = file.substring(file.lastIndexOf('/') + 1);
-
-    int line = pos.getFirstLine(),
-        start_offset = pos.getFirstOffset(),
-        end_offset = pos.getLastOffset();
-    return file + '@' + line + ':' + start_offset + '-' + end_offset;
   }
 
   /**

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/CallGraph2JSON.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/CallGraph2JSON.java
@@ -23,7 +23,7 @@ import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.collections.Iterator2Iterable;
 import com.ibm.wala.util.collections.MapUtil;
 import com.ibm.wala.util.collections.Util;
-import java.util.ArrayList;
+import com.ibm.wala.util.graph.GraphPrint;
 import java.util.Map;
 import java.util.Set;
 
@@ -68,7 +68,7 @@ public class CallGraph2JSON {
 
   public String serialize(CallGraph cg) {
     Map<String, Set<String>> edges = extractEdges(cg);
-    return toJSON(edges);
+    return GraphPrint.toJSON(edges);
   }
 
   public Map<String, Set<String>> extractEdges(CallGraph cg) {
@@ -177,42 +177,5 @@ public class CallGraph2JSON {
         start_offset = pos.getFirstOffset(),
         end_offset = pos.getLastOffset();
     return file + '@' + line + ':' + start_offset + '-' + end_offset;
-  }
-
-  public static String toJSON(Map<String, Set<String>> map) {
-    StringBuilder res = new StringBuilder();
-    res.append("{\n");
-    res.append(
-        joinWith(
-            Util.mapToSet(
-                map.entrySet(),
-                e -> {
-                  StringBuilder res1 = new StringBuilder();
-                  if (e.getValue().size() > 0) {
-                    res1.append("    \"").append(e.getKey()).append("\": [\n");
-                    res1.append(
-                        joinWith(
-                            Util.mapToSet(e.getValue(), str -> "        \"" + str + '"'), ",\n"));
-                    res1.append("\n    ]");
-                  }
-                  return res1.length() == 0 ? null : res1.toString();
-                }),
-            ",\n"));
-    res.append("\n}");
-    return res.toString();
-  }
-
-  private static String joinWith(Iterable<String> lst, String sep) {
-    StringBuilder res = new StringBuilder();
-    ArrayList<String> strings = new ArrayList<>();
-    for (String s : lst) if (s != null) strings.add(s);
-
-    boolean fst = true;
-    for (String s : strings) {
-      if (fst) fst = false;
-      else res.append(sep);
-      res.append(s);
-    }
-    return res.toString();
   }
 }

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/CallGraph2JSON.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/CallGraph2JSON.java
@@ -218,6 +218,7 @@ public class CallGraph2JSON {
 
   /**
    * Pretty print a source position
+   *
    * @param pos the position
    * @return pretty-printed string representation
    */

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/CallGraph2JSON.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/CallGraph2JSON.java
@@ -216,7 +216,12 @@ public class CallGraph2JSON {
     return false;
   }
 
-  private static String ppPos(Position pos) {
+  /**
+   * Pretty print a source position
+   * @param pos the position
+   * @return pretty-printed string representation
+   */
+  public static String ppPos(Position pos) {
     String file = pos.getURL().getFile();
     file = file.substring(file.lastIndexOf('/') + 1);
 

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/FieldBasedCGUtil.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/FieldBasedCGUtil.java
@@ -17,11 +17,9 @@ import com.ibm.wala.cast.js.callgraph.fieldbased.FieldBasedCallGraphBuilder.Call
 import com.ibm.wala.cast.js.callgraph.fieldbased.OptimisticCallgraphBuilder;
 import com.ibm.wala.cast.js.callgraph.fieldbased.PessimisticCallGraphBuilder;
 import com.ibm.wala.cast.js.callgraph.fieldbased.WorklistBasedOptimisticCallgraphBuilder;
-import com.ibm.wala.cast.js.callgraph.fieldbased.flowgraph.vertices.ObjectVertex;
 import com.ibm.wala.cast.js.html.JSSourceExtractor;
 import com.ibm.wala.cast.js.html.WebPageLoaderFactory;
 import com.ibm.wala.cast.js.ipa.callgraph.JSAnalysisOptions;
-import com.ibm.wala.cast.js.ipa.callgraph.JSCallGraph;
 import com.ibm.wala.cast.js.ipa.callgraph.JSCallGraphUtil;
 import com.ibm.wala.cast.js.loader.JavaScriptLoader;
 import com.ibm.wala.cast.js.loader.JavaScriptLoaderFactory;
@@ -32,14 +30,12 @@ import com.ibm.wala.classLoader.SourceURLModule;
 import com.ibm.wala.ipa.callgraph.AnalysisCacheImpl;
 import com.ibm.wala.ipa.callgraph.Entrypoint;
 import com.ibm.wala.ipa.callgraph.IAnalysisCacheView;
-import com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis;
 import com.ibm.wala.ipa.cha.ClassHierarchyFactory;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.MonitorUtil.IProgressMonitor;
 import com.ibm.wala.util.NullProgressMonitor;
 import com.ibm.wala.util.WalaException;
-import com.ibm.wala.util.collections.Pair;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -106,7 +102,7 @@ public class FieldBasedCGUtil {
     this.translatorFactory = translatorFactory;
   }
 
-  public Pair<JSCallGraph, PointerAnalysis<ObjectVertex>> buildCG(
+  public CallGraphResult buildCG(
       URL url,
       BuilderType builderType,
       boolean supportFullPointerAnalysis,
@@ -116,7 +112,7 @@ public class FieldBasedCGUtil {
         url, builderType, new NullProgressMonitor(), supportFullPointerAnalysis, fExtractor);
   }
 
-  public Pair<JSCallGraph, PointerAnalysis<ObjectVertex>> buildCG(
+  public CallGraphResult buildCG(
       URL url,
       BuilderType builderType,
       IProgressMonitor monitor,
@@ -130,7 +126,7 @@ public class FieldBasedCGUtil {
     }
   }
 
-  public Pair<JSCallGraph, PointerAnalysis<ObjectVertex>> buildScriptCG(
+  public CallGraphResult buildScriptCG(
       URL url,
       BuilderType builderType,
       IProgressMonitor monitor,
@@ -146,7 +142,7 @@ public class FieldBasedCGUtil {
    * Construct a field-based call graph using all the {@code .js} files appearing in scriptDir or
    * any of its sub-directories
    */
-  public Pair<JSCallGraph, PointerAnalysis<ObjectVertex>> buildScriptDirCG(
+  public CallGraphResult buildScriptDirCG(
       Path scriptDir,
       BuilderType builderType,
       IProgressMonitor monitor,
@@ -168,7 +164,7 @@ public class FieldBasedCGUtil {
         loaders, scripts.toArray(new Module[0]), builderType, monitor, supportFullPointerAnalysis);
   }
 
-  public Pair<JSCallGraph, PointerAnalysis<ObjectVertex>> buildTestCG(
+  public CallGraphResult buildTestCG(
       String dir,
       String name,
       BuilderType builderType,
@@ -180,7 +176,7 @@ public class FieldBasedCGUtil {
     return buildCG(loaders, scripts, builderType, monitor, supportFullPointerAnalysis);
   }
 
-  public Pair<JSCallGraph, PointerAnalysis<ObjectVertex>> buildPageCG(
+  public CallGraphResult buildPageCG(
       URL url,
       BuilderType builderType,
       IProgressMonitor monitor,
@@ -192,7 +188,7 @@ public class FieldBasedCGUtil {
     return buildCG(loaders, scripts, builderType, monitor, supportFullPointerAnalysis);
   }
 
-  public Pair<JSCallGraph, PointerAnalysis<ObjectVertex>> buildCG(
+  public CallGraphResult buildCG(
       JavaScriptLoaderFactory loaders,
       Module[] scripts,
       BuilderType builderType,
@@ -208,8 +204,7 @@ public class FieldBasedCGUtil {
     final FieldBasedCallGraphBuilder builder =
         builderType.fieldBasedCallGraphBuilderFactory(
             cha, JSCallGraphUtil.makeOptions(scope, cha, roots), cache, supportFullPointerAnalysis);
-    CallGraphResult result = builder.buildCallGraph(roots, monitor);
-    return Pair.make(result.getCallGraph(), result.getPointerAnalysis());
+    return builder.buildCallGraph(roots, monitor);
   }
 
   /*

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/FieldBasedCGUtil.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/FieldBasedCGUtil.java
@@ -13,6 +13,7 @@ package com.ibm.wala.cast.js.util;
 import com.ibm.wala.cast.ipa.callgraph.CAstAnalysisScope;
 import com.ibm.wala.cast.ir.ssa.AstIRFactory;
 import com.ibm.wala.cast.js.callgraph.fieldbased.FieldBasedCallGraphBuilder;
+import com.ibm.wala.cast.js.callgraph.fieldbased.FieldBasedCallGraphBuilder.CallGraphResult;
 import com.ibm.wala.cast.js.callgraph.fieldbased.OptimisticCallgraphBuilder;
 import com.ibm.wala.cast.js.callgraph.fieldbased.PessimisticCallGraphBuilder;
 import com.ibm.wala.cast.js.callgraph.fieldbased.WorklistBasedOptimisticCallgraphBuilder;
@@ -176,7 +177,8 @@ public class FieldBasedCGUtil {
     final FieldBasedCallGraphBuilder builder =
         builderType.fieldBasedCallGraphBuilderFactory(
             cha, JSCallGraphUtil.makeOptions(scope, cha, roots), cache, supportFullPointerAnalysis);
-    return builder.buildCallGraph(roots, monitor);
+    CallGraphResult result = builder.buildCallGraph(roots, monitor);
+    return Pair.make(result.getCallGraph(), result.getPointerAnalysis());
   }
 
   /*

--- a/com.ibm.wala.cast.js/src/test/resources/tests/fieldbased/flowgraph_constraints.js
+++ b/com.ibm.wala.cast.js/src/test/resources/tests/fieldbased/flowgraph_constraints.js
@@ -1,0 +1,5 @@
+// IIFE, named function
+(function f1() {})();
+
+// IIFE, anon function
+(function () {})();

--- a/com.ibm.wala.cast.js/src/test/resources/tests/fieldbased/flowgraph_constraints.js
+++ b/com.ibm.wala.cast.js/src/test/resources/tests/fieldbased/flowgraph_constraints.js
@@ -3,3 +3,13 @@
 
 // IIFE, anon function
 (function () {})();
+
+// parameters and returns
+function id(p) {
+  return p;
+}
+
+function callId() {
+  var x = {};
+  var y = id(x);
+}

--- a/com.ibm.wala.cast.js/src/test/resources/tests/fieldbased/flowgraph_constraints.js
+++ b/com.ibm.wala.cast.js/src/test/resources/tests/fieldbased/flowgraph_constraints.js
@@ -13,3 +13,9 @@ function callId() {
   var x = {};
   var y = id(x);
 }
+
+function callIdHigherOrder() {
+  var fp = id;
+  var x = {};
+  var y = fp(x);
+}

--- a/com.ibm.wala.cast.js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestPointerAnalyses.java
+++ b/com.ibm.wala.cast.js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestPointerAnalyses.java
@@ -14,6 +14,7 @@ import com.ibm.wala.analysis.pointers.HeapGraph;
 import com.ibm.wala.cast.ipa.callgraph.GlobalObjectKey;
 import com.ibm.wala.cast.ir.ssa.AstGlobalWrite;
 import com.ibm.wala.cast.ir.ssa.AstPropertyWrite;
+import com.ibm.wala.cast.js.callgraph.fieldbased.FieldBasedCallGraphBuilder.CallGraphResult;
 import com.ibm.wala.cast.js.callgraph.fieldbased.flowgraph.vertices.GlobalVertex;
 import com.ibm.wala.cast.js.callgraph.fieldbased.flowgraph.vertices.ObjectVertex;
 import com.ibm.wala.cast.js.callgraph.fieldbased.flowgraph.vertices.PrototypeFieldVertex;
@@ -21,7 +22,6 @@ import com.ibm.wala.cast.js.callgraph.fieldbased.flowgraph.vertices.PrototypeFie
 import com.ibm.wala.cast.js.html.DefaultSourceExtractor;
 import com.ibm.wala.cast.js.html.JSSourceExtractor;
 import com.ibm.wala.cast.js.ipa.callgraph.JSCFABuilder;
-import com.ibm.wala.cast.js.ipa.callgraph.JSCallGraph;
 import com.ibm.wala.cast.js.ipa.callgraph.JSCallGraphUtil;
 import com.ibm.wala.cast.js.ipa.callgraph.TransitivePrototypeKey;
 import com.ibm.wala.cast.js.ipa.summaries.JavaScriptConstructorFunctions.JavaScriptConstructor;
@@ -181,14 +181,14 @@ public abstract class TestPointerAnalyses {
       throws WalaException, CancelException {
     try (ExtractingToPredictableFileNames predictable = new ExtractingToPredictableFileNames()) {
       FieldBasedCGUtil fb = new FieldBasedCGUtil(factory);
-      Pair<JSCallGraph, PointerAnalysis<ObjectVertex>> fbResult =
+      CallGraphResult fbResult =
           fb.buildCG(page, BuilderType.OPTIMISTIC, true, DefaultSourceExtractor.factory);
 
       JSCFABuilder propagationBuilder = JSCallGraphBuilderUtil.makeHTMLCGBuilder(page);
       CallGraph propCG = propagationBuilder.makeCallGraph(propagationBuilder.getOptions());
       PointerAnalysis<InstanceKey> propPA = propagationBuilder.getPointerAnalysis();
 
-      test(filter, test, fbResult.fst, fbResult.snd, propCG, propPA);
+      test(filter, test, fbResult.getCallGraph(), fbResult.getPointerAnalysis(), propCG, propPA);
     }
   }
 
@@ -204,14 +204,14 @@ public abstract class TestPointerAnalyses {
       JSSourceExtractor.USE_TEMP_NAME = false;
 
       FieldBasedCGUtil fb = new FieldBasedCGUtil(factory);
-      Pair<JSCallGraph, PointerAnalysis<ObjectVertex>> fbResult =
+      CallGraphResult fbResult =
           fb.buildTestCG(dir, name, BuilderType.OPTIMISTIC, new NullProgressMonitor(), true);
 
       JSCFABuilder propagationBuilder = JSCallGraphBuilderUtil.makeScriptCGBuilder(dir, name);
       CallGraph propCG = propagationBuilder.makeCallGraph(propagationBuilder.getOptions());
       PointerAnalysis<InstanceKey> propPA = propagationBuilder.getPointerAnalysis();
 
-      test(filter, test, fbResult.fst, fbResult.snd, propCG, propPA);
+      test(filter, test, fbResult.getCallGraph(), fbResult.getPointerAnalysis(), propCG, propPA);
 
     } finally {
       JSSourceExtractor.USE_TEMP_NAME = save;

--- a/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/tree/CAstSourcePositionMap.java
+++ b/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/tree/CAstSourcePositionMap.java
@@ -35,6 +35,20 @@ public interface CAstSourcePositionMap {
    * @author Julian Dolby (dolby@us.ibm.com)
    */
   public interface Position extends SourcePosition {
+
+    /**
+     * Pretty print a source position
+     *
+     * @return pretty-printed string representation
+     */
+    default String prettyPrint() {
+      String file = getURL().getFile();
+      file = file.substring(file.lastIndexOf('/') + 1);
+
+      int line = getFirstLine(), start_offset = getFirstOffset(), end_offset = getLastOffset();
+      return file + '@' + line + ':' + start_offset + '-' + end_offset;
+    }
+
     URL getURL();
 
     Reader getReader() throws IOException;

--- a/com.ibm.wala.ide.jsdt/src/main/java/com/ibm/wala/cast/js/client/EclipseJavaScriptAnalysisEngine.java
+++ b/com.ibm.wala.ide.jsdt/src/main/java/com/ibm/wala/cast/js/client/EclipseJavaScriptAnalysisEngine.java
@@ -13,6 +13,7 @@ package com.ibm.wala.cast.js.client;
 import com.ibm.wala.cast.ipa.callgraph.CAstAnalysisScope;
 import com.ibm.wala.cast.ir.ssa.AstIRFactory;
 import com.ibm.wala.cast.js.callgraph.fieldbased.FieldBasedCallGraphBuilder;
+import com.ibm.wala.cast.js.callgraph.fieldbased.FieldBasedCallGraphBuilder.CallGraphResult;
 import com.ibm.wala.cast.js.callgraph.fieldbased.OptimisticCallgraphBuilder;
 import com.ibm.wala.cast.js.callgraph.fieldbased.PessimisticCallGraphBuilder;
 import com.ibm.wala.cast.js.callgraph.fieldbased.flowgraph.FilteredFlowGraphBuilder;
@@ -193,6 +194,7 @@ public class EclipseJavaScriptAnalysisEngine
               }
             };
 
-    return builder.buildCallGraph(roots, new NullProgressMonitor());
+    CallGraphResult result = builder.buildCallGraph(roots, new NullProgressMonitor());
+    return Pair.make(result.getCallGraph(), result.getPointerAnalysis());
   }
 }

--- a/com.ibm.wala.util/src/main/java/com/ibm/wala/util/graph/GraphPrint.java
+++ b/com.ibm.wala.util/src/main/java/com/ibm/wala/util/graph/GraphPrint.java
@@ -11,13 +11,7 @@
 package com.ibm.wala.util.graph;
 
 import com.ibm.wala.util.collections.Iterator2Iterable;
-import com.ibm.wala.util.collections.MapUtil;
-import com.ibm.wala.util.collections.Util;
 import com.ibm.wala.util.graph.impl.SlowSparseNumberedGraph;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Set;
 
 /** Simple graph printing utility */
 public class GraphPrint {
@@ -38,52 +32,4 @@ public class GraphPrint {
     return sg.toString();
   }
 
-  public static <T> String graphToJSON(Graph<T> g) {
-    Map<String, Set<String>> edges = new LinkedHashMap<>();
-    for (T node : g) {
-      String nodeStr = node.toString();
-      Set<String> succs = MapUtil.findOrCreateSet(edges, nodeStr);
-      for (T succ : Iterator2Iterable.make(g.getSuccNodes(node))) {
-        succs.add(succ.toString());
-      }
-    }
-    return toJSON(edges);
-  }
-
-  public static String toJSON(Map<String, Set<String>> map) {
-    StringBuilder res = new StringBuilder();
-    res.append("{\n");
-    res.append(
-        joinWith(
-            Util.mapToSet(
-                map.entrySet(),
-                e -> {
-                  StringBuilder res1 = new StringBuilder();
-                  if (e.getValue().size() > 0) {
-                    res1.append("    \"").append(e.getKey()).append("\": [\n");
-                    res1.append(
-                        joinWith(
-                            Util.mapToSet(e.getValue(), str -> "        \"" + str + '"'), ",\n"));
-                    res1.append("\n    ]");
-                  }
-                  return res1.length() == 0 ? null : res1.toString();
-                }),
-            ",\n"));
-    res.append("\n}");
-    return res.toString();
-  }
-
-  private static String joinWith(Iterable<String> lst, String sep) {
-    StringBuilder res = new StringBuilder();
-    ArrayList<String> strings = new ArrayList<>();
-    for (String s : lst) if (s != null) strings.add(s);
-
-    boolean fst = true;
-    for (String s : strings) {
-      if (fst) fst = false;
-      else res.append(sep);
-      res.append(s);
-    }
-    return res.toString();
-  }
 }

--- a/com.ibm.wala.util/src/main/java/com/ibm/wala/util/graph/GraphPrint.java
+++ b/com.ibm.wala.util/src/main/java/com/ibm/wala/util/graph/GraphPrint.java
@@ -11,7 +11,13 @@
 package com.ibm.wala.util.graph;
 
 import com.ibm.wala.util.collections.Iterator2Iterable;
+import com.ibm.wala.util.collections.MapUtil;
+import com.ibm.wala.util.collections.Util;
 import com.ibm.wala.util.graph.impl.SlowSparseNumberedGraph;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
 
 /** Simple graph printing utility */
 public class GraphPrint {
@@ -30,5 +36,54 @@ public class GraphPrint {
       }
     }
     return sg.toString();
+  }
+
+  public static <T> String graphToJSON(Graph<T> g) {
+    Map<String, Set<String>> edges = new LinkedHashMap<>();
+    for (T node : g) {
+      String nodeStr = node.toString();
+      Set<String> succs = MapUtil.findOrCreateSet(edges, nodeStr);
+      for (T succ : Iterator2Iterable.make(g.getSuccNodes(node))) {
+        succs.add(succ.toString());
+      }
+    }
+    return toJSON(edges);
+  }
+
+  public static String toJSON(Map<String, Set<String>> map) {
+    StringBuilder res = new StringBuilder();
+    res.append("{\n");
+    res.append(
+        joinWith(
+            Util.mapToSet(
+                map.entrySet(),
+                e -> {
+                  StringBuilder res1 = new StringBuilder();
+                  if (e.getValue().size() > 0) {
+                    res1.append("    \"").append(e.getKey()).append("\": [\n");
+                    res1.append(
+                        joinWith(
+                            Util.mapToSet(e.getValue(), str -> "        \"" + str + '"'), ",\n"));
+                    res1.append("\n    ]");
+                  }
+                  return res1.length() == 0 ? null : res1.toString();
+                }),
+            ",\n"));
+    res.append("\n}");
+    return res.toString();
+  }
+
+  private static String joinWith(Iterable<String> lst, String sep) {
+    StringBuilder res = new StringBuilder();
+    ArrayList<String> strings = new ArrayList<>();
+    for (String s : lst) if (s != null) strings.add(s);
+
+    boolean fst = true;
+    for (String s : strings) {
+      if (fst) fst = false;
+      else res.append(sep);
+      res.append(s);
+    }
+    return res.toString();
   }
 }

--- a/com.ibm.wala.util/src/main/java/com/ibm/wala/util/graph/GraphPrint.java
+++ b/com.ibm.wala.util/src/main/java/com/ibm/wala/util/graph/GraphPrint.java
@@ -31,5 +31,4 @@ public class GraphPrint {
     }
     return sg.toString();
   }
-
 }


### PR DESCRIPTION
This required a refactoring to expose the `FlowGraph` in the relevant construction APIs.  Also, add the ability to print a nicer, source-level representation of `Vertex` nodes in the flow graph, rather than printing info about WALA SSA variables.