### PR TITLE
Don't access environment variables during task execution

### DIFF
--- a/com.ibm.wala.cast/build.gradle.kts
+++ b/com.ibm.wala.cast/build.gradle.kts
@@ -75,14 +75,17 @@ tasks.named<Test>("test") {
   doFirst { systemProperty("java.library.path", xlatorTestSharedLibrary.singleFile.parent) }
 
   if (rootProject.extra["isWindows"] as Boolean) {
+
     // Windows has nothing akin to RPATH for embedding DLL search paths in other DLLs or
     // executables.  Instead, we need to ensure that any required DLLs are in the standard
     // executable search path at test run time.
+    //
+    // Unfortunately, Windows environment variables are case-insensitive.  So we cannot simply
+    // append the DLL's path to `$PATH`.  Rather, we need to append to an environment variable whose
+    // name is case-insensitively equal to `"path"`, whether that's `$PATH`, `$Path`, `$path`, etc.
+
     inputs.files(castCastSharedLibrary)
-    doFirst {
-      val pathEntry = environment.entries.find { it.key.equals("path", true) }!!
-      environment[pathEntry.key] =
-          (pathEntry.value as String) + ";${castCastSharedLibrary.singleFile.parent}"
-    }
+    val pathEntry = environment.entries.find { it.key.equals("path", true) }!!
+    environment(pathEntry.key, "${pathEntry.value};${castCastSharedLibrary.singleFile.parent}")
   }
 }


### PR DESCRIPTION
Instead, fetch the required environment variables during task configuration.  Otherwise, we introduce an execution time access to the current `Project`, thereby making the task incompatible with the Gradle configuration cache.

That being said, even after this fix, this specific task won't get very far using the Gradle configuration cache, because the latter does not yet support native C++ compilation: gradle/gradle#13484, gradle/gradle#13485.