### PR TITLE
Reduce test parallelism

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ subprojects { subproject ->
 				csv.append("$trial,$descriptor.className,$descriptor.name,$result.resultType,$result.startTime,$result.endTime\n")
 			}
 		} else {
-			maxParallelForks = Integer.MAX_VALUE
+			maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 		}
 	}
 


### PR DESCRIPTION
This formula is suggested on [this page](https://guides.gradle.org/performance/).  I've found that using maximum parallelism for tests can slow things down since the JVM still needs to run GC threads, etc.  On my laptop, this change makes `:com.ibm.wala.dalvik:test` run significantly faster (from ~4m to ~2m45s).