### PR TITLE
Force dependence on old version of org.eclipse.ui.workbench to fix a compile error

### DIFF
--- a/com.ibm.wala.ide.tests/build.gradle
+++ b/com.ibm.wala.ide.tests/build.gradle
@@ -17,7 +17,6 @@ eclipseMavenCentral {
 				'org.eclipse.jface',
 				'org.eclipse.osgi',
 				'org.eclipse.ui.ide',
-				'org.eclipse.ui.workbench',
 		].each { dep 'testImplementation', it }
 		useNativesForRunningPlatform()
 	}
@@ -30,4 +29,7 @@ dependencies {
 			project(':com.ibm.wala.ide'),
 			project(':com.ibm.wala.util'),
 	)
+	testImplementation('org.eclipse.platform:org.eclipse.ui.workbench') {
+		version { strictly '3.120.0' }
+	}
 }


### PR DESCRIPTION
Somehow the dependence version of `org.eclipse.ui.workbench` got bumped, so code wasn't compiling anymore in Gradle on Java 8 (due to JDK 11 classes in the new jar).  Forcing an older version seems to fix it.  