### PR TITLE
Remove a noisy debug print

### DIFF
--- a/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
+++ b/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
@@ -337,17 +337,6 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
     Symbol S = context.currentScope().lookup(name);
     Scope definingScope = S.getDefiningScope();
     CAstEntity E = definingScope.getEntity();
-    System.err.println(
-        "script "
-            + name
-            + " "
-            + E.getPosition().getURL().getFile()
-            + " "
-            + E.equals(context.currentScope().getEntity())
-            + " "
-            + entity2WrittenNames.containsKey(E)
-            + " "
-            + entity2WrittenNames.get(E));
     if (E.equals(context.currentScope().getEntity())
         && !(entity2WrittenNames.containsKey(E)
             && entity2WrittenNames.get(E).stream()


### PR DESCRIPTION
I see many of these prints when building a CAst call graph and I think it slows down call graph construction.