### PR TITLE
Remove hundreds of redundant `final` qualifiers

### DIFF
--- a/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
+++ b/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
@@ -2278,7 +2278,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
         return "global scope";
       }
 
-      private final String mapName(String nm) {
+      private String mapName(String nm) {
         String mappedName = caseInsensitiveNames.get(nm.toLowerCase());
         return (mappedName == null) ? nm : mappedName;
       }
@@ -2447,7 +2447,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
     final Map<String, AbstractSymbol> typeSymbols = new LinkedHashMap<>();
     final Map<String, String> caseInsensitiveNames = new LinkedHashMap<>();
     return new Scope() {
-      private final String mapName(String nm) {
+      private String mapName(String nm) {
         String mappedName = caseInsensitiveNames.get(nm.toLowerCase());
         return (mappedName == null) ? nm : mappedName;
       }

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/core/util/ref/CacheReference.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/core/util/ref/CacheReference.java
@@ -26,7 +26,7 @@ public final class CacheReference {
   // should be SOFT except during debugging.
   private static final byte choice = SOFT;
 
-  public static final Object make(final Object referent) {
+  public static Object make(final Object referent) {
 
     switch (choice) {
       case SOFT:
@@ -41,7 +41,7 @@ public final class CacheReference {
     }
   }
 
-  public static final Object get(final Object reference) throws IllegalArgumentException {
+  public static Object get(final Object reference) throws IllegalArgumentException {
 
     if (reference == null) {
       return null;

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/core/util/strings/Atom.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/core/util/strings/Atom.java
@@ -142,26 +142,26 @@ public final class Atom implements Serializable {
 
   /** Return printable representation of "this" atom. Does not correctly handle UTF8 translation. */
   @Override
-  public final String toString() {
+  public String toString() {
     return new String(val);
   }
 
   /** Return printable representation of "this" atom. */
-  public final String toUnicodeString() throws java.io.UTFDataFormatException {
+  public String toUnicodeString() throws java.io.UTFDataFormatException {
     return UTF8Convert.fromUTF8(val);
   }
 
   /** New Atom containing first count bytes */
-  public final Atom left(int count) {
+  public Atom left(int count) {
     return findOrCreate(val, 0, count);
   }
 
   /** New Atom containing last count bytes */
-  public final Atom right(int count) {
+  public Atom right(int count) {
     return findOrCreate(val, val.length - count, count);
   }
 
-  public final boolean startsWith(Atom start) {
+  public boolean startsWith(Atom start) {
     assert (start != null);
 
     // can't start with something that's longer.
@@ -181,7 +181,7 @@ public final class Atom implements Serializable {
    *
    * @return array descriptor - something like "[I" or "[Ljava/lang/Object;"
    */
-  public final Atom arrayDescriptorFromElementDescriptor() {
+  public Atom arrayDescriptorFromElementDescriptor() {
     byte sig[] = new byte[1 + val.length];
     sig[0] = (byte) '[';
     for (int i = 0, n = val.length; i < n; ++i) sig[i + 1] = val[i];
@@ -192,7 +192,7 @@ public final class Atom implements Serializable {
    * Is "this" atom a reserved member name? Note: Sun has reserved all member names starting with
    * '&lt;' for future use. At present, only &lt;init&gt; and &lt;clinit&gt; are used.
    */
-  public final boolean isReservedMemberName() {
+  public boolean isReservedMemberName() {
     if (length() == 0) {
       return false;
     }
@@ -200,7 +200,7 @@ public final class Atom implements Serializable {
   }
 
   /** Is "this" atom a class descriptor? */
-  public final boolean isClassDescriptor() {
+  public boolean isClassDescriptor() {
     if (length() == 0) {
       return false;
     }
@@ -208,7 +208,7 @@ public final class Atom implements Serializable {
   }
 
   /** Is "this" atom an array descriptor? */
-  public final boolean isArrayDescriptor() {
+  public boolean isArrayDescriptor() {
     if (length() == 0) {
       return false;
     }
@@ -216,14 +216,14 @@ public final class Atom implements Serializable {
   }
 
   /** Is "this" atom a method descriptor? */
-  public final boolean isMethodDescriptor() throws IllegalArgumentException {
+  public boolean isMethodDescriptor() throws IllegalArgumentException {
     if (length() == 0) {
       return false;
     }
     return val[0] == '(';
   }
 
-  public final int length() {
+  public int length() {
     return val.length;
   }
 
@@ -239,7 +239,7 @@ public final class Atom implements Serializable {
    *
    * @return array element descriptor - something like "I"
    */
-  public final Atom parseForArrayElementDescriptor() throws IllegalArgumentException {
+  public Atom parseForArrayElementDescriptor() throws IllegalArgumentException {
     if (val.length == 0) {
       throw new IllegalArgumentException("empty atom is not an array");
     }
@@ -253,7 +253,7 @@ public final class Atom implements Serializable {
    * @return dimensionality - something like "1" or "2"
    * @throws IllegalStateException if this Atom does not represent an array
    */
-  public final int parseForArrayDimensionality() throws IllegalArgumentException {
+  public int parseForArrayDimensionality() throws IllegalArgumentException {
     if (val.length == 0) {
       throw new IllegalArgumentException("empty atom is not an array");
     }
@@ -273,7 +273,7 @@ public final class Atom implements Serializable {
    *
    * @throws IllegalStateException if this Atom does not represent an array descriptor
    */
-  public final Atom parseForInnermostArrayElementDescriptor() throws IllegalArgumentException {
+  public Atom parseForInnermostArrayElementDescriptor() throws IllegalArgumentException {
     if (val.length == 0) {
       throw new IllegalArgumentException("empty atom is not an array");
     }
@@ -307,7 +307,7 @@ public final class Atom implements Serializable {
     }
 
     @Override
-    public final boolean equals(Object other) {
+    public boolean equals(Object other) {
 
       assert (other != null && this.getClass().equals(other.getClass()));
       if (this == other) {
@@ -328,12 +328,12 @@ public final class Atom implements Serializable {
      * Return printable representation of "this" atom. Does not correctly handle UTF8 translation.
      */
     @Override
-    public final String toString() {
+    public String toString() {
       return new String(val);
     }
 
     @Override
-    public final int hashCode() {
+    public int hashCode() {
       return hash;
     }
   }

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/types/FieldReference.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/types/FieldReference.java
@@ -77,12 +77,12 @@ public final class FieldReference extends MemberReference {
   }
 
   /** @return the descriptor component of this member reference */
-  public final TypeReference getFieldType() {
+  public TypeReference getFieldType() {
     return fieldType;
   }
 
   @Override
-  public final String toString() {
+  public String toString() {
     return "< "
         + getDeclaringClass().getClassLoader().getName()
         + ", "

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/types/MethodReference.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/types/MethodReference.java
@@ -157,12 +157,12 @@ public final class MethodReference extends MemberReference {
   }
 
   /** @return the descriptor component of this member reference */
-  public final Descriptor getDescriptor() {
+  public Descriptor getDescriptor() {
     return selector.getDescriptor();
   }
 
   @Override
-  public final String toString() {
+  public String toString() {
     return "< "
         + getDeclaringClass().getClassLoader().getName()
         + ", "
@@ -193,12 +193,12 @@ public final class MethodReference extends MemberReference {
   }
 
   /** @return return type of the method */
-  public final TypeReference getReturnType() {
+  public TypeReference getReturnType() {
     return returnType;
   }
 
   /** @return ith parameter to the method. This does NOT include the implicit "this" pointer. */
-  public final TypeReference getParameterType(int i) throws IllegalArgumentException {
+  public TypeReference getParameterType(int i) throws IllegalArgumentException {
     if (parameterTypes == null || i >= parameterTypes.length) {
       throw new IllegalArgumentException("illegal parameter number " + i + " for " + this);
     }

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/types/TypeName.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/types/TypeName.java
@@ -190,27 +190,27 @@ public final class TypeName implements Serializable {
    * @return the dimensionality of the type. By convention, class types have dimensionality 0,
    *     primitives -1, and arrays the number of [ in their descriptor.
    */
-  public final int getDerivedMask() {
+  public int getDerivedMask() {
     return key.dim;
   }
 
   /** Does 'this' refer to a class? */
-  public final boolean isClassType() {
+  public boolean isClassType() {
     return key.dim == 0;
   }
 
   /** Does 'this' refer to an array? */
-  public final boolean isArrayType() {
+  public boolean isArrayType() {
     return key.dim > 0;
   }
 
   /** Does 'this' refer to a primitive type */
-  public final boolean isPrimitiveType() {
+  public boolean isPrimitiveType() {
     return key.dim == -1;
   }
 
   /** Return the innermost element type reference for an array */
-  public final TypeName getInnermostElementType() {
+  public TypeName getInnermostElementType() {
     short newDim = ((key.dim & ElementMask) == PrimitiveMask) ? (short) -1 : 0;
     return findOrCreate(key.packageName, key.className, newDim);
   }

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/types/TypeReference.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/types/TypeReference.java
@@ -554,12 +554,12 @@ public final class TypeReference implements Serializable {
   }
 
   /** @return the classloader component of this type reference */
-  public final ClassLoaderReference getClassLoader() {
+  public ClassLoaderReference getClassLoader() {
     return classloader;
   }
 
   /** @return the type name component of this type reference */
-  public final TypeName getName() {
+  public TypeName getName() {
     return name;
   }
 
@@ -567,13 +567,13 @@ public final class TypeReference implements Serializable {
    * TODO: specialized form of TypeReference for arrays, please. Get the element type of for this
    * array type.
    */
-  public final TypeReference getArrayElementType() {
+  public TypeReference getArrayElementType() {
     TypeName element = name.parseForArrayElementName();
     return findOrCreate(classloader, element);
   }
 
   /** Get array type corresponding to "this" array element type. */
-  public final TypeReference getArrayTypeForElementType() {
+  public TypeReference getArrayTypeForElementType() {
     return findOrCreate(classloader, name.getArrayTypeForElementType());
   }
 
@@ -581,37 +581,37 @@ public final class TypeReference implements Serializable {
    * Return the dimensionality of the type. By convention, class types have dimensionality 0,
    * primitives -1, and arrays the number of [ in their descriptor.
    */
-  public final int getDerivedMask() {
+  public int getDerivedMask() {
     return name.getDerivedMask();
   }
 
   /** Return the innermost element type reference for an array */
-  public final TypeReference getInnermostElementType() {
+  public TypeReference getInnermostElementType() {
     return findOrCreate(classloader, name.getInnermostElementType());
   }
 
   /** Does 'this' refer to a class? */
-  public final boolean isClassType() {
+  public boolean isClassType() {
     return !isArrayType() && !isPrimitiveType();
   }
 
   /** Does 'this' refer to an array? */
-  public final boolean isArrayType() {
+  public boolean isArrayType() {
     return name.isArrayType();
   }
 
   /** Does 'this' refer to a primitive type */
-  public final boolean isPrimitiveType() {
+  public boolean isPrimitiveType() {
     return isPrimitiveType(name);
   }
 
   /** Does 'this' refer to a reference type */
-  public final boolean isReferenceType() {
+  public boolean isReferenceType() {
     return !isPrimitiveType();
   }
 
   @Override
-  public final int hashCode() {
+  public int hashCode() {
     return name.hashCode();
   }
 
@@ -624,12 +624,12 @@ public final class TypeReference implements Serializable {
    * both represent the IClass which is named &lt;Primordial,java.lang.Object&gt;
    */
   @Override
-  public final boolean equals(Object other) {
+  public boolean equals(Object other) {
     return (this == other);
   }
 
   @Override
-  public final String toString() {
+  public String toString() {
     return "<" + classloader.getName() + ',' + name + '>';
   }
 

--- a/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/SourcePositionTableReader.java
+++ b/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/SourcePositionTableReader.java
@@ -124,7 +124,7 @@ public final class SourcePositionTableReader extends AttributeReader {
 
   private static final int ATTRIBUTE_HEADER_SIZE = 6;
 
-  private static final byte[] getData(ClassReader cr, int rawOffset, int rawSize) {
+  private static byte[] getData(ClassReader cr, int rawOffset, int rawSize) {
     // prepare raw data of attribute to pass to sourceinfo
     byte klass[] = cr.getBytes();
     int size = rawSize - ATTRIBUTE_HEADER_SIZE;
@@ -146,7 +146,7 @@ public final class SourcePositionTableReader extends AttributeReader {
     }
   }
 
-  private static final Position convert(Range r) {
+  private static Position convert(Range r) {
     Position pos = null;
 
     if (r != null) {

--- a/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrike/sourcepos/CRTData.java
+++ b/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrike/sourcepos/CRTData.java
@@ -144,7 +144,7 @@ public final class CRTData {
     this.flags = new CRTFlags(flags);
   }
 
-  public final CRTFlags getFlags() {
+  public CRTFlags getFlags() {
     return this.flags;
   }
 
@@ -154,7 +154,7 @@ public final class CRTData {
    * @param pc the index to test
    * @return whether the given index lies within the range of this data or not.
    */
-  public final boolean isInRange(int pc) {
+  public boolean isInRange(int pc) {
     return pc_start_index <= pc && pc <= pc_end_index;
   }
 
@@ -165,7 +165,7 @@ public final class CRTData {
    * @param d the data to test with
    * @return whether the given data is consistently.
    */
-  public final boolean matches(CRTData d) {
+  public boolean matches(CRTData d) {
     return d != null && (isMorePrecise(d) || d.isMorePrecise(this));
   }
 
@@ -178,7 +178,7 @@ public final class CRTData {
    * @param d the data to test with
    * @return whether this data is equal to or more precise than the given one.
    */
-  public final boolean isMorePrecise(CRTData d) {
+  public boolean isMorePrecise(CRTData d) {
     return d != null
         && pc_start_index >= d.pc_start_index
         && pc_end_index <= d.pc_end_index
@@ -200,7 +200,7 @@ public final class CRTData {
    * @return The returned array consists of four positions: the start line number, the start column
    *     number, the end line number, the end column number
    */
-  public final Range getSourceInfo() {
+  public Range getSourceInfo() {
     return source_positions;
   }
 

--- a/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrike/sourcepos/CRTFlags.java
+++ b/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrike/sourcepos/CRTFlags.java
@@ -70,7 +70,7 @@ public final class CRTFlags {
    *
    * @return An array of Strings containing the flag names.
    */
-  public final String[] getFlagNames() {
+  public String[] getFlagNames() {
     LinkedList<String> names = new LinkedList<>();
     int index = 0;
     short tFlags = flags;

--- a/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrike/sourcepos/CRTable.java
+++ b/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrike/sourcepos/CRTable.java
@@ -56,7 +56,7 @@ public final class CRTable extends PositionsAttribute {
   }
 
   @Override
-  protected final void readData(DataInputStream in) throws IOException {
+  protected void readData(DataInputStream in) throws IOException {
     assert in != null;
     short crt_length = in.readShort();
     crt = new CRTData[crt_length];
@@ -85,7 +85,7 @@ public final class CRTable extends PositionsAttribute {
    * @param pc the index in the code array of the code attribute
    * @return the most precise source position range
    */
-  public final Range getSourceInfo(int pc) {
+  public Range getSourceInfo(int pc) {
     CRTData sourceInfo = null;
     int sourceInfoIndex = 0;
     for (int i = 0; i < crt.length; i++) {

--- a/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrike/sourcepos/MethodPositions.java
+++ b/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrike/sourcepos/MethodPositions.java
@@ -81,7 +81,7 @@ public final class MethodPositions extends PositionsAttribute {
   }
 
   @Override
-  protected final void readData(DataInputStream in) throws IOException {
+  protected void readData(DataInputStream in) throws IOException {
     declaration = readRange(in, "declaration_start", "declaration_end", false);
     parameter = readRange(in, "parameter_start", "parameter_end", true);
     block_end = readRange(in, "block_end_start", "block_end_end", false);
@@ -184,7 +184,7 @@ public final class MethodPositions extends PositionsAttribute {
    *
    * @return the source position range of the method declaration
    */
-  public final Range getHeaderInfo() {
+  public Range getHeaderInfo() {
     return declaration;
   }
 
@@ -193,7 +193,7 @@ public final class MethodPositions extends PositionsAttribute {
    *
    * @return the source position range of the method parameter declaration
    */
-  public final Range getMethodInfo() {
+  public Range getMethodInfo() {
     return parameter;
   }
 
@@ -202,7 +202,7 @@ public final class MethodPositions extends PositionsAttribute {
    *
    * @return the source position range of the end of the method block
    */
-  public final Range getFooterInfo() {
+  public Range getFooterInfo() {
     return block_end;
   }
 

--- a/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrike/sourcepos/Position.java
+++ b/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrike/sourcepos/Position.java
@@ -82,7 +82,7 @@ public final class Position {
    *
    * @return the line number
    */
-  public final int getLine() {
+  public int getLine() {
     return position >>> LINE_SHIFT;
   }
 
@@ -91,7 +91,7 @@ public final class Position {
    *
    * @return the column number
    */
-  public final int getColumn() {
+  public int getColumn() {
     return position & COLUMN_MASK;
   }
 
@@ -100,7 +100,7 @@ public final class Position {
    *
    * @return true if this position is undefined
    */
-  public final boolean isUndefined() {
+  public boolean isUndefined() {
     return position == NOPOS;
   }
 

--- a/com.ibm.wala.util/src/main/java/com/ibm/wala/util/intset/OffsetBitVector.java
+++ b/com.ibm.wala.util/src/main/java/com/ibm/wala/util/intset/OffsetBitVector.java
@@ -98,7 +98,7 @@ public final class OffsetBitVector extends BitVectorBase<OffsetBitVector> {
    * @param bit the bit to be set
    */
   @Override
-  public final void set(int bit) {
+  public void set(int bit) {
     if (bit < 0) {
       throw new IllegalArgumentException("illegal bit: " + bit);
     }
@@ -132,7 +132,7 @@ public final class OffsetBitVector extends BitVectorBase<OffsetBitVector> {
    * @param bit the bit to be cleared
    */
   @Override
-  public final void clear(int bit) {
+  public void clear(int bit) {
     if (bit < offset) {
       return;
     }
@@ -152,7 +152,7 @@ public final class OffsetBitVector extends BitVectorBase<OffsetBitVector> {
    * @param bit the bit to be gotten
    */
   @Override
-  public final boolean get(int bit) {
+  public boolean get(int bit) {
     if (DEBUG) {
       assert bit >= 0;
     }
@@ -177,7 +177,7 @@ public final class OffsetBitVector extends BitVectorBase<OffsetBitVector> {
   }
 
   /** Logically NOT this bit string */
-  public final void not() {
+  public void not() {
     if (offset != 0) {
       expand(0, offset + length() - 1);
     }
@@ -196,12 +196,12 @@ public final class OffsetBitVector extends BitVectorBase<OffsetBitVector> {
    * element.
    */
   @Override
-  public final int length() {
+  public int length() {
     return (bits.length << LOG_BITS_PER_UNIT) + offset;
   }
 
   /** Sets all bits. */
-  public final void setAll() {
+  public void setAll() {
     expand(0, length() - 1);
     Arrays.fill(bits, MASK);
   }
@@ -231,7 +231,7 @@ public final class OffsetBitVector extends BitVectorBase<OffsetBitVector> {
    * @throws IllegalArgumentException if set == null
    */
   @Override
-  public final boolean intersectionEmpty(OffsetBitVector set) throws IllegalArgumentException {
+  public boolean intersectionEmpty(OffsetBitVector set) throws IllegalArgumentException {
     if (set == null) {
       throw new IllegalArgumentException("set == null");
     }
@@ -261,7 +261,7 @@ public final class OffsetBitVector extends BitVectorBase<OffsetBitVector> {
    * @throws IllegalArgumentException if set == null
    */
   @Override
-  public final boolean sameBits(OffsetBitVector set) throws IllegalArgumentException {
+  public boolean sameBits(OffsetBitVector set) throws IllegalArgumentException {
     if (set == null) {
       throw new IllegalArgumentException("set == null");
     }
@@ -352,7 +352,7 @@ public final class OffsetBitVector extends BitVectorBase<OffsetBitVector> {
    * @param set the bit set to copy the bits from
    * @throws IllegalArgumentException if set is null
    */
-  public final void copyBits(OffsetBitVector set) {
+  public void copyBits(OffsetBitVector set) {
     if (set == null) {
       throw new IllegalArgumentException("set is null");
     }
@@ -367,7 +367,7 @@ public final class OffsetBitVector extends BitVectorBase<OffsetBitVector> {
    * @throws IllegalArgumentException if set == null
    */
   @Override
-  public final void and(OffsetBitVector set) throws IllegalArgumentException {
+  public void and(OffsetBitVector set) throws IllegalArgumentException {
     if (set == null) {
       throw new IllegalArgumentException("set == null");
     }
@@ -400,7 +400,7 @@ public final class OffsetBitVector extends BitVectorBase<OffsetBitVector> {
    * @throws IllegalArgumentException if set == null
    */
   @Override
-  public final void or(OffsetBitVector set) throws IllegalArgumentException {
+  public void or(OffsetBitVector set) throws IllegalArgumentException {
     if (set == null) {
       throw new IllegalArgumentException("set == null");
     }
@@ -426,7 +426,7 @@ public final class OffsetBitVector extends BitVectorBase<OffsetBitVector> {
    * @throws IllegalArgumentException if set == null
    */
   @Override
-  public final void xor(OffsetBitVector set) throws IllegalArgumentException {
+  public void xor(OffsetBitVector set) throws IllegalArgumentException {
     if (set == null) {
       throw new IllegalArgumentException("set == null");
     }


### PR DESCRIPTION
In a `final` class, all methods are implicitly `final`.  No need to make that explicit.