### PR TITLE
Use more convenient URI factory

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
@@ -1,7 +1,5 @@
 package com.ibm.wala.gradle
 
-import java.net.URI
-
 plugins {
   `java-library`
   `java-test-fixtures`
@@ -125,7 +123,7 @@ val repositories = publishing.repositories
 val mavenRepository =
     repositories.maven {
       url =
-          URI(
+          uri(
               (if (isSnapshot)
                   project.properties.getOrDefault(
                       "SNAPSHOT_REPOSITORY_URL",


### PR DESCRIPTION
`project.uri` is a bit easier for us to use here, since it does not require importing `java.net.URI`.