### PR TITLE
Update an inspection scope for new JLex location

### DIFF
--- a/.idea/scopes/Java_Sources_as_Test_Subjects.xml
+++ b/.idea/scopes/Java_Sources_as_Test_Subjects.xml
@@ -1,3 +1,3 @@
 <component name="DependencyValidationManager">
-  <scope name="Java Sources as Test Subjects" pattern="file[com.ibm.wala.com.ibm.wala.cast.java.test.data.test]:java//*||file[com.ibm.wala.com.ibm.wala.core.testSubjects]:java//*" />
+  <scope name="Java Sources as Test Subjects" pattern="file[com.ibm.wala.com.ibm.wala.cast.java.test.data.test]:*/||file[com.ibm.wala.com.ibm.wala.core.testSubjects]:java//*" />
 </component>


### PR DESCRIPTION
The "Java Sources as Test Subjects" IntelliJ IDEA files scope no longer included the download JLex sources after we moved those under `build/downloadJLex`, which in turn meant that we were no longer skipping certain inspections for these files.  This commit corrects that regression.