### PR TITLE
Remove unnecessary Java toolchain de-configuration

### DIFF
--- a/buildSrc/src/main/groovy/java-compile-using-ecj.groovy
+++ b/buildSrc/src/main/groovy/java-compile-using-ecj.groovy
@@ -17,10 +17,6 @@ class JavaCompileUsingEcj extends JavaCompile {
 				project.configurations.detachedConfiguration(
 						project.dependencies.create('org.eclipse.jdt:ecj:3.21.0'))
 
-		// Advise Gradle that this task will not be using the Java compilation API associated with the
-		// standard Java toolchain.  Instead, we will use an external compiler command, configured below.
-		javaCompiler.set(project.provider { null })
-
 		options.with {
 			// Add Eclipse JDT configuration, especially for warnings/errors.
 			compilerArgs << '-properties' << project.layout.projectDirectory.file('.settings/org.eclipse.jdt.core.prefs').asFile


### PR DESCRIPTION
As [pointed out by `$RANDOM_INTERNET_PERSON`](https://github.com/TwoStone/gradle-eclipse-compiler-plugin/issues/13#issuecomment-995488621), this extra step is not needed.  Setting an executable in the fork options (which we do) is sufficient.