### PR TITLE
Configure IntelliJ IDEA issue navigation

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -10,6 +10,16 @@
       </inspection_tool>
     </profile>
   </component>
+  <component name="IssueNavigationConfiguration">
+    <option name="links">
+      <list>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="#(\d+)" />
+          <option name="linkRegexp" value="https://github.com/wala/WALA/issues/$1" />
+        </IssueNavigationLink>
+      </list>
+    </option>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
   </component>


### PR DESCRIPTION
This extra bit of project metadata teaches IntelliJ IDEA to recognize
mentions of issues in commit messages and turn them into GitHub WALA
project links.  Subtle, but handy!

See https://www.jetbrains.com/help/idea/handling-issues.html for more
information about this IntelliJ IDEA feature.