### PR TITLE
IntelliJ IDEA Ant unknown property fixes

### DIFF
--- a/com.ibm.wala.cast.java.test.data/build.xml
+++ b/com.ibm.wala.cast.java.test.data/build.xml
@@ -2,11 +2,6 @@
 <!DOCTYPE project>
 <project name="com.ibm.wala.cast.java.test.data" default="jar" basedir=".">
 
-  <property name="basews" value="${ws}"/>
-  <property name="baseos" value="${os}"/>
-  <property name="basearch" value="${arch}"/>
-  <property name="basenl" value="${nl}"/>
-
   <!-- Compiler settings. -->
   <property name="javacFailOnError" value="true"/>
   <property name="javacDebugInfo" value="on"/>

--- a/com.ibm.wala.cast.java.test.data/build.xml
+++ b/com.ibm.wala.cast.java.test.data/build.xml
@@ -73,6 +73,7 @@
   </target>
   
   <target name="init" depends="properties">
+    <!--suppress AntResolveInspection -->
     <condition property="pluginTemp" value="${buildTempFolder}/plugins">
       <isset property="buildTempFolder"/>
     </condition>


### PR DESCRIPTION
### Ignore safe use of unknown `buildTempFolder` property

The embedded `isset` element ensures that we will only `buildTempFolder` to set the value of `pluginTemp` if `buildTempFolder` is actually set.

### Remove unused Ant properties 

Each of these `base*` properties is defined using some other Ant property that IntelliJ IDEA thinks is unknown. Those other properties might be set in one of the Eclipse launchers (`JDTJava15IRTests.launch`), but I don't see them being set anywhere else. In any case, none of the four `base*` properties are ever mentioned again anywhere in this `build.xml` file. My guess is that these properties are no longer used, and therefore that they can be removed.