### PR TITLE
Updated constructor instancing for >=java 9

### DIFF
--- a/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
+++ b/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
@@ -100,7 +100,7 @@ public class AndroidManifestXMLReader {
     try (final FileInputStream in = new FileInputStream(xmlFile)) {
       readXML(in);
     } catch (Exception e) {
-      e.printStackTrace();
+      //e.printStackTrace();
       throw new IllegalStateException("Exception was thrown");
     }
   }
@@ -112,7 +112,7 @@ public class AndroidManifestXMLReader {
     try {
       readXML(xmlFile);
     } catch (Exception e) {
-      e.printStackTrace();
+      //e.printStackTrace();
       throw new IllegalStateException("Exception was thrown");
     }
   }
@@ -264,7 +264,7 @@ public class AndroidManifestXMLReader {
           e.getCause().printStackTrace();
           throw new IllegalStateException("InstantiationException was thrown");
         } catch (java.lang.IllegalAccessException e) {
-          e.printStackTrace();
+          //e.printStackTrace();
           if (e.getCause() != null) {
             e.getCause().printStackTrace();
           }

--- a/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
+++ b/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
@@ -258,7 +258,7 @@ public class AndroidManifestXMLReader {
       this.allowedSubTagsHolder = allowedSubTags;
       if (item != null) {
         try {
-          this.item = item.newInstance();
+          this.item = item.getConstructor().newInstance();
           this.item.setSelf(this);
         } catch (java.lang.InstantiationException e) {
           e.getCause().printStackTrace();
@@ -269,6 +269,18 @@ public class AndroidManifestXMLReader {
             e.getCause().printStackTrace();
           }
           throw new IllegalStateException("IllegalAccessException was thrown");
+        } catch (java.lang.NoSuchMethodException e) {
+          e.printStackTrace();
+          if (e.getCause() != null) {
+            e.getCause().printStackTrace();
+          }
+          throw new IllegalStateException("NoSuchMethodException was thrown");
+        } catch (java.lang.reflect.InvocationTargetException e) {
+          e.printStackTrace();
+          if (e.getCause() != null) {
+            e.getCause().printStackTrace();
+          }
+          throw new IllegalStateException("InvocationTargetException was thrown");
         }
       } else {
         this.item = null;

--- a/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
+++ b/com.ibm.wala.dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
@@ -100,7 +100,7 @@ public class AndroidManifestXMLReader {
     try (final FileInputStream in = new FileInputStream(xmlFile)) {
       readXML(in);
     } catch (Exception e) {
-      //e.printStackTrace();
+      // e.printStackTrace();
       throw new IllegalStateException("Exception was thrown");
     }
   }
@@ -112,7 +112,7 @@ public class AndroidManifestXMLReader {
     try {
       readXML(xmlFile);
     } catch (Exception e) {
-      //e.printStackTrace();
+      // e.printStackTrace();
       throw new IllegalStateException("Exception was thrown");
     }
   }
@@ -264,7 +264,7 @@ public class AndroidManifestXMLReader {
           e.getCause().printStackTrace();
           throw new IllegalStateException("InstantiationException was thrown");
         } catch (java.lang.IllegalAccessException e) {
-          //e.printStackTrace();
+          // e.printStackTrace();
           if (e.getCause() != null) {
             e.getCause().printStackTrace();
           }

--- a/com.ibm.wala.util/src/main/java/com/ibm/wala/util/intset/IntSetUtil.java
+++ b/com.ibm.wala.util/src/main/java/com/ibm/wala/util/intset/IntSetUtil.java
@@ -30,7 +30,7 @@ public class IntSetUtil {
         Class<? extends MutableIntSetFactory<?>> intSetFactoryClass =
             (Class<? extends MutableIntSetFactory<?>>)
                 Class.forName(System.getProperty(INT_SET_FACTORY_CONFIG_PROPERTY_NAME));
-        MutableIntSetFactory<?> intSetFactory = intSetFactoryClass.newInstance();
+        MutableIntSetFactory<?> intSetFactory = intSetFactoryClass.getConstructor().newInstance();
         setDefaultIntSetFactory(intSetFactory);
       } catch (Exception e) {
         System.err.println(


### PR DESCRIPTION
Updated instance based construction to follow java 9+ standard after the old method was deprecated. I also added associated error handling to make sure any potential issue was treated per existing convention 