### PR TITLE
The `downloads` task doesn't really have inputs

### DIFF
--- a/buildSrc/src/main/kotlin/com/ibm/wala/gradle/subproject.gradle.kts
+++ b/buildSrc/src/main/kotlin/com/ibm/wala/gradle/subproject.gradle.kts
@@ -19,7 +19,7 @@ version = rootProject.version
 //
 
 tasks.register("downloads") {
-  inputs.files(
+  dependsOn(
       tasks.withType<VerifiedDownload>().matching {
         // not used in typical builds
         it.name != "downloadOcamlJava"


### PR DESCRIPTION
This task depends on all download tasks.  But it doesn't read input from any of the files that those downloads create.