### PR TITLE
`compileTestJavaUsingEcj` depends on `downloadJLex`

### DIFF
--- a/com.ibm.wala.cast.java.test.data/build.gradle
+++ b/com.ibm.wala.cast.java.test.data/build.gradle
@@ -22,6 +22,10 @@ tasks.named('compileTestJava') {
 	dependsOn downloadJLex
 }
 
+tasks.named('compileTestJavaUsingEcj') {
+	dependsOn downloadJLex
+}
+
 tasks.named('clean') {
 	dependsOn cleanDownloadJLex
 }


### PR DESCRIPTION
`compileTestJavaUsingEcj` uses an output file created by `downloadJLex`, but the former did not previously declare the latter as a dependency. By adding that dependency now, we resolve a Gradle warning, enable certain Gradle execution optimizations, and remove a potential source of task-order-dependent non-determinism in builds.