### PR TITLE
Fix handling of default case in switch statements

### DIFF
--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/TestFieldBasedCG.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/TestFieldBasedCG.java
@@ -191,6 +191,17 @@ public class TestFieldBasedCG extends AbstractFieldBasedTest {
         BuilderType.OPTIMISTIC_WORKLIST);
   }
 
+  @Test
+  public void testSwitchDefault() throws WalaException, Error, CancelException {
+    runTest(
+        "tests/switch_default.js",
+        new Object[][] {
+          new Object[] {"suffix:withSwitch", new String[] {"suffix:fun1", "suffix:fun2"}},
+          new Object[] {"suffix:withSwitchStr", new String[] {"suffix:fun3", "suffix:fun4"}}
+        },
+        BuilderType.OPTIMISTIC_WORKLIST);
+  }
+
   // @Test
   public void testBug2979() throws WalaException, Error, CancelException {
     System.err.println(

--- a/com.ibm.wala.cast.js/src/test/resources/tests/switch_default.js
+++ b/com.ibm.wala.cast.js/src/test/resources/tests/switch_default.js
@@ -1,0 +1,23 @@
+function fun1() {}
+function fun2() {}
+
+function withSwitch(i) {
+  switch (i) {
+    case 0: return fun1();
+    default: return fun2();
+  }
+}
+
+withSwitch(2);
+
+function fun3() {}
+function fun4() {}
+
+function withSwitchStr(s) {
+  switch (s) {
+    case 'Hello': return fun3();
+    default: return fun4();
+  }
+}
+
+withSwitchStr('Goodbye');

--- a/com.ibm.wala.cast.js/src/test/resources/tests/switch_default.js
+++ b/com.ibm.wala.cast.js/src/test/resources/tests/switch_default.js
@@ -1,5 +1,5 @@
-function fun1() {}
-function fun2() {}
+function fun1() { return 1; }
+function fun2() { return 2; }
 
 function withSwitch(i) {
   switch (i) {
@@ -10,8 +10,8 @@ function withSwitch(i) {
 
 withSwitch(2);
 
-function fun3() {}
-function fun4() {}
+function fun3() { return 3; }
+function fun4() { return 4; }
 
 function withSwitchStr(s) {
   switch (s) {


### PR DESCRIPTION
Before, the explicit default case in the generated CFG was unreachable, leading to the code being deleted completely from the IR.  Add some comments and a JavaScript test.  Presumably Java (and other CAst languages) are also affected by this fix.