### PR TITLE
Add CI step to cancel previous workflows for same branch / PR

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,6 +21,10 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
       - name: Check out WALA sources
         uses: actions/checkout@v2
       - name: Cache Goomph


### PR DESCRIPTION
Sometimes I end up pushing multiple times to a PR in a short time, and by default GitHub will run CI jobs for each push.  But only the most recent CI job "counts" in terms of checking the changes.  This changes adds a step to cancel running but outdated workflows; see https://github.com/styfle/cancel-workflow-action/blob/main/README.md