### PR TITLE
Add Gradle tasks and GitHub workflow for IntelliJ IDEA inspections

### DIFF
--- a/.github/workflows/IntelliJ-IDEA-inspections.yml
+++ b/.github/workflows/IntelliJ-IDEA-inspections.yml
@@ -1,0 +1,26 @@
+name: IntelliJ IDEA inspections
+on:
+  schedule:
+    - cron: 38 4 * * 4
+  workflow_dispatch:
+jobs:
+  intellij_idea_inspections:
+    name: 'Run and check IntelliJ IDEA inspections'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out WALA sources
+        uses: actions/checkout@v2
+      - name: Install IntelliJ IDEA snap
+        run: sudo snap install intellij-idea-community --classic
+      - name: Run IntelliJ IDEA inspections
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments:
+            - -PrunInspections.IntelliJ-IDEA.command=intellij-idea-community
+            - runInspections
+      - name: Check IntelliJ IDEA inspection results
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments:
+            - -PrunInspections.IntelliJ-IDEA.command=intellij-idea-community
+            - checkInspectionResults

--- a/build.gradle
+++ b/build.gradle
@@ -392,7 +392,8 @@ final runInspections = tasks.register('runInspections', Exec) {
 	// changed.
 	inputs.files fileLister.obtainPartialFileTree()
 
-	commandLine 'idea', 'inspect', rootDir, inspectionProfile, textResultsFile, '-v1', '-format', 'plain'
+	executable = findProperty('runInspections.IntelliJ-IDEA.command') ?: 'idea'
+	args 'inspect', rootDir, inspectionProfile, textResultsFile, '-v1', '-format', 'plain'
 
 	// The `idea` command above always fails with an
 	// `IllegalArgumentException` arising from

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
 }
 
 plugins {
+	id 'all.shared.gradle.file-lister' version '1.0.2'
 	id 'com.diffplug.eclipse.mavencentral' version '3.33.0' apply false
 	id 'com.dorongold.task-tree' version '2.1.0'
 	id 'com.github.ben-manes.versions' version '0.39.0'
@@ -358,6 +359,76 @@ final check = tasks.register('check') {
 
 tasks.register('build') {
 	dependsOn check
+}
+
+
+////////////////////////////////////////////////////////////////////////
+//
+//  Run IntelliJ IDEA inspections on entire project tree
+//
+//  We don't make `check` depend on `checkInspectionResults` for two
+//  reasons.  First, `runInspections` is quite slow.  Second,
+//  `runInspections` cannot run while the same user account is running a
+//  regular, graphical instance of IntelliJ IDEA.  These limitations
+//  make `runInspections` and `checkInspectionResults` more suitable for
+//  use in CI/CD pipelines than for daily use by live WALA developers.
+//
+
+final runInspections = tasks.register('runInspections', Exec) {
+	group = 'intellij-idea'
+	description = 'Run all enabled IntelliJ IDEA inspections on the entire WALA project'
+
+	final ideaDir = file "$rootDir/.idea"
+	inputs.dir "$ideaDir/scopes"
+
+	final inspectionProfile = file "$ideaDir/inspectionProfiles/No_Back_Sliding.xml"
+	inputs.file inspectionProfile
+
+	final textResultsFile = file "$buildDir/${name}.txt"
+	outputs.file textResultsFile
+
+	// Inspections examine a wide variety of files, not just Java
+	// sources, so this task is out-of-date if nearly any other file has
+	// changed.
+	inputs.files fileLister.obtainPartialFileTree()
+
+	commandLine 'idea', 'inspect', rootDir, inspectionProfile, textResultsFile, '-v1', '-format', 'plain'
+
+	// The `idea` command above always fails with an
+	// `IllegalArgumentException` arising from
+	// `PlainTextFormatter.getPath`.  Fortunately, this only happens
+	// *after* `idea` has already written out the results file.  So we
+	// should ignore that command's exit value, and only fail this task
+	// if the results file is missing.
+	ignoreExitValue = true
+	doLast {
+		if (!textResultsFile.exists()) {
+			throw new GradleException("IntelliJ IDEA command failed without creating $textResultsFile.")
+		}
+	}
+}
+
+tasks.register('checkInspectionResults') {
+	group = 'intellij-idea'
+	description = 'Fail if any IntelliJ IDEA inspections produced errors or warnings'
+
+	inputs.files runInspections
+	doFirst {
+		def failed = false
+		inputs.files.singleFile.eachLine {
+			if (it =~ /\[(ERROR|WARNING)\]/) {
+				failed = true
+				println it
+			}
+		}
+		if (failed) {
+			throw new GradleException("One or more IntelliJ IDEA inspections failed.  See logged problems above, or \"$inputs.files.singleFile\" for full details.  WEAK WARNINGs are allowed, but all ERRORs and WARNINGs must be corrected.")
+		}
+	}
+
+	final stampFile = file("$buildDir/${name}.stamp")
+	outputs.file stampFile
+	doLast { stampFile.createNewFile() }
 }
 
 

--- a/buildscript-gradle.lockfile
+++ b/buildscript-gradle.lockfile
@@ -1,6 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+all.shared.gradle.file-lister:all.shared.gradle.file-lister.gradle.plugin:1.0.2=classpath
 biz.aQute.bnd:biz.aQute.bndlib:5.3.0=classpath
 com.diffplug.durian:durian-collect:1.2.0=classpath
 com.diffplug.durian:durian-core:1.2.0=classpath
@@ -21,6 +22,7 @@ com.squareup.okhttp3:okhttp:4.3.1=classpath
 com.squareup.okio:okio:2.4.3=classpath
 com.thoughtworks.xstream:xstream:1.4.17=classpath
 commons-io:commons-io:2.11.0=classpath
+gradle.plugin.all.shared.gradle.file-lister:file-lister:1.0.2=classpath
 gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.9=classpath
 io.github.x-stream:mxparser:1.2.1=classpath
 javax.inject:javax.inject:1=classpath


### PR DESCRIPTION
**Add two new top-level Gradle tasks:**

* `runInspections` applies all configured IntelliJ IDEA inspections to the entire WALA project and records the results for future examination. IntelliJ IDEA must already be installed; we don’t download and install it automatically.

* `checkInspectionResults` examines `runInspections` results, summarizes any errors or non-weak warnings, and fails if any such errors or non-weak warnings were found.

---

**Add a new GitHub Actions workflow that installs IntelliJ IDEA Community Edition and runs the above tasks.**

`runInspections` takes about 30 minutes to run as a GitHub Actions workflow: too slow to use in every merge or pull request. So instead, this workflow runs once per week. It can also be started manually, either via GitHub’s REST API or using the GitHub web site. (Only available after these changes are merged into the default `master` branch.)