### PR TITLE
Add a basic graph implementation

### DIFF
--- a/com.ibm.wala.util/build.gradle
+++ b/com.ibm.wala.util/build.gradle
@@ -4,6 +4,12 @@ plugins {
 
 eclipse.project.natures 'org.eclipse.pde.PluginNature'
 
+dependencies {
+	testImplementation(
+			'junit:junit:4.13.2',
+			'org.hamcrest:hamcrest:2.2',
+	)
+}
 tasks.named('javadoc') {
 	classpath += files project(':com.ibm.wala.core').tasks.named('compileJava', JavaCompile)
 	final currentJavaVersion = JavaVersion.current()

--- a/com.ibm.wala.util/gradle.lockfile
+++ b/com.ibm.wala.util/gradle.lockfile
@@ -1,4 +1,6 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-empty=annotationProcessor,compileClasspath,runtimeClasspath,signatures,testAnnotationProcessor,testCompileClasspath,testFixturesAnnotationProcessor,testFixturesCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+junit:junit:4.13.2=testCompileClasspath,testRuntimeClasspath
+org.hamcrest:hamcrest:2.2=testCompileClasspath,testRuntimeClasspath
+empty=annotationProcessor,compileClasspath,runtimeClasspath,signatures,testAnnotationProcessor,testFixturesAnnotationProcessor,testFixturesCompileClasspath,testFixturesRuntimeClasspath

--- a/com.ibm.wala.util/src/main/java/com/ibm/wala/util/graph/impl/BasicEdgeManager.java
+++ b/com.ibm.wala.util/src/main/java/com/ibm/wala/util/graph/impl/BasicEdgeManager.java
@@ -13,6 +13,7 @@ package com.ibm.wala.util.graph.impl;
 import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.collections.MapUtil;
 import com.ibm.wala.util.graph.EdgeManager;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -28,22 +29,26 @@ public class BasicEdgeManager<T> implements EdgeManager<T> {
 
   @Override
   public Iterator<T> getPredNodes(T n) {
-    return preds.get(n).iterator();
+    Set<T> nodePreds = this.preds.get(n);
+    return nodePreds != null ? nodePreds.iterator() : Collections.<T>emptySet().iterator();
   }
 
   @Override
   public int getPredNodeCount(T n) {
-    return preds.get(n).size();
+    Set<T> nodePreds = this.preds.get(n);
+    return nodePreds != null ? nodePreds.size() : 0;
   }
 
   @Override
   public Iterator<T> getSuccNodes(T n) {
-    return succs.get(n).iterator();
+    Set<T> nodeSuccs = this.succs.get(n);
+    return nodeSuccs != null ? nodeSuccs.iterator() : Collections.<T>emptySet().iterator();
   }
 
   @Override
-  public int getSuccNodeCount(T N) {
-    return succs.get(N).size();
+  public int getSuccNodeCount(T n) {
+    Set<T> nodeSuccs = this.succs.get(n);
+    return nodeSuccs != null ? nodeSuccs.size() : 0;
   }
 
   @Override

--- a/com.ibm.wala.util/src/main/java/com/ibm/wala/util/graph/impl/BasicEdgeManager.java
+++ b/com.ibm.wala.util/src/main/java/com/ibm/wala/util/graph/impl/BasicEdgeManager.java
@@ -30,7 +30,7 @@ public class BasicEdgeManager<T> implements EdgeManager<T> {
   @Override
   public Iterator<T> getPredNodes(T n) {
     Set<T> nodePreds = this.preds.get(n);
-    return nodePreds != null ? nodePreds.iterator() : Collections.<T>emptySet().iterator();
+    return nodePreds != null ? nodePreds.iterator() : Collections.emptyIterator();
   }
 
   @Override
@@ -42,7 +42,7 @@ public class BasicEdgeManager<T> implements EdgeManager<T> {
   @Override
   public Iterator<T> getSuccNodes(T n) {
     Set<T> nodeSuccs = this.succs.get(n);
-    return nodeSuccs != null ? nodeSuccs.iterator() : Collections.<T>emptySet().iterator();
+    return nodeSuccs != null ? nodeSuccs.iterator() : Collections.emptyIterator();
   }
 
   @Override

--- a/com.ibm.wala.util/src/main/java/com/ibm/wala/util/graph/impl/BasicEdgeManager.java
+++ b/com.ibm.wala.util/src/main/java/com/ibm/wala/util/graph/impl/BasicEdgeManager.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2002 - 2021 IBM Corporation.
+ * Copyright (c) 2021 IBM Corporation.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ *     Manu Sridharan - initial API and implementation
  */
 package com.ibm.wala.util.graph.impl;
 

--- a/com.ibm.wala.util/src/main/java/com/ibm/wala/util/graph/impl/BasicEdgeManager.java
+++ b/com.ibm.wala.util/src/main/java/com/ibm/wala/util/graph/impl/BasicEdgeManager.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2002 - 2021 IBM Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ */
+package com.ibm.wala.util.graph.impl;
+
+import com.ibm.wala.util.collections.HashMapFactory;
+import com.ibm.wala.util.collections.MapUtil;
+import com.ibm.wala.util.graph.EdgeManager;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Simple implementation of an {@link com.ibm.wala.util.graph.EdgeManager}. Does not support edge
+ * deletion.
+ */
+public class BasicEdgeManager<T> implements EdgeManager<T> {
+  private final Map<T, Set<T>> preds = HashMapFactory.make();
+
+  private final Map<T, Set<T>> succs = HashMapFactory.make();
+
+  @Override
+  public Iterator<T> getPredNodes(T n) {
+    return preds.get(n).iterator();
+  }
+
+  @Override
+  public int getPredNodeCount(T n) {
+    return preds.get(n).size();
+  }
+
+  @Override
+  public Iterator<T> getSuccNodes(T n) {
+    return succs.get(n).iterator();
+  }
+
+  @Override
+  public int getSuccNodeCount(T N) {
+    return succs.get(N).size();
+  }
+
+  @Override
+  public void addEdge(T src, T dst) {
+    MapUtil.findOrCreateSet(succs, src).add(dst);
+    MapUtil.findOrCreateSet(preds, dst).add(src);
+  }
+
+  @Override
+  public void removeEdge(T src, T dst) throws UnsupportedOperationException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void removeAllIncidentEdges(T node) throws UnsupportedOperationException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void removeIncomingEdges(T node) throws UnsupportedOperationException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void removeOutgoingEdges(T node) throws UnsupportedOperationException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean hasEdge(T src, T dst) {
+    Set<T> succsForSrc = succs.get(src);
+    return succsForSrc != null && succsForSrc.contains(dst);
+  }
+}

--- a/com.ibm.wala.util/src/main/java/com/ibm/wala/util/graph/impl/BasicGraph.java
+++ b/com.ibm.wala.util/src/main/java/com/ibm/wala/util/graph/impl/BasicGraph.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2002 - 2021 IBM Corporation.
+ * Copyright (c) 2021 IBM Corporation.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ *     Manu Sridharan - initial API and implementation
  */
 package com.ibm.wala.util.graph.impl;
 

--- a/com.ibm.wala.util/src/main/java/com/ibm/wala/util/graph/impl/BasicGraph.java
+++ b/com.ibm.wala.util/src/main/java/com/ibm/wala/util/graph/impl/BasicGraph.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002 - 2021 IBM Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ */
+package com.ibm.wala.util.graph.impl;
+
+import com.ibm.wala.util.graph.AbstractGraph;
+import com.ibm.wala.util.graph.EdgeManager;
+import com.ibm.wala.util.graph.NodeManager;
+
+/**
+ * Basic implementation of a {@link com.ibm.wala.util.graph.Graph}. Does not support node or edge
+ * deletion.
+ */
+public class BasicGraph<T> extends AbstractGraph<T> {
+
+  private final NodeManager<T> nodeManager = new BasicNodeManager<>();
+
+  private final EdgeManager<T> edgeManager = new BasicEdgeManager<>();
+
+  @Override
+  protected NodeManager<T> getNodeManager() {
+    return nodeManager;
+  }
+
+  @Override
+  protected EdgeManager<T> getEdgeManager() {
+    return edgeManager;
+  }
+}

--- a/com.ibm.wala.util/src/test/java/com/ibm/wala/util/test/BasicGraphTest.java
+++ b/com.ibm.wala.util/src/test/java/com/ibm/wala/util/test/BasicGraphTest.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2021 IBM Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Manu Sridharan - initial API and implementation
+ */
 package com.ibm.wala.util.test;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/com.ibm.wala.util/src/test/java/com/ibm/wala/util/test/BasicGraphTest.java
+++ b/com.ibm.wala.util/src/test/java/com/ibm/wala/util/test/BasicGraphTest.java
@@ -1,0 +1,27 @@
+package com.ibm.wala.util.test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+
+import com.ibm.wala.util.collections.Iterator2Collection;
+import com.ibm.wala.util.graph.impl.BasicGraph;
+import org.junit.Assert;
+import org.junit.Test;
+
+/** Tests for {@link com.ibm.wala.util.graph.impl.BasicGraph}. */
+public class BasicGraphTest {
+
+  @Test
+  public void testSingleEdge() {
+    BasicGraph<String> graph = new BasicGraph<>();
+    String root = "root";
+    String leaf = "leaf";
+    graph.addNode(root);
+    graph.addNode(leaf);
+    graph.addEdge(root, leaf);
+    Assert.assertTrue(graph.containsNode(root));
+    Assert.assertTrue(graph.containsNode(leaf));
+    assertThat(Iterator2Collection.toList(graph.getPredNodes(leaf)), contains(root));
+    assertThat(Iterator2Collection.toList(graph.getSuccNodes(root)), contains(leaf));
+  }
+}


### PR DESCRIPTION
This way, we have an implementation that does not require node numbering, as an example and to use in tests, etc.