### PR TITLE
Re-enable snapshot uploads

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,137 +5,137 @@ on:
     branches-ignore:
       - 'dependabot/**'
 jobs:
-  build_gradle:
-    name: "JDK ${{ matrix.java }} on ${{ matrix.os }}"
-    strategy:
-      matrix:
-        include:
-          - os: macos-latest
-            java: 8
-          - os: windows-latest
-            java: 8
-          - os: ubuntu-latest
-            java: 8
-          - os: ubuntu-latest
-            java: 11
-      fail-fast: false
-    runs-on: ${{ matrix.os }}
-    steps:
-#      - name: Cancel Previous Runs
-#        uses: styfle/cancel-workflow-action@0.9.1
-#        with:
-#          access_token: ${{ github.token }}
-      - name: Check out WALA sources
-        uses: actions/checkout@v2
-      - name: Cache Goomph
-        uses: actions/cache@v1
-        with:
-          path: ~/.goomph
-          key: ${{ runner.os }}-goomph-${{ hashFiles('build.gradle') }}
-          restore-keys: ${{ runner.os }}-goomph-
-      - name: Cache Gradle caches
-        uses: actions/cache@v1
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle-caches-
-      - name: Cache Gradle wrapper
-        uses: actions/cache@v1
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradlew-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: ${{ runner.os }}-gradlew-wrapper-
-      - name: 'Set up JDK ${{ matrix.java }}'
-        uses: actions/setup-java@v2
-        with:
-          java-version: ${{ matrix.java }}
-          distribution: 'adopt'
-      - name: Build and test using Gradle and Java 8
-        run: xvfb-run --auto-servernum ./gradlew --no-build-cache --no-daemon javadoc build lintGradle
-        # testing ECJ compilation on any one OS is sufficient; we choose Linux arbitrarily
-        if: runner.os == 'Linux' && matrix.java == '8'
-      - name: Build and test using Gradle and Java 11
-        run: xvfb-run --auto-servernum ./gradlew --no-build-cache --no-daemon :com.ibm.wala.core:test
-        if: runner.os == 'Linux' && matrix.java == '11'
-      - name: Build and test using Gradle but without ECJ
-        run: ./gradlew --no-build-cache --no-daemon javadoc build -PskipJavaUsingEcjTasks
-        if: runner.os != 'Linux'
-      - name: Check for Git cleanliness after build and test
-        run: ./check-git-cleanliness.sh
-        # not running in Borne or POSIX shell on Windows
-        if: runner.os != 'Windows'
-      - name: Clean up Gradle caches
-        run: travis/before-cache-gradle
-  build_maven:
-    name: "Maven Eclipse Tests"
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            java: 8
-      fail-fast: false
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Check out WALA sources
-        uses: actions/checkout@v2
-      - name: 'Cache local Maven repository'
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: 'Set up JDK ${{ matrix.java }}'
-        uses: actions/setup-java@v2
-        with:
-          java-version: ${{ matrix.java }}
-          distribution: 'adopt'
-      - name: 'Prep for Maven'
-        shell: bash
-        run: ./gradlew prepareMavenBuild publishToMavenLocal -x javadoc
-      - name: 'Maven Tests'
-        shell: bash
-        run: mvn clean install -B -q -Dmaven.javadoc.skip=true
-  generate_docs:
-    name: 'Generate latest docs'
-    needs: [build_gradle, build_maven]
-    if: github.event_name == 'push' && github.repository == 'wala/WALA' && github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
-    steps:
-      - name: 'Check out repository'
-        uses: actions/checkout@v2
-      - name: Cache Goomph
-        uses: actions/cache@v1
-        with:
-          path: ~/.goomph
-          key: ${{ runner.os }}-goomph-${{ hashFiles('build.gradle') }}
-          restore-keys: ${{ runner.os }}-goomph-
-      - name: Cache Gradle caches
-        uses: actions/cache@v1
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle-caches-
-      - name: Cache Gradle wrapper
-        uses: actions/cache@v1
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradlew-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: ${{ runner.os }}-gradlew-wrapper-
-      - name: 'Set up JDK 8'
-        uses: actions/setup-java@v2
-        with:
-          java-version: 8
-          distribution: 'adopt'
-      - name: 'Generate latest docs'
-        env:
-          GITHUB_TOKEN: ${{ secrets.WALA_BOT_GH_TOKEN }}
-        run: ./generate-latest-docs.sh
+#   build_gradle:
+#     name: "JDK ${{ matrix.java }} on ${{ matrix.os }}"
+#     strategy:
+#       matrix:
+#         include:
+#           - os: macos-latest
+#             java: 8
+#           - os: windows-latest
+#             java: 8
+#           - os: ubuntu-latest
+#             java: 8
+#           - os: ubuntu-latest
+#             java: 11
+#       fail-fast: false
+#     runs-on: ${{ matrix.os }}
+#     steps:
+# #      - name: Cancel Previous Runs
+# #        uses: styfle/cancel-workflow-action@0.9.1
+# #        with:
+# #          access_token: ${{ github.token }}
+#       - name: Check out WALA sources
+#         uses: actions/checkout@v2
+#       - name: Cache Goomph
+#         uses: actions/cache@v1
+#         with:
+#           path: ~/.goomph
+#           key: ${{ runner.os }}-goomph-${{ hashFiles('build.gradle') }}
+#           restore-keys: ${{ runner.os }}-goomph-
+#       - name: Cache Gradle caches
+#         uses: actions/cache@v1
+#         with:
+#           path: ~/.gradle/caches
+#           key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle') }}
+#           restore-keys: ${{ runner.os }}-gradle-caches-
+#       - name: Cache Gradle wrapper
+#         uses: actions/cache@v1
+#         with:
+#           path: ~/.gradle/wrapper
+#           key: ${{ runner.os }}-gradlew-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+#           restore-keys: ${{ runner.os }}-gradlew-wrapper-
+#       - name: 'Set up JDK ${{ matrix.java }}'
+#         uses: actions/setup-java@v2
+#         with:
+#           java-version: ${{ matrix.java }}
+#           distribution: 'adopt'
+#       - name: Build and test using Gradle and Java 8
+#         run: xvfb-run --auto-servernum ./gradlew --no-build-cache --no-daemon javadoc build lintGradle
+#         # testing ECJ compilation on any one OS is sufficient; we choose Linux arbitrarily
+#         if: runner.os == 'Linux' && matrix.java == '8'
+#       - name: Build and test using Gradle and Java 11
+#         run: xvfb-run --auto-servernum ./gradlew --no-build-cache --no-daemon :com.ibm.wala.core:test
+#         if: runner.os == 'Linux' && matrix.java == '11'
+#       - name: Build and test using Gradle but without ECJ
+#         run: ./gradlew --no-build-cache --no-daemon javadoc build -PskipJavaUsingEcjTasks
+#         if: runner.os != 'Linux'
+#       - name: Check for Git cleanliness after build and test
+#         run: ./check-git-cleanliness.sh
+#         # not running in Borne or POSIX shell on Windows
+#         if: runner.os != 'Windows'
+#       - name: Clean up Gradle caches
+#         run: travis/before-cache-gradle
+#   build_maven:
+#     name: "Maven Eclipse Tests"
+#     strategy:
+#       matrix:
+#         include:
+#           - os: ubuntu-latest
+#             java: 8
+#       fail-fast: false
+#     runs-on: ${{ matrix.os }}
+#     steps:
+#       - name: Check out WALA sources
+#         uses: actions/checkout@v2
+#       - name: 'Cache local Maven repository'
+#         uses: actions/cache@v2
+#         with:
+#           path: ~/.m2/repository
+#           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+#           restore-keys: |
+#             ${{ runner.os }}-maven-
+#       - name: 'Set up JDK ${{ matrix.java }}'
+#         uses: actions/setup-java@v2
+#         with:
+#           java-version: ${{ matrix.java }}
+#           distribution: 'adopt'
+#       - name: 'Prep for Maven'
+#         shell: bash
+#         run: ./gradlew prepareMavenBuild publishToMavenLocal -x javadoc
+#       - name: 'Maven Tests'
+#         shell: bash
+#         run: mvn clean install -B -q -Dmaven.javadoc.skip=true
+#   generate_docs:
+#     name: 'Generate latest docs'
+#     needs: [build_gradle, build_maven]
+#     if: github.event_name == 'push' && github.repository == 'wala/WALA' && github.ref == 'refs/heads/master'
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: 'Check out repository'
+#         uses: actions/checkout@v2
+#       - name: Cache Goomph
+#         uses: actions/cache@v1
+#         with:
+#           path: ~/.goomph
+#           key: ${{ runner.os }}-goomph-${{ hashFiles('build.gradle') }}
+#           restore-keys: ${{ runner.os }}-goomph-
+#       - name: Cache Gradle caches
+#         uses: actions/cache@v1
+#         with:
+#           path: ~/.gradle/caches
+#           key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle') }}
+#           restore-keys: ${{ runner.os }}-gradle-caches-
+#       - name: Cache Gradle wrapper
+#         uses: actions/cache@v1
+#         with:
+#           path: ~/.gradle/wrapper
+#           key: ${{ runner.os }}-gradlew-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+#           restore-keys: ${{ runner.os }}-gradlew-wrapper-
+#       - name: 'Set up JDK 8'
+#         uses: actions/setup-java@v2
+#         with:
+#           java-version: 8
+#           distribution: 'adopt'
+#       - name: 'Generate latest docs'
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.WALA_BOT_GH_TOKEN }}
+#         run: ./generate-latest-docs.sh
   publish_snapshot:
     name: 'Publish snapshot'
-    needs: [build_gradle, build_maven]
-#    if: github.event_name == 'push' && github.repository == 'wala/WALA' && github.ref == 'refs/heads/master'
-    if: ${{ false }} # disable temporarily
+#    needs: [build_gradle, build_maven]
+    if: github.event_name == 'push' && github.repository == 'wala/WALA' && github.ref == 'refs/heads/fix-snapshot-upload'
+#    if: ${{ false }} # disable temporarily
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out repository'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,137 +5,136 @@ on:
     branches-ignore:
       - 'dependabot/**'
 jobs:
-#   build_gradle:
-#     name: "JDK ${{ matrix.java }} on ${{ matrix.os }}"
-#     strategy:
-#       matrix:
-#         include:
-#           - os: macos-latest
-#             java: 8
-#           - os: windows-latest
-#             java: 8
-#           - os: ubuntu-latest
-#             java: 8
-#           - os: ubuntu-latest
-#             java: 11
-#       fail-fast: false
-#     runs-on: ${{ matrix.os }}
-#     steps:
-# #      - name: Cancel Previous Runs
-# #        uses: styfle/cancel-workflow-action@0.9.1
-# #        with:
-# #          access_token: ${{ github.token }}
-#       - name: Check out WALA sources
-#         uses: actions/checkout@v2
-#       - name: Cache Goomph
-#         uses: actions/cache@v1
-#         with:
-#           path: ~/.goomph
-#           key: ${{ runner.os }}-goomph-${{ hashFiles('build.gradle') }}
-#           restore-keys: ${{ runner.os }}-goomph-
-#       - name: Cache Gradle caches
-#         uses: actions/cache@v1
-#         with:
-#           path: ~/.gradle/caches
-#           key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle') }}
-#           restore-keys: ${{ runner.os }}-gradle-caches-
-#       - name: Cache Gradle wrapper
-#         uses: actions/cache@v1
-#         with:
-#           path: ~/.gradle/wrapper
-#           key: ${{ runner.os }}-gradlew-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-#           restore-keys: ${{ runner.os }}-gradlew-wrapper-
-#       - name: 'Set up JDK ${{ matrix.java }}'
-#         uses: actions/setup-java@v2
-#         with:
-#           java-version: ${{ matrix.java }}
-#           distribution: 'adopt'
-#       - name: Build and test using Gradle and Java 8
-#         run: xvfb-run --auto-servernum ./gradlew --no-build-cache --no-daemon javadoc build lintGradle
-#         # testing ECJ compilation on any one OS is sufficient; we choose Linux arbitrarily
-#         if: runner.os == 'Linux' && matrix.java == '8'
-#       - name: Build and test using Gradle and Java 11
-#         run: xvfb-run --auto-servernum ./gradlew --no-build-cache --no-daemon :com.ibm.wala.core:test
-#         if: runner.os == 'Linux' && matrix.java == '11'
-#       - name: Build and test using Gradle but without ECJ
-#         run: ./gradlew --no-build-cache --no-daemon javadoc build -PskipJavaUsingEcjTasks
-#         if: runner.os != 'Linux'
-#       - name: Check for Git cleanliness after build and test
-#         run: ./check-git-cleanliness.sh
-#         # not running in Borne or POSIX shell on Windows
-#         if: runner.os != 'Windows'
-#       - name: Clean up Gradle caches
-#         run: travis/before-cache-gradle
-#   build_maven:
-#     name: "Maven Eclipse Tests"
-#     strategy:
-#       matrix:
-#         include:
-#           - os: ubuntu-latest
-#             java: 8
-#       fail-fast: false
-#     runs-on: ${{ matrix.os }}
-#     steps:
-#       - name: Check out WALA sources
-#         uses: actions/checkout@v2
-#       - name: 'Cache local Maven repository'
-#         uses: actions/cache@v2
-#         with:
-#           path: ~/.m2/repository
-#           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-#           restore-keys: |
-#             ${{ runner.os }}-maven-
-#       - name: 'Set up JDK ${{ matrix.java }}'
-#         uses: actions/setup-java@v2
-#         with:
-#           java-version: ${{ matrix.java }}
-#           distribution: 'adopt'
-#       - name: 'Prep for Maven'
-#         shell: bash
-#         run: ./gradlew prepareMavenBuild publishToMavenLocal -x javadoc
-#       - name: 'Maven Tests'
-#         shell: bash
-#         run: mvn clean install -B -q -Dmaven.javadoc.skip=true
-#   generate_docs:
-#     name: 'Generate latest docs'
-#     needs: [build_gradle, build_maven]
-#     if: github.event_name == 'push' && github.repository == 'wala/WALA' && github.ref == 'refs/heads/master'
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: 'Check out repository'
-#         uses: actions/checkout@v2
-#       - name: Cache Goomph
-#         uses: actions/cache@v1
-#         with:
-#           path: ~/.goomph
-#           key: ${{ runner.os }}-goomph-${{ hashFiles('build.gradle') }}
-#           restore-keys: ${{ runner.os }}-goomph-
-#       - name: Cache Gradle caches
-#         uses: actions/cache@v1
-#         with:
-#           path: ~/.gradle/caches
-#           key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle') }}
-#           restore-keys: ${{ runner.os }}-gradle-caches-
-#       - name: Cache Gradle wrapper
-#         uses: actions/cache@v1
-#         with:
-#           path: ~/.gradle/wrapper
-#           key: ${{ runner.os }}-gradlew-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-#           restore-keys: ${{ runner.os }}-gradlew-wrapper-
-#       - name: 'Set up JDK 8'
-#         uses: actions/setup-java@v2
-#         with:
-#           java-version: 8
-#           distribution: 'adopt'
-#       - name: 'Generate latest docs'
-#         env:
-#           GITHUB_TOKEN: ${{ secrets.WALA_BOT_GH_TOKEN }}
-#         run: ./generate-latest-docs.sh
+  build_gradle:
+    name: "JDK ${{ matrix.java }} on ${{ matrix.os }}"
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            java: 8
+          - os: windows-latest
+            java: 8
+          - os: ubuntu-latest
+            java: 8
+          - os: ubuntu-latest
+            java: 11
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+#      - name: Cancel Previous Runs
+#        uses: styfle/cancel-workflow-action@0.9.1
+#        with:
+#          access_token: ${{ github.token }}
+      - name: Check out WALA sources
+        uses: actions/checkout@v2
+      - name: Cache Goomph
+        uses: actions/cache@v1
+        with:
+          path: ~/.goomph
+          key: ${{ runner.os }}-goomph-${{ hashFiles('build.gradle') }}
+          restore-keys: ${{ runner.os }}-goomph-
+      - name: Cache Gradle caches
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle-caches-
+      - name: Cache Gradle wrapper
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradlew-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradlew-wrapper-
+      - name: 'Set up JDK ${{ matrix.java }}'
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'adopt'
+      - name: Build and test using Gradle and Java 8
+        run: xvfb-run --auto-servernum ./gradlew --no-build-cache --no-daemon javadoc build lintGradle
+        # testing ECJ compilation on any one OS is sufficient; we choose Linux arbitrarily
+        if: runner.os == 'Linux' && matrix.java == '8'
+      - name: Build and test using Gradle and Java 11
+        run: xvfb-run --auto-servernum ./gradlew --no-build-cache --no-daemon :com.ibm.wala.core:test
+        if: runner.os == 'Linux' && matrix.java == '11'
+      - name: Build and test using Gradle but without ECJ
+        run: ./gradlew --no-build-cache --no-daemon javadoc build -PskipJavaUsingEcjTasks
+        if: runner.os != 'Linux'
+      - name: Check for Git cleanliness after build and test
+        run: ./check-git-cleanliness.sh
+        # not running in Borne or POSIX shell on Windows
+        if: runner.os != 'Windows'
+      - name: Clean up Gradle caches
+        run: travis/before-cache-gradle
+  build_maven:
+    name: "Maven Eclipse Tests"
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            java: 8
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Check out WALA sources
+        uses: actions/checkout@v2
+      - name: 'Cache local Maven repository'
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: 'Set up JDK ${{ matrix.java }}'
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'adopt'
+      - name: 'Prep for Maven'
+        shell: bash
+        run: ./gradlew prepareMavenBuild publishToMavenLocal -x javadoc
+      - name: 'Maven Tests'
+        shell: bash
+        run: mvn clean install -B -q -Dmaven.javadoc.skip=true
+  generate_docs:
+    name: 'Generate latest docs'
+    needs: [build_gradle, build_maven]
+    if: github.event_name == 'push' && github.repository == 'wala/WALA' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Check out repository'
+        uses: actions/checkout@v2
+      - name: Cache Goomph
+        uses: actions/cache@v1
+        with:
+          path: ~/.goomph
+          key: ${{ runner.os }}-goomph-${{ hashFiles('build.gradle') }}
+          restore-keys: ${{ runner.os }}-goomph-
+      - name: Cache Gradle caches
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle-caches-
+      - name: Cache Gradle wrapper
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradlew-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradlew-wrapper-
+      - name: 'Set up JDK 8'
+        uses: actions/setup-java@v2
+        with:
+          java-version: 8
+          distribution: 'adopt'
+      - name: 'Generate latest docs'
+        env:
+          GITHUB_TOKEN: ${{ secrets.WALA_BOT_GH_TOKEN }}
+        run: ./generate-latest-docs.sh
   publish_snapshot:
     name: 'Publish snapshot'
-#    needs: [build_gradle, build_maven]
-    if: github.event_name == 'push' && github.repository == 'wala/WALA' && github.ref == 'refs/heads/fix-snapshot-upload'
-#    if: ${{ false }} # disable temporarily
+    needs: [build_gradle, build_maven]
+    if: github.event_name == 'push' && github.repository == 'wala/WALA' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out repository'


### PR DESCRIPTION
Looks like yesterday's failures were transient.  I tried the snapshot upload on a branch just now and it succeeded:

https://github.com/wala/WALA/runs/3624072775?check_suite_focus=true

Fixes #981 