### PR TITLE
Remove JUnit as an implementation dependence of cast.js

### DIFF
--- a/com.ibm.wala.cast.js/build.gradle
+++ b/com.ibm.wala.cast.js/build.gradle
@@ -4,7 +4,6 @@ dependencies {
 	}
 	implementation(
 			'commons-io:commons-io:2.11.0',
-			'junit:junit:4.13.2',
 			'net.htmlparser.jericho:jericho-html:3.2',
 			'com.google.code.gson:gson:2.8.8',
 			project(':com.ibm.wala.core'),

--- a/com.ibm.wala.cast.js/gradle.lockfile
+++ b/com.ibm.wala.cast.js/gradle.lockfile
@@ -3,9 +3,9 @@
 # This file is expected to be part of source control.
 com.google.code.gson:gson:2.8.8=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 commons-io:commons-io:2.11.0=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
-junit:junit:4.13.2=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+junit:junit:4.13.2=testCompileClasspath,testFixturesCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 net.htmlparser.jericho:jericho-html:3.2=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 org.apache.ant:ant-launcher:1.10.11=testFixturesRuntimeClasspath,testRuntimeClasspath
 org.apache.ant:ant:1.10.11=testFixturesRuntimeClasspath,testRuntimeClasspath
-org.hamcrest:hamcrest-core:1.3=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+org.hamcrest:hamcrest-core:1.3=testCompileClasspath,testFixturesCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 empty=annotationProcessor,signatures,testAnnotationProcessor,testFixturesAnnotationProcessor


### PR DESCRIPTION
JUnit should only be required for tests.