### PR TITLE
Use third-party Gradle plugin for ShellCheck

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,9 +22,6 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Install ShellCheck on macOS
-        run: brew install shellcheck
-        if: runner.os == 'macOS'
       - name: Check out WALA sources
         uses: actions/checkout@v3
       - name: Cache Goomph
@@ -42,7 +39,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           gradle-executable: xvfb-gradle.sh
-          arguments: aggregatedJavadocs build publishAllPublicationsToFakeRemoteRepository
+          arguments: aggregatedJavadocs build publishAllPublicationsToFakeRemoteRepository shellcheck
         # testing ECJ compilation on any one OS is sufficient; we choose Linux arbitrarily
         if: runner.os == 'Linux'
       - name: Build and test using Gradle but without ECJ

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,6 +22,9 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Install ShellCheck on macOS
+        run: brew install shellcheck
+        if: runner.os == 'macOS'
       - name: Check out WALA sources
         uses: actions/checkout@v3
       - name: Cache Goomph

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ plugins {
   alias(libs.plugins.eclipse.mavencentral)
   alias(libs.plugins.file.lister)
   alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.shellcheck)
   alias(libs.plugins.task.tree)
   alias(libs.plugins.versions)
   id("com.ibm.wala.gradle.javadoc")
@@ -85,35 +86,21 @@ tasks.register<Javadoc>("aggregatedJavadocs") {
 //
 
 // shell scripts, provided they have ".sh" extension
-if (isWindows) {
-  // create a no-op "shellCheck" task so that "gradlew shellCheck" vacuously passes on Windows
-  tasks.register("shellCheck")
-} else {
-  // create a real "shellCheck" task that actually runs the "shellcheck" linter, if available
-  tasks.register<Exec>("shellCheck") {
-    description = "Check all shell scripts using shellcheck, if available"
-    group = "verification"
-
-    inputs.files(fileTree(".").exclude("**/build").include("**/*.sh"))
-    outputs.file(project.layout.buildDirectory.file("shellcheck.log"))
-
-    doFirst {
-      // quietly succeed if "shellcheck" is not available
-      executable = "shellcheck"
-      val execPaths = System.getenv("PATH").split(File.pathSeparator)
-      val isAvailable = execPaths.any { file("$it/$executable").exists() }
-      if (!isAvailable) executable = "true"
-
-      args(inputs.files)
-
-      val consoleOutput = System.out
-      val fileOutput = outputs.files.singleFile.outputStream()
-      org.apache.tools.ant.util.TeeOutputStream(consoleOutput, fileOutput).let {
-        standardOutput = it
-        errorOutput = it
+shellcheck {
+  isUseDocker = false
+  shellcheckBinary = "shellcheck"
+  sourceFiles =
+      fileTree(".") {
+        exclude("**/build")
+        include("**/*.sh")
       }
-    }
-  }
+}
+
+val shellcheckTask = tasks.named("shellcheck") { group = "verification" }
+
+tasks.named("check") {
+  // <https://github.com/felipefzdz/gradle-shellcheck-plugin/issues/7>
+  if (!isWindows) dependsOn(shellcheckTask)
 }
 
 spotless {
@@ -129,13 +116,6 @@ tasks.register<Copy>("installGitHooks") {
   into(".git/hooks")
   fileMode = 0b111_111_111
 }
-
-// run all known linters
-val check by
-    tasks.existing {
-      group = "verification"
-      dependsOn("shellCheck")
-    }
 
 ////////////////////////////////////////////////////////////////////////
 //

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,11 +98,6 @@ shellcheck {
 
 val shellcheckTask = tasks.named("shellcheck") { group = "verification" }
 
-tasks.named("check") {
-  // <https://github.com/felipefzdz/gradle-shellcheck-plugin/issues/7>
-  if (!isWindows) dependsOn(shellcheckTask)
-}
-
 spotless {
   kotlin {
     target("buildSrc/*.kts", "buildSrc/src/**/*.kt", "buildSrc/src/**/*.kts")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,7 @@ google-java-format = "com.github.sherter.google-java-format:0.9"
 jarTest = "com.github.hauner.jarTest:1.0.1"
 kotlin-jvm = "org.jetbrains.kotlin.jvm:1.8.0"
 ktfmt = "com.ncorti.ktfmt.gradle:0.11.0"
+shellcheck = "com.felipefzdz.gradle.shellcheck:1.4.6"
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 task-tree = "com.dorongold.task-tree:2.1.1"
 versions = "com.github.ben-manes.versions:0.44.0"


### PR DESCRIPTION
Also, require that ShellCheck pass for all macOS and Linux builds, not just builds where a `shellcheck` executable can be found.  If you want to build WALA, you need to install ShellCheck.  Fortunately, [ShellCheck is quite easy to
install](https://github.com/koalaman/shellcheck#installing) on all supported platforms.

Unfortunately, this ShellCheck plugin [does not work reliably on Windows](https://github.com/felipefzdz/gradle-shellcheck-plugin/issues/7). Until that bug is fixed, it's simpler to just skip ShellCheck on Windows.  We still run ShellCheck on macOS and Linux, so there's no risk of a bad shell script slipping into `master`.