### PR TITLE
Don't run CI jobs on pushes to dependabot branches

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,7 +1,9 @@
 name: Continuous integration
 on:
-  - pull_request
-  - push
+  pull_request:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
 jobs:
   build_gradle:
     name: "JDK ${{ matrix.java }} on ${{ matrix.os }}"


### PR DESCRIPTION
Dependabot pushes to branches in the `wala/WALA` repo for its changes, which means that right now, two sets of (redundant) jobs run on these PRs: one set for the pull request, and one for the push to the branch.  This change eliminates the jobs on the branch push, which will save some CI resources.  Not a huge deal in the grand scheme of things, but I hate wasting compute 🙂