### PR TITLE
Fix crash in JS CG construction for malformed calls to new Function

### DIFF
--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/AbstractFieldBasedTest.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/AbstractFieldBasedTest.java
@@ -55,7 +55,7 @@ public abstract class AbstractFieldBasedTest extends TestJSCallGraphShape {
         System.err.println(cg);
         verifyGraphAssertions(cg, assertions);
       } catch (AssertionError afe) {
-        throw new AssertionError(builderType + ": " + afe.getMessage());
+        throw new AssertionError(builderType + ": " + afe.getMessage(), afe);
       }
     }
     return cg;

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/TestFieldBasedCG.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/TestFieldBasedCG.java
@@ -218,6 +218,9 @@ public class TestFieldBasedCG extends AbstractFieldBasedTest {
 
   @Test
   public void testBadNewFunctionCall() throws WalaException, CancelException {
-    runTest("tests/fieldbased/bad_new_function_call.js", new Object[][] {}, BuilderType.OPTIMISTIC_WORKLIST);
+    runTest(
+        "tests/fieldbased/bad_new_function_call.js",
+        new Object[][] {},
+        BuilderType.OPTIMISTIC_WORKLIST);
   }
 }

--- a/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/TestFieldBasedCG.java
+++ b/com.ibm.wala.cast.js.rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/TestFieldBasedCG.java
@@ -215,4 +215,9 @@ public class TestFieldBasedCG extends AbstractFieldBasedTest {
             BuilderType.OPTIMISTIC,
             BuilderType.OPTIMISTIC_WORKLIST));
   }
+
+  @Test
+  public void testBadNewFunctionCall() throws WalaException, CancelException {
+    runTest("tests/fieldbased/bad_new_function_call.js", new Object[][] {}, BuilderType.OPTIMISTIC_WORKLIST);
+  }
 }

--- a/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/ipa/summaries/JavaScriptConstructorFunctions.java
+++ b/com.ibm.wala.cast.js/src/main/java/com/ibm/wala/cast/js/ipa/summaries/JavaScriptConstructorFunctions.java
@@ -581,9 +581,14 @@ public class JavaScriptConstructorFunctions {
             }
           }
 
-          assert fcls != null : "cannot find class for " + fileName + " amongst " + fnNames;
-
-          return makeFunctionConstructor(cls, fcls);
+          if (fcls == null) {
+            // This can happen, e.g., if the arguments to the Function constructor call are
+            // malformed.
+            // In this case, return a synthetic constructor similar to the 0-argument case
+            return makeFunctionConstructor(cls, cls);
+          } else {
+            return makeFunctionConstructor(cls, fcls);
+          }
 
         } catch (IOException e) {
 

--- a/com.ibm.wala.cast.js/src/test/resources/tests/fieldbased/bad_new_function_call.js
+++ b/com.ibm.wala.cast.js/src/test/resources/tests/fieldbased/bad_new_function_call.js
@@ -1,0 +1,1 @@
+var x = new Function('bogus1', 'bogus2');


### PR DESCRIPTION
Our code for handling `new Function(...)` calls tries to parse and analyze the body argument to the call if it is a string constant.  But, when that argument is malformed, previously we would crash.  This PR adds a null check to make WALA's behavior more robust for that case.