### PR TITLE
Don't access a `Configuration` during task execution

### DIFF
--- a/com.ibm.wala.cast/build.gradle.kts
+++ b/com.ibm.wala.cast/build.gradle.kts
@@ -72,7 +72,8 @@ tasks.named<Javadoc>("javadoc") {
 
 tasks.named<Test>("test") {
   inputs.files(xlatorTestSharedLibrary)
-  doFirst { systemProperty("java.library.path", xlatorTestSharedLibrary.singleFile.parent) }
+  val xlatorTestSharedLibrary = xlatorTestSharedLibrary.singleFile
+  doFirst { systemProperty("java.library.path", xlatorTestSharedLibrary.parent) }
 
   if (rootProject.extra["isWindows"] as Boolean) {
     // Windows has nothing akin to RPATH for embedding DLL search paths in other DLLs or


### PR DESCRIPTION
When using the Gradle configuration cache, accessing a `Configuration` during task execution is discouraged or outright forbidden.  Instead, fetch the required file from that `Configuration` when configuring the task that uses it.