### PR TITLE
Update name of Gradle build scripts

### DIFF
--- a/README-Gradle.md
+++ b/README-Gradle.md
@@ -81,7 +81,7 @@ generated `.classpath` and `.project` files will have the desired
 contents, likely by using [Gradle’s `eclipse`
 plugin](https://docs.gradle.org/current/userguide/eclipse_plugin.html).
 A few WALA sub-projects already use this:  look for `eclipse.project`
-in `*/build.gradle` for examples.
+in `*/build.gradle.kt` for examples.
 
 ## IntelliJ IDEA
 


### PR DESCRIPTION
These scripts were called `build.gradle` when they used Groovy. Now that they use Kotlin, they are called `build.gradle.kts`.