### PR TITLE
Enable Gradle's configuration cache by default

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 org.gradle.caching=true
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=384m
 org.gradle.parallel=true
+org.gradle.unsafe.configuration-cache=true
 
 VERSION_NAME=1.6.1-SNAPSHOT


### PR DESCRIPTION
[As noted](https://github.com/wala/WALA/issues/1206#issuecomment-1436129956), we'll have some unsightly (but harmless) warnings in any builds that include artifact-signing tasks or native-code-compilation tasks. Resolves #1206.