### PR TITLE
Double-quote a variable expansion

### DIFF
--- a/run-time-trials
+++ b/run-time-trials
@@ -12,5 +12,5 @@ for trial in {1..10}; do
   if [ -f orderly-shutdown ]; then
     break
   fi
-  ./gradlew test --no-build-cache --no-parallel --project-prop trial=$trial "$@"
+  ./gradlew test --no-build-cache --no-parallel --project-prop trial="$trial" "$@"
 done


### PR DESCRIPTION
This variable expansion is actually safe even without quoting, since it can only ever be a number from 1 through 10.  But ShellCheck apparently isn't smart enough to know that.  In general, we want to keep this kind of warning enabled, so the easiest thing to do is add the (unnecessary) quotes here to satisfy ShellCheck.