### PR TITLE
Fix Gradle configuration cache for `compileTestJava` tasks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,12 +11,12 @@ buildscript { dependencies.classpath(libs.commons.io) }
 plugins {
   idea
   java
-  alias(libs.plugins.eclipse.mavencentral)
   alias(libs.plugins.file.lister)
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.shellcheck)
   alias(libs.plugins.task.tree)
   alias(libs.plugins.versions)
+  id("com.diffplug.eclipse.mavencentral")
   id("com.ibm.wala.gradle.javadoc")
   id("com.ibm.wala.gradle.maven-eclipse-jsdt")
   id("com.ibm.wala.gradle.project")

--- a/com.ibm.wala.cast.java.ecj/build.gradle.kts
+++ b/com.ibm.wala.cast.java.ecj/build.gradle.kts
@@ -1,7 +1,7 @@
 @Suppress("DSL_SCOPE_VIOLATION") // https://github.com/gradle/gradle/issues/22797
 plugins {
   application
-  alias(libs.plugins.eclipse.mavencentral)
+  id("com.diffplug.eclipse.mavencentral")
   id("com.ibm.wala.gradle.java")
   id("com.ibm.wala.gradle.publishing")
 }

--- a/com.ibm.wala.ide.jdt.test/build.gradle.kts
+++ b/com.ibm.wala.ide.jdt.test/build.gradle.kts
@@ -1,6 +1,6 @@
 @Suppress("DSL_SCOPE_VIOLATION") // https://github.com/gradle/gradle/issues/22797
 plugins {
-  alias(libs.plugins.eclipse.mavencentral)
+  id("com.diffplug.eclipse.mavencentral")
   id("com.ibm.wala.gradle.java")
 }
 

--- a/com.ibm.wala.ide.jdt/build.gradle.kts
+++ b/com.ibm.wala.ide.jdt/build.gradle.kts
@@ -1,6 +1,6 @@
 @Suppress("DSL_SCOPE_VIOLATION") // https://github.com/gradle/gradle/issues/22797
 plugins {
-  alias(libs.plugins.eclipse.mavencentral)
+  id("com.diffplug.eclipse.mavencentral")
   id("com.ibm.wala.gradle.java")
 }
 

--- a/com.ibm.wala.ide.jsdt.tests/build.gradle.kts
+++ b/com.ibm.wala.ide.jsdt.tests/build.gradle.kts
@@ -1,6 +1,6 @@
 @Suppress("DSL_SCOPE_VIOLATION") // https://github.com/gradle/gradle/issues/22797
 plugins {
-  alias(libs.plugins.eclipse.mavencentral)
+  id("com.diffplug.eclipse.mavencentral")
   id("com.ibm.wala.gradle.java")
   id("com.ibm.wala.gradle.maven-eclipse-jsdt")
 }

--- a/com.ibm.wala.ide.jsdt/build.gradle.kts
+++ b/com.ibm.wala.ide.jsdt/build.gradle.kts
@@ -1,6 +1,6 @@
 @Suppress("DSL_SCOPE_VIOLATION") // https://github.com/gradle/gradle/issues/22797
 plugins {
-  alias(libs.plugins.eclipse.mavencentral)
+  id("com.diffplug.eclipse.mavencentral")
   id("com.ibm.wala.gradle.java")
   id("com.ibm.wala.gradle.maven-eclipse-jsdt")
 }

--- a/com.ibm.wala.ide.tests/build.gradle.kts
+++ b/com.ibm.wala.ide.tests/build.gradle.kts
@@ -3,9 +3,10 @@ import org.gradle.api.attributes.VerificationType.VERIFICATION_TYPE_ATTRIBUTE
 
 @Suppress("DSL_SCOPE_VIOLATION") // https://github.com/gradle/gradle/issues/22797
 plugins {
-  alias(libs.plugins.eclipse.mavencentral)
+  `java-library`
   alias(libs.plugins.jarTest)
   id("com.ibm.wala.gradle.java")
+  id("com.diffplug.eclipse.mavencentral")
 }
 
 eclipse.project.natures("org.eclipse.pde.PluginNature")

--- a/com.ibm.wala.ide/build.gradle.kts
+++ b/com.ibm.wala.ide/build.gradle.kts
@@ -1,6 +1,6 @@
 @Suppress("DSL_SCOPE_VIOLATION") // https://github.com/gradle/gradle/issues/22797
 plugins {
-  alias(libs.plugins.eclipse.mavencentral)
+  id("com.diffplug.eclipse.mavencentral")
   id("com.ibm.wala.gradle.java")
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,6 @@ slf4j-api = "org.slf4j:slf4j-api:2.0.6"
 w3c-css-sac = "org.eclipse.birt.runtime:org.w3c.css.sac:1.3.1.v200903091627"
 
 [plugins]
-eclipse-mavencentral = "com.diffplug.eclipse.mavencentral:3.40.0"
 file-lister = "all.shared.gradle.file-lister:1.0.2"
 google-java-format = "com.github.sherter.google-java-format:0.9"
 jarTest = "com.github.hauner.jarTest:1.0.1"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,7 @@
+buildscript { dependencies { classpath("com.diffplug.spotless:spotless-lib-extra:2.34.1") } }
+
+plugins { id("com.diffplug.configuration-cache-for-platform-specific-build") version "3.40.0" }
+
 enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
 
 rootProject.name = "com.ibm.wala"


### PR DESCRIPTION
Fixes #1230 using advice from diffplug/goomph#203.

Unfortunately, as far as I can tell, the `libs.versions.toml` version catalog we use elsewhere is not available in `settings.gradle{,.kts}` files.  The generated version accessors are associated with the root `Project` instance rather than the global `Settings` instance.