### PR TITLE
Avoid referring to other task during task execution

### DIFF
--- a/com.ibm.wala.cast/build.gradle
+++ b/com.ibm.wala.cast/build.gradle
@@ -23,14 +23,16 @@ tasks.named('javadoc', Javadoc) {
 	final jsTasks = project(':com.ibm.wala.cast.js').tasks
 	classpath += files jsTasks.named('compileJava', JavaCompile)
 	final jsCreatePackageList = jsTasks.named('createPackageList', CreatePackageList)
-	final packageListDirectory = jsCreatePackageList.flatMap { it.packageListDirectory }
+	final packageListDirectory = jsCreatePackageList.map { it.packageListDirectory.get() }
 	it.inputs.dir packageListDirectory
 
+	inputs.property 'extdocURL', jsTasks.named('javadoc', Javadoc).map { it.destinationDir.path }
+	inputs.property 'packagelistLoc', packageListDirectory.map { it.toString() }
+
 	doFirst {
-		final jsJavadoc = jsTasks.named('javadoc', Javadoc)
 		options.linksOffline(
-				jsJavadoc.get().destinationDir.path,
-				packageListDirectory.get().toString()
+				inputs.properties['extdocURL'],
+				inputs.properties['packagelistLoc']
 		)
 	}
 }

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -68,8 +68,7 @@ tasks.named('javadoc') {
 //
 
 final downloadKawa = tasks.register('downloadKawa', VerifiedDownload) {
-	ext.version = '3.0'
-	final archive = "kawa-${version}.zip"
+	final archive = 'kawa-3.0.zip'
 	src "https://ftp.gnu.org/pub/gnu/kawa/$archive"
 	dest project.layout.buildDirectory.file(archive)
 	checksum '2713e6dfb939274ba3b1d36daea68436'
@@ -81,8 +80,8 @@ tasks.register('extractKawa') {
 
 	doLast {
 		copy {
-			from(downloadKawa.map { zipTree it.dest }) {
-				include "kawa-${downloadKawa.get().version}/lib/${outputs.files.singleFile.name}"
+			from(zipTree(inputs.files.singleFile)) {
+				include "kawa-*/lib/${outputs.files.singleFile.name}"
 				eachFile {
 					relativePath RelativePath.parse(!directory, relativePath.lastName)
 				}


### PR DESCRIPTION
When a task is executing, it should not refer directly to the state of another task instance.  Doing so is incompatible with [configuration caching](https://docs.gradle.org/7.3/userguide/configuration_cache.html#config_cache:requirements:task_access).

Instead, each task should refer only to its own inputs and outputs, which in turn were defined during task *configuration* (not task *execution*).