### PR TITLE
Cache SourceFileModule.getURL() result

### DIFF
--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/classLoader/SourceFileModule.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/classLoader/SourceFileModule.java
@@ -21,6 +21,8 @@ import java.net.URL;
 public class SourceFileModule extends FileModule implements Module, ModuleEntry, SourceModule {
 
   private final String fileName;
+  /** cache result of {@link #getURL()}, for performance */
+  private URL url;
 
   public SourceFileModule(File f, String fileName, Module container) {
     super(f, container);
@@ -59,10 +61,13 @@ public class SourceFileModule extends FileModule implements Module, ModuleEntry,
 
   @Override
   public URL getURL() {
-    try {
-      return getFile().toURI().toURL();
-    } catch (MalformedURLException e) {
-      throw new Error("error making URL for " + getFile(), e);
+    if (url == null) {
+      try {
+        url = getFile().toURI().toURL();
+      } catch (MalformedURLException e) {
+        throw new Error("error making URL for " + getFile(), e);
+      }
     }
+    return url;
   }
 }


### PR DESCRIPTION
Before this change, calls to `getURL()` took up ~25% of the time to convert a JS source file to JavaScript IR, according to my local profiling.  A simple cache fixes the problem.