### PR TITLE
Don't compile JSDT projects with Gradle

### DIFF
--- a/com.ibm.wala.ide.jsdt/src/main/java/com/ibm/wala/ide/util/EclipseWebProjectPath.java
+++ b/com.ibm.wala.ide.jsdt/src/main/java/com/ibm/wala/ide/util/EclipseWebProjectPath.java
@@ -44,7 +44,7 @@ public class EclipseWebProjectPath extends JavaScriptEclipseProjectPath {
       String fileExtension) {
     List<Module> s = MapUtil.findOrCreateList(modules, loader);
     Iterator<FileModule> htmlPages =
-        new EclipseSourceDirectoryTreeModule(p, excfffludePaths, "html").getEntries();
+        new EclipseSourceDirectoryTreeModule(p, excludePaths, "html").getEntries();
     while (htmlPages.hasNext()) {
       FileModule htmlPage = htmlPages.next();
       Set<MappedSourceModule> scripts;

--- a/com.ibm.wala.ide.jsdt/src/main/java/com/ibm/wala/ide/util/EclipseWebProjectPath.java
+++ b/com.ibm.wala.ide.jsdt/src/main/java/com/ibm/wala/ide/util/EclipseWebProjectPath.java
@@ -44,7 +44,7 @@ public class EclipseWebProjectPath extends JavaScriptEclipseProjectPath {
       String fileExtension) {
     List<Module> s = MapUtil.findOrCreateList(modules, loader);
     Iterator<FileModule> htmlPages =
-        new EclipseSourceDirectoryTreeModule(p, excludePaths, "html").getEntries();
+        new EclipseSourceDirectoryTreeModule(p, excfffludePaths, "html").getEntries();
     while (htmlPages.hasNext()) {
       FileModule htmlPage = htmlPages.next();
       Set<MappedSourceModule> scripts;

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,12 +14,11 @@ include(
 	'com.ibm.wala.cast.js.nodejs',
 	'com.ibm.wala.cast.js.rhino',
 	'com.ibm.wala.core',
+	'com.ibm.wala.core.java11',
 	'com.ibm.wala.dalvik',
 	'com.ibm.wala.ide',
 	'com.ibm.wala.ide.jdt',
 	'com.ibm.wala.ide.jdt.test',
-	'com.ibm.wala.ide.jsdt',
-	'com.ibm.wala.ide.jsdt.tests',
 	'com.ibm.wala.ide.tests',
 	'com.ibm.wala.ide_feature',
 	'com.ibm.wala.scandroid',
@@ -27,5 +26,4 @@ include(
 	'com.ibm.wala.tests.ide_feature',
 	'com.ibm.wala.util',
 	'com.ibm.wala_feature',
-	'com.ibm.wala.core.java11'
 )


### PR DESCRIPTION
The JSDT Gradle projects pull artifacts from the Alfresco Maven repository, which now does not work due to an expired certificate.  Rather than trying to fix this in Gradle, this PR disables Gradle on the modules.  The modules are still built and tested via the "Maven Eclipse tests" CI job, which pulls the relevant artifacts from a p2 repository (via Tycho) so it is unaffected.