### PR TITLE
Upgrade to Gradle download plugin v5.0.1

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -3,5 +3,5 @@ repositories {
 }
 
 dependencies {
-	implementation 'de.undercouch:gradle-download-task:4.0.4'
+	implementation 'de.undercouch:gradle-download-task:5.0.1'
 }

--- a/buildSrc/src/main/groovy/verified-download.groovy
+++ b/buildSrc/src/main/groovy/verified-download.groovy
@@ -31,7 +31,7 @@ class VerifiedDownload extends org.gradle.api.DefaultTask {
 	@TaskAction
 	downloadAndVerify() {
 		def destFile = getDest()
-		project.download {
+		project.download.run {
 			src this.src
 			dest destFile
 			overwrite true
@@ -39,7 +39,7 @@ class VerifiedDownload extends org.gradle.api.DefaultTask {
 			useETag this.useETag
 			retries 5
 		}
-		project.verifyChecksum {
+		project.verifyChecksum.run {
 			src destFile
 			algorithm this.algorithm
 			checksum this.checksum


### PR DESCRIPTION
This release has [a few improvements](https://github.com/michel-kraemer/gradle-download-task/releases/tag/5.0.0) over the 4.x versions of this plugin. For example, it can download concurrently with other build tasks or downloads, and it shows the destination file name in the build progress message.