### PR TITLE
Make `private` fields `final` where possible

### DIFF
--- a/com.ibm.wala.cast.java.ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
+++ b/com.ibm.wala.cast.java.ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
@@ -1002,7 +1002,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
 
     private final ITypeBinding fType; // TAGALONG
 
-    private ITypeBinding fReturnType;
+    private final ITypeBinding fReturnType;
 
     private final int fModifiers;
 

--- a/com.ibm.wala.core.java11/src/testSubjects/java/nestmates/Outer.java
+++ b/com.ibm.wala.core.java11/src/testSubjects/java/nestmates/Outer.java
@@ -1,7 +1,7 @@
 package nestmates;
 
 public class Outer {
-  private int foo = 10;
+  private final int foo = 10;
 
   public class Inner {
     int triple() {


### PR DESCRIPTION
One of these is in a test subject, but the `final`ness of the field appears to be irrelevant to the test.