### PR TITLE
Use Spotless for Java and Kotlin formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,10 +21,11 @@ Beyond tests, other checks run as part of `./gradlew check` and `./gradlew build
 
 1. Compilation with the Java compiler from [Eclipse JDT Core](https://www.eclipse.org/jdt/core/),
 which runs additional lint checks
-2. Checking that all code is formatted according to [Google Java
-  Format](https://github.com/google/google-java-format) standards
+2. Checking that all Java and Kotlin code is formatted according to [Google Java
+   Format](https://github.com/google/google-java-format) and
+   [ktfmt](https://facebook.github.io/ktfmt/) standards, respectively.
 
-If your code fails check 2, you can run `./gradlew googleJavaFormat` to automatically format
+If your code fails check 2, you can run `./gradlew spotlessApply` to automatically format
 it.  The CI job runs `./gradlew build` and will fail if any of these additional
 checks fail.
 
@@ -32,7 +33,10 @@ checks fail.
 DOs and DON'Ts
 --------------
 
-* DO format your code using [Google Java Format](https://github.com/google/google-java-format).  You can do so by running `./gradlew googleJavaFormat`.  A CI job will fail if your code is not formatted in this way.
+* DO format your Java and Kotlin code using [Google Java
+  Format](https://github.com/google/google-java-format) and
+  [ktfmt](https://facebook.github.io/ktfmt/), respectively.  A CI job will fail if your code is not
+  formatted in this way.
 * DO include tests when adding new features. When fixing bugs, start with adding a test that highlights how the current behavior is broken.
 * DO keep the discussions focused. When a new or related topic comes up it's often better to create new issue than to side track the discussion.
 * DO make liberal use of Javadoc and comments to document code.

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -12,6 +12,7 @@ repositories {
 dependencies {
   implementation(libs.gradle.download.task)
   implementation(libs.gradle.errorprone.plugin)
+  implementation(libs.gradle.spotless.plugin)
 }
 
 kotlin.jvmToolchain { languageVersion.set(JavaLanguageVersion.of(11)) }

--- a/buildSrc/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/buildSrc/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -11,6 +11,7 @@ plugins {
   `java-test-fixtures`
   `maven-publish`
   signing
+  id("com.diffplug.spotless")
   id("com.ibm.wala.gradle.aggregated-javadoc")
   id("com.ibm.wala.gradle.javadoc")
   id("com.ibm.wala.gradle.subproject")
@@ -157,4 +158,14 @@ if (project.gradle.parent != null) {
 
     dependencies { "implementation"(configurations["testFixturesImplementation"].dependencies) }
   }
+}
+
+spotless.java {
+  googleJavaFormat(
+      rootProject
+          .the<VersionCatalogsExtension>()
+          .named("libs")
+          .findVersion("google-java-format")
+          .get()
+          .toString())
 }

--- a/buildSrc/src/main/kotlin/com/ibm/wala/gradle/project.gradle.kts
+++ b/buildSrc/src/main/kotlin/com/ibm/wala/gradle/project.gradle.kts
@@ -6,7 +6,12 @@ import org.gradle.plugins.ide.eclipse.model.EclipseModel
 
 // Build configuration shared by all projects *including* the root project.
 
-plugins { eclipse }
+plugins {
+  eclipse
+  id("com.diffplug.spotless")
+}
+
+repositories.mavenCentral()
 
 ////////////////////////////////////////////////////////////////////////
 //
@@ -31,3 +36,21 @@ the<EclipseModel>().classpath.file.whenMerged {
 // this task resolves dependencies in all sub-projects, making it easy to
 // generate lockfiles
 tasks.register<DependencyReportTask>("allDeps") {}
+
+////////////////////////////////////////////////////////////////////////
+//
+//  Code formatting
+//
+
+spotless.kotlin {
+  findProperty("spotless.ratchet.from")?.let { ratchetFrom(it as String) }
+
+  ktfmt(
+      rootProject
+          .the<VersionCatalogsExtension>()
+          .named("libs")
+          .findVersion("ktfmt")
+          .get()
+          .toString())
+  target("*.gradle.kts")
+}

--- a/com.ibm.wala.cast.java.test.data/build.gradle.kts
+++ b/com.ibm.wala.cast.java.test.data/build.gradle.kts
@@ -30,6 +30,11 @@ artifacts {
   add(testJavaSourceDirectory.name, sourceSets.test.map { it.java.srcDirs.first() })
 }
 
+// exclude since various tests make assertions based on
+// source positions in the test inputs.  to auto-format
+// we also need to update the test assertions
+spotless { java { targetExclude("**/*") } }
+
 ////////////////////////////////////////////////////////////////////////
 //
 //  download JLex

--- a/config/hooks/pre-commit
+++ b/config/hooks/pre-commit
@@ -18,7 +18,7 @@ REPO_ROOT_DIR="$(git rev-parse --show-toplevel)"
 # Recommended by <https://github.com/koalaman/shellcheck/wiki/SC2207>.
 files=()
 while IFS='' read -r line; do files+=("$line"); done \
-  < <(git diff --cached --name-only --diff-filter=ACMR | grep -Ei '\.java$')
+  < <(git diff --cached --name-only --diff-filter=ACMR | grep -Ei '\.(java|kts?)$')
 
 join() {
   local IFS="$1"
@@ -27,7 +27,6 @@ join() {
 }
 
 if [ "${#files[@]}" -gt 0 ]; then
-  comma_files=$(join , "${files[@]}")
-  "${REPO_ROOT_DIR}/gradlew" goJF -DgoogleJavaFormat.include="$comma_files" >/dev/null 2>&1
+  "${REPO_ROOT_DIR}/gradlew" spotlessApply -Pspotless.ratchet.from=HEAD >/dev/null 2>&1
   git add "${files[@]}"
 fi

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,9 @@
 [versions]
 eclipse = "4.21.0"
 eclipse-wst-jsdt = "1.0.201.v2010012803"
+google-java-format = "1.7"
+ktfmt = "0.42"
+spotless = "6.13.0"
 
 [libraries]
 android-tools = "com.android.tools:r8:2.2.42"
@@ -15,6 +18,7 @@ eclipse-wst-jsdt-ui = { module = "org.eclipse.wst.jsdt:ui", version.ref = "eclip
 errorprone-core = "com.google.errorprone:error_prone_core:2.18.0"
 gradle-download-task = "de.undercouch:gradle-download-task:5.3.0"
 gradle-errorprone-plugin = "net.ltgt.gradle:gradle-errorprone-plugin:3.0.1"
+gradle-spotless-plugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 gson = "com.google.code.gson:gson:2.10"
 guava = "com.google.guava:guava:31.1-jre"
 hamcrest = "org.hamcrest:hamcrest:2.2"
@@ -37,5 +41,6 @@ google-java-format = "com.github.sherter.google-java-format:0.9"
 jarTest = "com.github.hauner.jarTest:1.0.1"
 kotlin-jvm = "org.jetbrains.kotlin.jvm:1.8.0"
 ktfmt = "com.ncorti.ktfmt.gradle:0.11.0"
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 task-tree = "com.dorongold.task-tree:2.1.1"
 versions = "com.github.ben-manes.versions:0.44.0"


### PR DESCRIPTION
Spotless integrates nicely with the Java- and Kotlin-specific formatters we were already using, and also with Gradle.  Furthermore, it *appears* that Spotless may be ready for use with the Gradle configuration cache, which isn't the case for the Google Java formatter plugin we were using previously.  Thus, this change should move us a bit closer to #1206.