### PR TITLE
Preserve IntelliJ IDEA inspection results as workflow artifact

### DIFF
--- a/.github/workflows/IntelliJ-IDEA-inspections.yml
+++ b/.github/workflows/IntelliJ-IDEA-inspections.yml
@@ -18,6 +18,12 @@ jobs:
           arguments: |
             -PrunInspections.IntelliJ-IDEA.command=intellij-idea-community
             runInspections
+      - name: Preserve IntelliJ IDEA inspection results as workflow artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: runInspections.txt
+          path: build/runInspections.txt
+          retention-days: 14
       - name: Check IntelliJ IDEA inspection results
         uses: gradle/gradle-build-action@v2
         with:


### PR DESCRIPTION
If any inspections fail, it can be useful to examine the complete inspection results manually. This change has GitHub preserve those results whenever we run the IntelliJ IDEA inspections workflow.

Artifacts are preserved for 90 days by default, but that seems much longer than we'll need these results to be retained. We run this workflow once per week, so let's retain those results for two weeks.