### PR TITLE
Correct multiple arguments to Gradle actions

### DIFF
--- a/.github/workflows/IntelliJ-IDEA-inspections.yml
+++ b/.github/workflows/IntelliJ-IDEA-inspections.yml
@@ -15,12 +15,12 @@ jobs:
       - name: Run IntelliJ IDEA inspections
         uses: gradle/gradle-build-action@v2
         with:
-          arguments:
-            - -PrunInspections.IntelliJ-IDEA.command=intellij-idea-community
-            - runInspections
+          arguments: |
+            -PrunInspections.IntelliJ-IDEA.command=intellij-idea-community
+            runInspections
       - name: Check IntelliJ IDEA inspection results
         uses: gradle/gradle-build-action@v2
         with:
-          arguments:
-            - -PrunInspections.IntelliJ-IDEA.command=intellij-idea-community
-            - checkInspectionResults
+          arguments: |
+            -PrunInspections.IntelliJ-IDEA.command=intellij-idea-community
+            checkInspectionResults


### PR DESCRIPTION
I mistakenly assumed that each Gradle action could accept an array of `arguments`. Nope! But `arguments` can be a multi-line YAML string.

Unfortunately there’s just no easy way to test a manually triggered workflow *before* merging it to `master`.