### PR TITLE
Conform to IntelliJ IDEA restrictions on content roots

### DIFF
--- a/com.ibm.wala.cast.js.html.nu_validator/build.gradle
+++ b/com.ibm.wala.cast.js.html.nu_validator/build.gradle
@@ -12,7 +12,9 @@ dependencies {
 	)
 }
 
-sourceSets.test.resources.srcDir project(':com.ibm.wala.cast.js').tasks.named('processTestResources')
+tasks.named('processTestResources') {
+	from project(':com.ibm.wala.cast.js').tasks.named('processTestResources')
+}
 
 tasks.named('test') {
 	maxHeapSize = '800M'

--- a/com.ibm.wala.cast.js.rhino/build.gradle
+++ b/com.ibm.wala.cast.js.rhino/build.gradle
@@ -20,7 +20,9 @@ dependencies {
 	)
 }
 
-sourceSets.test.resources.srcDir project(':com.ibm.wala.cast.js').tasks.named('processTestResources')
+tasks.named('processTestResources') {
+	from project(':com.ibm.wala.cast.js').tasks.named('processTestResources')
+}
 
 tasks.named('test') {
 	environment 'TRAVIS', 1


### PR DESCRIPTION
Turns out, IntelliJ IDEA doesn't like having a single directory be a content root for more than one module.  OK, we can easily configure this differently so that resources are copied from another task without adding reusing that other task's resource directories to multiple `SourceSet`s.