### PR TITLE
IntelliJ IDEA regexp inspections fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -366,7 +366,7 @@ tasks.register('checkInspectionResults') {
 	doFirst {
 		def failed = false
 		inputs.files.singleFile.eachLine {
-			if (it =~ /\[(ERROR|WARNING)\]/) {
+			if (it =~ /\[(ERROR|WARNING)]/) {
 				failed = true
 				println it
 			}

--- a/com.ibm.wala.cast.java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
+++ b/com.ibm.wala.cast.java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
@@ -452,7 +452,7 @@ public abstract class IRTests {
    */
   public static MethodReference descriptorToMethodRef(
       String srcMethodDescriptor, IClassHierarchy cha) {
-    String[] ldrTypeMeth = srcMethodDescriptor.split("\\#");
+    String[] ldrTypeMeth = srcMethodDescriptor.split("#");
 
     String loaderName = ldrTypeMeth[0];
     String typeStr = ldrTypeMeth[1];

--- a/com.ibm.wala.core/src/test/java/com/ibm/wala/util/io/FileProviderTest.java
+++ b/com.ibm.wala.core/src/test/java/com/ibm/wala/util/io/FileProviderTest.java
@@ -44,7 +44,7 @@ public class FileProviderTest {
     assertThat(
         actual,
         PlatformUtil.onWindows()
-            ? matchesPattern("\\A/[A-Z]:/\\[Eclipse\\]/File.jar\\z")
+            ? matchesPattern("\\A/[A-Z]:/\\[Eclipse]/File.jar\\z")
             : equalTo("/[Eclipse]/File.jar"));
   }
 


### PR DESCRIPTION
No reason to escape `#` in Java regular expressions.

No need to escape `]` after escaped `\[`. An unescaped `]` has no special meaning for Java or Groovy regular expressions unless it's inside a character class that was introduced using an unescaped `[`.