### PR TITLE
Exclude deps on com.sun.jna group

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,17 @@ subprojects { subproject ->
 		mavenCentral()
 	}
 
+	configurations {
+		implementation {
+			// See https://github.com/wala/WALA/issues/823.  This group was renamed to
+			// net.java.dev.jna.  The com.sun.jna dependency is only pulled in from
+			// com.ibm.wala.ide.* projects.  Since we only try to compile those projects from
+			// Gradle, but not run them, excluding the group as a dependence is a reasonable
+			// solution.
+			exclude group: 'com.sun.jna'
+		}
+	}
+
 	eclipse {
 		synchronizationTasks 'processTestResources'
 	}

--- a/com.ibm.wala.ide/build.gradle
+++ b/com.ibm.wala.ide/build.gradle
@@ -30,12 +30,3 @@ dependencies {
 			project(':com.ibm.wala.util'),
 	)
 }
-
-configurations {
-	implementation {
-		// See https://github.com/wala/WALA/issues/823.  This group was renamed to net.java.dev.jna.
-		// Since we only try to compile this module from Gradle but not run it, just excluding
-		// the group is sufficient for the build to pass.
-		exclude group: 'com.sun.jna'
-	}
-}

--- a/com.ibm.wala.ide/build.gradle
+++ b/com.ibm.wala.ide/build.gradle
@@ -30,3 +30,12 @@ dependencies {
 			project(':com.ibm.wala.util'),
 	)
 }
+
+configurations {
+	implementation {
+		// See https://github.com/wala/WALA/issues/823.  This group was renamed to net.java.dev.jna.
+		// Since we only try to compile this module from Gradle but not run it, just excluding
+		// the group is sufficient for the build to pass.
+		exclude group: 'com.sun.jna'
+	}
+}


### PR DESCRIPTION
Fixes #823.  Since we only try to compile `com.ibm.wala.ide` code from Gradle, not run it, I think just excluding the entire `com.sun.jna` group is an ok solution.

