### PR TITLE
Minor Gradle 6 updates for better future-compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ subprojects { subproject ->
 
 		if (project.hasProperty('excludeSlowTests')) {
 			dependencies {
-				testRuntime testFixtures(project(':com.ibm.wala.core'))
+				testRuntimeOnly testFixtures(project(':com.ibm.wala.core'))
 			}
 			useJUnit {
 				excludeCategories 'com.ibm.wala.tests.util.SlowTests'

--- a/buildSrc/src/main/groovy/java-compile-using-ecj.groovy
+++ b/buildSrc/src/main/groovy/java-compile-using-ecj.groovy
@@ -29,7 +29,7 @@ class JavaCompileUsingEcj extends JavaCompile {
 		onlyIf { !project.hasProperty('skipJavaUsingEcjTasks') }
 	}
 
-	final void setSourceSet(SourceSet sourceSet) {
+	final void setSourceSet(final SourceSet sourceSet) {
 		// Imitate most of the behavior of the standard compilation task for the given sourceSet.
 		final standardCompileTaskName = sourceSet.getCompileTaskName('java')
 		final standardCompileTask = project.tasks.named(standardCompileTaskName, JavaCompile).get()
@@ -41,7 +41,7 @@ class JavaCompileUsingEcj extends JavaCompile {
 		destinationDirectory.set project.layout.buildDirectory.dir(destinationSubdir)
 	}
 
-	final static Provider<JavaCompileUsingEcj> withSourceSet(Project project, SourceSet sourceSet) {
+	final static Provider<JavaCompileUsingEcj> withSourceSet(final Project project, final SourceSet sourceSet) {
 		return project.tasks.register(sourceSet.getCompileTaskName('javaUsingEcj'), JavaCompileUsingEcj) { it ->
 			it.sourceSet = sourceSet
 		}

--- a/buildSrc/src/main/java/com/ibm/wala/gradle/EclipseJavaCompiler.java
+++ b/buildSrc/src/main/java/com/ibm/wala/gradle/EclipseJavaCompiler.java
@@ -32,7 +32,7 @@ class EclipseJavaCompiler implements Compiler<JavaCompileSpec> {
    *
    * @param project the project that will use this compiler
    */
-  EclipseJavaCompiler(Project project) {
+  EclipseJavaCompiler(final Project project) {
     this.project = project;
     ecjConfiguration =
         project

--- a/com.ibm.wala.cast.java.ecj/build.gradle
+++ b/com.ibm.wala.cast.java.ecj/build.gradle
@@ -26,9 +26,7 @@ dependencies {
 	)
 }
 
-application {
-	mainClassName = 'com.ibm.wala.cast.java.ecj.util.SourceDirCallGraph'
-}
+application.mainClass.set('com.ibm.wala.cast.java.ecj.util.SourceDirCallGraph')
 
 tasks.named('run') {
 	// this is for testing purposes

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -102,6 +102,8 @@ tasks.register('extractKawa') {
 @CacheableTask
 class CompileKawaScheme extends JavaExec {
 
+	@InputFile
+	@PathSensitive(PathSensitivity.NONE)
 	final RegularFileProperty schemeFile = project.objects.fileProperty()
 
 	CompileKawaScheme() {
@@ -115,7 +117,6 @@ class CompileKawaScheme extends JavaExec {
 		logging.captureStandardError LogLevel.INFO
 		args '--main', '-C'
 		argumentProviders.add({ -> [schemeFile.get() as String] } as CommandLineArgumentProvider)
-		inputs.file schemeFile
 	}
 }
 


### PR DESCRIPTION
These tweaks don't actually allow us to upgrade to Gradle 7: see wala/WALA#892. But they do smooth the path for a future upgrade by modernizing some things that are deprecated in Gradle 6 or 7.