### PR TITLE
compileTestJavaUsingEcj depends on downloadJLex

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -271,7 +271,7 @@ googleJavaFormat {
 	exclude 'com.ibm.wala.cast.java.test.data/**/*.java'
 }
 
-tasks.named('verifyGoogleJavaFormat') {
+final verifyGoogleJavaFormat = tasks.named('verifyGoogleJavaFormat') {
 	group 'verification'
 
 	// workaround for <https://github.com/sherter/google-java-format-gradle-plugin/issues/43>
@@ -300,7 +300,7 @@ final check = tasks.register('check') {
 	if (!(isWindows && System.getenv('GITHUB_ACTIONS') == 'true')) {
 		// Known to be broken on Windows when running as a GitHub Action, but not intentionally so.
 		// Please fix if you know how!  <https://github.com/wala/WALA/issues/608>
-		dependsOn 'verifyGoogleJavaFormat'
+		dependsOn verifyGoogleJavaFormat
 	}
 }
 

--- a/com.ibm.wala.cast.java.ecj/build.gradle
+++ b/com.ibm.wala.cast.java.ecj/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 
 application.mainClass.set('com.ibm.wala.cast.java.ecj.util.SourceDirCallGraph')
 
-tasks.named('run') {
+final run = tasks.named('run') {
 	// this is for testing purposes
 	final javaTestData = ':com.ibm.wala.cast.java.test.data'
 	evaluationDependsOn javaTestData
@@ -52,7 +52,7 @@ tasks.named('test') {
 	// temporarily turn off some tests on JDK 9+
 //	if (JavaVersion.current() <= JavaVersion.VERSION_1_8) {
 		// ensure the command-line driver for running ECJ works
-		dependsOn 'run'
+		dependsOn run
 //	} else {
 //		exclude '**/ECJJava17IRTest.class'
 //		exclude '**/ECJJavaIRTest.class'

--- a/com.ibm.wala.cast.java.test.data/build.gradle
+++ b/com.ibm.wala.cast.java.test.data/build.gradle
@@ -22,6 +22,10 @@ tasks.named('compileTestJava') {
 	dependsOn downloadJLex
 }
 
+tasks.named('compileTestJavaUsingEcj') {
+	dependsOn downloadJLex
+}
+
 tasks.named('clean') {
 	dependsOn cleanDownloadJLex
 }

--- a/com.ibm.wala.cast.java.test.data/build.gradle
+++ b/com.ibm.wala.cast.java.test.data/build.gradle
@@ -14,16 +14,16 @@ final downloadJLex = tasks.register('downloadJLex', VerifiedDownload) {
 	dest "${sourceSets.test.java.srcDirs.find()}/JLex/Main.java"
 }
 
-tasks.register('cleanDownloadJLex', Delete) {
+final cleanDownloadJLex = tasks.register('cleanDownloadJLex', Delete) {
 	delete downloadJLex.get().dest.parent
 }
 
 tasks.named('compileTestJava') {
-	dependsOn 'downloadJLex'
+	dependsOn downloadJLex
 }
 
 tasks.named('clean') {
-	dependsOn 'cleanDownloadJLex'
+	dependsOn cleanDownloadJLex
 }
 
 

--- a/com.ibm.wala.cast.js.nodejs/build.gradle
+++ b/com.ibm.wala.cast.js.nodejs/build.gradle
@@ -22,7 +22,7 @@ final downloadNodeJS = tasks.register('downloadNodeJS', VerifiedDownload) {
 	checksum '147ff79947752399b870fcf3f1fc37102100b545'
 }
 
-tasks.register('unpackNodeJSLib', Copy) {
+final unpackNodeJSLib = tasks.register('unpackNodeJSLib', Copy) {
 	from(downloadNodeJS.map { tarTree it.dest }) {
 		include 'node-v0.12.4/lib/*.js'
 		eachFile {
@@ -35,7 +35,7 @@ tasks.register('unpackNodeJSLib', Copy) {
 }
 
 tasks.named('processTestResources') {
-	dependsOn 'unpackNodeJSLib'
+	dependsOn unpackNodeJSLib
 }
 
 tasks.named('test') {


### PR DESCRIPTION
`compileTestJavaUsingEcj` uses an output file created by `downloadJLex`, but the former did not previously declare the latter as a dependency. By adding that dependency now, we resolve a Gradle warning, enable certain Gradle execution optimizations, and remove a potential source of task-order-dependent non-determinism in builds.