### PR TITLE
Avoid `int` shifts that implicitly cast to `long`

### DIFF
--- a/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/shrikeCT/tools/AddSerialVersion.java
+++ b/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/shrikeCT/tools/AddSerialVersion.java
@@ -188,10 +188,10 @@ public class AddSerialVersion {
         | (hash[1] & 0xFF) << 8
         | (hash[2] & 0xFF) << 16
         | hash[3] << 24
-        | (hash[4] & 0xFF) << 32
-        | (hash[5] & 0xFF) << 40
-        | (hash[6] & 0xFF) << 48
-        | (hash[7] & 0xFF) << 56;
+        | (hash[4] & 0xFFL) << 32
+        | (hash[5] & 0xFFL) << 40
+        | (hash[6] & 0xFFL) << 48
+        | (hash[7] & 0xFFL) << 56;
   }
 
   public static void main(String[] args) {

--- a/com.ibm.wala.util/src/main/java/com/ibm/wala/util/math/Logs.java
+++ b/com.ibm.wala.util/src/main/java/com/ibm/wala/util/math/Logs.java
@@ -83,7 +83,7 @@ public class Logs {
   /** Binary log: finds the smallest power k such that 2^k &gt;= n */
   public static int binaryLogUp(long n) {
     int k = 0;
-    while ((1 << k) < n) {
+    while ((1L << k) < n) {
       k++;
     }
     return k;


### PR DESCRIPTION
Instead, be explicit that we're working with `long` values from the start.