### PR TITLE
Remove redundant `unmodifiableCollection` wrapper

### DIFF
--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/ssa/Util.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/ssa/Util.java
@@ -17,7 +17,7 @@ import java.util.Collections;
 
 class Util {
   private static final Collection<TypeReference> TYPE_ERROR_EXCEPTIONS =
-      Collections.unmodifiableCollection(Collections.singleton(JavaScriptTypes.TypeError));
+      Collections.singleton(JavaScriptTypes.TypeError);
 
   public static Collection<TypeReference> typeErrorExceptions() {
     return TYPE_ERROR_EXCEPTIONS;


### PR DESCRIPTION
`Collections::singleton` already returns an unmodifiable collection.