### PR TITLE
[WIP] Fix for updated Eclipse dependencies that require JDK 11

### DIFF
--- a/com.ibm.wala.cast.java.ecj/build.gradle
+++ b/com.ibm.wala.cast.java.ecj/build.gradle
@@ -20,6 +20,9 @@ dependencies {
 			project(':com.ibm.wala.shrike'),
 			project(':com.ibm.wala.util'),
 	)
+	implementation('org.eclipse.platform:org.eclipse.equinox.common') {
+		version { strictly '3.14.100' }
+	}	
 	testImplementation(
 			'junit:junit:4.13.2',
 			testFixtures(project(':com.ibm.wala.cast.java')),

--- a/com.ibm.wala.ide.jdt.test/build.gradle
+++ b/com.ibm.wala.ide.jdt.test/build.gradle
@@ -33,6 +33,12 @@ dependencies {
 	testImplementation('javax.annotation:javax.annotation-api') {
 		version { strictly '1.3.2' }
 	}
+	testImplementation('org.eclipse.platform:org.eclipse.core.resources') {
+		version { strictly '3.14.0' }
+	}
+	testImplementation('org.eclipse.platform:org.eclipse.equinox.common') {
+		version { strictly '3.14.100' }
+	}
 }
 
 tasks.named('test') {

--- a/com.ibm.wala.ide.jdt/build.gradle
+++ b/com.ibm.wala.ide.jdt/build.gradle
@@ -32,4 +32,10 @@ dependencies {
 	implementation('javax.annotation:javax.annotation-api') {
 		version { strictly '1.3.2' }
 	}
+	implementation('org.eclipse.platform:org.eclipse.core.resources') {
+		version { strictly '3.14.0' }
+	}
+	implementation('org.eclipse.platform:org.eclipse.equinox.common') {
+		version { strictly '3.14.100' }
+	}
 }

--- a/com.ibm.wala.ide.jsdt.tests/build.gradle
+++ b/com.ibm.wala.ide.jsdt.tests/build.gradle
@@ -38,6 +38,12 @@ dependencies {
 	testImplementation('javax.annotation:javax.annotation-api') {
 		version { strictly '1.3.2' }
 	}
+	testImplementation('org.eclipse.platform:org.eclipse.core.resources') {
+		version { strictly '3.14.0' }
+	}
+	testImplementation('org.eclipse.platform:org.eclipse.equinox.common') {
+		version { strictly '3.14.100' }
+	}
 }
 
 tasks.named('test') {

--- a/com.ibm.wala.ide.jsdt/build.gradle
+++ b/com.ibm.wala.ide.jsdt/build.gradle
@@ -41,6 +41,12 @@ dependencies {
 	implementation('javax.annotation:javax.annotation-api') {
 		version { strictly '1.3.2' }
 	}
+	implementation('org.eclipse.platform:org.eclipse.core.resources') {
+		version { strictly '3.14.0' }
+	}
+	implementation('org.eclipse.platform:org.eclipse.equinox.common') {
+		version { strictly '3.14.100' }
+	}
 	testFixturesImplementation('javax.annotation:javax.annotation-api') {
 		version { strictly '1.3.2' }
 	}

--- a/com.ibm.wala.ide.tests/build.gradle
+++ b/com.ibm.wala.ide.tests/build.gradle
@@ -35,5 +35,10 @@ dependencies {
 	testImplementation('javax.annotation:javax.annotation-api') {
 		version { strictly '1.3.2' }
 	}
-
+	testImplementation('org.eclipse.platform:org.eclipse.core.resources') {
+		version { strictly '3.14.0' }
+	}
+	testImplementation('org.eclipse.platform:org.eclipse.equinox.common') {
+		version { strictly '3.14.100' }
+	}
 }

--- a/com.ibm.wala.ide/build.gradle
+++ b/com.ibm.wala.ide/build.gradle
@@ -32,6 +32,12 @@ dependencies {
 	implementation('javax.annotation:javax.annotation-api') {
 		version { strictly '1.3.2' }
 	}
+	implementation('org.eclipse.platform:org.eclipse.core.resources') {
+		version { strictly '3.14.0' }
+	}
+	implementation('org.eclipse.platform:org.eclipse.equinox.common') {
+		version { strictly '3.14.100' }
+	}	
 	testFixturesImplementation('javax.annotation:javax.annotation-api') {
 		version { strictly '1.3.2' }
 	}


### PR DESCRIPTION
WALA master no longer builds on JDK 8, due to the fact that some Eclipse dependencies got updated to versions that require JDK 11.  This PR fixes the compilation problem, but it's kind of a hack and I hope there is a better approach.

@liblit I'd appreciate it if you could take a look at this and answer a couple of questions:
1. Why does the WALA build even pull new versions of these dependencies?  I don't understand how the `com.diffplug.eclipse.mavencentral` plugin works, but is there any way we can tell it to "freeze" the version of the Eclipse dependencies that we use and not update them unless we specifically ask?  Unintended updates to transitive dependencies have bit us before.
2. What is the "right" way to fix this?  My change works by forcing old versions of jars, which works for compiling, but at runtime things are messed up (the `com.ibm.wala.cast.java.ecj` test is failing as there are still more jars that require JDK 11).  We need a way to get a consistent set of Eclipse jars in the dependencies, while preventing them from being uploaded without us asking.

I meant to cut a new release today but got caught up in this issue.  We need to figure out a way to make things more dependable.  Maybe we need to not use `com.diffplug.eclipse.mavencentral`, at least for the ECJ module, or put in place some kind of transitive dependency freezing.  
 
Anyway thoughts welcome here.