### PR TITLE
Restore more of the recently removed IDE metadata

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+*.iml
+/compiler.xml
+/gradle.xml
+/jarRepositories.xml
+/libraries/*.xml
+/modules.xml
+/shelf/
+/tasks.xml
+/usage.statistics.xml
+/workspace.xml

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+com.ibm.wala


### PR DESCRIPTION
Julian removed all IntelliJ IDEA project metadata in commit 2c8f34c39c68680d0a2cc865e22fc10e8af0a01d.  He restored most of that in commit 708ad6542908e0494df07aa3f383028f13a02fb9, but not all.  The overlooked files begin with `.`, so were probably missed by some `*` wildcard.  This commit restores those last two overlooked files.