### PR TITLE
Revamp of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![WALA logo](http://wala.sourceforge.net/wiki/images/9/94/WALA-banner.png)]
+
 WALA [![GitHub Actions status](https://github.com/wala/WALA/workflows/Continuous%20integration/badge.svg)](https://github.com/wala/WALA/actions?query=workflow%3A%22Continuous+integration%22) [![Build Status](https://travis-ci.org/wala/WALA.svg?branch=master)](https://travis-ci.org/wala/WALA) [![Join the chat at https://gitter.im/WALAHelp/Lobby](https://badges.gitter.im/WALAHelp/Lobby.svg)](https://gitter.im/WALAHelp/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 =====================
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,47 @@
 ![WALA logo](http://wala.sourceforge.net/wiki/images/9/94/WALA-banner.png)]
 
-WALA [![GitHub Actions status](https://github.com/wala/WALA/workflows/Continuous%20integration/badge.svg)](https://github.com/wala/WALA/actions?query=workflow%3A%22Continuous+integration%22) [![Build Status](https://travis-ci.org/wala/WALA.svg?branch=master)](https://travis-ci.org/wala/WALA) [![Join the chat at https://gitter.im/WALAHelp/Lobby](https://badges.gitter.im/WALAHelp/Lobby.svg)](https://gitter.im/WALAHelp/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![GitHub Actions status](https://github.com/wala/WALA/workflows/Continuous%20integration/badge.svg)](https://github.com/wala/WALA/actions?query=workflow%3A%22Continuous+integration%22) [![Build Status](https://travis-ci.org/wala/WALA.svg?branch=master)](https://travis-ci.org/wala/WALA) [![Join the chat at https://gitter.im/WALAHelp/Lobby](https://badges.gitter.im/WALAHelp/Lobby.svg)](https://gitter.im/WALAHelp/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 =====================
 
-This is the main source repository for WALA.  For more details on WALA, see [the WALA home page](http://wala.sourceforge.net) and [WALA Javadoc](https://wala.github.io/javadoc).
+The T. J. Watson Libraries for Analysis (WALA) provide static analysis capabilities for Java bytecode and related languages and for JavaScript. The system is licensed under the [Eclipse Public License](http://www.eclipse.org/legal/epl-v10.html), which has been approved by the [OSI](http://www.opensource.org/) (Open Source Initiative) as a fully certified open source license. The initial WALA infrastructure was independently developed as part of the DOMO research project at the [IBM T.J. Watson Research Center](http://www.research.ibm.com/). In 2006, [IBM](http://www.ibm.com/us/) donated the software to the community.
+
+For recent updates on WALA, join the [mailing list](http://sourceforge.net/p/wala/mailman/), or follow WALA on [Twitter](https://twitter.com/WALALibs) or [Google+](https://plus.google.com/117805259258761505726/posts).
+
+### Core WALA Features
+
+WALA features include:
+
+* Java type system and class hierarchy analysis
+* Source language framework supporting Java and JavaScript
+* Interprocedural dataflow analysis ([RHS](http://www.cs.wisc.edu/~reps/#popl95) solver)
+* Context-sensitive tabulation-based slicer
+* Pointer analysis and call graph construction
+* SSA-based register-transfer language IR
+* General framework for iterative dataflow
+* General analysis utilities and data structures
+* A bytecode instrumentation library ([[Shrike]]) and a dynamic load-time instrumentation library for Java ([[Dila]])
+
+### WALA Tools in JavaScript
+
+Recently, we have been expanding the set of WALA tools implemented in JavaScript. We have released a normalizer and some basic program analyses for JavaScript in the [JS_WALA GitHub repository](https://github.com/wala/JS_WALA). We have also made available [WALA Delta](https://github.com/wala/WALADelta), a delta debugger for JavaScript-processing tools. Please see the linked GitHub repositories for further details on these tools.
+
+### WALA-Based Tools
+
+Several groups have built open-source tools that enhance or build on WALA that may be useful to other WALA users. For details, see the [Wala-based tools](WALA-Based-Tools) page.
+
+### About this Wiki
+
+We're hosting all documentation for WALA on this wiki. **We've chosen a wiki format just so that _you_ can contribute.** Don't be shy!
+
+<!---
+TODO
+
+Replace the sourceforge mailing list link w/ somewhere else?
+-->
+
+The WALA publications department is populating this wiki with technical documentation on a demand-driven basis, driven by questions posted to the [wala-wala](http://sourceforge.net/p/wala/mailman/) mailing list. We recommend [this page](https://groups.google.com/forum/#!forum/wala-sourceforge-net) for searching the mailing list archives.
+
+Currently, we have the [JavaDoc documentation for the WALA code](TODO) being uploaded once per day. If you think a particular file deserves better javadoc, please [open a feature request](https://github.com/wala/WALA/issues).
 
 WALA uses Gradle as its build system.  If you intend to modify or
 build WALA yourself, then see [the Gradle-specific

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 ![WALA logo](http://wala.sourceforge.net/wiki/images/9/94/WALA-banner.png)
 
 [![GitHub Actions status](https://github.com/wala/WALA/workflows/Continuous%20integration/badge.svg)](https://github.com/wala/WALA/actions?query=workflow%3A%22Continuous+integration%22) [![Build Status](https://travis-ci.org/wala/WALA.svg?branch=master)](https://travis-ci.org/wala/WALA) [![Join the chat at https://gitter.im/WALAHelp/Lobby](https://badges.gitter.im/WALAHelp/Lobby.svg)](https://gitter.im/WALAHelp/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-=====================
+
+-------------------------
 
 The T. J. Watson Libraries for Analysis (WALA) provide static analysis capabilities for Java bytecode and related languages and for JavaScript. The system is licensed under the [Eclipse Public License](http://www.eclipse.org/legal/epl-v10.html), which has been approved by the [OSI](http://www.opensource.org/) (Open Source Initiative) as a fully certified open source license. The initial WALA infrastructure was independently developed as part of the DOMO research project at the [IBM T.J. Watson Research Center](http://www.research.ibm.com/). In 2006, [IBM](http://www.ibm.com/us/) donated the software to the community.
 
@@ -24,6 +25,7 @@ WALA features include:
 ### Getting Started
 
 The fastest way to get started with WALA is to use the packages in Maven Central, as noted [here](https://github.com/wala/WALA/wiki/Getting-Started#quick-start-using-maven-central-packages).  See the [WALA-start](https://github.com/wala/WALA-start) repo for a Gradle-based example.  We are actively re-organizing the deeper wiki technical documentation.  In the meantime, you can check out tutorial slides to get an overview of WALA:
+
 * [Core WALA](http://wala.sourceforge.net/files/PLDI_WALA_Tutorial.pdf) (PDF)
 * [WALA JavaScript](http://wala.sourceforge.net/files/WALAJavaScriptTutorial.pdf) (PDF)
 
@@ -54,5 +56,3 @@ Recently, we have been expanding the set of WALA tools implemented in JavaScript
 ### WALA-Based Tools
 
 Several groups have built open-source tools that enhance or build on WALA that may be useful to other WALA users. For details, see the [Wala-based tools](https://github.com/wala/WALA/wiki/WALA-Based-Tools) page.
-
-

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![WALA logo](http://wala.sourceforge.net/wiki/images/9/94/WALA-banner.png)]
+![WALA logo](http://wala.sourceforge.net/wiki/images/9/94/WALA-banner.png)
 
 [![GitHub Actions status](https://github.com/wala/WALA/workflows/Continuous%20integration/badge.svg)](https://github.com/wala/WALA/actions?query=workflow%3A%22Continuous+integration%22) [![Build Status](https://travis-ci.org/wala/WALA.svg?branch=master)](https://travis-ci.org/wala/WALA) [![Join the chat at https://gitter.im/WALAHelp/Lobby](https://badges.gitter.im/WALAHelp/Lobby.svg)](https://gitter.im/WALAHelp/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 =====================

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ The WALA publications department is populating this wiki with technical document
 
 Currently, we have the [JavaDoc documentation for the WALA code](https://wala.github.io/javadoc) being updated continuously. If you think a particular file deserves better javadoc, please [open a feature request](https://github.com/wala/WALA/issues).
 
+### Getting Help
+
+To get help with WALA, please either [email the mailing list](http://sourceforge.net/p/wala/mailman/), [ask a question on Gitter](https://gitter.im/WALAHelp/Lobby), or [open an issue](https://github.com/wala/WALA/issues).
+
 ### Building from Source
 
 WALA uses Gradle as its build system.  If you intend to modify or build WALA yourself, then see [the Gradle-specific README](README-Gradle.md) for more instructions and helpful tips.  You may also find `pom.xml` configuration files for Maven builds, but Maven is no longer well supported; use Gradle if at all possible.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 The T. J. Watson Libraries for Analysis (WALA) provide static analysis capabilities for Java bytecode and related languages and for JavaScript. The system is licensed under the [Eclipse Public License](http://www.eclipse.org/legal/epl-v10.html), which has been approved by the [OSI](http://www.opensource.org/) (Open Source Initiative) as a fully certified open source license. The initial WALA infrastructure was independently developed as part of the DOMO research project at the [IBM T.J. Watson Research Center](http://www.research.ibm.com/). In 2006, [IBM](http://www.ibm.com/us/) donated the software to the community.
 
-For recent updates on WALA, join the [mailing list](http://sourceforge.net/p/wala/mailman/), or follow WALA on [Twitter](https://twitter.com/WALALibs) or [Google+](https://plus.google.com/117805259258761505726/posts).
+For recent updates on WALA, join the [mailing list](http://sourceforge.net/p/wala/mailman/).
 
 ### Core WALA Features
 
@@ -19,32 +19,36 @@ WALA features include:
 * SSA-based register-transfer language IR
 * General framework for iterative dataflow
 * General analysis utilities and data structures
-* A bytecode instrumentation library ([[Shrike]]) and a dynamic load-time instrumentation library for Java ([[Dila]])
+* A bytecode instrumentation library ([Shrike](https://github.com/wala/WALA/wiki/Shrike))
+
+### Getting Started
+
+The fastest way to get started with WALA is to use the packages in Maven Central, as noted [here](https://github.com/wala/WALA/wiki/Getting-Started#quick-start-using-maven-central-packages).  See the [WALA-start](https://github.com/wala/WALA-start) repo for a Gradle-based example.  We are actively re-organizing the deeper wiki technical documentation.  In the meantime, you can check out tutorial slides to get an overview of WALA:
+* [Core WALA](http://wala.sourceforge.net/files/PLDI_WALA_Tutorial.pdf)
+* [WALA JavaScript](http://wala.sourceforge.net/files/WALAJavaScriptTutorial.pdf)
+
+You can also watch screencasts of the WALA JavaScript tutorial [here](https://www.youtube.com/user/WALALibraries/videos).
+
+Finally, for now, to search the wiki documentation, we recommend a site-specific search on Google, e.g., [a search for "call graph"](https://www.google.com/search?q=call+graph+site%3Ahttps%3A%2F%2Fgithub.com%2Fwala%2FWALA%2Fwiki&oq=call+graph+site%3Ahttps%3A%2F%2Fgithub.com%2Fwala%2FWALA%2Fwiki).
+
+### Documentation
+
+We're hosting documentation for WALA on [the GitHub wiki](https://github.com/wala/WALA/wiki).  **We've chosen a wiki format just so that _you_ can contribute.** Don't be shy!
+
+The WALA publications department is populating this wiki with technical documentation on a demand-driven basis, driven by questions posted to the [wala-wala](http://sourceforge.net/p/wala/mailman/) mailing list and also [Gitter](https://gitter.im/WALAHelp/Lobby). We recommend [this page](https://groups.google.com/forum/#!forum/wala-sourceforge-net) for searching the mailing list archives.
+
+Currently, we have the [JavaDoc documentation for the WALA code](https://wala.github.io/javadoc) being updated continuously. If you think a particular file deserves better javadoc, please [open a feature request](https://github.com/wala/WALA/issues).
+
+### Building from Source
+
+WALA uses Gradle as its build system.  If you intend to modify or build WALA yourself, then see [the Gradle-specific README](README-Gradle.md) for more instructions and helpful tips.  You may also find `pom.xml` configuration files for Maven builds, but Maven is no longer well supported; use Gradle if at all possible.
 
 ### WALA Tools in JavaScript
 
-Recently, we have been expanding the set of WALA tools implemented in JavaScript. We have released a normalizer and some basic program analyses for JavaScript in the [JS_WALA GitHub repository](https://github.com/wala/JS_WALA). We have also made available [WALA Delta](https://github.com/wala/WALADelta), a delta debugger for JavaScript-processing tools. Please see the linked GitHub repositories for further details on these tools.
+Recently, we have been expanding the set of WALA tools implemented in JavaScript. We have released a normalizer and some basic program analyses for JavaScript in the [JS_WALA GitHub repository](https://github.com/wala/JS_WALA). We have also made available [jsdelta](https://github.com/wala/jsdelta) and [WALA Delta](https://github.com/wala/WALADelta), delta debuggers for JavaScript-processing tools. Please see the linked GitHub repositories for further details on these tools.
 
 ### WALA-Based Tools
 
-Several groups have built open-source tools that enhance or build on WALA that may be useful to other WALA users. For details, see the [Wala-based tools](WALA-Based-Tools) page.
+Several groups have built open-source tools that enhance or build on WALA that may be useful to other WALA users. For details, see the [Wala-based tools](https://github.com/wala/WALA/wiki/WALA-Based-Tools) page.
 
-### About this Wiki
 
-We're hosting all documentation for WALA on this wiki. **We've chosen a wiki format just so that _you_ can contribute.** Don't be shy!
-
-<!---
-TODO
-
-Replace the sourceforge mailing list link w/ somewhere else?
--->
-
-The WALA publications department is populating this wiki with technical documentation on a demand-driven basis, driven by questions posted to the [wala-wala](http://sourceforge.net/p/wala/mailman/) mailing list. We recommend [this page](https://groups.google.com/forum/#!forum/wala-sourceforge-net) for searching the mailing list archives.
-
-Currently, we have the [JavaDoc documentation for the WALA code](TODO) being uploaded once per day. If you think a particular file deserves better javadoc, please [open a feature request](https://github.com/wala/WALA/issues).
-
-WALA uses Gradle as its build system.  If you intend to modify or
-build WALA yourself, then see [the Gradle-specific
-README](README-Gradle.md) for more instructions and helpful tips.  You
-may also find `pom.xml` configuration files for Maven builds, but
-Maven is no longer well supported; use Gradle if at all possible.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The T. J. Watson Libraries for Analysis (WALA) provide static analysis capabilit
 
 For recent updates on WALA, join the [mailing list](http://sourceforge.net/p/wala/mailman/).
 
-### Core WALA Features
+## Core WALA Features
 
 WALA features include:
 
@@ -22,7 +22,7 @@ WALA features include:
 * General analysis utilities and data structures
 * A bytecode instrumentation library ([Shrike](https://github.com/wala/WALA/wiki/Shrike))
 
-### Getting Started
+## Getting Started
 
 The fastest way to get started with WALA is to use the packages in Maven Central, as noted [here](https://github.com/wala/WALA/wiki/Getting-Started#quick-start-using-maven-central-packages).  See the [WALA-start](https://github.com/wala/WALA-start) repo for a Gradle-based example.  We are actively re-organizing the deeper wiki technical documentation.  In the meantime, you can check out tutorial slides to get an overview of WALA:
 
@@ -33,7 +33,7 @@ You can also watch screencasts of the WALA JavaScript tutorial [here](https://ww
 
 Finally, for now, to search the wiki documentation, we recommend a site-specific search on Google, e.g., [a search for "call graph"](https://www.google.com/search?q=call+graph+site%3Ahttps%3A%2F%2Fgithub.com%2Fwala%2FWALA%2Fwiki&oq=call+graph+site%3Ahttps%3A%2F%2Fgithub.com%2Fwala%2FWALA%2Fwiki).
 
-### Documentation
+## Documentation
 
 We're hosting documentation for WALA on [the GitHub wiki](https://github.com/wala/WALA/wiki).  **We've chosen a wiki format just so that _you_ can contribute.** Don't be shy!
 
@@ -41,18 +41,18 @@ The WALA publications department is populating this wiki with technical document
 
 Currently, we have the [JavaDoc documentation for the WALA code](https://wala.github.io/javadoc) being updated continuously. If you think a particular file deserves better javadoc, please [open a feature request](https://github.com/wala/WALA/issues).
 
-### Getting Help
+## Getting Help
 
 To get help with WALA, please either [email the mailing list](http://sourceforge.net/p/wala/mailman/), [ask a question on Gitter](https://gitter.im/WALAHelp/Lobby), or [open an issue](https://github.com/wala/WALA/issues).
 
-### Building from Source
+## Building from Source
 
 WALA uses Gradle as its build system.  If you intend to modify or build WALA yourself, then see [the Gradle-specific README](README-Gradle.md) for more instructions and helpful tips.  You may also find `pom.xml` configuration files for Maven builds, but Maven is no longer well supported; use Gradle if at all possible.
 
-### WALA Tools in JavaScript
+## WALA Tools in JavaScript
 
 Recently, we have been expanding the set of WALA tools implemented in JavaScript. We have released a normalizer and some basic program analyses for JavaScript in the [JS_WALA GitHub repository](https://github.com/wala/JS_WALA). We have also made available [jsdelta](https://github.com/wala/jsdelta) and [WALA Delta](https://github.com/wala/WALADelta), delta debuggers for JavaScript-processing tools. Please see the linked GitHub repositories for further details on these tools.
 
-### WALA-Based Tools
+## WALA-Based Tools
 
 Several groups have built open-source tools that enhance or build on WALA that may be useful to other WALA users. For details, see the [Wala-based tools](https://github.com/wala/WALA/wiki/WALA-Based-Tools) page.

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ WALA features include:
 ### Getting Started
 
 The fastest way to get started with WALA is to use the packages in Maven Central, as noted [here](https://github.com/wala/WALA/wiki/Getting-Started#quick-start-using-maven-central-packages).  See the [WALA-start](https://github.com/wala/WALA-start) repo for a Gradle-based example.  We are actively re-organizing the deeper wiki technical documentation.  In the meantime, you can check out tutorial slides to get an overview of WALA:
-* [Core WALA](http://wala.sourceforge.net/files/PLDI_WALA_Tutorial.pdf)
-* [WALA JavaScript](http://wala.sourceforge.net/files/WALAJavaScriptTutorial.pdf)
+* [Core WALA](http://wala.sourceforge.net/files/PLDI_WALA_Tutorial.pdf) (PDF)
+* [WALA JavaScript](http://wala.sourceforge.net/files/WALAJavaScriptTutorial.pdf) (PDF)
 
 You can also watch screencasts of the WALA JavaScript tutorial [here](https://www.youtube.com/user/WALALibraries/videos).
 


### PR DESCRIPTION
See #626, specifically https://github.com/wala/WALA/issues/626#issuecomment-641469315.  This is the revamped README.  Some of this content will become the new WALA home page at https://wala.sourceforge.net.

I kept the build instructions that were there in the README before but it's now further down the page.