### PR TITLE
add k-limited object sensitivity (#801)

### DIFF
--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/core/tests/util/TestConstants.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/core/tests/util/TestConstants.java
@@ -145,4 +145,8 @@ public interface TestConstants {
   public static final String SLICE_TESTINETADDR = "Lslice/TestInetAddr";
 
   public static final String SLICE_JUSTTHROW = "Lslice/JustThrow";
+
+  public static final String OBJECT_SENSITIVE_TEST1 = "LobjSensitive/TestObjSensitive1";
+
+  public static final String OBJECT_SENSITIVE_TEST2 = "LobjSensitive/TestObjSensitive2";
 }

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/impl/Util.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/impl/Util.java
@@ -28,6 +28,7 @@ import com.ibm.wala.ipa.callgraph.propagation.cfa.ZeroXCFABuilder;
 import com.ibm.wala.ipa.callgraph.propagation.cfa.ZeroXContainerCFABuilder;
 import com.ibm.wala.ipa.callgraph.propagation.cfa.ZeroXInstanceKeys;
 import com.ibm.wala.ipa.callgraph.propagation.cfa.nCFABuilder;
+import com.ibm.wala.ipa.callgraph.propagation.cfa.nObjBuilder;
 import com.ibm.wala.ipa.callgraph.propagation.rta.BasicRTABuilder;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.ipa.summaries.BypassClassTargetSelector;
@@ -580,6 +581,62 @@ public class Util {
                 | ZeroXInstanceKeys.SMUSH_PRIMITIVE_HOLDERS
                 | ZeroXInstanceKeys.SMUSH_STRINGS
                 | ZeroXInstanceKeys.SMUSH_THROWABLES));
+    return result;
+  }
+
+  /**
+   * make a {@link CallGraphBuilder} that uses object context sensitivity, with allocation-string
+   * length limited to n
+   */
+  public static SSAPropagationCallGraphBuilder makeNObjBuilder(
+      int n,
+      AnalysisOptions options,
+      IAnalysisCacheView cache,
+      IClassHierarchy cha,
+      AnalysisScope scope) {
+    if (options == null) {
+      throw new IllegalArgumentException("options is null");
+    }
+    addDefaultSelectors(options, cha);
+    addDefaultBypassLogic(options, scope, Util.class.getClassLoader(), cha);
+    ContextSelector appSelector = null;
+    SSAContextInterpreter appInterpreter = null;
+    SSAPropagationCallGraphBuilder result =
+        new nObjBuilder(
+            n,
+            cha,
+            options,
+            cache,
+            appSelector,
+            appInterpreter,
+            ZeroXInstanceKeys.ALLOCATIONS
+                | ZeroXInstanceKeys.SMUSH_MANY
+                | ZeroXInstanceKeys.SMUSH_PRIMITIVE_HOLDERS
+                | ZeroXInstanceKeys.SMUSH_STRINGS
+                | ZeroXInstanceKeys.SMUSH_THROWABLES);
+    return result;
+  }
+
+  /**
+   * make a {@link CallGraphBuilder} that uses object context sensitivity, with allocation-string
+   * length limited to n
+   */
+  public static SSAPropagationCallGraphBuilder makeVanillaNObjBuilder(
+      int n,
+      AnalysisOptions options,
+      IAnalysisCacheView cache,
+      IClassHierarchy cha,
+      AnalysisScope scope) {
+    if (options == null) {
+      throw new IllegalArgumentException("options is null");
+    }
+    addDefaultSelectors(options, cha);
+    addDefaultBypassLogic(options, scope, Util.class.getClassLoader(), cha);
+    ContextSelector appSelector = null;
+    SSAContextInterpreter appInterpreter = null;
+    SSAPropagationCallGraphBuilder result =
+        new nObjBuilder(
+            n, cha, options, cache, appSelector, appInterpreter, ZeroXInstanceKeys.ALLOCATIONS);
     return result;
   }
 

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/AllocationString.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/AllocationString.java
@@ -1,0 +1,52 @@
+package com.ibm.wala.ipa.callgraph.propagation.cfa;
+
+import com.ibm.wala.ipa.callgraph.ContextItem;
+import com.ibm.wala.ipa.callgraph.propagation.AllocationSite;
+import java.util.Arrays;
+
+/** @author genli */
+public class AllocationString implements ContextItem {
+
+  private final AllocationSite[] allocationSites;
+
+  public AllocationString(AllocationSite allocationSite) {
+    if (allocationSite == null) {
+      throw new IllegalArgumentException("null allocationSite");
+    }
+    allocationSites = new AllocationSite[] {allocationSite};
+  }
+
+  public AllocationString(AllocationSite[] allocationSites) {
+    this.allocationSites = allocationSites;
+  }
+
+  public AllocationSite[] getAllocationSites() {
+    return allocationSites;
+  }
+
+  public int getLength() {
+    return allocationSites.length;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof AllocationString)) {
+      return false;
+    }
+    AllocationString that = (AllocationString) o;
+    return Arrays.equals(getAllocationSites(), that.getAllocationSites());
+  }
+
+  @Override
+  public int hashCode() {
+    return Arrays.hashCode(getAllocationSites());
+  }
+
+  @Override
+  public String toString() {
+    return "AllocationString{" + "allocationSites=" + Arrays.toString(allocationSites) + '}';
+  }
+}

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/AllocationString.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/AllocationString.java
@@ -1,10 +1,23 @@
+/*
+ * Copyright (c) 2002 - 2020 IBM Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ */
 package com.ibm.wala.ipa.callgraph.propagation.cfa;
 
 import com.ibm.wala.ipa.callgraph.ContextItem;
 import com.ibm.wala.ipa.callgraph.propagation.AllocationSite;
 import java.util.Arrays;
 
-/** @author genli */
+/**
+ * This is a {@link ContextItem} that records n allocation sites, the 0th element represents the
+ * most recently used receiver obj, which is an {@code AllocationSiteInNode}
+ */
 public class AllocationString implements ContextItem {
 
   private final AllocationSite[] allocationSites;
@@ -17,6 +30,9 @@ public class AllocationString implements ContextItem {
   }
 
   public AllocationString(AllocationSite[] allocationSites) {
+    if (allocationSites == null) {
+      throw new IllegalArgumentException("null allocationSites");
+    }
     this.allocationSites = allocationSites;
   }
 

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/AllocationStringContext.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/AllocationStringContext.java
@@ -1,0 +1,46 @@
+package com.ibm.wala.ipa.callgraph.propagation.cfa;
+
+import com.ibm.wala.ipa.callgraph.Context;
+import com.ibm.wala.ipa.callgraph.ContextItem;
+import com.ibm.wala.ipa.callgraph.ContextKey;
+import java.util.Objects;
+
+/** @author genli */
+public class AllocationStringContext implements Context {
+
+  private final AllocationString allocationString;
+
+  public AllocationStringContext(AllocationString allocationString) {
+    this.allocationString = allocationString;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof AllocationStringContext)) {
+      return false;
+    }
+    AllocationStringContext that = (AllocationStringContext) o;
+    return allocationString.equals(that.allocationString);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(allocationString);
+  }
+
+  @Override
+  public ContextItem get(ContextKey name) {
+    if (name == nObjContextSelector.ALLOCATION_STRING_KEY) {
+      return allocationString;
+    }
+    return null;
+  }
+
+  @Override
+  public String toString() {
+    return "AllocationStringContext{" + "allocationString=" + allocationString + '}';
+  }
+}

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/AllocationStringContext.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/AllocationStringContext.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2002 - 2020 IBM Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ */
 package com.ibm.wala.ipa.callgraph.propagation.cfa;
 
 import com.ibm.wala.ipa.callgraph.Context;
@@ -5,7 +15,7 @@ import com.ibm.wala.ipa.callgraph.ContextItem;
 import com.ibm.wala.ipa.callgraph.ContextKey;
 import java.util.Objects;
 
-/** @author genli */
+/** This {@link Context} consists of an {@link AllocationString} that records n allocation sites */
 public class AllocationStringContext implements Context {
 
   private final AllocationString allocationString;

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/nObjBuilder.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/nObjBuilder.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2002 - 2020 IBM Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ */
 package com.ibm.wala.ipa.callgraph.propagation.cfa;
 
 import com.ibm.wala.classLoader.Language;
@@ -9,7 +19,7 @@ import com.ibm.wala.ipa.callgraph.impl.DelegatingContextSelector;
 import com.ibm.wala.ipa.callgraph.propagation.SSAContextInterpreter;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 
-/** @author genli */
+/** call graph builder based on object sensitivity */
 public class nObjBuilder extends ZeroXCFABuilder {
 
   public nObjBuilder(

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/nObjBuilder.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/nObjBuilder.java
@@ -1,0 +1,42 @@
+package com.ibm.wala.ipa.callgraph.propagation.cfa;
+
+import com.ibm.wala.classLoader.Language;
+import com.ibm.wala.ipa.callgraph.AnalysisOptions;
+import com.ibm.wala.ipa.callgraph.ContextSelector;
+import com.ibm.wala.ipa.callgraph.IAnalysisCacheView;
+import com.ibm.wala.ipa.callgraph.impl.DefaultContextSelector;
+import com.ibm.wala.ipa.callgraph.impl.DelegatingContextSelector;
+import com.ibm.wala.ipa.callgraph.propagation.SSAContextInterpreter;
+import com.ibm.wala.ipa.cha.IClassHierarchy;
+
+/** @author genli */
+public class nObjBuilder extends ZeroXCFABuilder {
+
+  public nObjBuilder(
+      int n,
+      IClassHierarchy cha,
+      AnalysisOptions options,
+      IAnalysisCacheView cache,
+      ContextSelector appContextSelector,
+      SSAContextInterpreter appContextInterpreter,
+      int instancePolicy) {
+
+    super(
+        Language.JAVA,
+        cha,
+        options,
+        cache,
+        appContextSelector,
+        appContextInterpreter,
+        instancePolicy);
+
+    ContextSelector def = new DefaultContextSelector(options, cha);
+
+    ContextSelector contextSelector =
+        appContextSelector == null ? def : new DelegatingContextSelector(appContextSelector, def);
+
+    ContextSelector nObjContextSelector = new nObjContextSelector(n, contextSelector);
+
+    setContextSelector(nObjContextSelector);
+  }
+}

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/nObjContextSelector.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/nObjContextSelector.java
@@ -1,0 +1,122 @@
+package com.ibm.wala.ipa.callgraph.propagation.cfa;
+
+import com.ibm.wala.classLoader.CallSiteReference;
+import com.ibm.wala.classLoader.IMethod;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.Context;
+import com.ibm.wala.ipa.callgraph.ContextKey;
+import com.ibm.wala.ipa.callgraph.ContextSelector;
+import com.ibm.wala.ipa.callgraph.DelegatingContext;
+import com.ibm.wala.ipa.callgraph.impl.Everywhere;
+import com.ibm.wala.ipa.callgraph.propagation.AllocationSite;
+import com.ibm.wala.ipa.callgraph.propagation.AllocationSiteInNode;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.util.intset.EmptyIntSet;
+import com.ibm.wala.util.intset.IntSet;
+import com.ibm.wala.util.intset.IntSetUtil;
+
+/**
+ * k-limited object sensitive context selector
+ *
+ * <ul>
+ *   <li>for static method : For a few well-known static factory methods from the standard
+ *       libraries, use {@code CallerSiteContext}.Otherwise, directly copy the context of the last
+ *       non-static method
+ *   <li>for virtual method : The context consists of n allocation sites
+ *   <li>for an object(fixed at allocation) : The heap context consists of n allocation sites
+ *       inherited from CGNode
+ * </ul>
+ *
+ * @author genli
+ */
+public class nObjContextSelector implements ContextSelector {
+
+  public static final ContextKey ALLOCATION_STRING_KEY =
+      new ContextKey() {
+        @Override
+        public String toString() {
+          return "ALLOCATION_STRING_KEY";
+        }
+      };
+
+  private final int n;
+
+  private final ContextSelector base;
+
+  public nObjContextSelector(int n, ContextSelector base) {
+    if (n <= 0) {
+      throw new IllegalArgumentException("n must be a positive number");
+    }
+    this.n = n;
+    this.base = base;
+  }
+
+  @Override
+  public Context getCalleeTarget(
+      CGNode caller, CallSiteReference site, IMethod callee, InstanceKey[] actualParameters) {
+
+    Context calleeContext = Everywhere.EVERYWHERE;
+
+    InstanceKey receiver =
+        (actualParameters != null && actualParameters.length > 0 && actualParameters[0] != null)
+            ? actualParameters[0]
+            : null;
+
+    if (site.isStatic()) {
+      calleeContext = getCalleeTargetForStaticCall(caller, site, callee, actualParameters);
+    } else if (receiver instanceof AllocationSiteInNode) {
+      AllocationString allocationString =
+          assemblyReceiverAllocString((AllocationSiteInNode) receiver);
+      calleeContext = new AllocationStringContext(allocationString);
+    }
+
+    Context baseContext = base.getCalleeTarget(caller, site, callee, actualParameters);
+    return appendBaseContext(calleeContext, baseContext);
+  }
+
+  private AllocationString assemblyReceiverAllocString(AllocationSiteInNode receiver) {
+    Context receiverHeapContext = receiver.getNode().getContext();
+    AllocationSite receiverAllocSite =
+        new AllocationSite(
+            receiver.getNode().getMethod(), receiver.getSite(), receiver.getConcreteType());
+
+    if (receiverHeapContext.get(ALLOCATION_STRING_KEY) != null) {
+      AllocationString receiverAllocString =
+          (AllocationString) receiverHeapContext.get(ALLOCATION_STRING_KEY);
+
+      int siteLength = Math.min(n, receiverAllocString.getLength() + 1);
+      AllocationSite[] sites = new AllocationSite[siteLength];
+      sites[0] = receiverAllocSite;
+      System.arraycopy(receiverAllocString.getAllocationSites(), 0, sites, 1, siteLength - 1);
+      return new AllocationString(sites);
+    } else {
+      return new AllocationString(receiverAllocSite);
+    }
+  }
+
+  protected Context getCalleeTargetForStaticCall(
+      CGNode caller, CallSiteReference site, IMethod callee, InstanceKey[] actualParameters) {
+    return ContainerContextSelector.isWellKnownStaticFactory(callee.getReference())
+        ? new CallerSiteContext(caller, site)
+        : caller.getContext();
+  }
+
+  private Context appendBaseContext(Context curr, Context base) {
+    if (curr == Everywhere.EVERYWHERE) {
+      return base;
+    } else {
+      return base == Everywhere.EVERYWHERE ? curr : new DelegatingContext(curr, base);
+    }
+  }
+
+  private static final IntSet thisParameter = IntSetUtil.make(new int[] {0});
+
+  @Override
+  public IntSet getRelevantParameters(CGNode caller, CallSiteReference site) {
+    if (site.isDispatch()) {
+      return thisParameter;
+    } else {
+      return EmptyIntSet.instance;
+    }
+  }
+}

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/nObjContextSelector.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/nObjContextSelector.java
@@ -63,7 +63,7 @@ public class nObjContextSelector implements ContextSelector {
             : null;
 
     if (site.isStatic()) {
-      calleeContext = getCalleeTargetForStaticCall(caller, site, callee, actualParameters);
+      calleeContext = getCalleeTargetForStaticCall(caller, site, callee);
     } else if (receiver instanceof AllocationSiteInNode) {
       AllocationString allocationString =
           assemblyReceiverAllocString((AllocationSiteInNode) receiver);
@@ -95,7 +95,7 @@ public class nObjContextSelector implements ContextSelector {
   }
 
   protected Context getCalleeTargetForStaticCall(
-      CGNode caller, CallSiteReference site, IMethod callee, InstanceKey[] actualParameters) {
+      CGNode caller, CallSiteReference site, IMethod callee) {
     return ContainerContextSelector.isWellKnownStaticFactory(callee.getReference())
         ? new CallerSiteContext(caller, site)
         : caller.getContext();

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/nObjContextSelector.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/nObjContextSelector.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2002 - 2020 IBM Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ */
 package com.ibm.wala.ipa.callgraph.propagation.cfa;
 
 import com.ibm.wala.classLoader.CallSiteReference;
@@ -20,14 +30,12 @@ import com.ibm.wala.util.intset.IntSetUtil;
  *
  * <ul>
  *   <li>for static method : For a few well-known static factory methods from the standard
- *       libraries, use {@code CallerSiteContext}.Otherwise, directly copy the context of the last
+ *       libraries, use {@link CallerSiteContext}.Otherwise, directly copy the context of the last
  *       non-static method
- *   <li>for virtual method : The context consists of n allocation sites
+ *   <li>for virtual method : The {@link Context} consists of n allocation sites
  *   <li>for an object(fixed at allocation) : The heap context consists of n allocation sites
- *       inherited from CGNode
+ *       inherited from {@link CGNode}
  * </ul>
- *
- * @author genli
  */
 public class nObjContextSelector implements ContextSelector {
 

--- a/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/ptrs/ObjectSensitiveTest.java
+++ b/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/ptrs/ObjectSensitiveTest.java
@@ -1,0 +1,100 @@
+package com.ibm.wala.core.tests.ptrs;
+
+import com.ibm.wala.core.tests.callGraph.CallGraphTestUtil;
+import com.ibm.wala.core.tests.util.TestConstants;
+import com.ibm.wala.ipa.callgraph.AnalysisCacheImpl;
+import com.ibm.wala.ipa.callgraph.AnalysisOptions;
+import com.ibm.wala.ipa.callgraph.AnalysisScope;
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.ipa.callgraph.CallGraph;
+import com.ibm.wala.ipa.callgraph.CallGraphBuilder;
+import com.ibm.wala.ipa.callgraph.CallGraphBuilderCancelException;
+import com.ibm.wala.ipa.callgraph.Entrypoint;
+import com.ibm.wala.ipa.callgraph.impl.Util;
+import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
+import com.ibm.wala.ipa.callgraph.propagation.LocalPointerKey;
+import com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis;
+import com.ibm.wala.ipa.cha.ClassHierarchy;
+import com.ibm.wala.ipa.cha.ClassHierarchyException;
+import com.ibm.wala.ipa.cha.ClassHierarchyFactory;
+import com.ibm.wala.types.ClassLoaderReference;
+import com.ibm.wala.types.MethodReference;
+import com.ibm.wala.types.TypeReference;
+import com.ibm.wala.util.collections.Pair;
+import com.ibm.wala.util.intset.OrdinalSet;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * test case for nObjBuilder
+ *
+ * @author genli
+ */
+public class ObjectSensitiveTest {
+
+  @Test
+  public void testObjSensitive1()
+      throws IOException, ClassHierarchyException, CallGraphBuilderCancelException {
+    doPointsToSizeTest(1, TestConstants.OBJECT_SENSITIVE_TEST1, 1);
+  }
+
+  @Test
+  public void testObjSensitive2()
+      throws IOException, ClassHierarchyException, CallGraphBuilderCancelException {
+    // If n is set to 2, the pts of the parameter will be inaccurate
+    doPointsToSizeTest(2, TestConstants.OBJECT_SENSITIVE_TEST2, 2);
+
+    doPointsToSizeTest(3, TestConstants.OBJECT_SENSITIVE_TEST2, 1);
+  }
+
+  public static void doPointsToSizeTest(int n, String mainClass, int exceptedSize)
+      throws IOException, ClassHierarchyException, CallGraphBuilderCancelException {
+    Pair<CallGraph, PointerAnalysis<InstanceKey>> pair = initCallGraph(n, mainClass);
+    CallGraph cg = pair.fst;
+    PointerAnalysis<InstanceKey> pa = pair.snd;
+
+    // find the doNothing call, and check the parameter's points-to set
+    CGNode doNothing = findDoNothingCall(cg, mainClass);
+
+    LocalPointerKey localPointerKey =
+        new LocalPointerKey(doNothing, doNothing.getIR().getParameter(0));
+    OrdinalSet<InstanceKey> pts = pa.getPointsToSet(localPointerKey);
+
+    Assert.assertTrue(pts.size() == exceptedSize);
+  }
+
+  private static Pair<CallGraph, PointerAnalysis<InstanceKey>> initCallGraph(
+      int n, String mainClass)
+      throws IOException, ClassHierarchyException, CallGraphBuilderCancelException {
+    AnalysisScope scope =
+        CallGraphTestUtil.makeJ2SEAnalysisScope(
+            TestConstants.WALA_TESTDATA, CallGraphTestUtil.REGRESSION_EXCLUSIONS);
+    ClassHierarchy cha = ClassHierarchyFactory.make(scope);
+    Iterable<Entrypoint> entrypoints =
+        com.ibm.wala.ipa.callgraph.impl.Util.makeMainEntrypoints(scope, cha, mainClass);
+    AnalysisOptions options = CallGraphTestUtil.makeAnalysisOptions(scope, entrypoints);
+
+    CallGraphBuilder<InstanceKey> builder =
+        Util.makeVanillaNObjBuilder(n, options, new AnalysisCacheImpl(), cha, scope);
+
+    CallGraph cg = builder.makeCallGraph(options, null);
+    PointerAnalysis<InstanceKey> pa = builder.getPointerAnalysis();
+    return Pair.make(cg, pa);
+  }
+
+  private static CGNode findDoNothingCall(CallGraph cg, String mainClass) {
+    TypeReference mainClassTr =
+        TypeReference.findOrCreate(ClassLoaderReference.Application, mainClass);
+    MethodReference mr =
+        MethodReference.findOrCreate(mainClassTr, "doNothing", "(Ljava/lang/Object;)V");
+    Set<CGNode> nodes = cg.getNodes(mr);
+    Assert.assertTrue(nodes.size() == 1);
+
+    Optional<CGNode> firstMatched = nodes.stream().findFirst();
+    Assert.assertTrue(firstMatched.isPresent());
+    return firstMatched.get();
+  }
+}

--- a/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/ptrs/ObjectSensitiveTest.java
+++ b/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/ptrs/ObjectSensitiveTest.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2002 - 2020 IBM Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ */
 package com.ibm.wala.core.tests.ptrs;
 
 import com.ibm.wala.core.tests.callGraph.CallGraphTestUtil;
@@ -28,11 +38,7 @@ import java.util.Set;
 import org.junit.Assert;
 import org.junit.Test;
 
-/**
- * test case for nObjBuilder
- *
- * @author genli
- */
+/** test case for nObjBuilder */
 public class ObjectSensitiveTest {
 
   @Test
@@ -50,7 +56,7 @@ public class ObjectSensitiveTest {
     doPointsToSizeTest(3, TestConstants.OBJECT_SENSITIVE_TEST2, 1);
   }
 
-  public static void doPointsToSizeTest(int n, String mainClass, int exceptedSize)
+  public static void doPointsToSizeTest(int n, String mainClass, int expectedSize)
       throws IOException, ClassHierarchyException, CallGraphBuilderCancelException {
     Pair<CallGraph, PointerAnalysis<InstanceKey>> pair = initCallGraph(n, mainClass);
     CallGraph cg = pair.fst;
@@ -63,7 +69,7 @@ public class ObjectSensitiveTest {
         new LocalPointerKey(doNothing, doNothing.getIR().getParameter(0));
     OrdinalSet<InstanceKey> pts = pa.getPointsToSet(localPointerKey);
 
-    Assert.assertTrue(pts.size() == exceptedSize);
+    Assert.assertTrue(pts.size() == expectedSize);
   }
 
   private static Pair<CallGraph, PointerAnalysis<InstanceKey>> initCallGraph(

--- a/com.ibm.wala.core/src/testSubjects/java/objSensitive/A.java
+++ b/com.ibm.wala.core/src/testSubjects/java/objSensitive/A.java
@@ -1,6 +1,15 @@
+/*
+ * Copyright (c) 2002 - 2020 IBM Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ */
 package objSensitive;
 
-/** @author genli */
 public class A {
 
   private B b;

--- a/com.ibm.wala.core/src/testSubjects/java/objSensitive/A.java
+++ b/com.ibm.wala.core/src/testSubjects/java/objSensitive/A.java
@@ -1,0 +1,24 @@
+package objSensitive;
+
+/** @author genli */
+public class A {
+
+  private B b;
+
+  public void set(B b) {
+    doSet(b);
+  }
+
+  public void doSet(B b) {
+    this.b = b;
+  }
+
+  public B getB() {
+    return this.b;
+  }
+
+  public Object foo(Object v) {
+    B b = new B();
+    return b.bar(v);
+  }
+}

--- a/com.ibm.wala.core/src/testSubjects/java/objSensitive/B.java
+++ b/com.ibm.wala.core/src/testSubjects/java/objSensitive/B.java
@@ -1,6 +1,15 @@
+/*
+ * Copyright (c) 2002 - 2020 IBM Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ */
 package objSensitive;
 
-/** @author genli */
 public class B {
   Object bar(Object v) {
     C c = new C();

--- a/com.ibm.wala.core/src/testSubjects/java/objSensitive/B.java
+++ b/com.ibm.wala.core/src/testSubjects/java/objSensitive/B.java
@@ -1,0 +1,9 @@
+package objSensitive;
+
+/** @author genli */
+public class B {
+  Object bar(Object v) {
+    C c = new C();
+    return c.identity(v);
+  }
+}

--- a/com.ibm.wala.core/src/testSubjects/java/objSensitive/C.java
+++ b/com.ibm.wala.core/src/testSubjects/java/objSensitive/C.java
@@ -1,6 +1,15 @@
+/*
+ * Copyright (c) 2002 - 2020 IBM Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ */
 package objSensitive;
 
-/** @author genli */
 public class C {
   Object identity(Object v) {
     return v;

--- a/com.ibm.wala.core/src/testSubjects/java/objSensitive/C.java
+++ b/com.ibm.wala.core/src/testSubjects/java/objSensitive/C.java
@@ -1,0 +1,8 @@
+package objSensitive;
+
+/** @author genli */
+public class C {
+  Object identity(Object v) {
+    return v;
+  }
+}

--- a/com.ibm.wala.core/src/testSubjects/java/objSensitive/TestObjSensitive1.java
+++ b/com.ibm.wala.core/src/testSubjects/java/objSensitive/TestObjSensitive1.java
@@ -1,0 +1,25 @@
+package objSensitive;
+
+/**
+ * test case for nObjBuilder
+ *
+ * @author genli
+ */
+public class TestObjSensitive1 {
+
+  public static void main(String[] args) {
+    A a1 = new A();
+    A a2 = new A();
+    B b1 = new B(); // B/1
+    B b2 = new B(); // B/2
+
+    a1.set(b1);
+    a2.set(b2);
+
+    B b = a1.getB(); // pts(b) -> {B/1} , n = 1
+
+    doNothing(b);
+  }
+
+  static void doNothing(Object o) {}
+}

--- a/com.ibm.wala.core/src/testSubjects/java/objSensitive/TestObjSensitive1.java
+++ b/com.ibm.wala.core/src/testSubjects/java/objSensitive/TestObjSensitive1.java
@@ -1,10 +1,16 @@
+/*
+ * Copyright (c) 2002 - 2020 IBM Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ */
 package objSensitive;
 
-/**
- * test case for nObjBuilder
- *
- * @author genli
- */
+/** test case for nObjBuilder */
 public class TestObjSensitive1 {
 
   public static void main(String[] args) {

--- a/com.ibm.wala.core/src/testSubjects/java/objSensitive/TestObjSensitive2.java
+++ b/com.ibm.wala.core/src/testSubjects/java/objSensitive/TestObjSensitive2.java
@@ -1,9 +1,15 @@
-package objSensitive;
-/**
- * test case for nObjBuilder
+/*
+ * Copyright (c) 2002 - 2020 IBM Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
  *
- * @author genli
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
  */
+package objSensitive;
+/** test case for nObjBuilder */
 public class TestObjSensitive2 {
 
   public static void main(String[] args) {

--- a/com.ibm.wala.core/src/testSubjects/java/objSensitive/TestObjSensitive2.java
+++ b/com.ibm.wala.core/src/testSubjects/java/objSensitive/TestObjSensitive2.java
@@ -1,0 +1,22 @@
+package objSensitive;
+/**
+ * test case for nObjBuilder
+ *
+ * @author genli
+ */
+public class TestObjSensitive2 {
+
+  public static void main(String[] args) {
+    A a1 = new A();
+    Object o1 = new Object(); //  Object/1
+    Object result1 = a1.foo(o1);
+
+    A a2 = new A();
+    Object o2 = new Object(); //   Object/2
+    Object result2 = a2.foo(o2); //   pts(result2) -> {Object/2} , n = 3
+
+    doNothing(result2);
+  }
+
+  static void doNothing(Object o) {}
+}


### PR DESCRIPTION
First of all, I am sorry to submit the pr after so long. Considering that if `HeapContextSelector` is introduced, it may not be consistent with the existing logic of `GetClassContextSelector`, `CloneContextSelector`, etc., eventually there may be problems in processing reflection. So I finally changed the implementation of object sensitivity and decided to make `CGNode `and `AllocationSiteInNode` use the same `Context`, as you mentioned before.

If there is something inappropriate, you can contact me. :blush:
