### PR TITLE
Extract Gradle logic for Javadoc tasks

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -41,13 +41,13 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           gradle-executable: xvfb-gradle.sh
-          arguments: javadoc build lintGradle
+          arguments: aggregatedJavadocs javadoc build lintGradle
         # testing ECJ compilation on any one OS is sufficient; we choose Linux arbitrarily
         if: runner.os == 'Linux'
       - name: Build and test using Gradle but without ECJ
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: javadoc build -PskipJavaUsingEcjTasks
+          arguments: aggregatedJavadocs javadoc build -PskipJavaUsingEcjTasks
         if: runner.os != 'Linux'
       - name: Check for Git cleanliness after build and test
         run: ./check-git-cleanliness.sh

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,8 @@ plugins {
 	id 'nebula.lint' version '17.2.3'
 }
 
+apply from: "$rootDir/wala-javadoc.gradle"
+
 repositories {
 	// to get the google-java-format jar and dependencies
 	mavenCentral()

--- a/wala-java.gradle
+++ b/wala-java.gradle
@@ -4,6 +4,8 @@ apply plugin: 'java-test-fixtures'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
+apply from: "$rootDir/wala-javadoc.gradle"
+
 java.sourceCompatibility = JavaVersion.VERSION_1_8
 java.targetCompatibility = JavaVersion.VERSION_1_8
 
@@ -74,13 +76,6 @@ project.tasks.named('check').configure {
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'
-}
-
-tasks.withType(Javadoc).configureEach {
-	options.addBooleanOption('Xdoclint:all,-missing', true)
-	options.encoding = 'UTF-8'
-	options.quiet()
-	options.tags += "apiNote:a:API Note:"
 }
 
 // Special hack for WALA as an included build.  Composite

--- a/wala-javadoc.gradle
+++ b/wala-javadoc.gradle
@@ -1,0 +1,6 @@
+tasks.withType(Javadoc).configureEach {
+	options.addBooleanOption 'Xdoclint:all,-missing', true
+	options.encoding = 'UTF-8'
+	options.quiet()
+	options.tags += "apiNote:a:API Note:"
+}


### PR DESCRIPTION
Javadoc tasks only arise in Java-containing subprojects, with one important exception: the `aggregatedJavadocs` task in the top-level project.  Extract Javadoc-specific configuration into its own script plugin that we can reuse wherever we need it, even in projects that do not contain any Java code of their own.

Corrects [a regression](https://github.com/wala/WALA/runs/4424048891?check_suite_focus=true) that was introduced by pull request #1075.

I'm also adding `aggregatedJavadocs` to the standard tasks performed by all pre-merge GitHub CI jobs.  That should help us catch any future regressions of this task earlier, before merging to `master`.