### PR TITLE
Clean up Spotless format checks

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,6 +1,8 @@
+@Suppress("DSL_SCOPE_VIOLATION") // https://github.com/gradle/gradle/issues/22797
 plugins {
   `kotlin-dsl`
   `kotlin-dsl-precompiled-script-plugins`
+  alias(libs.plugins.spotless)
 }
 
 repositories {
@@ -15,3 +17,22 @@ dependencies {
 }
 
 kotlin.jvmToolchain { languageVersion.set(JavaLanguageVersion.of(11)) }
+
+spotless {
+  val ktfmtVersion =
+      rootProject
+          .the<VersionCatalogsExtension>()
+          .named("libs")
+          .findVersion("ktfmt")
+          .get()
+          .toString()
+
+  kotlin {
+    ktfmt(ktfmtVersion)
+    targetExclude("build/")
+  }
+
+  kotlinGradle { ktfmt(ktfmtVersion) }
+
+  findProperty("spotless.ratchet.from")?.let { ratchetFrom(it as String) }
+}

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/project.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/project.gradle.kts
@@ -42,15 +42,16 @@ tasks.register<DependencyReportTask>("allDeps") {}
 //  Code formatting
 //
 
-spotless.kotlin {
+spotless {
   findProperty("spotless.ratchet.from")?.let { ratchetFrom(it as String) }
 
-  ktfmt(
-      rootProject
-          .the<VersionCatalogsExtension>()
-          .named("libs")
-          .findVersion("ktfmt")
-          .get()
-          .toString())
-  target("*.gradle.kts")
+  kotlinGradle {
+    ktfmt(
+        rootProject
+            .the<VersionCatalogsExtension>()
+            .named("libs")
+            .findVersion("ktfmt")
+            .get()
+            .toString())
+  }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,18 +98,16 @@ shellcheck {
 
 val shellcheckTask = tasks.named("shellcheck") { group = "verification" }
 
-spotless {
-  kotlin {
-    target("buildSrc/*.kts", "buildSrc/src/**/*.kt", "buildSrc/src/**/*.kts")
-  }
-}
-
 // install Java reformatter as git pre-commit hook
 tasks.register<Copy>("installGitHooks") {
   from("config/hooks/pre-commit-stub")
   rename { "pre-commit" }
   into(".git/hooks")
   fileMode = 0b111_111_111
+}
+
+listOf("check", "spotlessCheck", "spotlessApply").forEach {
+  tasks.named(it) { dependsOn(gradle.includedBuild("build-logic").task(":$it")) }
 }
 
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
I had not previously realized that Spotless offers a `kotlinGradle` configuration separate from its `kotlin` configuration.  Most of WALA is written in Java, with Kotlin only appearing in Gradle build scrips.  So for most of WALA, we want to configure Spotless for `java` and `kotlinGradle`, but not `kotlin`.  However, for the `build-logic` subproject, we want both `kotlin` and `kotlinGradle`, since this subproject uses Kotlin (and only Kotlin) for both its Gradle build scripts and for the code that those scripts are building.

Explicitly configure the top-level `check`, `spotlessCheck`, and `spotlessApply` tasks to depend on the same-named `build-logic` tasks. In general, tasks implicitly depend on same-named tasks in subprojects. But `build-logic` is an included build, not a subproject.  So for `build-logic`, we need to set things like this up manually.

Remove Spotless checks of Kotlin code under `buildSrc`.  We no longer use `buildSrc`, having already replaced it with `build-logic` as an included build.