### PR TITLE
Temporary fix for building CAst native code on M1 Macs

### DIFF
--- a/com.ibm.wala.cast/cast/build.gradle
+++ b/com.ibm.wala.cast/cast/build.gradle
@@ -5,7 +5,9 @@ plugins {
 library {
 	// Temporary change to build on M1 Mac machines, until https://github.com/gradle/gradle/issues/18876
 	// is fixed
-	targetMachines.add(machines.macOS.x86_64)
+	if (osName.equals('Mac OS X') && archName.equals('aarch64')) {
+		targetMachines.add(machines.macOS.x86_64)
+	}
 	binaries.whenElementFinalized {
 		compileTask.get().configure {
 			macros.put('BUILD_CAST_DLL', '1')

--- a/com.ibm.wala.cast/cast/build.gradle
+++ b/com.ibm.wala.cast/cast/build.gradle
@@ -3,6 +3,9 @@ plugins {
 }
 
 library {
+	// Temporary change to build on M1 Mac machines, until https://github.com/gradle/gradle/issues/18876
+	// is fixed
+	targetMachines.add(machines.macOS.x86_64)
 	binaries.whenElementFinalized {
 		compileTask.get().configure {
 			macros.put('BUILD_CAST_DLL', '1')

--- a/com.ibm.wala.cast/smoke_main/build.gradle
+++ b/com.ibm.wala.cast/smoke_main/build.gradle
@@ -5,6 +5,9 @@ plugins {
 evaluationDependsOn(':com.ibm.wala.cast:xlator_test')
 
 application {
+	// Temporary change to build on M1 Mac machines, until https://github.com/gradle/gradle/issues/18876
+	// is fixed
+	targetMachines.add(machines.macOS.x86_64)
 	dependencies {
 		implementation project(':com.ibm.wala.cast:cast')
 		implementation project(':com.ibm.wala.cast:xlator_test')

--- a/com.ibm.wala.cast/smoke_main/build.gradle
+++ b/com.ibm.wala.cast/smoke_main/build.gradle
@@ -7,7 +7,9 @@ evaluationDependsOn(':com.ibm.wala.cast:xlator_test')
 application {
 	// Temporary change to build on M1 Mac machines, until https://github.com/gradle/gradle/issues/18876
 	// is fixed
-	targetMachines.add(machines.macOS.x86_64)
+	if (osName.equals('Mac OS X') && archName.equals('aarch64')) {
+		targetMachines.add(machines.macOS.x86_64)
+	}
 	dependencies {
 		implementation project(':com.ibm.wala.cast:cast')
 		implementation project(':com.ibm.wala.cast:xlator_test')

--- a/com.ibm.wala.cast/xlator_test/build.gradle
+++ b/com.ibm.wala.cast/xlator_test/build.gradle
@@ -3,6 +3,9 @@ plugins {
 }
 
 library {
+	// Temporary change to build on M1 Mac machines, until https://github.com/gradle/gradle/issues/18876
+	// is fixed
+	targetMachines.add(machines.macOS.x86_64)
 	privateHeaders.from project(':com.ibm.wala.cast').tasks.named('compileTestJava').map {
 		it.options.headerOutputDirectory
 	}

--- a/com.ibm.wala.cast/xlator_test/build.gradle
+++ b/com.ibm.wala.cast/xlator_test/build.gradle
@@ -5,7 +5,9 @@ plugins {
 library {
 	// Temporary change to build on M1 Mac machines, until https://github.com/gradle/gradle/issues/18876
 	// is fixed
-	targetMachines.add(machines.macOS.x86_64)
+	if (osName.equals('Mac OS X') && archName.equals('aarch64')) {
+		targetMachines.add(machines.macOS.x86_64)
+	}
 	privateHeaders.from project(':com.ibm.wala.cast').tasks.named('compileTestJava').map {
 		it.options.headerOutputDirectory
 	}


### PR DESCRIPTION
This trick convinces Gradle to run the built-in Clang / gcc on M1 Macs to compile native CAst code, when executing with a native ARM JVM.  I don't think it should cause any harm on other platforms, since all we support otherwise is 64-bit x86.  If / when https://github.com/gradle/gradle/issues/18876 is fixed, we can remove this change.

Fixes #1045 