### PR TITLE
Clarify Javadoc of ClassHierarchy resolveMethod

### DIFF
--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/cha/ClassHierarchy.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/cha/ClassHierarchy.java
@@ -572,12 +572,6 @@ public class ClassHierarchy implements IClassHierarchy {
     return result;
   }
 
-  /**
-   * Return the unique receiver of an invocation of method on an object of type m.getDeclaredClass
-   *
-   * @return IMethod, or null if no appropriate receiver is found.
-   * @throws IllegalArgumentException if m is null
-   */
   @Override
   public IMethod resolveMethod(MethodReference m) {
     if (m == null) {
@@ -623,14 +617,6 @@ public class ClassHierarchy implements IClassHierarchy {
     return klass.getField(f.getName(), f.getFieldType().getName());
   }
 
-  /**
-   * Return the unique target of an invocation of method on an object of type declaringClass
-   *
-   * @param receiverClass type of receiver
-   * @param selector method signature
-   * @return Method resolved method abstraction
-   * @throws IllegalArgumentException if receiverClass is null
-   */
   @Override
   public IMethod resolveMethod(IClass receiverClass, Selector selector) {
     if (receiverClass == null) {

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/cha/IClassHierarchy.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/cha/IClassHierarchy.java
@@ -74,7 +74,10 @@ public interface IClassHierarchy extends Iterable<IClass> {
   public Set<IMethod> getPossibleTargets(IClass receiverClass, MethodReference ref);
 
   /**
-   * Return the unique receiver of an invocation of method on an object of type m.getDeclaredClass
+   * Return the unique receiver of an invocation of method on an object of type {@code
+   * m.getDeclaredClass()}. Note that for Java, {@code m.getDeclaredClass()} must represent a
+   * <em>class</em>, <em>not</em> an interface. This method does not work for finding inherited
+   * methods in interfaces.
    *
    * @return IMethod, or null if no appropriate receiver is found.
    * @throws IllegalArgumentException if m is null
@@ -95,9 +98,11 @@ public interface IClassHierarchy extends Iterable<IClass> {
   public IField resolveField(IClass klass, FieldReference f);
 
   /**
-   * Return the unique receiver of an invocation of method on an object of type declaringClass
+   * Return the unique target of an invocation of method on an object of type receiverClass
    *
-   * @param receiverClass type of receiver
+   * @param receiverClass type of receiver. Note that for Java, {@code receiverClass} must represent
+   *     a <em>class</em>, <em>not</em> an interface. This method does not work for finding
+   *     inherited methods in interfaces.
    * @param selector method signature
    * @return Method resolved method abstraction
    * @throws IllegalArgumentException if receiverClass is null


### PR DESCRIPTION
See #871.  Clarify that `resolveMethod()` only works when the receiver represents a class.

Also delete duplicative documentation between `IClassHierarchy` and `ClassHierarchy` for these methods.