### PR TITLE
Stop using external gpg command for signing artifacts

### DIFF
--- a/gradle-mvn-push.gradle
+++ b/gradle-mvn-push.gradle
@@ -141,10 +141,6 @@ publishing {
 }
 
 signing {
-	// Use external gpg cmd.  This makes it easy to use gpg-agent,
-	// to avoid being prompted for a password once per artifact.
-	useGpgCmd()
-
 	// If anything about signing is misconfigured, fail loudly rather than quietly continuing with
 	// unsigned artifacts.
 	required = true


### PR DESCRIPTION
It seems the external gpg command support is poor and doesn't really work out of the box with `gpg2`.  I have re-configured the signing config on my local machine to be compatible and `gpg2` and the built-in Gradle signing functionality.  So this is no longer necessary.  I will also update the documentation at https://github.com/wala/WALA/wiki/WALA-Releases-and-Snapshots#initial-setup appropriately.

I've tested locally and signing seems to work, though the true test will only happen next time we want to cut a release (which should probably be soon anyway).