### PR TITLE
JavaScript: make refs to enclosing function names lexical

### DIFF
--- a/com.ibm.wala.cast.js.rhino/src/main/java/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
+++ b/com.ibm.wala.cast.js.rhino/src/main/java/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
@@ -412,8 +412,18 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
         namePosition = makePosition(f.getFunctionName());
         f.flattenSymbolTable(false);
         int i = 0;
-        arguments = new String[f.getParamCount() + 1];
-        // arguments[i++] = name;
+        // The name of the function is declared within the scope of the function itself if it is a
+        // function expression.  Otherwise, the name is declared in the same scope as the function
+        // declaration.
+        boolean isFunctionExpression =
+            f.getFunctionType() == FunctionNode.FUNCTION_EXPRESSION
+                || f.getFunctionType() == FunctionNode.FUNCTION_EXPRESSION_STATEMENT;
+        if (isFunctionExpression) {
+          arguments = new String[f.getParamCount() + 2];
+          arguments[i++] = name;
+        } else {
+          arguments = new String[f.getParamCount() + 1];
+        }
         arguments[i++] = "this";
         for (int j = 0; j < f.getParamCount(); j++) {
           arguments[i++] = f.getParamOrVarName(j);

--- a/com.ibm.wala.cast.js.rhino/src/main/java/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
+++ b/com.ibm.wala.cast.js.rhino/src/main/java/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
@@ -412,8 +412,8 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
         namePosition = makePosition(f.getFunctionName());
         f.flattenSymbolTable(false);
         int i = 0;
-        arguments = new String[f.getParamCount() + 2];
-        arguments[i++] = name;
+        arguments = new String[f.getParamCount() + 1];
+        // arguments[i++] = name;
         arguments[i++] = "this";
         for (int j = 0; j < f.getParamCount(); j++) {
           arguments[i++] = f.getParamOrVarName(j);

--- a/com.ibm.wala.cast.js.rhino/src/main/java/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
+++ b/com.ibm.wala.cast.js.rhino/src/main/java/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
@@ -418,11 +418,14 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
         boolean isFunctionExpression =
             f.getFunctionType() == FunctionNode.FUNCTION_EXPRESSION
                 || f.getFunctionType() == FunctionNode.FUNCTION_EXPRESSION_STATEMENT;
+        arguments = new String[f.getParamCount() + 2];
         if (isFunctionExpression) {
-          arguments = new String[f.getParamCount() + 2];
           arguments[i++] = name;
         } else {
-          arguments = new String[f.getParamCount() + 1];
+          // Obfuscate the name, so any references within the method to the actual function name
+          // become lexical accesses.  We still need to keep the argument since in the WALA IR for
+          // JavaScript calls, the function value itself is always passed as the first argument.
+          arguments[i++] = "__WALA__int3rnal__fn__" + name;
         }
         arguments[i++] = "this";
         for (int j = 0; j < f.getParamCount(); j++) {

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/TestFieldBasedCG.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/TestFieldBasedCG.java
@@ -165,6 +165,11 @@ public class TestFieldBasedCG extends AbstractFieldBasedTest {
     runTest("tests/fieldbased/new_fn_empty.js", new Object[][] {}, BuilderType.OPTIMISTIC_WORKLIST);
   }
 
+  @Test
+  public void testRecursiveLexWrite() throws WalaException, Error, CancelException {
+    runTest("tests/recursive_lex_write.js", new Object[][] {}, BuilderType.OPTIMISTIC_WORKLIST);
+  }
+
   // @Test
   public void testBug2979() throws WalaException, Error, CancelException {
     System.err.println(

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/TestFieldBasedCG.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/TestFieldBasedCG.java
@@ -72,8 +72,7 @@ public class TestFieldBasedCG extends AbstractFieldBasedTest {
 
   @Test
   public void testCallbacksOptimistic() throws WalaException, Error, CancelException {
-    runTest(
-        "tests/fieldbased/callbacks.js", assertionsForCallbacks, BuilderType.OPTIMISTIC_WORKLIST);
+    runTest("tests/fieldbased/callbacks.js", assertionsForCallbacks, BuilderType.OPTIMISTIC);
   }
 
   @Test
@@ -165,9 +164,15 @@ public class TestFieldBasedCG extends AbstractFieldBasedTest {
     runTest("tests/fieldbased/new_fn_empty.js", new Object[][] {}, BuilderType.OPTIMISTIC_WORKLIST);
   }
 
+  private static final Object[][] assertionsForRecursiveLexWrite =
+      new Object[][] {new Object[] {"suffix:outer", new String[] {"suffix:foo", "suffix:bar"}}};
+
   @Test
   public void testRecursiveLexWrite() throws WalaException, Error, CancelException {
-    runTest("tests/recursive_lex_write.js", new Object[][] {}, BuilderType.OPTIMISTIC_WORKLIST);
+    runTest(
+        "tests/recursive_lex_write.js",
+        assertionsForRecursiveLexWrite,
+        BuilderType.OPTIMISTIC_WORKLIST);
   }
 
   // @Test

--- a/com.ibm.wala.cast.js/src/test/resources/tests/recursive_lex_write.js
+++ b/com.ibm.wala.cast.js/src/test/resources/tests/recursive_lex_write.js
@@ -1,0 +1,8 @@
+(function () {
+  function foo() {
+      foo = function() { return 3; }
+      return 4;
+  }
+  foo();
+  foo();
+})();

--- a/com.ibm.wala.cast.js/src/test/resources/tests/recursive_lex_write.js
+++ b/com.ibm.wala.cast.js/src/test/resources/tests/recursive_lex_write.js
@@ -1,8 +1,11 @@
-(function () {
+function outer() {
   function foo() {
-      foo = function() { return 3; }
+    function bar() { return 3; }
+      foo = bar;
       return 4;
   }
   foo();
   foo();
-})();
+}
+
+outer();

--- a/com.ibm.wala.cast.js/src/test/resources/tests/recursive_lex_write.js
+++ b/com.ibm.wala.cast.js/src/test/resources/tests/recursive_lex_write.js
@@ -1,8 +1,8 @@
 function outer() {
   function foo() {
     function bar() { return 3; }
-      foo = bar;
-      return 4;
+    foo = bar;
+    return 4;
   }
   foo();
   foo();


### PR DESCRIPTION
Previously, we always treated the name of a function as being declared in the scope of the function body.  But this is only true for function expressions, not function statements.  Hence, there were cases when WALA IR was modeling a read of a function name as a local variable access, when in fact it was a lexical access.  This PR fixes the bug and adds a corresponding test `recursive_lex_write.js` that we would previously handle unsoundly.