### PR TITLE
Avoid configuring some tasks prematurely

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ tasks.register('aggregatedJavadocs', Javadoc) { aggregated ->
 	options.author true
 
 	subprojects.each { proj ->
-		proj.tasks.withType(Javadoc) { javadocTask ->
+		proj.tasks.withType(Javadoc).configureEach { javadocTask ->
 			aggregated.source += javadocTask.source
 			aggregated.classpath += javadocTask.classpath
 			aggregated.excludes += javadocTask.excludes

--- a/buildSrc/src/main/groovy/wala-subproject.gradle
+++ b/buildSrc/src/main/groovy/wala-subproject.gradle
@@ -15,12 +15,10 @@ version rootProject.version
 //
 
 tasks.register('downloads') {
-	final allDownloaders = tasks.withType(VerifiedDownload)
-	final neededDownloaders = allDownloaders.findAll {
+	inputs.files tasks.withType(VerifiedDownload).matching {
 		// not used in typical builds
 		it.name != 'downloadOcamlJava'
 	}
-	inputs.files neededDownloaders
 }
 
 


### PR DESCRIPTION
For the best Gradle performance, we should always use Gradle task-configuration-avoidance APIs to configure tasks only when truly needed.