### PR TITLE
Revert "only run CI jobs on push to master (#858)"

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,9 +1,7 @@
 name: Continuous integration
 on:
-  pull_request:
-  push:
-    branches:
-      - master
+  - pull_request
+  - push
 jobs:
   build_gradle:
     name: "JDK ${{ matrix.java }} on ${{ matrix.os }}"


### PR DESCRIPTION
This reverts commit 4118f17e5986f305cb23e947ac8f6d4cbb08e66c.

I'd like to be able to see GitHub actions results on my branches *before* I turn them into pull requests.