### PR TITLE
Handle ARROW_FUNCTION in visitFunctionNode

### DIFF
--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestSimpleCallGraphShapeRhino.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestSimpleCallGraphShapeRhino.java
@@ -13,6 +13,7 @@ package com.ibm.wala.cast.js.test;
 import com.ibm.wala.cast.js.ipa.callgraph.JSCFABuilder;
 import com.ibm.wala.cast.js.translator.CAstRhinoTranslatorFactory;
 import com.ibm.wala.cast.js.util.JSCallGraphBuilderUtil;
+import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.WalaException;
@@ -48,6 +49,19 @@ public class TestSimpleCallGraphShapeRhino extends TestSimpleCallGraphShape {
   public void testRepr()
       throws IllegalArgumentException, IOException, CancelException, WalaException {
     JSCallGraphBuilderUtil.makeScriptCG("tests", "repr.js");
+  }
+
+  private static final Object[][] arrowFunctionCGAssertions =
+      new Object[][] {
+        new Object[] {ROOT, new String[] {"arrowfunction.js"}},
+        new Object[] {"suffix:applyFunction", new String[] {"suffix:arrowfunction.js@55"}}
+      };
+
+  @Test
+  public void testArrowFunction()
+      throws IllegalArgumentException, IOException, CancelException, WalaException {
+    CallGraph CG = JSCallGraphBuilderUtil.makeScriptCG("tests", "arrowfunction.js");
+    verifyGraphAssertions(CG, arrowFunctionCGAssertions);
   }
 
   @Test

--- a/com.ibm.wala.cast.js/src/test/resources/tests/arrowfunction.js
+++ b/com.ibm.wala.cast.js/src/test/resources/tests/arrowfunction.js
@@ -1,0 +1,5 @@
+function applyFunction(f) {
+	f(null);
+}
+
+applyFunction((r)=>{});


### PR DESCRIPTION
For example:

```js
var https=require('https');

https.get({}, (r)=>{}); // AST: v21 = dispatch v20:#get@18 v10,v22,v17:#null
```

But for:

```js
var https=require('https');

// AST: v21 = construct v24@16 v23:#example.js@42 exception:v2example.js [28->58] (line 2)
https.get({}, function (r) {}); // AST: v16 = dispatch v15:#get@17 v5,v17,v21
```

I think [this predicate](https://github.com/wala/WALA/blob/60af67444dafe4071cd571b538cc2aff78b9d0ca/com.ibm.wala.cast.js.rhino/src/main/java/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java#L1250) should consider `FunctionNode.ARROW_FUNCTION` as well.