### PR TITLE
Avoid Eclipse artifact versions that require Java 11+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,18 @@ subprojects { subproject ->
 		}
 	}
 
+    dependencies.constraints {
+    	[
+    			'org.eclipse.platform:org.eclipse.core.resources',
+    			'org.eclipse.platform:org.eclipse.equinox.common',
+    	].forEach {
+    		implementation(it) {
+    			version { strictly '(,3.15)' }
+    			because 'Versions 3.15 and later of this artifact require Java 11.'
+    		}
+    	}
+    }
+
 	configurations {
 		implementation {
 			// See https://github.com/wala/WALA/issues/823.  This group was renamed to


### PR DESCRIPTION
This pull request is an alternative to #898 that centralizes constraint configuration in one place for all subprojects.