### PR TITLE
AllowContextInsensitiveRTAInterpreter to call the correct CodeScanner method when working with Dex Files

### DIFF
--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/classLoader/CodeScanner.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/classLoader/CodeScanner.java
@@ -301,7 +301,7 @@ public class CodeScanner {
    * @param statements list of ssa statements
    * @return List of InvokeInstruction
    */
-  private static List<NewSiteReference> getNewSites(SSAInstruction[] statements) {
+  public static List<NewSiteReference> getNewSites(SSAInstruction[] statements) {
     final List<NewSiteReference> result = new LinkedList<>();
     Visitor v =
         new Visitor() {


### PR DESCRIPTION
This is a proposed fix for #888. 

Currently, adding dex files to the AnalysisScope and then attempting to build a callgraph results in a java.lang.ClassCastException when using the RTABuilder or the context-sensitive CFAZeroOneBuilder/the deprecated CFAZeroOneContainerBuilder. 

The issue lies in the CodeScanner.java file  and the ContextInsensitiveRTAInterpreter.java file. The ContextInsensitiveRTAInterpreter calls the public method CodeScanner.getNewSites(). However, that method is geared toward either SyntheticMethods or ShrikeBTMethods, not DexIMethods. There is a secondary CodeScanner.getNewSites() that would work perfectly with DexIMethods; the only problem is that it has private access and takes a SSAInstruction array, rather than an IMethod, as an argument. 

The proposed changes are to: 
1) make the relevant getNewSites() method public &
2) have the ContextInsensitiveRTAInterpreter call the getNewSites() method that is compatible with DexIMethods when encountering a method that is not a SyntheticMethod or a ShrikeBTMethod