### PR TITLE
Enlarge Gradle daemon's metaspace size limit

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 org.gradle.caching=true
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=384m
 org.gradle.parallel=true
 
 VERSION_NAME=1.6.0-SNAPSHOT


### PR DESCRIPTION
I was seeing out-of-memory errors during concurrent Java compilation, specifically reporting depletion of the metaspace.  That space defaults to 256 MB, so let's enlarge it by 50% and see if the errors go away.