### PR TITLE
Restore generation of whole-project Javadocs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ tasks.register('aggregatedJavadocs', Javadoc) { aggregated ->
 	options.author true
 
 	subprojects.each { proj ->
-		proj.tasks.withType(Javadoc).configureEach { javadocTask ->
+		proj.tasks.withType(Javadoc) { javadocTask ->
 			aggregated.source += javadocTask.source
 			aggregated.classpath += javadocTask.classpath
 			aggregated.excludes += javadocTask.excludes


### PR DESCRIPTION
My recent attempt to avoid premature task configuration accidentally
broke the `aggregatedJavadocs` task.  This commit corrects that
regression.