### PR TITLE
Bump dependency versions for GitHub Actions configuration

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,15 +25,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out WALA sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache Goomph
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.goomph
           key: ${{ runner.os }}-goomph-${{ hashFiles('build.gradle') }}
           restore-keys: ${{ runner.os }}-goomph-
       - name: 'Set up JDK ${{ matrix.java }}'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -64,16 +64,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out WALA sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: 'Cache local Maven repository'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: 'Set up JDK ${{ matrix.java }}'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
@@ -90,15 +90,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out repository'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache Goomph
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.goomph
           key: ${{ runner.os }}-goomph-${{ hashFiles('build.gradle') }}
           restore-keys: ${{ runner.os }}-goomph-
       - name: 'Set up JDK 8'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 8
           distribution: 'temurin'
@@ -113,15 +113,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out repository'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache Goomph
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.goomph
           key: ${{ runner.os }}-goomph-${{ hashFiles('build.gradle') }}
           restore-keys: ${{ runner.os }}-goomph-
       - name: 'Set up JDK 8'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 8
           distribution: 'temurin'


### PR DESCRIPTION
We were getting various warnings about use of deprecated constructs before, e.g., here:

https://github.com/wala/WALA/actions/runs/3356903414

Switching to more recent versions of standard actions seems to fix these problems.