### PR TITLE
Trigger CI workflow for new items in merge queue

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,5 +1,6 @@
 name: Continuous integration
 on:
+  merge_group:
   pull_request:
   push:
     branches-ignore:


### PR DESCRIPTION
After this change is approve and merged, we'll enable GitHub's beta "Require merge queue" branch protection rule for the `master` branch.