### PR TITLE
Remove unnecessary uses of `.run`

### DIFF
--- a/buildSrc/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
@@ -92,7 +92,7 @@ val publishing: PublishingExtension by extensions
 
 val java: JavaPluginExtension by extensions
 
-publishing.run {
+publishing {
   publications {
 
     // Everything we want to publish to remote repositories.  That includes code, sources, and
@@ -187,7 +187,7 @@ configure<SigningExtension> {
 // Only sign releases; snapshots are unsigned.
 tasks.withType<Sign>().configureEach { onlyIf { !isSnapshot } }
 
-java.run {
+java {
   withJavadocJar()
   withSourcesJar()
 }


### PR DESCRIPTION
Gradle's Kotlin API lets us use `publishing` and `java` with code blocks (closures) in which the appropriate object is already scoped as `this`. So there's no effect and no benefit from using `.run` here.