### PR TITLE
Resolve Kotlin warnings about inferred platform types

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,16 +52,16 @@ group = name
 version = properties["VERSION_NAME"] as String
 
 // version of Eclipse JARs to use for Eclipse-integrated WALA components.
-val eclipseVersion by extra(libs.versions.eclipse.asProvider()::get)
+val eclipseVersion: String by extra(libs.versions.eclipse.asProvider()::get)
 
 ///////////////////////////////////////////////////////////////////////
 //
 //  Javadoc documentation
 //
 
-val aggregatedJavadocClasspath by configurations.creating { isCanBeConsumed = false }
+val aggregatedJavadocClasspath: Configuration by configurations.creating { isCanBeConsumed = false }
 
-val aggregatedJavadocSource by configurations.creating { isCanBeConsumed = false }
+val aggregatedJavadocSource: Configuration by configurations.creating { isCanBeConsumed = false }
 
 eclipseMavenCentral { release(eclipseVersion) { useNativesForRunningPlatform() } }
 


### PR DESCRIPTION
Kotlin's compiler doesn't know whether these calls to non-Kotlin code return nullable or non-nullable results.  Add explicit types to avoid some weak IntelliJ IDEA warnings.