### PR TITLE
Remove Gradle subprojects that don't do anything

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,6 @@
 rootProject.name = 'com.ibm.wala'
 
 include(
-	'com.ibm.wala-repository',
 	'com.ibm.wala.cast',
 	'com.ibm.wala.cast:smoke_main',
 	'com.ibm.wala.cast:xlator_test',
@@ -20,10 +19,7 @@ include(
 	'com.ibm.wala.ide.jdt',
 	'com.ibm.wala.ide.jdt.test',
 	'com.ibm.wala.ide.tests',
-	'com.ibm.wala.ide_feature',
 	'com.ibm.wala.scandroid',
 	'com.ibm.wala.shrike',
-	'com.ibm.wala.tests.ide_feature',
 	'com.ibm.wala.util',
-	'com.ibm.wala_feature',
 )


### PR DESCRIPTION
These subprojects have no sources and no `build.gradle` files.  They define no useful tasks and provide nothing of value to the rest of the Gradle build configuration.  There's really no benefit in treating these subdirectories as subprojects.

Could these subdirectories be removed entirely?  Or are they important somehow when this project is opened in Eclipse instead of IntelliJ IDEA?