### PR TITLE
Remove `VerifiedDownload` convenience setters

### DIFF
--- a/buildSrc/src/main/kotlin/com/ibm/wala/gradle/VerifiedDownload.kt
+++ b/buildSrc/src/main/kotlin/com/ibm/wala/gradle/VerifiedDownload.kt
@@ -24,27 +24,17 @@ abstract class VerifiedDownload : DefaultTask() {
   // URL of resource to download
   @get:Input abstract val src: Property<URL>
 
-  fun src(url: String) = src.set(URL(url))
-
   // expected checksum of resource as hex digits
   @get:Input abstract val checksum: Property<String>
-
-  fun checksum(hex: String) = checksum.set(hex)
 
   // algorithm to use for computing checksum
   @get:Input val algorithm: Property<String> = project.objects.property<String>().convention("MD5")
 
-  fun algorithm(algorithmName: String) = algorithm.set(algorithmName)
-
   // whether to use ETag for selective downloading
   @get:Input val useETag: Property<Boolean> = project.objects.property<Boolean>().convention(true)
 
-  fun useETag(enabled: Boolean) = useETag.set(enabled)
-
   // local file into which resource should be saved
   @get:OutputFile abstract val dest: RegularFileProperty
-
-  fun dest(file: Any): RegularFileProperty = dest.value { project.file(file) }
 
   @TaskAction
   fun downloadAndVerify() =

--- a/com.ibm.wala.cast.java.test.data/build.gradle.kts
+++ b/com.ibm.wala.cast.java.test.data/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.ibm.wala.gradle.VerifiedDownload
+import java.net.URL
 import net.ltgt.gradle.errorprone.errorprone
 
 plugins { id("com.ibm.wala.gradle.java") }
@@ -42,10 +43,10 @@ spotless { java { targetExclude("**/*") } }
 
 val downloadJLex by
     tasks.registering(VerifiedDownload::class) {
-      src("https://www.cs.princeton.edu/~appel/modern/java/JLex/current/Main.java")
-      checksum("fe0cff5db3e2f0f5d67a153cf6c783af")
+      src.set(URL("https://www.cs.princeton.edu/~appel/modern/java/JLex/current/Main.java"))
+      checksum.set("fe0cff5db3e2f0f5d67a153cf6c783af")
       val downloadedSourceDir by extra(layout.buildDirectory.dir(name))
-      dest(downloadedSourceDir.map { "$it/JLex/Main.java" })
+      dest.set(downloadedSourceDir.map { it.file("JLex/Main.java") })
     }
 
 sourceSets.test.get().java.srcDir(downloadJLex.map { it.extra["downloadedSourceDir"]!! })

--- a/com.ibm.wala.cast.js.nodejs/build.gradle.kts
+++ b/com.ibm.wala.cast.js.nodejs/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.ibm.wala.gradle.VerifiedDownload
+import java.net.URL
 
 plugins { id("com.ibm.wala.gradle.java") }
 
@@ -18,10 +19,10 @@ dependencies {
 
 val downloadNodeJS by
     tasks.registering(VerifiedDownload::class) {
-      src("https://nodejs.org/dist/v0.12.4/node-v0.12.4.tar.gz")
-      dest(project.layout.buildDirectory.file("nodejs.tar.gz"))
-      algorithm("SHA-1")
-      checksum("147ff79947752399b870fcf3f1fc37102100b545")
+      src.set(URL("https://nodejs.org/dist/v0.12.4/node-v0.12.4.tar.gz"))
+      dest.set(project.layout.buildDirectory.file("nodejs.tar.gz"))
+      algorithm.set("SHA-1")
+      checksum.set("147ff79947752399b870fcf3f1fc37102100b545")
     }
 
 val unpackNodeJSLib by

--- a/com.ibm.wala.cast.js/build.gradle.kts
+++ b/com.ibm.wala.cast.js/build.gradle.kts
@@ -1,5 +1,6 @@
 import com.ibm.wala.gradle.CreatePackageList
 import com.ibm.wala.gradle.VerifiedDownload
+import java.net.URL
 
 plugins {
   id("com.ibm.wala.gradle.java")
@@ -39,10 +40,11 @@ val downloadAjaxslt by
     tasks.registering(VerifiedDownload::class) {
       val version = "0.8.1"
       val versionedArchive = "ajaxslt-${version}.tar.gz"
-      src(
-          "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/ajaxslt/$versionedArchive")
-      dest(project.layout.buildDirectory.file(versionedArchive))
-      checksum("c995abe3310a401bb4db7f28a6409756")
+      src.set(
+          URL(
+              "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/ajaxslt/$versionedArchive"))
+      dest.set(project.layout.buildDirectory.file(versionedArchive))
+      checksum.set("c995abe3310a401bb4db7f28a6409756")
     }
 
 val unpackAjaxslt by

--- a/com.ibm.wala.core/build.gradle.kts
+++ b/com.ibm.wala.core/build.gradle.kts
@@ -1,6 +1,7 @@
 import com.ibm.wala.gradle.CompileKawaScheme
 import com.ibm.wala.gradle.JavaCompileUsingEcj
 import com.ibm.wala.gradle.VerifiedDownload
+import java.net.URL
 import net.ltgt.gradle.errorprone.errorprone
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.plugins.ide.eclipse.model.AbstractClasspathEntry
@@ -74,9 +75,9 @@ dependencies {
 val downloadKawa by
     tasks.registering(VerifiedDownload::class) {
       val archive = "kawa-3.0.zip"
-      src("https://ftp.gnu.org/pub/gnu/kawa/$archive")
-      dest(project.layout.buildDirectory.file(archive))
-      checksum("2713e6dfb939274ba3b1d36daea68436")
+      src.set(URL("https://ftp.gnu.org/pub/gnu/kawa/$archive"))
+      dest.set(project.layout.buildDirectory.file(archive))
+      checksum.set("2713e6dfb939274ba3b1d36daea68436")
     }
 
 val extractKawa by
@@ -105,9 +106,9 @@ val kawaChessCommitHash = "f1d2dcc707a1ef19dc159e2eaee5aecc8a41d7a8"
 
 val downloadKawaChess by
     tasks.registering(VerifiedDownload::class) {
-      src("https://github.com/ttu-fpclub/kawa-chess/archive/${kawaChessCommitHash}.zip")
-      dest(project.layout.buildDirectory.file("kawa-chess.zip"))
-      checksum("cf29613d2be5f476a475ee28b4df9d9e")
+      src.set(URL("https://github.com/ttu-fpclub/kawa-chess/archive/${kawaChessCommitHash}.zip"))
+      dest.set(project.layout.buildDirectory.file("kawa-chess.zip"))
+      checksum.set("cf29613d2be5f476a475ee28b4df9d9e")
     }
 
 val unpackKawaChess by
@@ -164,10 +165,10 @@ val downloadBcel by
     tasks.registering(VerifiedDownload::class) {
       val basename by extra("bcel-5.2")
       val archive = "${basename}.tar.gz"
-      src("https://archive.apache.org/dist/jakarta/bcel/binaries/$archive")
-      dest(project.layout.buildDirectory.file(archive))
-      checksum("19bffd7f217b0eae415f1ef87af2f0bc")
-      useETag(false)
+      src.set(URL("https://archive.apache.org/dist/jakarta/bcel/binaries/$archive"))
+      dest.set(project.layout.buildDirectory.file(archive))
+      checksum.set("19bffd7f217b0eae415f1ef87af2f0bc")
+      useETag.set(false)
     }
 
 val extractBcel by
@@ -198,9 +199,9 @@ val extractBcel by
 val downloadJavaCup by
     tasks.registering(VerifiedDownload::class) {
       val archive = "java-cup-11a.jar"
-      src("http://www2.cs.tum.edu/projects/cup/$archive")
-      dest(layout.buildDirectory.file("$name/$archive"))
-      checksum("2bda8c40abd0cbc295d3038643d6e4ec")
+      src.set(URL("http://www2.cs.tum.edu/projects/cup/$archive"))
+      dest.set(layout.buildDirectory.file("$name/$archive"))
+      checksum.set("2bda8c40abd0cbc295d3038643d6e4ec")
     }
 
 ////////////////////////////////////////////////////////////////////////
@@ -235,9 +236,9 @@ val downloadOcamlJava by
       val version = "2.0-alpha1"
       val basename by extra("ocamljava-$version")
       val archive = "$basename.tar.gz"
-      src("http://www.ocamljava.org/downloads/download.php?version=$version-bin")
-      dest(project.layout.buildDirectory.file(archive))
-      checksum("45feec6e3889f5073a39c2c4c84878d1")
+      src.set(URL("http://www.ocamljava.org/downloads/download.php?version=$version-bin"))
+      dest.set(project.layout.buildDirectory.file(archive))
+      checksum.set("45feec6e3889f5073a39c2c4c84878d1")
     }
 
 val unpackOcamlJava by

--- a/com.ibm.wala.dalvik/build.gradle.kts
+++ b/com.ibm.wala.dalvik/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.ibm.wala.gradle.VerifiedDownload
+import java.net.URL
 
 plugins {
   id("com.ibm.wala.gradle.java")
@@ -107,9 +108,11 @@ dependencies {
 
 val downloadDroidBench by
     tasks.registering(VerifiedDownload::class) {
-      src("https://codeload.github.com/secure-software-engineering/DroidBench/zip/DroidBench_2.0")
-      dest(project.layout.buildDirectory.file("DroidBench_2.0.zip"))
-      checksum("16726a48329835140e14f18470a1b4a3")
+      src.set(
+          URL(
+              "https://codeload.github.com/secure-software-engineering/DroidBench/zip/DroidBench_2.0"))
+      dest.set(project.layout.buildDirectory.file("DroidBench_2.0.zip"))
+      checksum.set("16726a48329835140e14f18470a1b4a3")
     }
 
 val unpackDroidBench by
@@ -142,10 +145,10 @@ val downloadAndroidSdk by
           })
           .run {
             val archive = "commandlinetools-$sdkOs-7583922_latest.zip"
-            src("https://dl.google.com/android/repository/$archive")
-            dest(project.layout.buildDirectory.file(archive))
-            checksum(checksum)
-            algorithm("SHA-256")
+            src.set(URL("https://dl.google.com/android/repository/$archive"))
+            dest.set(project.layout.buildDirectory.file(archive))
+            this@registering.checksum.set(checksum)
+            algorithm.set("SHA-256")
           }
     }
 
@@ -173,9 +176,9 @@ val extractSampleCup by
 
 val downloadSampleLex by
     tasks.registering(VerifiedDownload::class) {
-      src("https://www.cs.princeton.edu/~appel/modern/java/JLex/current/sample.lex")
-      dest(layout.buildDirectory.file("$name/sample.lex"))
-      checksum("ae887758b2657981d023a72a165da830")
+      src.set(URL("https://www.cs.princeton.edu/~appel/modern/java/JLex/current/sample.lex"))
+      dest.set(layout.buildDirectory.file("$name/sample.lex"))
+      checksum.set("ae887758b2657981d023a72a165da830")
     }
 
 tasks.named<Copy>("processTestResources") {


### PR DESCRIPTION
Previously, the `VerifiedDownload` class provided convenience setters for each configurable `Property`.  However, the `dest` convenience setter used `project`, making it incompatible with the Gradle configuration cache if called during task execution.  So that setter needed to go away.  For consistency, let's just get rid of all of these convenience setters.  Instead, users of this task should use the `Property.set` methods of the individual properties.