### PR TITLE
Add a non-null check in IntSetVariable.containsAny()

### DIFF
--- a/com.ibm.wala.util/src/main/java/com/ibm/wala/fixpoint/IntSetVariable.java
+++ b/com.ibm.wala.util/src/main/java/com/ibm/wala/fixpoint/IntSetVariable.java
@@ -133,6 +133,9 @@ public abstract class IntSetVariable<T extends IntSetVariable<T>> extends Abstra
   }
 
   public boolean containsAny(IntSet instances) {
+    if (V == null) {
+      return false;
+    }
     return V.containsAny(instances);
   }
 


### PR DESCRIPTION
Thank you for contributing to WALA!  Please see the contribution guidelines at https://github.com/wala/WALA/blob/master/CONTRIBUTING.md for information on code style and general guidelines for pull requests.

The filed `V` here may be `null`, also, other APIs of `IntSetVariable` will do a non-null check. So it seems consistent and safe to add a non-null check here.

Here we return false when `V` is null, it's straightforward to see that, when a points-to set is null, it contains nothing. Furthermore, the case that argument `IntSet instances` is null will be handled by the `V.containsAny`(see [here](https://github.com/wala/WALA/blob/6bd373104e4f4fca5888f0c2557bb427f76f1892/com.ibm.wala.util/src/main/java/com/ibm/wala/util/intset/BitVectorIntSet.java#L409)).