### PR TITLE
fix resource leak due to Files.walk and Files.list

### DIFF
--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/FieldBasedCGUtil.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/util/FieldBasedCGUtil.java
@@ -152,7 +152,9 @@ public class FieldBasedCGUtil {
     JavaScriptLoaderFactory loaders = new JavaScriptLoaderFactory(translatorFactory);
     List<Path> jsFiles = Collections.emptyList();
     try (Stream<Path> stream = Files.walk(scriptDir)) {
-        jsFiles = stream.filter(p -> p.toString().toLowerCase().endsWith(".js"))
+      jsFiles =
+          stream
+              .filter(p -> p.toString().toLowerCase().endsWith(".js"))
               .collect(Collectors.toList());
     }
     List<Module> scripts = new ArrayList<>();

--- a/com.ibm.wala.util/src/main/java/com/ibm/wala/util/PlatformUtil.java
+++ b/com.ibm.wala.util/src/main/java/com/ibm/wala/util/PlatformUtil.java
@@ -59,9 +59,7 @@ public class PlatformUtil {
       try (Stream<Path> stream = Files.list(Paths.get(System.getProperty("java.home"), "jmods"))) {
         classpath =
             String.join(
-                File.pathSeparator,
-                    stream.map(Path::toString)
-                    .collect(Collectors.toList()));
+                File.pathSeparator, stream.map(Path::toString).collect(Collectors.toList()));
       } catch (IOException e) {
         throw new IllegalStateException(e);
       }


### PR DESCRIPTION
Files.walk and Files.list will open stream, we should close it.

see jdk:
the {try} -with-resources construct should be used to ensure that the
stream's

{[@link|https://github.com/link] Stream#close close}
method is invoked after the stream
operations are completed.