### PR TITLE
Prefix publications with `com.ibm.wala`

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
@@ -39,6 +39,9 @@ val mavenPublication =
     publishing.publications.create<MavenPublication>("maven") {
       from(javaComponent)
 
+      groupId = "com.ibm.wala"
+      artifactId = the<BasePluginExtension>().archivesName.get()
+
       val testFixturesCodeElementsNames =
           listOf("testFixturesApiElements", "testFixturesRuntimeElements")
       testFixturesCodeElementsNames.forEach(this::suppressPomMetadataWarningsFor)


### PR DESCRIPTION
This used to happen implicitly, because `com.ibm.wala` was the root project's name and `com.ibm.wala.` was a prefix for all subproject names.  In #1247 we shortened the project name to just `wala` and removed the common `com.ibm.wala.` prefix from all subproject names.  So now we need to tweak things a bit to bring those prefixes back for publications.

Tested locally using the `publishAllPublicationsToFakeRemoteRepository` task, which actually just "publishes" to the local file system under `build/maven-fake-remote-repository`.  The published files now consist of:

* `com/ibm/wala/com.ibm.wala.*/maven-metadata.xml*`
* `com/ibm/wala/com.ibm.wala.*/1.6.1-SNAPSHOT/com.ibm.wala.*`
* `com/ibm/wala/com.ibm.wala.*/1.6.1-SNAPSHOT/maven-metadata.xml*`

The complete publication listing consists of:

```
maven-fake-remote-repository/
└── com/
    └── ibm/
        └── wala/
            ├── com.ibm.wala.cast/
            │   └── 1.6.1-SNAPSHOT/
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1.jar
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1.jar.md5
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1.jar.sha1
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1.jar.sha256
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1.jar.sha512
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1-javadoc.jar
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1-javadoc.jar.md5
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1-javadoc.jar.sha1
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1-javadoc.jar.sha256
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1-javadoc.jar.sha512
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1.module
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1.module.md5
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1.module.sha1
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1.module.sha256
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1.module.sha512
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1.pom
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1.pom.md5
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1.pom.sha1
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1.pom.sha256
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1.pom.sha512
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1-sources.jar
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1-sources.jar.md5
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1-sources.jar.sha1
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1-sources.jar.sha256
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1-sources.jar.sha512
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1-test-fixtures.jar
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1-test-fixtures.jar.md5
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1-test-fixtures.jar.sha1
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1-test-fixtures.jar.sha256
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1-test-fixtures.jar.sha512
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1-test-fixtures-javadoc.jar
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1-test-fixtures-javadoc.jar.md5
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1-test-fixtures-javadoc.jar.sha1
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1-test-fixtures-javadoc.jar.sha256
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1-test-fixtures-javadoc.jar.sha512
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1-test-fixtures-sources.jar
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1-test-fixtures-sources.jar.md5
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1-test-fixtures-sources.jar.sha1
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1-test-fixtures-sources.jar.sha256
            │       ├── com.ibm.wala.cast-1.6.1-20230304.220659-1-test-fixtures-sources.jar.sha512
            │       ├── maven-metadata.xml
            │       ├── maven-metadata.xml.md5
            │       ├── maven-metadata.xml.sha1
            │       ├── maven-metadata.xml.sha256
            │       └── maven-metadata.xml.sha512
            ├── com.ibm.wala.cast.java/
            │   └── 1.6.1-SNAPSHOT/
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1.jar
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1.jar.md5
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1.jar.sha1
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1.jar.sha256
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1.jar.sha512
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1-javadoc.jar
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1-javadoc.jar.md5
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1-javadoc.jar.sha1
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1-javadoc.jar.sha256
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1-javadoc.jar.sha512
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1.module
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1.module.md5
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1.module.sha1
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1.module.sha256
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1.module.sha512
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1.pom
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1.pom.md5
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1.pom.sha1
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1.pom.sha256
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1.pom.sha512
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1-sources.jar
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1-sources.jar.md5
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1-sources.jar.sha1
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1-sources.jar.sha256
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1-sources.jar.sha512
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1-test-fixtures.jar
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1-test-fixtures.jar.md5
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1-test-fixtures.jar.sha1
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1-test-fixtures.jar.sha256
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1-test-fixtures.jar.sha512
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1-test-fixtures-javadoc.jar
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1-test-fixtures-javadoc.jar.md5
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1-test-fixtures-javadoc.jar.sha1
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1-test-fixtures-javadoc.jar.sha256
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1-test-fixtures-javadoc.jar.sha512
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1-test-fixtures-sources.jar
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1-test-fixtures-sources.jar.md5
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1-test-fixtures-sources.jar.sha1
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1-test-fixtures-sources.jar.sha256
            │       ├── com.ibm.wala.cast.java-1.6.1-20230304.220659-1-test-fixtures-sources.jar.sha512
            │       ├── maven-metadata.xml
            │       ├── maven-metadata.xml.md5
            │       ├── maven-metadata.xml.sha1
            │       ├── maven-metadata.xml.sha256
            │       └── maven-metadata.xml.sha512
            ├── com.ibm.wala.cast.java.ecj/
            │   ├── 1.6.1-SNAPSHOT/
            │   │   ├── com.ibm.wala.cast.java.ecj-1.6.1-20230304.220659-1.jar
            │   │   ├── com.ibm.wala.cast.java.ecj-1.6.1-20230304.220659-1.jar.md5
            │   │   ├── com.ibm.wala.cast.java.ecj-1.6.1-20230304.220659-1.jar.sha1
            │   │   ├── com.ibm.wala.cast.java.ecj-1.6.1-20230304.220659-1.jar.sha256
            │   │   ├── com.ibm.wala.cast.java.ecj-1.6.1-20230304.220659-1.jar.sha512
            │   │   ├── com.ibm.wala.cast.java.ecj-1.6.1-20230304.220659-1-javadoc.jar
            │   │   ├── com.ibm.wala.cast.java.ecj-1.6.1-20230304.220659-1-javadoc.jar.md5
            │   │   ├── com.ibm.wala.cast.java.ecj-1.6.1-20230304.220659-1-javadoc.jar.sha1
            │   │   ├── com.ibm.wala.cast.java.ecj-1.6.1-20230304.220659-1-javadoc.jar.sha256
            │   │   ├── com.ibm.wala.cast.java.ecj-1.6.1-20230304.220659-1-javadoc.jar.sha512
            │   │   ├── com.ibm.wala.cast.java.ecj-1.6.1-20230304.220659-1.module
            │   │   ├── com.ibm.wala.cast.java.ecj-1.6.1-20230304.220659-1.module.md5
            │   │   ├── com.ibm.wala.cast.java.ecj-1.6.1-20230304.220659-1.module.sha1
            │   │   ├── com.ibm.wala.cast.java.ecj-1.6.1-20230304.220659-1.module.sha256
            │   │   ├── com.ibm.wala.cast.java.ecj-1.6.1-20230304.220659-1.module.sha512
            │   │   ├── com.ibm.wala.cast.java.ecj-1.6.1-20230304.220659-1.pom
            │   │   ├── com.ibm.wala.cast.java.ecj-1.6.1-20230304.220659-1.pom.md5
            │   │   ├── com.ibm.wala.cast.java.ecj-1.6.1-20230304.220659-1.pom.sha1
            │   │   ├── com.ibm.wala.cast.java.ecj-1.6.1-20230304.220659-1.pom.sha256
            │   │   ├── com.ibm.wala.cast.java.ecj-1.6.1-20230304.220659-1.pom.sha512
            │   │   ├── com.ibm.wala.cast.java.ecj-1.6.1-20230304.220659-1-sources.jar
            │   │   ├── com.ibm.wala.cast.java.ecj-1.6.1-20230304.220659-1-sources.jar.md5
            │   │   ├── com.ibm.wala.cast.java.ecj-1.6.1-20230304.220659-1-sources.jar.sha1
            │   │   ├── com.ibm.wala.cast.java.ecj-1.6.1-20230304.220659-1-sources.jar.sha256
            │   │   ├── com.ibm.wala.cast.java.ecj-1.6.1-20230304.220659-1-sources.jar.sha512
            │   │   ├── maven-metadata.xml
            │   │   ├── maven-metadata.xml.md5
            │   │   ├── maven-metadata.xml.sha1
            │   │   ├── maven-metadata.xml.sha256
            │   │   └── maven-metadata.xml.sha512
            │   ├── maven-metadata.xml
            │   ├── maven-metadata.xml.md5
            │   ├── maven-metadata.xml.sha1
            │   ├── maven-metadata.xml.sha256
            │   ├── maven-metadata.xml.sha512
            │   ├── maven-metadata.xml
            │   ├── maven-metadata.xml.md5
            │   ├── maven-metadata.xml.sha1
            │   ├── maven-metadata.xml.sha256
            │   └── maven-metadata.xml.sha512
            ├── com.ibm.wala.cast.js/
            │   ├── 1.6.1-SNAPSHOT/
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1.jar
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1.jar.md5
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1.jar.sha1
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1.jar.sha256
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1.jar.sha512
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1-javadoc.jar
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1-javadoc.jar.md5
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1-javadoc.jar.sha1
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1-javadoc.jar.sha256
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1-javadoc.jar.sha512
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1.module
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1.module.md5
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1.module.sha1
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1.module.sha256
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1.module.sha512
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1.pom
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1.pom.md5
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1.pom.sha1
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1.pom.sha256
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1.pom.sha512
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1-sources.jar
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1-sources.jar.md5
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1-sources.jar.sha1
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1-sources.jar.sha256
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1-sources.jar.sha512
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1-test-fixtures.jar
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1-test-fixtures.jar.md5
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1-test-fixtures.jar.sha1
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1-test-fixtures.jar.sha256
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1-test-fixtures.jar.sha512
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1-test-fixtures-javadoc.jar
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1-test-fixtures-javadoc.jar.md5
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1-test-fixtures-javadoc.jar.sha1
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1-test-fixtures-javadoc.jar.sha256
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1-test-fixtures-javadoc.jar.sha512
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1-test-fixtures-sources.jar
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1-test-fixtures-sources.jar.md5
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1-test-fixtures-sources.jar.sha1
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1-test-fixtures-sources.jar.sha256
            │   │   ├── com.ibm.wala.cast.js-1.6.1-20230304.220659-1-test-fixtures-sources.jar.sha512
            │   │   ├── maven-metadata.xml
            │   │   ├── maven-metadata.xml.md5
            │   │   ├── maven-metadata.xml.sha1
            │   │   ├── maven-metadata.xml.sha256
            │   │   └── maven-metadata.xml.sha512
            │   ├── maven-metadata.xml
            │   ├── maven-metadata.xml.md5
            │   ├── maven-metadata.xml.sha1
            │   ├── maven-metadata.xml.sha256
            │   └── maven-metadata.xml.sha512
            ├── com.ibm.wala.cast.js.rhino/
            │   ├── 1.6.1-SNAPSHOT/
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1.jar
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1.jar.md5
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1.jar.sha1
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1.jar.sha256
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1.jar.sha512
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1-javadoc.jar
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1-javadoc.jar.md5
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1-javadoc.jar.sha1
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1-javadoc.jar.sha256
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1-javadoc.jar.sha512
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1.module
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1.module.md5
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1.module.sha1
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1.module.sha256
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1.module.sha512
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1.pom
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1.pom.md5
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1.pom.sha1
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1.pom.sha256
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1.pom.sha512
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1-sources.jar
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1-sources.jar.md5
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1-sources.jar.sha1
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1-sources.jar.sha256
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1-sources.jar.sha512
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1-test-fixtures.jar
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1-test-fixtures.jar.md5
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1-test-fixtures.jar.sha1
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1-test-fixtures.jar.sha256
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1-test-fixtures.jar.sha512
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1-test-fixtures-javadoc.jar
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1-test-fixtures-javadoc.jar.md5
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1-test-fixtures-javadoc.jar.sha1
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1-test-fixtures-javadoc.jar.sha256
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1-test-fixtures-javadoc.jar.sha512
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1-test-fixtures-sources.jar
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1-test-fixtures-sources.jar.md5
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1-test-fixtures-sources.jar.sha1
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1-test-fixtures-sources.jar.sha256
            │   │   ├── com.ibm.wala.cast.js.rhino-1.6.1-20230304.220659-1-test-fixtures-sources.jar.sha512
            │   │   ├── maven-metadata.xml
            │   │   ├── maven-metadata.xml.md5
            │   │   ├── maven-metadata.xml.sha1
            │   │   ├── maven-metadata.xml.sha256
            │   │   └── maven-metadata.xml.sha512
            │   ├── maven-metadata.xml
            │   ├── maven-metadata.xml.md5
            │   ├── maven-metadata.xml.sha1
            │   ├── maven-metadata.xml.sha256
            │   ├── maven-metadata.xml.sha512
            │   ├── maven-metadata.xml
            │   ├── maven-metadata.xml.md5
            │   ├── maven-metadata.xml.sha1
            │   ├── maven-metadata.xml.sha256
            │   └── maven-metadata.xml.sha512
            ├── com.ibm.wala.core/
            │   ├── 1.6.1-SNAPSHOT/
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1.jar
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1.jar.md5
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1.jar.sha1
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1.jar.sha256
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1.jar.sha512
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1-javadoc.jar
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1-javadoc.jar.md5
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1-javadoc.jar.sha1
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1-javadoc.jar.sha256
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1-javadoc.jar.sha512
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1.module
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1.module.md5
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1.module.sha1
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1.module.sha256
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1.module.sha512
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1.pom
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1.pom.md5
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1.pom.sha1
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1.pom.sha256
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1.pom.sha512
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1-sources.jar
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1-sources.jar.md5
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1-sources.jar.sha1
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1-sources.jar.sha256
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1-sources.jar.sha512
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1-test-fixtures.jar
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1-test-fixtures.jar.md5
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1-test-fixtures.jar.sha1
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1-test-fixtures.jar.sha256
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1-test-fixtures.jar.sha512
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1-test-fixtures-javadoc.jar
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1-test-fixtures-javadoc.jar.md5
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1-test-fixtures-javadoc.jar.sha1
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1-test-fixtures-javadoc.jar.sha256
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1-test-fixtures-javadoc.jar.sha512
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1-test-fixtures-sources.jar
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1-test-fixtures-sources.jar.md5
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1-test-fixtures-sources.jar.sha1
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1-test-fixtures-sources.jar.sha256
            │   │   ├── com.ibm.wala.core-1.6.1-20230304.220659-1-test-fixtures-sources.jar.sha512
            │   │   ├── maven-metadata.xml
            │   │   ├── maven-metadata.xml.md5
            │   │   ├── maven-metadata.xml.sha1
            │   │   ├── maven-metadata.xml.sha256
            │   │   └── maven-metadata.xml.sha512
            │   ├── maven-metadata.xml
            │   ├── maven-metadata.xml.md5
            │   ├── maven-metadata.xml.sha1
            │   ├── maven-metadata.xml.sha256
            │   └── maven-metadata.xml.sha512
            ├── com.ibm.wala.dalvik/
            │   ├── 1.6.1-SNAPSHOT/
            │   │   ├── com.ibm.wala.dalvik-1.6.1-20230304.220659-1.jar
            │   │   ├── com.ibm.wala.dalvik-1.6.1-20230304.220659-1.jar.md5
            │   │   ├── com.ibm.wala.dalvik-1.6.1-20230304.220659-1.jar.sha1
            │   │   ├── com.ibm.wala.dalvik-1.6.1-20230304.220659-1.jar.sha256
            │   │   ├── com.ibm.wala.dalvik-1.6.1-20230304.220659-1.jar.sha512
            │   │   ├── com.ibm.wala.dalvik-1.6.1-20230304.220659-1-javadoc.jar
            │   │   ├── com.ibm.wala.dalvik-1.6.1-20230304.220659-1-javadoc.jar.md5
            │   │   ├── com.ibm.wala.dalvik-1.6.1-20230304.220659-1-javadoc.jar.sha1
            │   │   ├── com.ibm.wala.dalvik-1.6.1-20230304.220659-1-javadoc.jar.sha256
            │   │   ├── com.ibm.wala.dalvik-1.6.1-20230304.220659-1-javadoc.jar.sha512
            │   │   ├── com.ibm.wala.dalvik-1.6.1-20230304.220659-1.module
            │   │   ├── com.ibm.wala.dalvik-1.6.1-20230304.220659-1.module.md5
            │   │   ├── com.ibm.wala.dalvik-1.6.1-20230304.220659-1.module.sha1
            │   │   ├── com.ibm.wala.dalvik-1.6.1-20230304.220659-1.module.sha256
            │   │   ├── com.ibm.wala.dalvik-1.6.1-20230304.220659-1.module.sha512
            │   │   ├── com.ibm.wala.dalvik-1.6.1-20230304.220659-1.pom
            │   │   ├── com.ibm.wala.dalvik-1.6.1-20230304.220659-1.pom.md5
            │   │   ├── com.ibm.wala.dalvik-1.6.1-20230304.220659-1.pom.sha1
            │   │   ├── com.ibm.wala.dalvik-1.6.1-20230304.220659-1.pom.sha256
            │   │   ├── com.ibm.wala.dalvik-1.6.1-20230304.220659-1.pom.sha512
            │   │   ├── com.ibm.wala.dalvik-1.6.1-20230304.220659-1-sources.jar
            │   │   ├── com.ibm.wala.dalvik-1.6.1-20230304.220659-1-sources.jar.md5
            │   │   ├── com.ibm.wala.dalvik-1.6.1-20230304.220659-1-sources.jar.sha1
            │   │   ├── com.ibm.wala.dalvik-1.6.1-20230304.220659-1-sources.jar.sha256
            │   │   ├── com.ibm.wala.dalvik-1.6.1-20230304.220659-1-sources.jar.sha512
            │   │   ├── maven-metadata.xml
            │   │   ├── maven-metadata.xml.md5
            │   │   ├── maven-metadata.xml.sha1
            │   │   ├── maven-metadata.xml.sha256
            │   │   └── maven-metadata.xml.sha512
            │   ├── maven-metadata.xml
            │   ├── maven-metadata.xml.md5
            │   ├── maven-metadata.xml.sha1
            │   ├── maven-metadata.xml.sha256
            │   └── maven-metadata.xml.sha512
            ├── com.ibm.wala.scandroid/
            │   ├── 1.6.1-SNAPSHOT/
            │   │   ├── com.ibm.wala.scandroid-1.6.1-20230304.220659-1.jar
            │   │   ├── com.ibm.wala.scandroid-1.6.1-20230304.220659-1.jar.md5
            │   │   ├── com.ibm.wala.scandroid-1.6.1-20230304.220659-1.jar.sha1
            │   │   ├── com.ibm.wala.scandroid-1.6.1-20230304.220659-1.jar.sha256
            │   │   ├── com.ibm.wala.scandroid-1.6.1-20230304.220659-1.jar.sha512
            │   │   ├── com.ibm.wala.scandroid-1.6.1-20230304.220659-1-javadoc.jar
            │   │   ├── com.ibm.wala.scandroid-1.6.1-20230304.220659-1-javadoc.jar.md5
            │   │   ├── com.ibm.wala.scandroid-1.6.1-20230304.220659-1-javadoc.jar.sha1
            │   │   ├── com.ibm.wala.scandroid-1.6.1-20230304.220659-1-javadoc.jar.sha256
            │   │   ├── com.ibm.wala.scandroid-1.6.1-20230304.220659-1-javadoc.jar.sha512
            │   │   ├── com.ibm.wala.scandroid-1.6.1-20230304.220659-1.module
            │   │   ├── com.ibm.wala.scandroid-1.6.1-20230304.220659-1.module.md5
            │   │   ├── com.ibm.wala.scandroid-1.6.1-20230304.220659-1.module.sha1
            │   │   ├── com.ibm.wala.scandroid-1.6.1-20230304.220659-1.module.sha256
            │   │   ├── com.ibm.wala.scandroid-1.6.1-20230304.220659-1.module.sha512
            │   │   ├── com.ibm.wala.scandroid-1.6.1-20230304.220659-1.pom
            │   │   ├── com.ibm.wala.scandroid-1.6.1-20230304.220659-1.pom.md5
            │   │   ├── com.ibm.wala.scandroid-1.6.1-20230304.220659-1.pom.sha1
            │   │   ├── com.ibm.wala.scandroid-1.6.1-20230304.220659-1.pom.sha256
            │   │   ├── com.ibm.wala.scandroid-1.6.1-20230304.220659-1.pom.sha512
            │   │   ├── com.ibm.wala.scandroid-1.6.1-20230304.220659-1-sources.jar
            │   │   ├── com.ibm.wala.scandroid-1.6.1-20230304.220659-1-sources.jar.md5
            │   │   ├── com.ibm.wala.scandroid-1.6.1-20230304.220659-1-sources.jar.sha1
            │   │   ├── com.ibm.wala.scandroid-1.6.1-20230304.220659-1-sources.jar.sha256
            │   │   ├── com.ibm.wala.scandroid-1.6.1-20230304.220659-1-sources.jar.sha512
            │   │   ├── maven-metadata.xml
            │   │   ├── maven-metadata.xml.md5
            │   │   ├── maven-metadata.xml.sha1
            │   │   ├── maven-metadata.xml.sha256
            │   │   └── maven-metadata.xml.sha512
            │   ├── maven-metadata.xml
            │   ├── maven-metadata.xml.md5
            │   ├── maven-metadata.xml.sha1
            │   ├── maven-metadata.xml.sha256
            │   └── maven-metadata.xml.sha512
            ├── com.ibm.wala.shrike/
            │   ├── 1.6.1-SNAPSHOT/
            │   │   ├── com.ibm.wala.shrike-1.6.1-20230304.220659-1.jar
            │   │   ├── com.ibm.wala.shrike-1.6.1-20230304.220659-1.jar.md5
            │   │   ├── com.ibm.wala.shrike-1.6.1-20230304.220659-1.jar.sha1
            │   │   ├── com.ibm.wala.shrike-1.6.1-20230304.220659-1.jar.sha256
            │   │   ├── com.ibm.wala.shrike-1.6.1-20230304.220659-1.jar.sha512
            │   │   ├── com.ibm.wala.shrike-1.6.1-20230304.220659-1-javadoc.jar
            │   │   ├── com.ibm.wala.shrike-1.6.1-20230304.220659-1-javadoc.jar.md5
            │   │   ├── com.ibm.wala.shrike-1.6.1-20230304.220659-1-javadoc.jar.sha1
            │   │   ├── com.ibm.wala.shrike-1.6.1-20230304.220659-1-javadoc.jar.sha256
            │   │   ├── com.ibm.wala.shrike-1.6.1-20230304.220659-1-javadoc.jar.sha512
            │   │   ├── com.ibm.wala.shrike-1.6.1-20230304.220659-1.module
            │   │   ├── com.ibm.wala.shrike-1.6.1-20230304.220659-1.module.md5
            │   │   ├── com.ibm.wala.shrike-1.6.1-20230304.220659-1.module.sha1
            │   │   ├── com.ibm.wala.shrike-1.6.1-20230304.220659-1.module.sha256
            │   │   ├── com.ibm.wala.shrike-1.6.1-20230304.220659-1.module.sha512
            │   │   ├── com.ibm.wala.shrike-1.6.1-20230304.220659-1.pom
            │   │   ├── com.ibm.wala.shrike-1.6.1-20230304.220659-1.pom.md5
            │   │   ├── com.ibm.wala.shrike-1.6.1-20230304.220659-1.pom.sha1
            │   │   ├── com.ibm.wala.shrike-1.6.1-20230304.220659-1.pom.sha256
            │   │   ├── com.ibm.wala.shrike-1.6.1-20230304.220659-1.pom.sha512
            │   │   ├── com.ibm.wala.shrike-1.6.1-20230304.220659-1-sources.jar
            │   │   ├── com.ibm.wala.shrike-1.6.1-20230304.220659-1-sources.jar.md5
            │   │   ├── com.ibm.wala.shrike-1.6.1-20230304.220659-1-sources.jar.sha1
            │   │   ├── com.ibm.wala.shrike-1.6.1-20230304.220659-1-sources.jar.sha256
            │   │   ├── com.ibm.wala.shrike-1.6.1-20230304.220659-1-sources.jar.sha512
            │   │   ├── maven-metadata.xml
            │   │   ├── maven-metadata.xml.md5
            │   │   ├── maven-metadata.xml.sha1
            │   │   ├── maven-metadata.xml.sha256
            │   │   └── maven-metadata.xml.sha512
            │   ├── maven-metadata.xml
            │   ├── maven-metadata.xml.md5
            │   ├── maven-metadata.xml.sha1
            │   ├── maven-metadata.xml.sha256
            │   └── maven-metadata.xml.sha512
            └── com.ibm.wala.util/
                ├── 1.6.1-SNAPSHOT/
                │   ├── com.ibm.wala.util-1.6.1-20230304.220659-1.jar
                │   ├── com.ibm.wala.util-1.6.1-20230304.220659-1.jar.md5
                │   ├── com.ibm.wala.util-1.6.1-20230304.220659-1.jar.sha1
                │   ├── com.ibm.wala.util-1.6.1-20230304.220659-1.jar.sha256
                │   ├── com.ibm.wala.util-1.6.1-20230304.220659-1.jar.sha512
                │   ├── com.ibm.wala.util-1.6.1-20230304.220659-1-javadoc.jar
                │   ├── com.ibm.wala.util-1.6.1-20230304.220659-1-javadoc.jar.md5
                │   ├── com.ibm.wala.util-1.6.1-20230304.220659-1-javadoc.jar.sha1
                │   ├── com.ibm.wala.util-1.6.1-20230304.220659-1-javadoc.jar.sha256
                │   ├── com.ibm.wala.util-1.6.1-20230304.220659-1-javadoc.jar.sha512
                │   ├── com.ibm.wala.util-1.6.1-20230304.220659-1.module
                │   ├── com.ibm.wala.util-1.6.1-20230304.220659-1.module.md5
                │   ├── com.ibm.wala.util-1.6.1-20230304.220659-1.module.sha1
                │   ├── com.ibm.wala.util-1.6.1-20230304.220659-1.module.sha256
                │   ├── com.ibm.wala.util-1.6.1-20230304.220659-1.module.sha512
                │   ├── com.ibm.wala.util-1.6.1-20230304.220659-1.pom
                │   ├── com.ibm.wala.util-1.6.1-20230304.220659-1.pom.md5
                │   ├── com.ibm.wala.util-1.6.1-20230304.220659-1.pom.sha1
                │   ├── com.ibm.wala.util-1.6.1-20230304.220659-1.pom.sha256
                │   ├── com.ibm.wala.util-1.6.1-20230304.220659-1.pom.sha512
                │   ├── com.ibm.wala.util-1.6.1-20230304.220659-1-sources.jar
                │   ├── com.ibm.wala.util-1.6.1-20230304.220659-1-sources.jar.md5
                │   ├── com.ibm.wala.util-1.6.1-20230304.220659-1-sources.jar.sha1
                │   ├── com.ibm.wala.util-1.6.1-20230304.220659-1-sources.jar.sha256
                │   ├── com.ibm.wala.util-1.6.1-20230304.220659-1-sources.jar.sha512
                │   ├── maven-metadata.xml
                │   ├── maven-metadata.xml.md5
                │   ├── maven-metadata.xml.sha1
                │   ├── maven-metadata.xml.sha256
                │   └── maven-metadata.xml.sha512
                ├── maven-metadata.xml
                ├── maven-metadata.xml.md5
                ├── maven-metadata.xml.sha1
                ├── maven-metadata.xml.sha256
                └── maven-metadata.xml.sha512
```

That looks correct to me.

Fixes #1248.