### PR TITLE
Refine gathering of classpath for whole-project Javadoc

### DIFF
--- a/wala-java.gradle
+++ b/wala-java.gradle
@@ -25,6 +25,7 @@ configurations {
 			substitute module('org.hamcrest:hamcrest-core') using module('org.hamcrest:hamcrest:2.2') because 'junit depends on hamcrest-core, but all hamcrest-core classes have been incorporated into hamcrest'
 		}
 	}
+
 	implementation {
 		// See https://github.com/wala/WALA/issues/823.  This group was renamed to
 		// net.java.dev.jna.  The com.sun.jna dependency is only pulled in from
@@ -32,6 +33,16 @@ configurations {
 		// Gradle, but not run them, excluding the group as a dependence is a reasonable
 		// solution.
 		exclude group: 'com.sun.jna'
+	}
+
+	aggregatedJavadocClasspath
+}
+
+tasks.withType(Javadoc).configureEach {
+	classpath.each { path ->
+		artifacts {
+			aggregatedJavadocClasspath path
+		}
 	}
 }
 


### PR DESCRIPTION
Our previous approach triggered deprecation warnings.  This new approach works fine, and should be compatible with some future Gradle 8.x release.  The important change seems to be to treat subprojects' Javadoc tasks' class paths as Gradle "artifacts", which are allowed to be produced and consumed in different (sub)projects.

Fixes #1079.