### PR TITLE
Add ReflectiveCallVertex to JS flow graph

### DIFF
--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestFlowGraphJSON.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestFlowGraphJSON.java
@@ -70,16 +70,15 @@ public class TestFlowGraphJSON {
   @Test
   public void testCallAndApply() {
     assertThat(
-        Arrays.asList(parsedJSON.get("Var(flowgraph_constraints.js@29, [x, $$destructure$rcvr7])")),
+        Arrays.asList(
+            parsedJSON.get("Var(flowgraph_constraints.js@29, [nested, x, $$destructure$rcvr7])")),
         hasItems(
             "ReflectiveCallee(flowgraph_constraints.js@33)",
-            "ReflectiveCallee(flowgraph_constraints.js@32)"));
+            "ReflectiveCallee(flowgraph_constraints.js@32)",
+            "Param(Func(flowgraph_constraints.js@30), 2)"));
     assertThat(
-        Arrays.asList(parsedJSON.get("Var(flowgraph_constraints.js@29, [nested])")),
-        hasItem("Param(Func(flowgraph_constraints.js@8), 2)"));
-    assertThat(
-        Arrays.asList(parsedJSON.get("Ret(Func(flowgraph_constraints.js@8))")),
-        hasItem("Var(flowgraph_constraints.js@29, [res1])"));
+        Arrays.asList(parsedJSON.get("Ret(Func(flowgraph_constraints.js@30))")),
+        containsInAnyOrder("Var(flowgraph_constraints.js@29, [res1])"));
   }
 
   private static Map<String, String[]> getParsedFlowGraphJSON(String script)

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestFlowGraphJSON.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/test/TestFlowGraphJSON.java
@@ -1,6 +1,5 @@
 package com.ibm.wala.cast.js.test;
 
-import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/AbstractVertexVisitor.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/AbstractVertexVisitor.java
@@ -79,4 +79,9 @@ public class AbstractVertexVisitor<T> implements VertexVisitor<T> {
   public T visitPrototypeVertex(PrototypeFieldVertex protoVertex) {
     return visitVertex();
   }
+
+  @Override
+  public T visitReflectiveCallVertex(ReflectiveCallVertex reflectiveCallVertex) {
+    return visitVertex();
+  }
 }

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/ReflectiveCallVertex.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/ReflectiveCallVertex.java
@@ -1,0 +1,57 @@
+package com.ibm.wala.cast.js.callgraph.fieldbased.flowgraph.vertices;
+
+import com.ibm.wala.cast.js.ssa.JavaScriptInvoke;
+import com.ibm.wala.cast.loader.AstMethod;
+import com.ibm.wala.cast.types.AstMethodReference;
+import com.ibm.wala.classLoader.CallSiteReference;
+import com.ibm.wala.classLoader.IClass;
+import com.ibm.wala.ipa.callgraph.IAnalysisCacheView;
+
+public class ReflectiveCallVertex extends Vertex {
+
+  // method containing the call
+  private final FuncVertex caller;
+
+  // PC of the call site
+  private final CallSiteReference site;
+
+  // the call instruction itself
+  private final JavaScriptInvoke invk;
+
+  public ReflectiveCallVertex(FuncVertex caller, CallSiteReference site, JavaScriptInvoke invk) {
+    this.caller = caller;
+    this.site = site;
+    this.invk = invk;
+  }
+
+  public FuncVertex getCaller() {
+    return caller;
+  }
+
+  public CallSiteReference getSite() {
+    return site;
+  }
+
+  public JavaScriptInvoke getInstruction() {
+    return invk;
+  }
+
+  @Override
+  public <T> T accept(VertexVisitor<T> visitor) {
+    return visitor.visitReflectiveCallVertex(this);
+  }
+
+  @Override
+  public String toString() {
+    return "ReflectiveCallee(" + caller + ", " + site + ')';
+  }
+
+  @Override
+  public String toSourceLevelString(IAnalysisCacheView cache) {
+    IClass concreteType = caller.getConcreteType();
+    AstMethod method = (AstMethod) concreteType.getMethod(AstMethodReference.fnSelector);
+    return "ReflectiveCallee("
+        + method.getSourcePosition(site.getProgramCounter()).prettyPrint()
+        + ")";
+  }
+}

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/VertexFactory.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/VertexFactory.java
@@ -29,6 +29,8 @@ import java.util.Map;
 public class VertexFactory {
   private final Map<Pair<FuncVertex, CallSiteReference>, CallVertex> callVertexCache =
       HashMapFactory.make();
+  private final Map<Pair<FuncVertex, CallSiteReference>, ReflectiveCallVertex>
+      reflectiveCallVertexCache = HashMapFactory.make();
   private final Map<IClass, FuncVertex> funcVertexCache = HashMapFactory.make();
   private final Map<Pair<FuncVertex, Integer>, ParamVertex> paramVertexCache =
       HashMapFactory.make();
@@ -46,6 +48,16 @@ public class VertexFactory {
     Pair<FuncVertex, CallSiteReference> key = Pair.make(func, site);
     CallVertex value = callVertexCache.get(key);
     if (value == null) callVertexCache.put(key, value = new CallVertex(func, site, invk));
+    return value;
+  }
+
+  public ReflectiveCallVertex makeReflectiveCallVertex(FuncVertex func, JavaScriptInvoke invk) {
+    CallSiteReference site = invk.getCallSite();
+    Pair<FuncVertex, CallSiteReference> key = Pair.make(func, site);
+    ReflectiveCallVertex value = reflectiveCallVertexCache.get(key);
+    if (value == null) {
+      reflectiveCallVertexCache.put(key, value = new ReflectiveCallVertex(func, site, invk));
+    }
     return value;
   }
 

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/VertexVisitor.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/VertexVisitor.java
@@ -34,4 +34,6 @@ public interface VertexVisitor<T> {
   public abstract T visitGlobalVertex(GlobalVertex globalVertex);
 
   public abstract T visitPrototypeVertex(PrototypeFieldVertex protoVertex);
+
+  public abstract T visitReflectiveCallVertex(ReflectiveCallVertex reflectiveCallVertex);
 }

--- a/com.ibm.wala.cast.js/src/test/resources/tests/fieldbased/flowgraph_constraints.js
+++ b/com.ibm.wala.cast.js/src/test/resources/tests/fieldbased/flowgraph_constraints.js
@@ -28,7 +28,7 @@ voidFun();
 
 function functionPrototypeCallApply() {
   function nested() {}
-  var x = id;
+  var x = nested;
   var res1 = x.call(this, nested);
   var res2 = x.apply(this, [nested]);
 }

--- a/com.ibm.wala.cast.js/src/test/resources/tests/fieldbased/flowgraph_constraints.js
+++ b/com.ibm.wala.cast.js/src/test/resources/tests/fieldbased/flowgraph_constraints.js
@@ -29,6 +29,6 @@ voidFun();
 function functionPrototypeCallApply() {
   function nested() {}
   var x = nested;
-  var res1 = x.call(this, nested);
-  var res2 = x.apply(this, [nested]);
+  var res1 = x.call(null, nested);
+  var res2 = x.apply(null, [nested]);
 }

--- a/com.ibm.wala.cast.js/src/test/resources/tests/fieldbased/flowgraph_constraints.js
+++ b/com.ibm.wala.cast.js/src/test/resources/tests/fieldbased/flowgraph_constraints.js
@@ -25,3 +25,10 @@ function voidFun() {
 }
 
 voidFun();
+
+function functionPrototypeCallApply() {
+  function nested() {}
+  var x = id;
+  var res1 = x.call(this, nested);
+  var res2 = x.apply(this, [nested]);
+}


### PR DESCRIPTION
This vertex more explicitly captures which variable holds the function invoked when using `Function.prototype.call` and `Function.prototype.apply`.  The addition does not affect the computed call graph, but can be helpful for downstream clients inspecting the flow graph.