### PR TITLE
Set $JAVA_HOME for Android SDK installer

### DIFF
--- a/com.ibm.wala.dalvik/build.gradle.kts
+++ b/com.ibm.wala.dalvik/build.gradle.kts
@@ -20,6 +20,12 @@ val installAndroidSdk by
 
       doLast {
         exec {
+
+          // Running the Android SDK manager requires that `$JAVA_HOME` be set.
+          environment(
+              "JAVA_HOME",
+              javaToolchains.launcherFor(java.toolchain).get().metadata.installationPath)
+
           data class Details(
               val shell: String,
               val shellFlags: String,


### PR DESCRIPTION
The Android SDK installer requires that `$JAVA_HOME` be set to some reasonable Java installation.  We shouldn't assume that's already set in the environment.  Instead, set it ourselves to whatever Java 11 SDK we're using for the rest of the build.

It may seem unlikely for a build to get this far with no `$JAVA_HOME`, but it is possible.  I recently set up IntelliJ IDEA to build WALA on a Windows machine that I had not previously used for Java development. IntelliJ IDEA downloaded and used a JVM automatically, which was quite helpful.  But that JVM was not installed system-wide and no `$JAVA_HOME` was set to its location.