### PR TITLE
Correct regression in aggregated Javadocs

### DIFF
--- a/buildSrc/src/main/kotlin/com/ibm/wala/gradle/aggregated-javadoc.gradle.kts
+++ b/buildSrc/src/main/kotlin/com/ibm/wala/gradle/aggregated-javadoc.gradle.kts
@@ -1,0 +1,17 @@
+/**
+ * [Configuration]s representing subprojects' contributions toward project-wide Javadoc.
+ *
+ * *Every* project and subproject defines these configurations. A subproject with no Java code
+ * simply leaves these configuations empty. Defining these configurations everywhere simplifies
+ * logic in the root project, since it can aggregate these from all subprojects without needing to
+ * carefully filter out non-Java subprojects.
+ */
+package com.ibm.wala.gradle
+
+val javadocClasspath by
+    configurations.creating { description = "Classpath used during Javadoc creation." }
+
+val javadocSource by
+    configurations.creating {
+      description = "Java source files from which Javadoc should be extracted."
+    }

--- a/buildSrc/src/main/kotlin/com/ibm/wala/gradle/javadoc.gradle.kts
+++ b/buildSrc/src/main/kotlin/com/ibm/wala/gradle/javadoc.gradle.kts
@@ -2,9 +2,13 @@ package com.ibm.wala.gradle
 
 import org.gradle.kotlin.dsl.withType
 
+plugins { id("com.ibm.wala.gradle.aggregated-javadoc") }
+
 // Build configuration for projects that include `Javadoc` tasks.
 
 tasks.withType<Javadoc>().configureEach {
+  classpath = configurations.named("javadocClasspath").get()
+  source(configurations.named("javadocSource"))
   with(options as StandardJavadocDocletOptions) {
     addBooleanOption("Xdoclint:all,-missing", true)
     encoding = "UTF-8"

--- a/buildSrc/src/main/kotlin/com/ibm/wala/gradle/maven-eclipse-jsdt.gradle.kts
+++ b/buildSrc/src/main/kotlin/com/ibm/wala/gradle/maven-eclipse-jsdt.gradle.kts
@@ -1,0 +1,9 @@
+/** Define a Maven repository containing Eclipse JSDT packages. */
+package com.ibm.wala.gradle
+
+repositories {
+  maven {
+    url = uri("https://artifacts.alfresco.com/nexus/content/repositories/public/")
+    content { includeGroup("org.eclipse.wst.jsdt") }
+  }
+}

--- a/buildSrc/src/main/kotlin/com/ibm/wala/gradle/subproject.gradle.kts
+++ b/buildSrc/src/main/kotlin/com/ibm/wala/gradle/subproject.gradle.kts
@@ -6,6 +6,7 @@ import org.gradle.plugins.ide.idea.model.IdeaModel
 
 plugins {
   idea
+  id("com.ibm.wala.gradle.aggregated-javadoc")
   id("com.ibm.wala.gradle.project")
   id("de.undercouch.download")
 }

--- a/com.ibm.wala.cast.js/build.gradle.kts
+++ b/com.ibm.wala.cast.js/build.gradle.kts
@@ -6,8 +6,6 @@ plugins {
   id("com.ibm.wala.gradle.publishing")
 }
 
-val extraJavadocClasspath: Configuration by configurations.creating { isCanBeConsumed = false }
-
 dependencies {
   api(project(":com.ibm.wala.cast")) {
     because("public class JSCallGraphUtil extends class CAstCallGraphUtil")
@@ -18,7 +16,7 @@ dependencies {
   implementation(project(":com.ibm.wala.core"))
   implementation(project(":com.ibm.wala.shrike"))
   implementation(project(":com.ibm.wala.util"))
-  extraJavadocClasspath(project(":com.ibm.wala.cast.js.rhino"))
+  javadocClasspath(project(":com.ibm.wala.cast.js.rhino"))
   testFixturesImplementation("junit:junit:4.13.2")
   testFixturesImplementation(testFixtures(project(":com.ibm.wala.cast")))
   testFixturesImplementation(testFixtures(project(":com.ibm.wala.core")))
@@ -31,8 +29,6 @@ val createPackageList by
     tasks.registering(CreatePackageList::class) { sourceSet(sourceSets.main.get()) }
 
 val packageListDirectory: Configuration by configurations.creating { isCanBeResolved = false }
-
-val javadoc by tasks.existing(Javadoc::class) { classpath += extraJavadocClasspath }
 
 val javadocDestinationDirectory: Configuration by
     configurations.creating { isCanBeResolved = false }

--- a/com.ibm.wala.cast/build.gradle.kts
+++ b/com.ibm.wala.cast/build.gradle.kts
@@ -23,8 +23,6 @@ val castJsJavadocDestinationDirectory: Configuration by
 
 val castJsPackageListDirectory: Configuration by configurations.creating { isCanBeConsumed = false }
 
-val extraJavadocClasspath: Configuration by configurations.creating { isCanBeConsumed = false }
-
 val xlatorTestSharedLibrary: Configuration by
     configurations.creating {
       isCanBeConsumed = false
@@ -49,7 +47,7 @@ dependencies {
   castCastSharedLibrary(project(":com.ibm.wala.cast:cast"))
   castJsPackageListDirectory(
       project(mapOf("path" to ":com.ibm.wala.cast.js", "configuration" to "packageListDirectory")))
-  extraJavadocClasspath(project(":com.ibm.wala.cast.js"))
+  javadocClasspath(project(":com.ibm.wala.cast.js"))
   testImplementation(
       "junit:junit:4.13.2",
   )
@@ -64,7 +62,6 @@ artifacts.add(
     tasks.named<JavaCompile>("compileTestJava").map { it.options.headerOutputDirectory })
 
 tasks.named<Javadoc>("javadoc") {
-  classpath += extraJavadocClasspath
   inputs.files(castJsPackageListDirectory)
 
   inputs.property("extdocURL", castJsJavadocDestinationDirectory.singleFile)

--- a/com.ibm.wala.core/build.gradle.kts
+++ b/com.ibm.wala.core/build.gradle.kts
@@ -72,11 +72,7 @@ dependencies {
   )
 }
 
-val extraJavadocClasspath: Configuration by configurations.creating { isCanBeConsumed = false }
-
-dependencies { extraJavadocClasspath(project(":com.ibm.wala.dalvik")) }
-
-tasks.named<Javadoc>("javadoc") { classpath += extraJavadocClasspath }
+dependencies { javadocClasspath(project(":com.ibm.wala.dalvik")) }
 
 ////////////////////////////////////////////////////////////////////////
 //

--- a/com.ibm.wala.ide.jsdt.tests/build.gradle.kts
+++ b/com.ibm.wala.ide.jsdt.tests/build.gradle.kts
@@ -1,13 +1,7 @@
 plugins {
   id("com.diffplug.eclipse.mavencentral")
   id("com.ibm.wala.gradle.java")
-}
-
-repositories {
-  maven {
-    url = uri("https://artifacts.alfresco.com/nexus/content/repositories/public/")
-    content { includeGroup("org.eclipse.wst.jsdt") }
-  }
+  id("com.ibm.wala.gradle.maven-eclipse-jsdt")
 }
 
 eclipseMavenCentral {

--- a/com.ibm.wala.ide.jsdt/build.gradle.kts
+++ b/com.ibm.wala.ide.jsdt/build.gradle.kts
@@ -1,13 +1,7 @@
 plugins {
   id("com.diffplug.eclipse.mavencentral")
   id("com.ibm.wala.gradle.java")
-}
-
-repositories {
-  maven {
-    url = uri("https://artifacts.alfresco.com/nexus/content/repositories/public/")
-    content { includeGroup("org.eclipse.wst.jsdt") }
-  }
+  id("com.ibm.wala.gradle.maven-eclipse-jsdt")
 }
 
 eclipseMavenCentral {

--- a/com.ibm.wala.util/build.gradle.kts
+++ b/com.ibm.wala.util/build.gradle.kts
@@ -4,13 +4,11 @@ plugins {
   id("com.ibm.wala.gradle.publishing")
 }
 
-val extraJavadocClasspath: Configuration by configurations.creating { isCanBeConsumed = false }
-
 eclipse.project.natures("org.eclipse.pde.PluginNature")
 
 dependencies {
   compileOnly("org.jspecify:jspecify:0.3.0")
-  extraJavadocClasspath(project(":com.ibm.wala.core"))
+  javadocClasspath(project(":com.ibm.wala.core"))
   testImplementation("junit:junit:4.13.2")
   testImplementation(
       "org.hamcrest:hamcrest:2.2",
@@ -19,7 +17,6 @@ dependencies {
 }
 
 tasks.named<Javadoc>("javadoc") {
-  classpath += extraJavadocClasspath
   val currentJavaVersion = JavaVersion.current()
   val linksPrefix = if (currentJavaVersion >= JavaVersion.VERSION_11) "en/java/" else ""
   (options as StandardJavadocDocletOptions).run {


### PR DESCRIPTION
The previous approach used cross-project task access, which is strongly discouraged and which actually broke when we converted the build from Gradle+Groovy to Gradle+Kotlin.  The new approach implemented here uses `Configuration`s to export relevant sets of Javadoc-related files and paths from each subproject.  The root project's can build dependencies on these so that the root `aggregatedJavadoc` task will have access to the right material when needed.