### PR TITLE
Remove spurious IntelliJ IDEA metadata about a non-existent module

### DIFF
--- a/.idea/WALA-fix.iml
+++ b/.idea/WALA-fix.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/WALA-fix.iml" filepath="$PROJECT_DIR$/.idea/WALA-fix.iml" />
-    </modules>
-  </component>
-</project>


### PR DESCRIPTION
These metadata files were added without review in
abe0e1d39c08380790eb0c540336c133feb60757, presumably by accident.