### PR TITLE
Revert unpacking NodeJs code to test resources rather than main resources

### DIFF
--- a/com.ibm.wala.cast.js.nodejs/build.gradle
+++ b/com.ibm.wala.cast.js.nodejs/build.gradle
@@ -36,7 +36,7 @@ final unpackNodeJSLib = tasks.register('unpackNodeJSLib', Copy) {
 }
 
 tasks.named('processResources') {
-	dependsOn 'unpackNodeJSLib'
+	dependsOn unpackNodeJSLib
 }
 
 tasks.named('test') {

--- a/com.ibm.wala.cast.js.nodejs/build.gradle
+++ b/com.ibm.wala.cast.js.nodejs/build.gradle
@@ -31,6 +31,12 @@ final unpackNodeJSLib = tasks.register('unpackNodeJSLib', Copy) {
 		}
 	}
 
+	// It is important to unpack the the NodeJs library files into the main resources directory,
+	// so they are packaged inside the jar artifact for this module.  That way, the packaged jar
+	// will work when used by third-party code.  The downside is that we cannot release this jar
+	// artifact to Maven Central with third-party source code included.  Eventually, we should find
+	// a way to remove the reliance on packaging this code (e.g., allow the nodejs library directory
+	// to be specified via a JVM property), so we can release the artifact to Maven Central.
 	into "${tasks.named('processResources', Copy).get().destinationDir}/core-modules"
 	includeEmptyDirs false
 }

--- a/com.ibm.wala.cast.js.nodejs/build.gradle
+++ b/com.ibm.wala.cast.js.nodejs/build.gradle
@@ -31,12 +31,12 @@ final unpackNodeJSLib = tasks.register('unpackNodeJSLib', Copy) {
 		}
 	}
 
-	into "${tasks.named('processTestResources', Copy).get().destinationDir}/core-modules"
+	into "${tasks.named('processResources', Copy).get().destinationDir}/core-modules"
 	includeEmptyDirs false
 }
 
-tasks.named('processTestResources') {
-	dependsOn unpackNodeJSLib
+tasks.named('processResources') {
+	dependsOn 'unpackNodeJSLib'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
This reverts commit a9157d8cce595798baffef04ae62e27a9e96c909.

Fixes #1033.  Unfortunately, I am not sure why I made this change in the first place, but it seems wrong to me now, as the built `wala.cast.js.nodejs` artifact won't work without these resources packaged in.  I may have been thinking about how we could package up `nodejs` for release to Maven Central (since we wouldn't want to re-distribute NodeJs code in such a case).  But since we still haven't done that, for now revert the change.