### PR TITLE
Fix SourceMapTest so it can run on CI

### DIFF
--- a/com.ibm.wala.core.java11/build.gradle
+++ b/com.ibm.wala.core.java11/build.gradle
@@ -47,7 +47,6 @@ tasks.named('processTestResources') {
 
 tasks.named('test') {
 	maxHeapSize = '1500M'
-	systemProperty 'com.ibm.wala.junit.analyzingJar', 'true'
 	systemProperty 'com.ibm.wala.junit.profile', 'short'
 	// classpath += files project(':com.ibm.wala.core.java11').sourceSets.test.java.outputDir
 	testLogging {

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -54,6 +54,7 @@ dependencies {
 	)
 	testRuntimeOnly(
 			sourceSets.testSubjects.output.classesDirs,
+			layout.files(sourceSets.testSubjects.java.srcDirs)
 	)
 }
 
@@ -346,7 +347,6 @@ tasks.named('processTestResources') {
 
 tasks.named('test') {
 	maxHeapSize = '1500M'
-	systemProperty 'com.ibm.wala.junit.analyzingJar', 'true'
 	systemProperty 'com.ibm.wala.junit.profile', 'short'
 	classpath += files project(':com.ibm.wala.core').sourceSets.test.output.classesDirs
 	testLogging {

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -54,6 +54,7 @@ dependencies {
 	)
 	testRuntimeOnly(
 			sourceSets.testSubjects.output.classesDirs,
+			// add the testSubjects source files to enable SourceMapTest to pass
 			layout.files(sourceSets.testSubjects.java.srcDirs)
 	)
 }

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -55,7 +55,7 @@ dependencies {
 	testRuntimeOnly(
 			sourceSets.testSubjects.output.classesDirs,
 			// add the testSubjects source files to enable SourceMapTest to pass
-			layout.files(sourceSets.testSubjects.java.srcDirs)
+			files(sourceSets.testSubjects.java.srcDirs),
 	)
 }
 

--- a/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/callGraph/CallGraphTest.java
+++ b/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/callGraph/CallGraphTest.java
@@ -145,7 +145,6 @@ public class CallGraphTest extends WalaTestCase {
   @Test
   public void testHello()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    if (analyzingJar()) return;
     AnalysisScope scope =
         CallGraphTestUtil.makeJ2SEAnalysisScope(
             TestConstants.HELLO, CallGraphTestUtil.REGRESSION_EXCLUSIONS);
@@ -251,7 +250,6 @@ public class CallGraphTest extends WalaTestCase {
   @Test
   public void testHelloAllEntrypoints()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
-    if (analyzingJar()) return;
     AnalysisScope scope =
         CallGraphTestUtil.makeJ2SEAnalysisScope(
             TestConstants.HELLO, CallGraphTestUtil.REGRESSION_EXCLUSIONS);

--- a/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/cha/SourceMapTest.java
+++ b/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/cha/SourceMapTest.java
@@ -33,7 +33,6 @@ public class SourceMapTest extends WalaTestCase {
 
   @Test
   public void testHello() throws ClassHierarchyException, IOException {
-    if (analyzingJar()) return;
     AnalysisScope scope = null;
     scope = AnalysisScopeReader.instance.readJavaScope(TestConstants.HELLO, null, MY_CLASSLOADER);
     // TODO: it's annoying to have to build a class hierarchy here.
@@ -50,7 +49,6 @@ public class SourceMapTest extends WalaTestCase {
 
   @Test
   public void testFromJar() throws ClassHierarchyException, IOException {
-    if (analyzingJar()) return;
     AnalysisScope scope = null;
     scope = AnalysisScopeReader.instance.readJavaScope(TestConstants.HELLO, null, MY_CLASSLOADER);
     // TODO: it's annoying to have to build a class hierarchy here.

--- a/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/shrike/FloatingPointsTest.java
+++ b/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/shrike/FloatingPointsTest.java
@@ -36,7 +36,7 @@ public class FloatingPointsTest extends WalaTestCase {
   }
 
   public FloatingPointsTest() {
-    this(getClasspathEntry("testSubjects"));
+    this(getClasspathEntry("classes" + File.separator + "java" + File.separator + "testSubjects"));
   }
 
   @Before

--- a/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/shrike/FloatingPointsTest.java
+++ b/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/shrike/FloatingPointsTest.java
@@ -36,7 +36,7 @@ public class FloatingPointsTest extends WalaTestCase {
   }
 
   public FloatingPointsTest() {
-    this(getClasspathEntry("classes" + File.separator + "java" + File.separator + "testSubjects"));
+    this(getClasspathEntry(String.join(File.separator, "classes", "java", "testSubjects")));
   }
 
   @Before

--- a/com.ibm.wala.core/src/testFixtures/java/com/ibm/wala/core/tests/util/WalaTestCase.java
+++ b/com.ibm.wala.core/src/testFixtures/java/com/ibm/wala/core/tests/util/WalaTestCase.java
@@ -34,10 +34,6 @@ public abstract class WalaTestCase {
     }
   }
 
-  public static boolean analyzingJar() {
-    return "true".equals(System.getProperty("com.ibm.wala.junit.analyzingJar"));
-  }
-
   @Before
   public void setUp() throws Exception {}
 


### PR DESCRIPTION
In order for the `SourceMapTest` tests to pass, they must be able to see files inside the wala.core `testSubjects` source directory.  This PR adjusts the `testRuntimeOnly` path to include this directory, so the tests now pass.  This change enables removing the `analyzingJar` configuration that was added to skip the tests.