### PR TITLE
Cache all predecessors in CHACallGraph

### DIFF
--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/cha/CHACallGraph.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/cha/CHACallGraph.java
@@ -41,7 +41,6 @@ import com.ibm.wala.util.graph.NumberedEdgeManager;
 import com.ibm.wala.util.intset.IntSet;
 import com.ibm.wala.util.intset.IntSetUtil;
 import com.ibm.wala.util.intset.MutableIntSet;
-import java.lang.ref.SoftReference;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
@@ -320,7 +319,6 @@ public class CHACallGraph extends BasicCallGraph<CHAContextInterpreter> {
       int x = getNumber(src);
       int y = getNumber(dst);
       predecessors.add(y, x);
-
     }
 
     @Override
@@ -356,7 +354,6 @@ public class CHACallGraph extends BasicCallGraph<CHAContextInterpreter> {
       }
       return result;
     }
-
   }
 
   private final CHACallGraphEdgeManager edgeManager = new CHACallGraphEdgeManager();

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/cha/CHACallGraph.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/cha/CHACallGraph.java
@@ -22,6 +22,7 @@ import com.ibm.wala.ipa.callgraph.Entrypoint;
 import com.ibm.wala.ipa.callgraph.IAnalysisCacheView;
 import com.ibm.wala.ipa.callgraph.impl.BasicCallGraph;
 import com.ibm.wala.ipa.callgraph.impl.Everywhere;
+import com.ibm.wala.ipa.callgraph.impl.ExplicitPredecessorsEdgeManager;
 import com.ibm.wala.ipa.callgraph.impl.FakeWorldClinitMethod;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.shrike.shrikeBT.IInvokeInstruction;
@@ -255,6 +256,7 @@ public class CHACallGraph extends BasicCallGraph<CHAContextInterpreter> {
               if (n == getFakeRootNode()) {
                 registerEntrypoint(callee);
               }
+              edgeManager.addEdge(n, callee);
             }
           }
         }
@@ -277,112 +279,97 @@ public class CHACallGraph extends BasicCallGraph<CHAContextInterpreter> {
     return n;
   }
 
+  private class CHACallGraphEdgeManager extends ExplicitPredecessorsEdgeManager {
+
+    protected CHACallGraphEdgeManager() {
+      super(CHACallGraph.this);
+    }
+
+    @Override
+    public Iterator<CGNode> getSuccNodes(final CGNode n) {
+      return new FilterIterator<>(
+          new ComposedIterator<CallSiteReference, CGNode>(n.iterateCallSites()) {
+            @Override
+            public Iterator<? extends CGNode> makeInner(CallSiteReference outer) {
+              return getPossibleTargets(n, outer).iterator();
+            }
+          },
+          new Predicate<CGNode>() {
+            private final MutableIntSet nodes = IntSetUtil.make();
+
+            @Override
+            public boolean test(CGNode o) {
+              if (nodes.contains(o.getGraphNodeId())) {
+                return false;
+              } else {
+                nodes.add(o.getGraphNodeId());
+                return true;
+              }
+            }
+          });
+    }
+
+    @Override
+    public int getSuccNodeCount(CGNode N) {
+      return IteratorUtil.count(getSuccNodes(N));
+    }
+
+    @Override
+    public void addEdge(CGNode src, CGNode dst) {
+      int x = getNumber(src);
+      int y = getNumber(dst);
+      predecessors.add(y, x);
+
+    }
+
+    @Override
+    public void removeEdge(CGNode src, CGNode dst) throws UnsupportedOperationException {
+      assert false;
+    }
+
+    @Override
+    public void removeAllIncidentEdges(CGNode node) throws UnsupportedOperationException {
+      assert false;
+    }
+
+    @Override
+    public void removeIncomingEdges(CGNode node) throws UnsupportedOperationException {
+      assert false;
+    }
+
+    @Override
+    public void removeOutgoingEdges(CGNode node) throws UnsupportedOperationException {
+      assert false;
+    }
+
+    @Override
+    public boolean hasEdge(CGNode src, CGNode dst) {
+      return getPossibleSites(src, dst).hasNext();
+    }
+
+    @Override
+    public IntSet getSuccNodeNumbers(CGNode node) {
+      MutableIntSet result = IntSetUtil.make();
+      for (CGNode s : Iterator2Iterable.make(getSuccNodes(node))) {
+        result.add(s.getGraphNodeId());
+      }
+      return result;
+    }
+
+    @Override
+    public IntSet getPredNodeNumbers(CGNode node) {
+      MutableIntSet result = IntSetUtil.make();
+      for (CGNode s : Iterator2Iterable.make(getPredNodes(node))) {
+        result.add(s.getGraphNodeId());
+      }
+      return result;
+    }
+  }
+
+  private final CHACallGraphEdgeManager edgeManager = new CHACallGraphEdgeManager();
+
   @Override
   protected NumberedEdgeManager<CGNode> getEdgeManager() {
-    return new NumberedEdgeManager<CGNode>() {
-      private final Map<CGNode, SoftReference<Set<CGNode>>> predecessors = HashMapFactory.make();
-
-      private Set<CGNode> getPreds(CGNode n) {
-        if (predecessors.containsKey(n) && predecessors.get(n).get() != null) {
-          return predecessors.get(n).get();
-        } else {
-          Set<CGNode> preds = HashSetFactory.make();
-          for (CGNode node : CHACallGraph.this) {
-            if (getPossibleSites(node, n).hasNext()) {
-              preds.add(node);
-            }
-          }
-          predecessors.put(n, new SoftReference<>(preds));
-          return preds;
-        }
-      }
-
-      @Override
-      public Iterator<CGNode> getPredNodes(CGNode n) {
-        return getPreds(n).iterator();
-      }
-
-      @Override
-      public int getPredNodeCount(CGNode n) {
-        return getPreds(n).size();
-      }
-
-      @Override
-      public Iterator<CGNode> getSuccNodes(final CGNode n) {
-        return new FilterIterator<>(
-            new ComposedIterator<CallSiteReference, CGNode>(n.iterateCallSites()) {
-              @Override
-              public Iterator<? extends CGNode> makeInner(CallSiteReference outer) {
-                return getPossibleTargets(n, outer).iterator();
-              }
-            },
-            new Predicate<CGNode>() {
-              private final MutableIntSet nodes = IntSetUtil.make();
-
-              @Override
-              public boolean test(CGNode o) {
-                if (nodes.contains(o.getGraphNodeId())) {
-                  return false;
-                } else {
-                  nodes.add(o.getGraphNodeId());
-                  return true;
-                }
-              }
-            });
-      }
-
-      @Override
-      public int getSuccNodeCount(CGNode N) {
-        return IteratorUtil.count(getSuccNodes(N));
-      }
-
-      @Override
-      public void addEdge(CGNode src, CGNode dst) {
-        assert false;
-      }
-
-      @Override
-      public void removeEdge(CGNode src, CGNode dst) throws UnsupportedOperationException {
-        assert false;
-      }
-
-      @Override
-      public void removeAllIncidentEdges(CGNode node) throws UnsupportedOperationException {
-        assert false;
-      }
-
-      @Override
-      public void removeIncomingEdges(CGNode node) throws UnsupportedOperationException {
-        assert false;
-      }
-
-      @Override
-      public void removeOutgoingEdges(CGNode node) throws UnsupportedOperationException {
-        assert false;
-      }
-
-      @Override
-      public boolean hasEdge(CGNode src, CGNode dst) {
-        return getPossibleSites(src, dst).hasNext();
-      }
-
-      @Override
-      public IntSet getSuccNodeNumbers(CGNode node) {
-        MutableIntSet result = IntSetUtil.make();
-        for (CGNode s : Iterator2Iterable.make(getSuccNodes(node))) {
-          result.add(s.getGraphNodeId());
-        }
-        return result;
-      }
-
-      @Override
-      public IntSet getPredNodeNumbers(CGNode node) {
-        MutableIntSet result = IntSetUtil.make();
-        for (CGNode s : Iterator2Iterable.make(getPredNodes(node))) {
-          result.add(s.getGraphNodeId());
-        }
-        return result;
-      }
-    };
+    return edgeManager;
   }
 }

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/cha/CHACallGraph.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/cha/CHACallGraph.java
@@ -235,6 +235,7 @@ public class CHACallGraph extends BasicCallGraph<CHAContextInterpreter> {
             CallSiteReference.make(
                 clinitPC++, clinit.getReference(), IInvokeInstruction.Dispatch.STATIC),
             cln);
+        edgeManager.addEdge(clinits, cln);
       }
     }
     return n;
@@ -256,8 +257,8 @@ public class CHACallGraph extends BasicCallGraph<CHAContextInterpreter> {
               if (n == getFakeRootNode()) {
                 registerEntrypoint(callee);
               }
-              edgeManager.addEdge(n, callee);
             }
+            edgeManager.addEdge(n, callee);
           }
         }
       }
@@ -356,14 +357,6 @@ public class CHACallGraph extends BasicCallGraph<CHAContextInterpreter> {
       return result;
     }
 
-    @Override
-    public IntSet getPredNodeNumbers(CGNode node) {
-      MutableIntSet result = IntSetUtil.make();
-      for (CGNode s : Iterator2Iterable.make(getPredNodes(node))) {
-        result.add(s.getGraphNodeId());
-      }
-      return result;
-    }
   }
 
   private final CHACallGraphEdgeManager edgeManager = new CHACallGraphEdgeManager();

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/cha/CHACallGraph.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/cha/CHACallGraph.java
@@ -48,6 +48,7 @@ import java.util.Set;
 import java.util.Stack;
 import java.util.function.Predicate;
 
+/** Call graph in which call targets are determined entirely based on an {@link IClassHierarchy}. */
 public class CHACallGraph extends BasicCallGraph<CHAContextInterpreter> {
   private final IClassHierarchy cha;
   private final AnalysisOptions options;
@@ -103,10 +104,18 @@ public class CHACallGraph extends BasicCallGraph<CHAContextInterpreter> {
     }
   }
 
+  /**
+   * NOTE: after calling this contructor, {@link #init(Iterable)} must be invoked to complete
+   * initialization
+   */
   public CHACallGraph(IClassHierarchy cha) {
     this(cha, false);
   }
 
+  /**
+   * NOTE: after calling this contructor, {@link #init(Iterable)} must be invoked to complete
+   * initialization
+   */
   public CHACallGraph(IClassHierarchy cha, boolean applicationOnly) {
     this.cha = cha;
     this.options = new AnalysisOptions();
@@ -115,6 +124,10 @@ public class CHACallGraph extends BasicCallGraph<CHAContextInterpreter> {
     setInterpreter(new ContextInsensitiveCHAContextInterpreter());
   }
 
+  /**
+   * Builds the call graph data structures. The call graph will only include methods reachable from
+   * the provided entrypoints.
+   */
   public void init(Iterable<Entrypoint> entrypoints) throws CancelException {
     super.init();
 

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/impl/ExplicitPredecessorsEdgeManager.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/impl/ExplicitPredecessorsEdgeManager.java
@@ -11,6 +11,10 @@ import com.ibm.wala.util.intset.IntSet;
 import java.util.Iterator;
 import java.util.function.IntFunction;
 
+/**
+ * An abstract {@link NumberedEdgeManager} where predecessor edges are represented explicitly.
+ * The representation of successor edges is determined by concrete subclasses.
+ */
 public abstract class ExplicitPredecessorsEdgeManager implements NumberedEdgeManager<CGNode> {
 
   private final NumberedNodeManager<CGNode> nodeManager;
@@ -24,14 +28,7 @@ public abstract class ExplicitPredecessorsEdgeManager implements NumberedEdgeMan
 
   protected ExplicitPredecessorsEdgeManager(NumberedNodeManager<CGNode> nodeManager) {
     this.nodeManager = nodeManager;
-    toNode =
-        i -> {
-          CGNode result = nodeManager.getNode(i);
-          // if (Assertions.verifyAssertions && result == null) {
-          // Assertions.UNREACHABLE("uh oh " + i);
-          // }
-          return result;
-        };
+    toNode = nodeManager::getNode;
   }
 
   @Override

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/impl/ExplicitPredecessorsEdgeManager.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/impl/ExplicitPredecessorsEdgeManager.java
@@ -12,8 +12,8 @@ import java.util.Iterator;
 import java.util.function.IntFunction;
 
 /**
- * An abstract {@link NumberedEdgeManager} where predecessor edges are represented explicitly.
- * The representation of successor edges is determined by concrete subclasses.
+ * An abstract {@link NumberedEdgeManager} where predecessor edges are represented explicitly. The
+ * representation of successor edges is determined by concrete subclasses.
  */
 public abstract class ExplicitPredecessorsEdgeManager implements NumberedEdgeManager<CGNode> {
 

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/impl/ExplicitPredecessorsEdgeManager.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/impl/ExplicitPredecessorsEdgeManager.java
@@ -1,0 +1,58 @@
+package com.ibm.wala.ipa.callgraph.impl;
+
+import com.ibm.wala.ipa.callgraph.CGNode;
+import com.ibm.wala.util.collections.EmptyIterator;
+import com.ibm.wala.util.collections.IntMapIterator;
+import com.ibm.wala.util.graph.NumberedEdgeManager;
+import com.ibm.wala.util.graph.NumberedNodeManager;
+import com.ibm.wala.util.intset.BasicNaturalRelation;
+import com.ibm.wala.util.intset.IBinaryNaturalRelation;
+import com.ibm.wala.util.intset.IntSet;
+import java.util.Iterator;
+import java.util.function.IntFunction;
+
+public abstract class ExplicitPredecessorsEdgeManager implements NumberedEdgeManager<CGNode> {
+
+  private final NumberedNodeManager<CGNode> nodeManager;
+
+  protected final IntFunction<CGNode> toNode;
+
+  /** for each y, the {x | (x,y) is an edge) */
+  protected final IBinaryNaturalRelation predecessors =
+      new BasicNaturalRelation(
+          new byte[] {BasicNaturalRelation.SIMPLE_SPACE_STINGY}, BasicNaturalRelation.SIMPLE);
+
+  protected ExplicitPredecessorsEdgeManager(NumberedNodeManager<CGNode> nodeManager) {
+    this.nodeManager = nodeManager;
+    toNode =
+        i -> {
+          CGNode result = nodeManager.getNode(i);
+          // if (Assertions.verifyAssertions && result == null) {
+          // Assertions.UNREACHABLE("uh oh " + i);
+          // }
+          return result;
+        };
+  }
+
+  @Override
+  public IntSet getPredNodeNumbers(CGNode node) {
+    int y = nodeManager.getNumber(node);
+    return predecessors.getRelated(y);
+  }
+
+  @Override
+  public Iterator<CGNode> getPredNodes(CGNode N) {
+    IntSet s = getPredNodeNumbers(N);
+    if (s == null) {
+      return EmptyIterator.instance();
+    } else {
+      return new IntMapIterator<>(s.intIterator(), toNode);
+    }
+  }
+
+  @Override
+  public int getPredNodeCount(CGNode node) {
+    int y = nodeManager.getNumber(node);
+    return predecessors.getRelatedCount(y);
+  }
+}

--- a/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/callGraph/CHACallGraphTest.java
+++ b/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/callGraph/CHACallGraphTest.java
@@ -57,14 +57,18 @@ public class CHACallGraphTest {
     CG.init(makeEntrypoints.apply(cha));
     System.err.println(CallGraphStats.getCGStats(CG));
     // basic well-formedness
-    for (CGNode node: CG) {
+    for (CGNode node : CG) {
       int nodeNum = CG.getNumber(node);
-      CG.getSuccNodeNumbers(node).foreach(succNum -> {
-        CGNode succNode = CG.getNode(succNum);
-        IntSet predNodeNumbers = CG.getPredNodeNumbers(succNode);
-        Assert.assertNotNull("no predecessors for " + succNode + " which is called by " + node, predNodeNumbers);
-        Assert.assertTrue(predNodeNumbers.contains(nodeNum));
-      });
+      CG.getSuccNodeNumbers(node)
+          .foreach(
+              succNum -> {
+                CGNode succNode = CG.getNode(succNum);
+                IntSet predNodeNumbers = CG.getPredNodeNumbers(succNode);
+                Assert.assertNotNull(
+                    "no predecessors for " + succNode + " which is called by " + node,
+                    predNodeNumbers);
+                Assert.assertTrue(predNodeNumbers.contains(nodeNum));
+              });
     }
     return CG;
   }

--- a/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/callGraph/CHACallGraphTest.java
+++ b/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/callGraph/CHACallGraphTest.java
@@ -12,7 +12,9 @@ package com.ibm.wala.core.tests.callGraph;
 
 import com.ibm.wala.core.tests.util.TestConstants;
 import com.ibm.wala.ipa.callgraph.AnalysisScope;
+import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.CallGraph;
+import com.ibm.wala.ipa.callgraph.CallGraphStats;
 import com.ibm.wala.ipa.callgraph.Entrypoint;
 import com.ibm.wala.ipa.callgraph.cha.CHACallGraph;
 import com.ibm.wala.ipa.callgraph.impl.Util;
@@ -20,8 +22,10 @@ import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.ipa.cha.ClassHierarchyFactory;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.util.CancelException;
+import com.ibm.wala.util.intset.IntSet;
 import java.io.IOException;
 import java.util.function.Function;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class CHACallGraphTest {
@@ -51,7 +55,17 @@ public class CHACallGraphTest {
 
     CHACallGraph CG = new CHACallGraph(cha);
     CG.init(makeEntrypoints.apply(cha));
-
+    System.err.println(CallGraphStats.getCGStats(CG));
+    // basic well-formedness
+    for (CGNode node: CG) {
+      int nodeNum = CG.getNumber(node);
+      CG.getSuccNodeNumbers(node).foreach(succNum -> {
+        CGNode succNode = CG.getNode(succNum);
+        IntSet predNodeNumbers = CG.getPredNodeNumbers(succNode);
+        Assert.assertNotNull("no predecessors for " + succNode + " which is called by " + node, predNodeNumbers);
+        Assert.assertTrue(predNodeNumbers.contains(nodeNum));
+      });
+    }
     return CG;
   }
 


### PR DESCRIPTION
Previously, computing the predecessors of each node in the `CHACallGraph` would require traversing all call graph nodes, a very expensive operation.  This PR changes the implementation to store the predecessors in a data structure from the beginning, making predecessor lookup fast.  This consumes more memory, but the benefits in running time are worth it.