### PR TITLE
Ensure that JUnit can find `SlowTests` category

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -103,10 +103,6 @@ tasks.named<Test>("test") {
   include("**/Test*.class")
   exclude("**/*AndroidLibs*.class")
 
-  if (project.hasProperty("excludeSlowTests")) {
-    useJUnit { excludeCategories("com.ibm.wala.tests.util.SlowTests") }
-  }
-
   val trial = project.findProperty("trial")
   if (trial != null) {
     outputs.upToDateWhen { false }
@@ -123,6 +119,11 @@ tasks.named<Test>("test") {
   } else {
     maxParallelForks = Runtime.getRuntime().availableProcessors().div(2).takeIf { it > 0 } ?: 1
   }
+}
+
+if (project.hasProperty("excludeSlowTests")) {
+  dependencies { testImplementation(testFixtures(project(":com.ibm.wala.core"))) }
+  tasks.named<Test>("test") { useJUnit { excludeCategories("com.ibm.wala.tests.util.SlowTests") } }
 }
 
 val ecjCompileTaskProviders =


### PR DESCRIPTION
If we're asking JUnit to exclude tests in the `SlowTests` category, then JUnit needs to be able to find the `SlowTests` interface.  That interface is implemented in the `testFixtures` source set of the `com.ibm.wala.core` subproject.

Without this fix, asking to exclude slow tests would fail in subprojects that have no slow tests and no other reason to depend on the `testFixtures` source set of the `com.ibm.wala.core` subproject.  For example, `./gradlew :com.ibm.wala.ide.tests:test -PexcludeSlowTests` would fail before this fix.  Now that command, correctly excluding the zero slow tests in the `com.ibm.wala.ide.tests` subproject.