### PR TITLE
Update IntelliJ IDEA Kotlin version

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.7.10" />
+    <option name="version" value="1.8.0" />
   </component>
 </project>


### PR DESCRIPTION
We recently upgraded to Kotlin 1.8.0 in the plugins configuration.  This change reflects that in IntelliJ IDEA's project metadata.