### PR TITLE
Build against Eclipse 4.21.0 on ARM-based Macs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,9 @@ repositories {
 }
 
 ext.osName = System.getProperty('os.name')
+ext.archName = System.getProperty('os.arch')
 ext.isWindows = osName.startsWith('Windows ')
+
 
 
 ////////////////////////////////////////////////////////////////////////
@@ -35,7 +37,7 @@ group name
 version VERSION_NAME
 
 // version of Eclipse JARs to use for Eclipse-integrated WALA components
-ext.eclipseVersion = '4.21.0'
+ext.eclipseVersion = (osName.equals('Mac OS X') && archName.equals('aarch64')) ? '4.21.0' : '4.14.0'
 ext.eclipseWstJsdtVersion = '1.0.201.v2010012803'
 
 subprojects { subproject ->

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ group name
 version VERSION_NAME
 
 // version of Eclipse JARs to use for Eclipse-integrated WALA components
-ext.eclipseVersion = '4.14.0'
+ext.eclipseVersion = '4.21.0'
 ext.eclipseWstJsdtVersion = '1.0.201.v2010012803'
 
 subprojects { subproject ->

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,10 @@ ext.isWindows = osName.startsWith('Windows ')
 group name
 version VERSION_NAME
 
-// version of Eclipse JARs to use for Eclipse-integrated WALA components
+// version of Eclipse JARs to use for Eclipse-integrated WALA components.  On ARM-based Mac OS
+// machines, we use a more recent Eclipse version which includes an SWT library built for the
+// platform.  We only use the recent version on ARM-based Macs as it requires JDK 11, and we would
+// like to preserve JDK 8 compatibility on other platforms.
 ext.eclipseVersion = (osName.equals('Mac OS X') && archName.equals('aarch64')) ? '4.21.0' : '4.14.0'
 ext.eclipseWstJsdtVersion = '1.0.201.v2010012803'
 

--- a/com.ibm.wala.cast.java.ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/FakeExceptionTypeBinding.java
+++ b/com.ibm.wala.cast.java.ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/FakeExceptionTypeBinding.java
@@ -289,9 +289,10 @@ public class FakeExceptionTypeBinding implements ITypeBinding {
   }
 
   /**
-   * This overrides a method introduced in recent versions of the {@link ITypeBinding} class to
-   * handle records. We do not use the {@code @Override} annotation to allow the code to build
-   * against earlier versions of the library where ITypeBinding does not contain this method.
+   * This overrides a method introduced in recent versions of the {@code ITypeBinding} interface to
+   * handle records. We omit the {@code @Override} annotation to allow building against earlier
+   * versions of {@code org.eclipse.jdt.core}, where {@code ITypeBinding} does not contain this
+   * method.
    */
   public boolean isRecord() {
     return false;

--- a/com.ibm.wala.cast.java.ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/FakeExceptionTypeBinding.java
+++ b/com.ibm.wala.cast.java.ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/FakeExceptionTypeBinding.java
@@ -289,6 +289,11 @@ public class FakeExceptionTypeBinding implements ITypeBinding {
   }
 
   @Override
+  public boolean isRecord() {
+    return false;
+  }
+
+  @Override
   public boolean isFromSource() {
     Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
     return false;

--- a/com.ibm.wala.cast.java.ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/FakeExceptionTypeBinding.java
+++ b/com.ibm.wala.cast.java.ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/FakeExceptionTypeBinding.java
@@ -288,7 +288,11 @@ public class FakeExceptionTypeBinding implements ITypeBinding {
     return false;
   }
 
-  @Override
+  /**
+   * This overrides a method introduced in recent versions of the {@link ITypeBinding} class to
+   * handle records. We do not use the {@code @Override} annotation to allow the code to build
+   * against earlier versions of the library where ITypeBinding does not contain this method.
+   */
   public boolean isRecord() {
     return false;
   }


### PR DESCRIPTION
This change allows for Eclipse-based code that uses SWT to build on ARM-based Macs.  A more recent Eclipse version is needed since an SWT artifact for ARM Mac was only introduced recently.  We do not bump the Eclipse version globally since recent Eclipse versions require JDK 11, and we want to preserve the ability to run this code on JDK 8.  