### PR TITLE
Remove a gratuitous unary negation

### DIFF
--- a/com.ibm.wala.cast.java.test.data/src/test/java/StaticInitializers.java
+++ b/com.ibm.wala.cast.java.test.data/src/test/java/StaticInitializers.java
@@ -19,6 +19,7 @@ public class StaticInitializers {
     }
 
     int diff() {
+      //noinspection UnnecessaryUnaryMinus
       return x+-y;
     }
   }

--- a/com.ibm.wala.cast.java.test.data/src/test/java/foo/bar/hello/world/InnerClasses.java
+++ b/com.ibm.wala.cast.java.test.data/src/test/java/foo/bar/hello/world/InnerClasses.java
@@ -145,6 +145,7 @@ class SuperEnclosing2 {
 	class SubEnclosed2 extends SuperEnclosing2 {
 		SubEnclosed2() {
 			// this.seVar = 5; // illegal 
+			//noinspection UnnecessaryUnaryMinus,UnaryPlus
 			SuperEnclosing2.this.seVar += -(-(+7)); // makes 13
 		}
 		int hello() {

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/analysis/arraybounds/ArrayBoundsGraph.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/analysis/arraybounds/ArrayBoundsGraph.java
@@ -233,7 +233,7 @@ public class ArrayBoundsGraph extends DirectedHyperGraph<Integer> {
 
   public Integer generateNewVar() {
     final int result = this.arrayCounter;
-    this.arrayCounter += -1;
+    this.arrayCounter -= 1;
     return result;
   }
 


### PR DESCRIPTION
Also mark two other seemingly-gratuitous uses of unary `-` or `+` as ignored.  These occur in test inputs and are presumably intentional.