### PR TITLE
Prefer to depend on tasks implicitly

### DIFF
--- a/com.ibm.wala.cast/build.gradle
+++ b/com.ibm.wala.cast/build.gradle
@@ -45,7 +45,7 @@ final getProjectLibraryDirectory(project_name, link_task_name) {
 tasks.named('test') {
 	final xlator_project_name = 'xlator_test'
 	final link_task_name = 'linkDebug'
-	dependsOn "$xlator_project_name:$link_task_name"
+	inputs.files project(xlator_project_name).tasks.named(link_task_name)
 
 	doFirst {
 		systemProperty 'java.library.path', getProjectLibraryDirectory(xlator_project_name, link_task_name)

--- a/com.ibm.wala.cast/xlator_test/build.gradle
+++ b/com.ibm.wala.cast/xlator_test/build.gradle
@@ -17,8 +17,4 @@ library {
 	}
 
 	addCastLibrary(project, it)
-
-	binaries.whenElementFinalized { binary ->
-		binary.compileTask.get().dependsOn(':com.ibm.wala.cast:compileTestJava')
-	}
 }


### PR DESCRIPTION
Instead of task A explicitly declaring that it `dependsOn` task B, the preferred style is for task A to declare that its inputs include task B's outputs (or some subset thereof).  The dependency between the tasks should be implicit, to be inferred by Gradle.