### PR TITLE
Update R8 using different Maven repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,8 +59,11 @@ subprojects { subproject ->
 	version rootProject.version
 
 	repositories {
-		google() // to get r8
 		mavenCentral()
+		// to get r8
+		maven {
+			url 'https://storage.googleapis.com/r8-releases/raw'
+		}
 	}
 
 	configurations {

--- a/com.ibm.wala.dalvik/build.gradle
+++ b/com.ibm.wala.dalvik/build.gradle
@@ -127,7 +127,7 @@ dependencies {
 	)
 	sampleCup 'java_cup:java_cup:0.9e:sources'
 	testImplementation(
-			'com.android.tools:r8:2.0.99',
+			'com.android.tools:r8:2.2.42',
 			'junit:junit:4.13.1',
 			'org.smali:dexlib2:2.4.0',
 			project(':com.ibm.wala.core'),


### PR DESCRIPTION
It seems R8 releases are not pushed to the main Google Maven repo very often.  Pull them from the alternate repo instead.