### PR TITLE
Remove some test exclusions for JDK 11, and document the remaining one

### DIFF
--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -356,10 +356,8 @@ tasks.named('test') {
 	}
 	// temporarily turn off some tests on JDK 11+
 	if (JavaVersion.current() >= JavaVersion.VERSION_11) {
-		exclude '**/exceptionpruning/ExceptionAnalysisTest.class'
-		exclude '**/exceptionpruning/ExceptionAnalysis2EdgeFilterTest.class'
+		// https://github.com/wala/WALA/issues/963
 		exclude '**/cha/LibraryVersionTest.class'
-		exclude '**/ir/TypeAnnotationTest.class'
 	}
 
 	outputs.file layout.buildDirectory.file('report')


### PR DESCRIPTION
These tests that were excluded seem to be passing now.  There is one test that still fails on JDK 11, due to #963 