### PR TITLE
Update Gradle 7 deprecations

### DIFF
--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -374,7 +374,7 @@ tasks.named('test') {
 	maxHeapSize = '1500M'
 	systemProperty 'com.ibm.wala.junit.analyzingJar', 'true'
 	systemProperty 'com.ibm.wala.junit.profile', 'short'
-	classpath += files project(':com.ibm.wala.core').sourceSets.test.java.outputDir
+	classpath += files project(':com.ibm.wala.core').sourceSets.test.output.classesDirs
 	testLogging {
 		exceptionFormat = 'full'
 		events 'passed', 'skipped', 'failed'

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -119,7 +119,7 @@ class CompileKawaScheme extends JavaExec {
 
 	CompileKawaScheme() {
 		classpath project.tasks.named('extractKawa')
-		main 'kawa.repl'
+		mainClass.set('kawa.repl')
 
 		final outputDir = project.layout.buildDirectory.dir(name)
 		args '-d', outputDir.get().asFile
@@ -292,7 +292,7 @@ final generateHelloHashJar = tasks.register('generateHelloHashJar', JavaExec) {
 	inputs.file ocamlJavaJar
 	classpath ocamlJavaJar
 
-	main 'ocaml.compilers.ocamljavaMain'
+	mainClass.set('ocaml.compilers.ocamljavaMain')
 	args '-o', jarTarget
 	argumentProviders.add({ ->
 		[ocamlSource.get().toString()]


### PR DESCRIPTION
### Replace deprecated `JavaExec.main`

[`JavaExec.main`](https://docs.gradle.org/7.2/dsl/org.gradle.api.tasks.JavaExec.html#org.gradle.api.tasks.JavaExec:main) is deprecated in Gradle 7 and will be removed in Gradle 8.  Replace it with `JavaExec.mainClass`.

### Replace deprecated `SourceDirectorySet.outputDir`

[`SourceDirectorySet.outputDir`](https://docs.gradle.org/7.2/dsl/org.gradle.api.file.SourceDirectorySet.html#org.gradle.api.file.SourceDirectorySet:outputDir) is deprecated in Gradle 7 and will be removed in Gradle 8.  Its direct replacement is `SourceDirectorySet.outputDir`, but I prefer a different replacement that would potentially include directories containing class files that did not come from Java.

