### PR TITLE
fix a typo in SSAPropagationCallGraphBuilder.java

### DIFF
--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/SSAPropagationCallGraphBuilder.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/SSAPropagationCallGraphBuilder.java
@@ -254,7 +254,7 @@ public abstract class SSAPropagationCallGraphBuilder extends PropagationCallGrap
     }
   }
 
-  /** Hook for aubclasses to add pointer flow constraints based on values in a given node */
+  /** Hook for subclasses to add pointer flow constraints based on values in a given node */
   @SuppressWarnings("unused")
   protected void addNodeValueConstraints(CGNode node, IProgressMonitor monitor)
       throws CancelException {}


### PR DESCRIPTION
in the comment, this `aubclasses` should be `subclasses` ?