### PR TITLE
Download JLex into build subdir, not sources

### DIFF
--- a/com.ibm.wala.cast.java.test.data/build.gradle
+++ b/com.ibm.wala.cast.java.test.data/build.gradle
@@ -11,24 +11,11 @@ plugins {
 final downloadJLex = tasks.register('downloadJLex', VerifiedDownload) {
 	src 'https://www.cs.princeton.edu/~appel/modern/java/JLex/current/Main.java'
 	checksum 'fe0cff5db3e2f0f5d67a153cf6c783af'
-	dest "${sourceSets.test.java.srcDirs.find()}/JLex/Main.java"
+	ext.downloadedSourceDir = layout.buildDirectory.dir name
+	dest downloadedSourceDir.map { "$it/JLex/Main.java" }
 }
 
-final cleanDownloadJLex = tasks.register('cleanDownloadJLex', Delete) {
-	delete downloadJLex.get().dest.parent
-}
-
-tasks.named('compileTestJava') {
-	dependsOn downloadJLex
-}
-
-tasks.named('compileTestJavaUsingEcj') {
-	dependsOn downloadJLex
-}
-
-tasks.named('clean') {
-	dependsOn cleanDownloadJLex
-}
+sourceSets.test.java.srcDir downloadJLex.map { it.downloadedSourceDir }
 
 
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The `JLex.java` file that we download is compiled as part of the `com.ibm.wala.test.data` test sources, but we still shouldn't treat it as "real" hand-authored, git-tracked source code.  This file is built by running a task, just like any other build artifact.

Happily, treating `JLex.java` as a built actually makes the relevant build script simpler.  There's some subtlety to the way that this download gets hooked up as source to compile, but now that we know how to do that, this change lets us shrink the build logic by about a dozen lines.