### PR TITLE
Remove --continue flag from Gradle jobs on CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -47,14 +47,14 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: 'adopt'
       - name: Build and test using Gradle and Java 8
-        run: ./gradlew --continue --no-build-cache --no-daemon javadoc build
+        run: ./gradlew --no-build-cache --no-daemon javadoc build
         # testing ECJ compilation on any one OS is sufficient; we choose Linux arbitrarily
         if: runner.os == 'Linux' && matrix.java == '8'
       - name: Build and test using Gradle and Java 11
-        run: ./gradlew --continue --no-build-cache --no-daemon :com.ibm.wala.core:test
+        run: ./gradlew --no-build-cache --no-daemon :com.ibm.wala.core:test
         if: runner.os == 'Linux' && matrix.java == '11'
       - name: Build and test using Gradle but without ECJ
-        run: ./gradlew --continue --no-build-cache --no-daemon javadoc build -PskipJavaUsingEcjTasks
+        run: ./gradlew --no-build-cache --no-daemon javadoc build -PskipJavaUsingEcjTasks
         if: runner.os != 'Linux'
       - name: Check for Git cleanliness after build and test
         run: ./check-git-cleanliness.sh


### PR DESCRIPTION
The advantage of `--continue` is that you might see more CI failures in one run.  But there are disadvantages, including:

1. It takes longer to get notified when some failure exists.
2. It can be hard to search through the extra log output for the root cause of the failure.

Overall, I think we're better off without `--continue`.