### PR TITLE
Specialize String emptiness checks

### DIFF
--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/JSMethodInstructionVisitor.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/JSMethodInstructionVisitor.java
@@ -60,7 +60,7 @@ public class JSMethodInstructionVisitor extends JSAbstractInstructionVisitor {
           }
           // this may be a genuine use of "new Function()", not a declaration/expression
           if (!symtab.isStringConstant(invk.getUse(1))
-              || symtab.getStringValue(invk.getUse(1)).equals("")) {
+              || symtab.getStringValue(invk.getUse(1)).isEmpty()) {
             return false;
           }
           return true;

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/ipa/summaries/JavaScriptConstructorFunctions.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/ipa/summaries/JavaScriptConstructorFunctions.java
@@ -466,7 +466,7 @@ public class JavaScriptConstructorFunctions {
         return makeFunctionConstructor(cls, cls);
       case 1:
         if (ST.isStringConstant(callStmt.getUse(1))
-            && !ST.getStringValue(callStmt.getUse(1)).equals("")) {
+            && !ST.getStringValue(callStmt.getUse(1)).isEmpty()) {
           TypeReference ref =
               TypeReference.findOrCreate(
                   JavaScriptTypes.jsLoader,


### PR DESCRIPTION
`String::isEmpty` is preferred over using `String::equals` to compare a
`String` to `""`.