### PR TITLE
Disable merge queue

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,6 +1,5 @@
 name: Continuous integration
 on:
-  merge_group:
   pull_request:
   push:
     branches-ignore:


### PR DESCRIPTION
This reverts commit 2647cfb0033ae0fe2c8836491fb3ea9d0b06fa60.

I strongly believe that there should be some way to configure GitHub Actions to work _really_ well for us, including the beta merge queue feature. But…I just do not know how to do it. The more I read about GitHub Actions, triggers, jobs, cancellation, etc. the more confused I get.

I suspect that [our `concurrency` settings in `continuous-integration.yml`](https://github.com/wala/WALA/blob/d1b60945d006717b4dbab19b591ff6960bd62330/.github/workflows/continuous-integration.yml#L8-L10) might be interfering with the merge queue. But if I just remove that, then we're back to running wasteful jobs. We're also back to the potential for race conditions, as @msridhar pointed out in 1306282ca773d1b5d23526a38cf9150ff4ced605. So I don't know how to change what we are doing here without breaking other things.

[Skip Duplicate Actions](https://github.com/fkirc/skip-duplicate-actions) looks like it could be helpful. Perhaps this action could let us avoid bad/wasteful concurrency while still allowing the merge queue to work properly. But again, the more I read through this project's documentation, the less I think I understand how to set it up properly. The fact that we are using a job matrix, with other jobs that depend on the matrix jobs' outcomes, makes things even more confusing. Perhaps if that action's maintainers (@paescuj and @fkirc) see this message, they might take an interest in donating a suggested change to [WALA's workflow configuration](https://github.com/wala/WALA/blob/master/.github/workflows/continuous-integration.yml)?

That would be delightful. Barring that, though, I think we need to bail out on the merge queue for now.