### PR TITLE
Exclude `other.xml` from Git

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -4,6 +4,7 @@
 /jarRepositories.xml
 /libraries/*.xml
 /modules.xml
+/other.xml
 /shelf/
 /tasks.xml
 /usage.statistics.xml


### PR DESCRIPTION
So far, the only setting that I am seeing stored here is a preference for whether to activate a view that is specialized for Python scientific code.  This seems like a per-developer preference, not an intrinsic property of the WALA code base.