### PR TITLE
Make `extractSampleCup` compatible with configuration cache

### DIFF
--- a/com.ibm.wala.dalvik/build.gradle.kts
+++ b/com.ibm.wala.dalvik/build.gradle.kts
@@ -140,17 +140,24 @@ val downloadAndroidSdk by
 
 val isWindows: Boolean by rootProject.extra
 
+interface ExtractSampleCupServices {
+  @get:Inject val archive: ArchiveOperations
+  @get:Inject val fileSystem: FileSystemOperations
+}
+
 val extractSampleCup by
     tasks.registering {
       inputs.files(sampleCupSources)
       outputs.file(layout.buildDirectory.file("$name/sample.cup"))
 
-      doLast {
-        copy {
-          from(zipTree(inputs.files.singleFile))
-          include("parser.cup")
-          rename { outputs.files.singleFile.name }
-          into(outputs.files.singleFile.parent)
+      objects.newInstance<ExtractSampleCupServices>().run {
+        doLast {
+          fileSystem.copy {
+            from(archive.zipTree(inputs.files.singleFile))
+            include("parser.cup")
+            rename { outputs.files.singleFile.name }
+            into(outputs.files.singleFile.parent)
+          }
         }
       }
     }


### PR DESCRIPTION
Previously, executing this task used [`copy`](https://docs.gradle.org/7.6/javadoc/org/gradle/api/Project.html#copy-org.gradle.api.Action-) and [`zipTree`](https://docs.gradle.org/7.6/javadoc/org/gradle/api/Project.html#zipTree-java.lang.Object-) from the current [`Project`](https://docs.gradle.org/7.6/javadoc/org/gradle/api/Project.html).  However, [the Gradle configuration cache disallows direct `Project` access from tasks' execution logic](https://docs.gradle.org/7.6/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution).  Instead, we need to use these two features as provided by [injectable services](https://docs.gradle.org/7.6/userguide/custom_gradle_types.html#service_injection).  In particular, [`ArchiveOperations`](https://docs.gradle.org/7.6/javadoc/org/gradle/api/file/ArchiveOperations.html) gives us [`zipTree`](https://docs.gradle.org/7.6/javadoc/org/gradle/api/file/ArchiveOperations.html#zipTree-java.lang.Object-), while [`FileSystemOperations`](https://docs.gradle.org/7.6/javadoc/org/gradle/api/file/FileSystemOperations.html) gives us [`copy`](https://docs.gradle.org/7.6/javadoc/org/gradle/api/file/FileSystemOperations.html#copy-org.gradle.api.Action-).