### PR TITLE
Skip loading an unnecessary plugin

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,5 +1,4 @@
 plugins {
-  `java-library`
   `kotlin-dsl`
   `kotlin-dsl-precompiled-script-plugins`
 }


### PR DESCRIPTION
We're picking up the right Kotlin plugin(s) already, and we don't actually have any Java code in this `build-logic` project.