### PR TITLE
Switch download of bcel to https

### DIFF
--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -187,7 +187,7 @@ tasks.register('buildKawaTestJar', Jar) {
 final downloadBcel = tasks.register('downloadBcel', VerifiedDownload) {
 	ext.basename = 'bcel-5.2'
 	final archive = "${basename}.tar.gz"
-	src "http://archive.apache.org/dist/jakarta/bcel/binaries/$archive"
+	src "https://archive.apache.org/dist/jakarta/bcel/binaries/$archive"
 	dest project.layout.buildDirectory.file(archive)
 	checksum '19bffd7f217b0eae415f1ef87af2f0bc'
 	useETag false


### PR DESCRIPTION
As @liblit noted at https://github.com/wala/WALA/pull/1123#issuecomment-1246039827, this probably has no impact in terms of download integrity.  Still, using unencrypted http when not needed feels gross :-)  I tried switching the two other `http://` download URLs we have as well, but those didn't work with https.