### PR TITLE
Don't force premature task instantiation

### DIFF
--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -230,7 +230,7 @@ tasks.register('downloadJavaCup', VerifiedDownload) {
 //
 
 tasks.register('collectJLex', Jar) {
-	from project(':com.ibm.wala.cast.java.test.data').compileTestJava
+	from project(':com.ibm.wala.cast.java.test.data').tasks.named('compileTestJava')
 	include 'JLex/'
 	archiveFileName = 'JLex.jar'
 	destinationDirectory = layout.buildDirectory.dir name


### PR DESCRIPTION
As used here, it's enough to have a `Provider` for the `Task` that may eventually be created.  We don't need to force creation of that task right away.