### PR TITLE
Update gradle-download-task plugin

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/VerifiedDownload.kt
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/VerifiedDownload.kt
@@ -8,10 +8,10 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.property
-import org.gradle.kotlin.dsl.the
 
 ////////////////////////////////////////////////////////////////////////
 //
@@ -36,21 +36,30 @@ abstract class VerifiedDownload : DefaultTask() {
   // local file into which resource should be saved
   @get:OutputFile abstract val dest: RegularFileProperty
 
+  // plugin-provided extension for downloading a resource from some URL
+  @Internal
+  val downloadExtension: DownloadExtension =
+      project.objects.newInstance(DownloadExtension::class.java, this)
+
+  // plugin-provided extension for verifying that a file has the expected checksum
+  @Internal
+  val verifyExtension: VerifyExtension =
+      project.objects.newInstance(VerifyExtension::class.java, this)
+
   @TaskAction
-  fun downloadAndVerify() =
-      project.run {
-        the<DownloadExtension>().run {
-          src(this@VerifiedDownload.src)
-          dest(this@VerifiedDownload.dest)
-          overwrite(true)
-          onlyIfModified(true)
-          useETag(this@VerifiedDownload.useETag.get())
-          retries(5)
-        }
-        the<VerifyExtension>().run {
-          src(this@VerifiedDownload.dest.get().asFile)
-          algorithm(this@VerifiedDownload.algorithm.get())
-          checksum(this@VerifiedDownload.checksum.get())
-        }
-      }
+  fun downloadAndVerify() {
+    downloadExtension.run {
+      src(this@VerifiedDownload.src)
+      dest(this@VerifiedDownload.dest)
+      overwrite(true)
+      onlyIfModified(true)
+      useETag(this@VerifiedDownload.useETag.get())
+      retries(5)
+    }
+    verifyExtension.run {
+      src(this@VerifiedDownload.dest.get().asFile)
+      algorithm(this@VerifiedDownload.algorithm.get())
+      checksum(this@VerifiedDownload.checksum.get())
+    }
+  }
 }

--- a/com.ibm.wala.core/build.gradle.kts
+++ b/com.ibm.wala.core/build.gradle.kts
@@ -88,7 +88,7 @@ val downloadKawa by
 
 val extractKawa by
     tasks.registering {
-      inputs.files(downloadKawa)
+      inputs.files(downloadKawa.map { it.outputs.files })
       outputs.file(layout.buildDirectory.file("$name/kawa.jar"))
 
       objects.newInstance<ExtractServices>().run {
@@ -121,7 +121,7 @@ val downloadKawaChess by
 
 val unpackKawaChess by
     tasks.registering {
-      inputs.files(downloadKawaChess)
+      inputs.files(downloadKawaChess.map { it.outputs.files })
       outputs.dir(project.layout.buildDirectory.file("kawa-chess-$kawaChessCommitHash"))
 
       objects.newInstance<ExtractServices>().run {
@@ -185,7 +185,7 @@ val extractBcel by
     tasks.registering {
       val basename = downloadBcel.map { it.extra["basename"] as String }
       val jarFile = basename.flatMap { layout.buildDirectory.file("$name/${it}.jar") }
-      inputs.files(downloadBcel)
+      inputs.files(downloadBcel.map { it.outputs.files })
       outputs.file(jarFile)
 
       objects.newInstance<ExtractServices>().run {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ eclipse-osgi = "org.eclipse.platform:org.eclipse.osgi:3.17.0"
 eclipse-wst-jsdt-core = { module = "org.eclipse.wst.jsdt:core", version.ref = "eclipse-wst-jsdt" }
 eclipse-wst-jsdt-ui = { module = "org.eclipse.wst.jsdt:ui", version.ref = "eclipse-wst-jsdt" }
 errorprone-core = "com.google.errorprone:error_prone_core:2.18.0"
-gradle-download-task = "de.undercouch:gradle-download-task:5.3.0"
+gradle-download-task = "de.undercouch:gradle-download-task:5.3.1"
 gradle-errorprone-plugin = "net.ltgt.gradle:gradle-errorprone-plugin:3.0.1"
 gradle-spotless-plugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 gson = "com.google.code.gson:gson:2.10"


### PR DESCRIPTION
Also use some new features added to this plugin's latest release that let us avoid referring to the current `Project` during the action method of `VerifiedDownload` instances.  This change makes our `VerifiedDownload` tasks compatible with the Gradle configuration cache.

Unfortunately we also need to change how we set the inputs for a few tasks that postprocess downloads.  It's not clear to me whether this is due to a problem in our `VerifiedDownload` task, in the `gradle-download-task` plugin, or in Gradle itself.  I can live with this change for now, but it would be nice to understand it better.