### PR TITLE
Cancel outdated jobs using workflow concurrency

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,6 +23,9 @@ jobs:
             java: 11
       fail-fast: false
     runs-on: ${{ matrix.os }}
+
+
+    
     steps:
       - name: Check out WALA sources
         uses: actions/checkout@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches-ignore:
       - 'dependabot/**'
+concurrency: 
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   build_gradle:
     name: "JDK ${{ matrix.java }} on ${{ matrix.os }}"
@@ -21,10 +24,6 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-#      - name: Cancel Previous Runs
-#        uses: styfle/cancel-workflow-action@0.9.1
-#        with:
-#          access_token: ${{ github.token }}
       - name: Check out WALA sources
         uses: actions/checkout@v2
       - name: Cache Goomph

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,9 +23,6 @@ jobs:
             java: 11
       fail-fast: false
     runs-on: ${{ matrix.os }}
-
-
-    
     steps:
       - name: Check out WALA sources
         uses: actions/checkout@v2


### PR DESCRIPTION
This is an improved version of #976 using [the `concurrency` feature](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency) of GH Actions workflows.  This ensures our CI workflow only runs for the latest commit on any branch / PR, and also that only one workflow for each branch is running at any given time.  The latter is useful for the WALA master branch in particular, since before it was possible for workflows to upload Javadoc and snapshot builds out of order if one ran particularly slowly.