### PR TITLE
Remove useless empty @throws tags

### DIFF
--- a/com.ibm.wala.cast.java.ecj/src/main/java/com/ibm/wala/cast/java/ecj/util/SourceDirCallGraph.java
+++ b/com.ibm.wala.cast.java.ecj/src/main/java/com/ibm/wala/cast/java/ecj/util/SourceDirCallGraph.java
@@ -50,11 +50,6 @@ public class SourceDirCallGraph {
    * with an 'L'.
    *
    * <p>Example args: -sourceDir /tmp/srcTest -mainClass LFoo
-   *
-   * @throws IOException
-   * @throws CallGraphBuilderCancelException
-   * @throws IllegalArgumentException
-   * @throws ClassHierarchyException
    */
   public static void main(String[] args)
       throws ClassHierarchyException, IllegalArgumentException, CallGraphBuilderCancelException,


### PR DESCRIPTION
A Javadoc `@throws FooException` with no explanation as to the circumstances under which the exception arises is useless.  Presumably these were added at some point to pacify a linter's requirement that all thrown exceptions be documented.  An empty `@throws FooException` tag is *not* real documentation, and in fact, these empty tags are producing warning diagnostics of their own when building Javadoc.