### PR TITLE
Use official Gradle GitHub actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,39 +32,33 @@ jobs:
           path: ~/.goomph
           key: ${{ runner.os }}-goomph-${{ hashFiles('build.gradle') }}
           restore-keys: ${{ runner.os }}-goomph-
-      - name: Cache Gradle caches
-        uses: actions/cache@v1
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle-caches-
-      - name: Cache Gradle wrapper
-        uses: actions/cache@v1
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradlew-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: ${{ runner.os }}-gradlew-wrapper-
       - name: 'Set up JDK ${{ matrix.java }}'
         uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
           distribution: 'adopt'
       - name: Build and test using Gradle and Java 8
-        run: xvfb-run --auto-servernum ./gradlew --no-build-cache --no-daemon javadoc build lintGradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-executable: xvfb-gradle.sh
+          arguments: javadoc build lintGradle
         # testing ECJ compilation on any one OS is sufficient; we choose Linux arbitrarily
         if: runner.os == 'Linux' && matrix.java == '8'
       - name: Build and test using Gradle and Java 11
-        run: xvfb-run --auto-servernum ./gradlew --no-build-cache --no-daemon :com.ibm.wala.core:test
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-executable: xvfb-gradle.sh
+          arguments: :com.ibm.wala.core:test
         if: runner.os == 'Linux' && matrix.java == '11'
       - name: Build and test using Gradle but without ECJ
-        run: ./gradlew --no-build-cache --no-daemon javadoc build -PskipJavaUsingEcjTasks
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: javadoc build -PskipJavaUsingEcjTasks
         if: runner.os != 'Linux'
       - name: Check for Git cleanliness after build and test
         run: ./check-git-cleanliness.sh
         # not running in Borne or POSIX shell on Windows
         if: runner.os != 'Windows'
-      - name: Clean up Gradle caches
-        run: travis/before-cache-gradle
   build_maven:
     name: "Maven Eclipse Tests"
     strategy:
@@ -109,18 +103,6 @@ jobs:
           path: ~/.goomph
           key: ${{ runner.os }}-goomph-${{ hashFiles('build.gradle') }}
           restore-keys: ${{ runner.os }}-goomph-
-      - name: Cache Gradle caches
-        uses: actions/cache@v1
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle-caches-
-      - name: Cache Gradle wrapper
-        uses: actions/cache@v1
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradlew-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: ${{ runner.os }}-gradlew-wrapper-
       - name: 'Set up JDK 8'
         uses: actions/setup-java@v2
         with:
@@ -144,18 +126,6 @@ jobs:
           path: ~/.goomph
           key: ${{ runner.os }}-goomph-${{ hashFiles('build.gradle') }}
           restore-keys: ${{ runner.os }}-goomph-
-      - name: Cache Gradle caches
-        uses: actions/cache@v1
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle-caches-
-      - name: Cache Gradle wrapper
-        uses: actions/cache@v1
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradlew-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: ${{ runner.os }}-gradlew-wrapper-
       - name: 'Set up JDK 8'
         uses: actions/setup-java@v2
         with:
@@ -165,4 +135,6 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-        run: ./gradlew publishAllPublicationsToMavenRepository
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: publishAllPublicationsToMavenRepository

--- a/xvfb-gradle.sh
+++ b/xvfb-gradle.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -efu
+
+exec xvfb-run --auto-servernum ./gradlew "$@"


### PR DESCRIPTION
Presumably the Gradle developers know best how to configure things like caching.  I'm particularly interested in seeing our GitHub actions use better caching because we run those actions more frequently now due to our stricter `master`-branch merge policies.

Historically, we have disabled Gradle caching during CI/CD builds: `./gradlew --no-cache ...`.  Presumably we wanted to get a "clean" build every time for the strictest possible checking.  However, clean builds with no cache take a long time!  Furthermore, I believe that our build caching is extremely trustworthy.  I cannot remember the last time that something broken ended up in my cache.  Likewise, I cannot remember the last time that a build succeeded by using the cache, but should have failed if the cache were empty.

I propose that we allow caching, as in this commit.  We can do cache-free hermetic builds when preparing a new official release, but for the many CI/CD builds that happen in between releases, I think that some caching may give us a nice speedup.