### PR TITLE
Fix regression of "Publish snapshot" GitHub action

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -39,7 +39,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           gradle-executable: xvfb-gradle.sh
-          arguments: aggregatedJavadocs javadoc build
+          arguments: aggregatedJavadocs build publishAllPublicationsToFakeRemoteRepository
         # testing ECJ compilation on any one OS is sufficient; we choose Linux arbitrarily
         if: runner.os == 'Linux'
       - name: Build and test using Gradle but without ECJ

--- a/buildSrc/src/main/kotlin/com/ibm/wala/gradle/javadoc.gradle.kts
+++ b/buildSrc/src/main/kotlin/com/ibm/wala/gradle/javadoc.gradle.kts
@@ -6,9 +6,12 @@ plugins { id("com.ibm.wala.gradle.aggregated-javadoc") }
 
 // Build configuration for projects that include `Javadoc` tasks.
 
-tasks.withType<Javadoc>().configureEach {
+tasks.named<Javadoc>("javadoc") {
   classpath = configurations.named("javadocClasspath").get()
   source(configurations.named("javadocSource"))
+}
+
+tasks.withType<Javadoc>().configureEach {
   with(options as StandardJavadocDocletOptions) {
     addBooleanOption("Xdoclint:all,-missing", true)
     encoding = "UTF-8"


### PR DESCRIPTION
#1184 recently corrected a regression of the `aggregatedJavadocs` build task. Unfortunately, that fix caused a new regression in the "Publish snapshot" GitHub action. Here we correct the latter regression. We also improve our GitHub CI actions so that future regressions of this sort will be caught earlier.