### PR TITLE
Publish test fixtures everywhere and simplify signature configuration

### DIFF
--- a/buildSrc/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
@@ -14,160 +14,137 @@ val isSnapshot = "SNAPSHOT" in version as String
 
 val javaComponent = components["java"] as AdhocComponentWithVariants
 
-fun skipTestFixtures() {
-  listOf(
-          configurations["testFixturesApiElements"],
-          configurations["testFixturesRuntimeElements"],
-      )
-      .forEach { javaComponent.withVariantsFromConfiguration(it) { skip() } }
-}
+val allTestFixturesSource = the<SourceSetContainer>()["testFixtures"].allSource
 
-fun MavenPublication.sharedPublicationConfiguration() {
-  from(javaComponent)
-  pom {
-    name.set(project.properties["POM_NAME"] as String)
-    description.set("T. J. Watson Libraries for Analysis")
-    inceptionYear.set("2006")
-    url.set("https://github.com/wala/WALA")
-
-    ciManagement {
-      system.set("GitHub Actions")
-      url.set("https://github.com/wala/WALA/actions")
+val testFixturesJavadoc by
+    tasks.existing(Javadoc::class) {
+      setDestinationDir(project.the<JavaPluginExtension>().docsDir.get().dir(name).asFile)
     }
 
-    developers {
-      // Current WALA maintainers, alphabetical by ID
-      mapOf(
-              "juliandolby" to "Julian Dolby",
-              "liblit" to "Ben Liblit",
-              "msridhar" to "Manu Sridharan",
-              "sjfink" to "Stephen Fink",
-          )
-          .forEach { entry ->
-            developer {
-              id.set(entry.key)
-              name.set(entry.value)
-              url.set("https://github.com/{$entry.key}")
-            }
-          }
+val testFixturesJavadocJar by
+    tasks.registering(Jar::class) {
+      archiveClassifier.set("test-fixtures-javadoc")
+      from(testFixturesJavadoc.map { it.destinationDir!! })
     }
 
-    issueManagement {
-      system.set("GitHub")
-      url.set("${this@sharedPublicationConfiguration.pom.url.get()}/issues")
+val testFixturesSourcesJar by
+    tasks.registering(Jar::class) {
+      archiveClassifier.set("test-fixtures-sources")
+      from(allTestFixturesSource)
     }
-
-    licenses {
-      license {
-        name.set("Eclipse Public License v2.0")
-        url.set("${this@sharedPublicationConfiguration.pom.url.get()}/blob/master/LICENSE")
-      }
-    }
-
-    mailingLists {
-      listOf(
-              "commits",
-              "wala",
-          )
-          .forEach { topic ->
-            mailingList {
-              name.set("wala-$topic")
-              archive.set("https://sourceforge.net/p/wala/mailman/wala-$topic")
-              subscribe.set("https://sourceforge.net/projects/wala/lists/wala-$topic")
-              unsubscribe.set("https://sourceforge.net/projects/wala/lists/wala-$topic/unsubscribe")
-              post.set("wala-$topic@lists.sourceforge.net")
-            }
-          }
-    }
-
-    scm {
-      url.set(this@sharedPublicationConfiguration.pom.url)
-      connection.set("scm:git:git://github.com/wala/WALA.git")
-      developerConnection.set("scm:git:ssh://git@github.com/wala/WALA.git")
-    }
-  }
-}
 
 val publishing: PublishingExtension by extensions
 
-val java: JavaPluginExtension by extensions
+fun createPublication(publicationName: String) =
+    publishing.publications.create<MavenPublication>(publicationName) {
+      from(javaComponent)
 
-publishing {
-  publications {
-
-    // Everything we want to publish to remote repositories.  That includes code, sources, and
-    // Javadoc for main sourceSet, but not tests or test fixtures.
-    create<MavenPublication>("remote") {
-      this.sharedPublicationConfiguration()
-      skipTestFixtures()
-    }
-
-    // Everything we want to publish to local installations.  That includes code, sources, and
-    // Javadoc for the both main and test-fixtures sourceSets, but not tests.
-    create<MavenPublication>("local") {
-      this.sharedPublicationConfiguration()
-
-      val allTestFixturesSource = the<SourceSetContainer>()["testFixtures"].allSource
+      val testFixturesCodeElementsNames =
+          listOf("testFixturesApiElements", "testFixturesRuntimeElements")
+      testFixturesCodeElementsNames.forEach(this::suppressPomMetadataWarningsFor)
 
       if (allTestFixturesSource.isEmpty()) {
         // Test-fixtures jar would be empty except for the manifest, so skip it.
-        skipTestFixtures()
+        testFixturesCodeElementsNames.forEach {
+          javaComponent.withVariantsFromConfiguration(configurations[it]) { skip() }
+        }
       } else {
-
-        val testFixturesJar by tasks.existing(Jar::class)
-
         // Test-fixtures jar will have real contents, so add Javadoc and sources
-        val testFixturesJavadoc by
-            tasks.existing(Javadoc::class) {
-              setDestinationDir(project.the<JavaPluginExtension>().docsDir.get().dir(name).asFile)
-            }
-
-        val testFixturesJavadocJar by
-            tasks.registering(Jar::class) {
-              archiveClassifier.set("test-fixtures-javadoc")
-              from(testFixturesJavadoc.map { it.destinationDir!! })
-            }
-
-        val testFixturesSourcesJar by
-            tasks.registering(Jar::class) {
-              archiveClassifier.set("test-fixtures-sources")
-              from(allTestFixturesSource)
-            }
-
-        // For each subproject with test fixtures, the `artifact` calls below trigger
-        // creation of three tasks during configuration: `testFixturesJar`,
-        // `testFixturesJavadocJar`, and `testFixturesSourcesJar`.  Configuring those lazily
-        // instead will require a fix to <https://github.com/gradle/gradle/issues/6246>.
-        artifact(testFixturesJar)
         artifact(testFixturesJavadocJar)
         artifact(testFixturesSourcesJar)
       }
-    }
-  }
 
-  repositories {
-    maven {
-      url =
-          URI(
-              (if (isSnapshot)
-                  project.properties.getOrDefault(
-                      "SNAPSHOT_REPOSITORY_URL",
-                      "https://oss.sonatype.org/content/repositories/snapshots/")
-              else
-                  project.properties.getOrDefault(
-                      "RELEASE_REPOSITORY_URL",
-                      "https://oss.sonatype.org/service/local/staging/deploy/maven2/"))
-                  as String)
-      credentials {
-        username = project.properties["SONATYPE_NEXUS_USERNAME"] as String?
-        password = project.properties["SONATYPE_NEXUS_PASSWORD"] as String?
+      pom {
+        name.set(project.properties["POM_NAME"] as String)
+        description.set("T. J. Watson Libraries for Analysis")
+        inceptionYear.set("2006")
+        url.set("https://github.com/wala/WALA")
+        val pomUrl = url
+
+        ciManagement {
+          system.set("GitHub Actions")
+          url.set("https://github.com/wala/WALA/actions")
+        }
+
+        developers {
+          // Current WALA maintainers, alphabetical by ID
+          mapOf(
+                  "juliandolby" to "Julian Dolby",
+                  "liblit" to "Ben Liblit",
+                  "msridhar" to "Manu Sridharan",
+                  "sjfink" to "Stephen Fink",
+              )
+              .forEach { entry ->
+                developer {
+                  id.set(entry.key)
+                  name.set(entry.value)
+                  url.set("https://github.com/{$entry.key}")
+                }
+              }
+        }
+
+        issueManagement {
+          system.set("GitHub")
+          url.set(pomUrl.map { "$it/issues" })
+        }
+
+        licenses {
+          license {
+            name.set("Eclipse Public License v2.0")
+            url.set(pomUrl.map { "$it/blob/master/LICENSE" })
+          }
+        }
+
+        mailingLists {
+          listOf(
+                  "commits",
+                  "wala",
+              )
+              .forEach { topic ->
+                mailingList {
+                  name.set("wala-$topic")
+                  archive.set("https://sourceforge.net/p/wala/mailman/wala-$topic")
+                  subscribe.set("https://sourceforge.net/projects/wala/lists/wala-$topic")
+                  unsubscribe.set(
+                      "https://sourceforge.net/projects/wala/lists/wala-$topic/unsubscribe")
+                  post.set("wala-$topic@lists.sourceforge.net")
+                }
+              }
+        }
+
+        scm {
+          url.set(pomUrl)
+          connection.set("scm:git:git://github.com/wala/WALA.git")
+          developerConnection.set("scm:git:ssh://git@github.com/wala/WALA.git")
+        }
       }
     }
 
-    maven {
-      name = "fakeRemote"
-      url = uri("file://${rootProject.buildDir}/maven-fake-remote-repository")
+val localPublication = createPublication("local")
+val remotePublication = createPublication("remote")
+
+publishing.repositories {
+  maven {
+    url =
+        URI(
+            (if (isSnapshot)
+                project.properties.getOrDefault(
+                    "SNAPSHOT_REPOSITORY_URL",
+                    "https://oss.sonatype.org/content/repositories/snapshots/")
+            else
+                project.properties.getOrDefault(
+                    "RELEASE_REPOSITORY_URL",
+                    "https://oss.sonatype.org/service/local/staging/deploy/maven2/"))
+                as String)
+    credentials {
+      username = project.properties["SONATYPE_NEXUS_USERNAME"] as String?
+      password = project.properties["SONATYPE_NEXUS_PASSWORD"] as String?
     }
+  }
+
+  maven {
+    name = "fakeRemote"
+    url = uri("file://${rootProject.buildDir}/maven-fake-remote-repository")
   }
 }
 
@@ -181,7 +158,7 @@ configure<SigningExtension> {
   // `signRemotePublication` is created immediately and `generateMetadataFileForRemotePublication`
   // and `generatePomFileForRemotePublication` are created during configuration.  Creating these
   // lazily instead will require a fix to <https://github.com/gradle/gradle/issues/8796>.
-  sign(publishing.publications["remote"])
+  sign(remotePublication)
 }
 
 // Only sign releases; snapshots are unsigned.
@@ -192,12 +169,10 @@ java {
   withSourcesJar()
 }
 
-// Remote publication set goes to remote repositories, so we don't publicly publish test fixtures.
+// Remote publication set goes to remote repositories.
 tasks.withType<PublishToMavenRepository>().configureEach {
-  onlyIf { publication == publishing.publications["remote"] }
+  onlyIf { publication == remotePublication }
 }
 
-// Local publication set goes to local installations, so we can reuse test fixtures locally.
-tasks.withType<PublishToMavenLocal>().configureEach {
-  onlyIf { publication == publishing.publications["local"] }
-}
+// Local publication set goes to local installations.
+tasks.withType<PublishToMavenLocal>().configureEach { onlyIf { publication == localPublication } }


### PR DESCRIPTION
## Publish test fixtures everywhere

Resolves #1201.

## Simplify signature configuration

Previously we had two nearly identical publications: `local` and `remote`.  `local` was unsigned, and was only intended for local installation, but we could not really enforce that very well. Conversely, `remote` was signed (for non-snapshots) and was only intended for remote installation, which we likewise could not enforce very well.

Now we just have a single `maven` publication.  We always attempt to sign this publication's artifacts.  However, signature misconfiguration is quietly allowed unless we are publishing a non-snapshot to a real Maven remote repository.  Near as I can tell, this is the idiomatic way to sign official remote releases but not sign local installations or snapshot releases.

**Note:** [this wiki documentation](https://github.com/wala/WALA/wiki/Creating-Releases-and-Snapshots#publishing-released-versions-locally) should be updated after this commit is merged into `master`.  In fact, that entire section can probably just be deleted:  after this change, the obvious `publishToMavenLocal` target works as expected.  No signatures are required when installing only into the local Maven repository, even for non-snapshot releases.