### PR TITLE
Add Error Prone to build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ plugins {
 	id 'com.github.sherter.google-java-format' version '0.9'
 	id 'de.undercouch.download'
 	id 'nebula.lint' version '17.2.3'
+	id 'net.ltgt.errorprone' version '2.0.2' apply false
 	id 'wala-javadoc'
 	id 'wala-project'
 }

--- a/buildSrc/src/main/groovy/wala-java.gradle
+++ b/buildSrc/src/main/groovy/wala-java.gradle
@@ -28,7 +28,8 @@ dependencies {
 	if (JavaVersion.current().isJava9Compatible()) {
 		errorprone("com.google.errorprone:error_prone_core:2.15.0")
 	} else {
-		// to make the build still work; we disable Error Prone later
+		// We disable Error Prone for JDK 8, but we still need to set these dependencies as
+		// otherwise the build fails with a javac crash
 		errorprone("com.google.errorprone:error_prone_core:2.10.0")
 		errorproneJavac("com.google.errorprone:javac:9+181-r4173-1")
 	}
@@ -36,11 +37,14 @@ dependencies {
 
 tasks.withType(JavaCompile).configureEach {
 	if (!JavaVersion.current().isJava9Compatible()) {
+		// disable on JDK 8
 		options.errorprone.enabled = false
 	} else {
 		options.errorprone {
+			// don't run warning-level checks for now as they add too much lose
 			disableAllWarnings = true
-			// dummy setting. hack until https://github.com/google/error-prone/pull/3462 lands
+			// hack until https://github.com/google/error-prone/pull/3462 lands; we add a dummy
+			// setting of a severity level, to make the disableAllWarnings flag work
 			error("AsyncFunctionReturnsNull")
 		}
 

--- a/buildSrc/src/main/groovy/wala-java.gradle
+++ b/buildSrc/src/main/groovy/wala-java.gradle
@@ -24,30 +24,31 @@ repositories {
 	}
 }
 
+// only use Error Prone on JDK 9+ JVMs
+final useErrorProne = JavaVersion.current().isJava9Compatible()
+
 dependencies {
-	if (JavaVersion.current().isJava9Compatible()) {
-		errorprone("com.google.errorprone:error_prone_core:2.15.0")
+	if (useErrorProne) {
+		errorprone 'com.google.errorprone:error_prone_core:2.15.0'
 	} else {
-		// We disable Error Prone for JDK 8, but we still need to set these dependencies as
+		// We disable Error Prone for pre JDK 9+, but we still need to set these dependencies, as
 		// otherwise the build fails with a javac crash
-		errorprone("com.google.errorprone:error_prone_core:2.10.0")
-		errorproneJavac("com.google.errorprone:javac:9+181-r4173-1")
+		errorprone 'com.google.errorprone:error_prone_core:2.10.0'
+		errorproneJavac 'com.google.errorprone:javac:9+181-r4173-1'
 	}
 }
 
 tasks.withType(JavaCompile).configureEach {
-	if (!JavaVersion.current().isJava9Compatible()) {
-		// disable on JDK 8
-		options.errorprone.enabled = false
-	} else {
+	if (useErrorProne) {
 		options.errorprone {
-			// don't run warning-level checks for now as they add too much lose
+			// don't run warning-level checks for now as they add too much noise to build output
 			disableAllWarnings = true
 			// hack until https://github.com/google/error-prone/pull/3462 lands; we add a dummy
 			// setting of a severity level, to make the disableAllWarnings flag work
-			error("AsyncFunctionReturnsNull")
+			error 'AsyncFunctionReturnsNull'
 		}
-
+	} else {
+		options.errorprone.enabled = false
 	}
 }
 

--- a/buildSrc/src/main/groovy/wala-java.gradle
+++ b/buildSrc/src/main/groovy/wala-java.gradle
@@ -6,10 +6,12 @@ plugins {
 	id 'java-library'
 	id 'java-test-fixtures'
 	id 'maven-publish'
+	id 'net.ltgt.errorprone'
 	id 'signing'
 	id 'wala-javadoc'
 	id 'wala-subproject'
 }
+
 
 java.sourceCompatibility = JavaVersion.VERSION_1_8
 java.targetCompatibility = JavaVersion.VERSION_1_8
@@ -19,6 +21,29 @@ repositories {
 	// to get r8
 	maven {
 		url 'https://storage.googleapis.com/r8-releases/raw'
+	}
+}
+
+dependencies {
+	if (JavaVersion.current().isJava9Compatible()) {
+		errorprone("com.google.errorprone:error_prone_core:2.15.0")
+	} else {
+		// to make the build still work; we disable Error Prone later
+		errorprone("com.google.errorprone:error_prone_core:2.10.0")
+		errorproneJavac("com.google.errorprone:javac:9+181-r4173-1")
+	}
+}
+
+tasks.withType(JavaCompile).configureEach {
+	if (!JavaVersion.current().isJava9Compatible()) {
+		options.errorprone.enabled = false
+	} else {
+		options.errorprone {
+			disableAllWarnings = true
+			// dummy setting. hack until https://github.com/google/error-prone/pull/3462 lands
+			error("AsyncFunctionReturnsNull")
+		}
+
 	}
 }
 

--- a/com.ibm.wala.cast.java.ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
+++ b/com.ibm.wala.cast.java.ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
@@ -2965,7 +2965,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
     // SWITCH_DEFAULT
     // somewhere else
     // polyglot converts all labels to longs. why? who knows...
-    if (constant instanceof Character) constant = (long) (Character) constant;
+    if (constant instanceof Character) constant = (long) ((Character) constant).charValue();
     else if (constant instanceof Byte) constant = ((Byte) constant).longValue();
     else if (constant instanceof Integer) constant = ((Integer) constant).longValue();
     else if (constant instanceof Short) constant = ((Short) constant).longValue();

--- a/com.ibm.wala.cast.java.test.data/build.gradle
+++ b/com.ibm.wala.cast.java.test.data/build.gradle
@@ -2,6 +2,10 @@ plugins {
 	id 'wala-java'
 }
 
+tasks.named("compileTestJava").configure {
+	// No need to run Error Prone on our analysis test inputs
+	options.errorprone.enabled = false
+}
 
 ////////////////////////////////////////////////////////////////////////
 //

--- a/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/AstCallGraph.java
+++ b/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/AstCallGraph.java
@@ -115,6 +115,8 @@ public class AstCallGraph extends ExplicitCallGraph {
   }
 
   public class AstCGNode extends ExplicitNode {
+    // TODO should this be a Set<Consumer<Object>> instead?  I don't see the return values from the
+    // callbacks ever being used
     private Set<Function<Object, Object>> callbacks;
 
     private AstCGNode(IMethod method, Context context) {
@@ -127,7 +129,8 @@ public class AstCallGraph extends ExplicitCallGraph {
         while (!done) {
           try {
             for (Function<Object, Object> function : callbacks) {
-              function.apply(null);
+              @SuppressWarnings("unused")
+              Object ignored = function.apply(null);
             }
           } catch (ConcurrentModificationException e) {
             done = false;

--- a/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/loader/AstMethod.java
+++ b/com.ibm.wala.cast/src/main/java/com/ibm/wala/cast/loader/AstMethod.java
@@ -167,10 +167,6 @@ public abstract class AstMethod implements IMethod {
     return cfg;
   }
 
-  public boolean hasCatchBlock() {
-    return hasCatchBlock();
-  }
-
   public SymbolTable symbolTable() {
     return symtab;
   }

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -38,6 +38,10 @@ tasks.named('check') {
 	dependsOn ecjCompileJavaTestSubjects
 }
 
+tasks.named("compileTestSubjectsJava").configure {
+	options.errorprone.enabled = false
+}
+
 dependencies {
 	api(project(':com.ibm.wala.shrike')) {
 		because 'public class Entrypoint implements interface BytecodeConstraints'

--- a/com.ibm.wala.core/build.gradle
+++ b/com.ibm.wala.core/build.gradle
@@ -39,6 +39,7 @@ tasks.named('check') {
 }
 
 tasks.named("compileTestSubjectsJava").configure {
+	// No need to run Error Prone on our analysis test inputs
 	options.errorprone.enabled = false
 }
 

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/analysis/reflection/GetMethodContextSelector.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/analysis/reflection/GetMethodContextSelector.java
@@ -30,6 +30,7 @@ import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.intset.EmptyIntSet;
 import com.ibm.wala.util.intset.IntSet;
 import com.ibm.wala.util.intset.IntSetUtil;
+import java.util.Arrays;
 import java.util.Collection;
 
 /**
@@ -81,7 +82,7 @@ public class GetMethodContextSelector implements ContextSelector {
       if (symbolTable.isStringConstant(invokeInstructions[0].getUse(1))) {
         String sym = symbolTable.getStringValue(use);
         if (DEBUG) {
-          System.out.println(invokeInstructions);
+          System.out.println(Arrays.toString(invokeInstructions));
           System.out.println(", with constant := `" + sym + '`');
           for (InstanceKey instanceKey : receiver) {
             System.out.println(" " + instanceKey);

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/cfg/exc/intra/OperatorUtil.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/cfg/exc/intra/OperatorUtil.java
@@ -41,12 +41,13 @@ public class OperatorUtil {
       if (getClass() != o.getClass()) return false;
 
       UnaryOperatorSequence<?> other = (UnaryOperatorSequence<?>) o;
-      return operators.equals(other.operators);
+
+      return Arrays.equals(operators, other.operators);
     }
 
     @Override
     public int hashCode() {
-      return operators.hashCode();
+      return Arrays.hashCode(operators);
     }
 
     @Override

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/core/tests/callGraph/CallGraphTestUtil.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/core/tests/callGraph/CallGraphTestUtil.java
@@ -95,7 +95,8 @@ public class CallGraphTestUtil {
         Util.makeZeroCFABuilder(Language.JAVA, options, cache, cha);
     CallGraph cg = builder.makeCallGraph(options, null);
     if (testPAtoString) {
-      builder.getPointerAnalysis().toString();
+      @SuppressWarnings("unused")
+      String ignored = builder.getPointerAnalysis().toString();
     }
 
     if (CHECK_FOOTPRINT) {
@@ -141,7 +142,8 @@ public class CallGraphTestUtil {
         Util.makeZeroOneCFABuilder(Language.JAVA, options, cache, cha);
     CallGraph cg = builder.makeCallGraph(options, null);
     if (testPAtoString) {
-      builder.getPointerAnalysis().toString();
+      @SuppressWarnings("unused")
+      String ignored = builder.getPointerAnalysis().toString();
     }
 
     if (CHECK_FOOTPRINT) {

--- a/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/AnalysisScope.java
+++ b/com.ibm.wala.core/src/main/java/com/ibm/wala/ipa/callgraph/AnalysisScope.java
@@ -446,7 +446,7 @@ public class AnalysisScope {
           Assertions.UNREACHABLE("Module type isn't supported - " + m);
           continue;
         }
-        modulePath.replace("\\", "/");
+        modulePath = modulePath.replace("\\", "/");
         String moduleDescrLine =
             String.format("%s,%s,%s,%s", moduleLdr, moduleLang, moduleType, modulePath);
         moduleLines.add(moduleDescrLine);

--- a/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/basic/FloydWarshallTest.java
+++ b/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/basic/FloydWarshallTest.java
@@ -91,11 +91,6 @@ public class FloydWarshallTest extends WalaTestCase {
     public String toString() {
       return "<" + number + ">";
     }
-
-    @Override
-    public boolean equals(Object o) {
-      return this == o;
-    }
   }
 
   public static NumberedGraph<Node> makeGraph() {

--- a/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/collections/TwoLevelVectorTest.java
+++ b/com.ibm.wala.core/src/test/java/com/ibm/wala/core/tests/collections/TwoLevelVectorTest.java
@@ -20,6 +20,7 @@ package com.ibm.wala.core.tests.collections;
 
 import com.ibm.wala.core.tests.util.WalaTestCase;
 import com.ibm.wala.util.collections.TwoLevelVector;
+import java.util.Iterator;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -39,7 +40,8 @@ public final class TwoLevelVectorTest extends WalaTestCase {
   @Test
   public void testCase1() {
     final TwoLevelVector<Integer> tlVector = new TwoLevelVector<>();
-    tlVector.iterator();
+    @SuppressWarnings("unused")
+    Iterator<Integer> ignored = tlVector.iterator();
     tlVector.set(2147483647, 56);
     Assert.assertNotNull(tlVector.iterator());
     Assert.assertEquals(Integer.valueOf(56), tlVector.get(2147483647));

--- a/com.ibm.wala.scandroid/src/main/java/org/scandroid/util/AndroidAnalysisContext.java
+++ b/com.ibm.wala.scandroid/src/main/java/org/scandroid/util/AndroidAnalysisContext.java
@@ -39,7 +39,6 @@
  */
 package org.scandroid.util;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.Language;
@@ -75,7 +74,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 import java.util.Deque;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -148,36 +146,6 @@ public class AndroidAnalysisContext {
         customSelector,
         customInterpreter,
         ZeroXInstanceKeys.ALLOCATIONS | ZeroXInstanceKeys.CONSTANT_SPECIFIC);
-  }
-
-  /**
-   * @param options options that govern call graph construction
-   * @param cha governing class hierarchy
-   * @param scope representation of the analysis scope
-   * @param customSelector user-defined context selector, or null if none
-   * @param customInterpreter user-defined context interpreter, or null if none
-   * @return a 0-CFA Call Graph Builder.
-   * @throws IllegalArgumentException if options is null
-   *     <p>TODO: move
-   */
-  public static SSAPropagationCallGraphBuilder makeZeroCFABuilder(
-      AnalysisOptions options,
-      IAnalysisCacheView cache,
-      IClassHierarchy cha,
-      AnalysisScope scope,
-      ContextSelector customSelector,
-      SSAContextInterpreter customInterpreter,
-      List<InputStream> arrayList,
-      MethodSummary extraSummary) {
-    return makeZeroCFABuilder(
-        options,
-        cache,
-        cha,
-        scope,
-        customSelector,
-        customInterpreter,
-        Lists.newArrayList(arrayList),
-        extraSummary);
   }
 
   /**

--- a/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/SourcePositionTableReader.java
+++ b/com.ibm.wala.shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/SourcePositionTableReader.java
@@ -23,7 +23,7 @@ public final class SourcePositionTableReader extends AttributeReader {
     super(attr, CRTable.ATTRIBUTE_NAME);
   }
 
-  public static final class Position implements Comparable<Object> {
+  public static final class Position implements Comparable<Position> {
 
     public final int firstLine;
     public final int lastLine;
@@ -38,22 +38,17 @@ public final class SourcePositionTableReader extends AttributeReader {
     }
 
     @Override
-    public int compareTo(Object o) {
-      if (o instanceof Position) {
-        Position p = (Position) o;
-        if (firstLine != p.firstLine) {
-          return firstLine - p.firstLine;
-        } else if (firstCol != p.firstCol) {
-          return firstCol - p.firstCol;
-        } else if (lastLine != p.lastLine) {
-          return lastLine - p.lastLine;
-        } else if (lastCol != p.lastCol) {
-          return lastCol - p.lastCol;
-        } else {
-          return 0;
-        }
+    public int compareTo(Position p) {
+      if (firstLine != p.firstLine) {
+        return firstLine - p.firstLine;
+      } else if (firstCol != p.firstCol) {
+        return firstCol - p.firstCol;
+      } else if (lastLine != p.lastLine) {
+        return lastLine - p.lastLine;
+      } else if (lastCol != p.lastCol) {
+        return lastCol - p.lastCol;
       } else {
-        return -1;
+        return 0;
       }
     }
   }


### PR DESCRIPTION
We only run Error Prone on JDK 11 builds, as recent Error Prone releases do not run on JDK 8.  We also disable WARNING level checks for now, to reduce the noise in the build output (we get hundreds of WARNING-level messages from Error Prone, which we should try to fix gradually).

This PR also fixes all ERROR-level issues reported by Error Prone.