### PR TITLE
Gradle settings tweaks for `build-logic` project

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,6 +1,8 @@
-// The root project and its standard subprojects automatically use the version catalog in
-// `grable/libs.versions.toml`. To use the same version catalog for the `buildSrc` project, we must
-// configure it explicitly.
+rootProject.name = "build-logic"
+
+// The WALA root project and its standard subprojects automatically use the version catalog in
+// `gradle/libs.versions.toml`. To use the same version catalog for this `build-logic` project, we
+// must configure it explicitly.
 dependencyResolutionManagement.versionCatalogs
     .create("libs")
     .from(files("../gradle/libs.versions.toml"))


### PR DESCRIPTION
Set this included build's Gradle project name explicitly.  Unlike subprojects, an included build doesn't pick up its name from the project that included it.

Update an explanatory comment, which was still referring to `build-logic` as the `buildSrc` subproject.

Correct a typo in that same explanatory comment.