### PR TITLE
Be more strict when caching Gradle configuration

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
+
 rootProject.name = "com.ibm.wala"
 
 includeBuild("build-logic")


### PR DESCRIPTION
[We are not yet ready to enable the Gradle configuration cache by default.](https://github.com/orgs/wala/projects/1/views/2)  If someone turns it on locally, though, we should use it in [its stricter mode of behavior](https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:stable). Per the Gradle documentation, "It is recommended to enable [`STABLE_CONFIGURATION_CACHE`] as soon as possible in order to be ready for when we remove the flag and make the linked features the default."