### PR TITLE
Mark some kinds of tasks as incompatible with Gradle's configuration cache

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/cast/native.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/cast/native.gradle.kts
@@ -1,0 +1,5 @@
+package com.ibm.wala.gradle.cast
+
+tasks.withType<CppCompile> {
+  notCompatibleWithConfigurationCache("https://github.com/gradle/gradle/issues/13485")
+}

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
@@ -1,5 +1,7 @@
 package com.ibm.wala.gradle
 
+import java.lang.module.ModuleDescriptor.Version
+
 plugins {
   `java-library`
   `java-test-fixtures`
@@ -158,4 +160,10 @@ configure<SigningExtension> {
 java {
   withJavadocJar()
   withSourcesJar()
+}
+
+if (Version.parse(gradle.gradleVersion) < Version.parse("8.1-RC1")) {
+  tasks.withType<Sign> {
+    notCompatibleWithConfigurationCache("https://github.com/gradle/gradle/issues/13470")
+  }
 }

--- a/com.ibm.wala.cast/cast/build.gradle.kts
+++ b/com.ibm.wala.cast/cast/build.gradle.kts
@@ -3,6 +3,7 @@ import com.ibm.wala.gradle.cast.nativeLibraryOutput
 
 plugins {
   `cpp-library`
+  id("com.ibm.wala.gradle.cast.native")
   id("com.ibm.wala.gradle.subproject")
 }
 

--- a/com.ibm.wala.cast/smoke_main/build.gradle.kts
+++ b/com.ibm.wala.cast/smoke_main/build.gradle.kts
@@ -9,6 +9,7 @@ import org.gradle.language.cpp.CppBinary.OPTIMIZED_ATTRIBUTE
 
 plugins {
   `cpp-application`
+  id("com.ibm.wala.gradle.cast.native")
   id("com.ibm.wala.gradle.subproject")
 }
 
@@ -80,6 +81,8 @@ application {
               if (isDebuggable && !isOptimized) {
                 val checkSmokeMain by
                     tasks.registering(Exec::class) {
+                      notCompatibleWithConfigurationCache(
+                          "https://github.com/gradle/gradle/issues/13485")
 
                       // main executable to run for test
                       inputs.file(linkedFile)

--- a/com.ibm.wala.cast/xlator_test/build.gradle.kts
+++ b/com.ibm.wala.cast/xlator_test/build.gradle.kts
@@ -2,6 +2,7 @@ import com.ibm.wala.gradle.cast.addCastLibrary
 
 plugins {
   `cpp-library`
+  id("com.ibm.wala.gradle.cast.native")
   id("com.ibm.wala.gradle.subproject")
 }
 


### PR DESCRIPTION
If an incompatible task is scheduled to run, Gradle will warn about the incompatibility, but will not fail the build.  Instead, the configuration state will simply be discarded (not cached) when the build completes.

This approach seems like a reasonable compromise given that we use some standard Gradle tasks that are not yet compatible with the configuration cache.  It lets us still use the cache for builds that don't involve these incompatible tasks.