### PR TITLE
Tidy up Markdown and add `mdl` configuration

### DIFF
--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,1 @@
+style "markdownlint-wala.rb"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,55 +1,89 @@
 Contributing to WALA
 ====================
 
-WALA welcomes contributions of all kinds and sizes. This includes everything from from simple bug reports to large features.
+WALA welcomes contributions of all kinds and sizes. This includes
+everything from simple bug reports to large features.
 
 Workflow
 --------
 
 We love GitHub issues!
 
-For small feature requests, an issue first proposing it for discussion or demo implementation in a PR suffice.
+For small feature requests, an issue first proposing it for discussion
+or demo implementation in a PR suffice.
 
-For big features, please open an issue so that we can agree on the direction, and hopefully avoid investing a lot of time on a feature that might need reworking.
+For big features, please open an issue so that we can agree on the
+direction, and hopefully avoid investing a lot of time on a feature
+that might need reworking.
 
 Small pull requests for things like typos, bug fixes, etc are always welcome.
 
 Additional Checks
 -----------------
 
-Beyond tests, other checks run as part of `./gradlew check` and `./gradlew build`, including:
+Beyond tests, other checks run as part of `./gradlew check` and
+`./gradlew build`, including:
 
-1. Compilation with the Java compiler from [Eclipse JDT Core](https://www.eclipse.org/jdt/core/),
-which runs additional lint checks
-2. Checking that all Java and Kotlin code is formatted according to [Google Java
-   Format](https://github.com/google/google-java-format) and
-   [ktfmt](https://facebook.github.io/ktfmt/) standards, respectively.
+1. Compilation with the Java compiler from [Eclipse JDT
+   Core](https://www.eclipse.org/jdt/core/), which runs additional
+   lint checks
 
-If your code fails check 2, you can run `./gradlew spotlessApply` to automatically format
-it.  The CI job runs `./gradlew build` and will fail if any of these additional
-checks fail.
+1. Checking that all Java and Kotlin code is formatted according to
+   [Google Java Format](https://github.com/google/google-java-format)
+   and [ktfmt](https://facebook.github.io/ktfmt/) standards,
+   respectively.
 
+If your code fails check 2, you can run `./gradlew spotlessApply` to
+automatically format it.  The CI job runs `./gradlew build` and will
+fail if any of these additional checks fail.
 
 DOs and DON'Ts
 --------------
 
 * DO format your Java and Kotlin code using [Google Java
   Format](https://github.com/google/google-java-format) and
-  [ktfmt](https://facebook.github.io/ktfmt/), respectively.  A CI job will fail if your code is not
-  formatted in this way.
-* DO include tests when adding new features. When fixing bugs, start with adding a test that highlights how the current behavior is broken.
-* DO keep the discussions focused. When a new or related topic comes up it's often better to create new issue than to side track the discussion.
+  [ktfmt](https://facebook.github.io/ktfmt/), respectively.  A CI job
+  will fail if your code is not formatted in this way.
+
+* DO include tests when adding new features. When fixing bugs, start
+  with adding a test that highlights how the current behavior is
+  broken.
+
+* DO keep the discussions focused. When a new or related topic comes
+  up it's often better to create new issue than to side track the
+  discussion.
+
 * DO make liberal use of Javadoc and comments to document code.
-* DO use the `com.ibm.wala.util.debug.Assertions` class liberally. All calls to `assert()` must be guarded by `Assertions.verifyAssertions`. Use the `productionAssert` entrypoints for assertions that should be enabled in production, and thus not guarded.
-* DO make code deterministic.  Construct `HashMap`s and `HashSet`s using `com.ibm.wala.util.collections.HashMapFactory.make()` and ``com.ibm.wala.util.collections.HashSetFactory.make()` respectively.  Avoid use of `System.identityHashCode()` and finalizers.  
 
-* DON'T write to `System.out` or `System.err`. Use the `com.ibm.wala.util.debug.Trace` facility to write debugging and trace messages.
-* DON'T submit PRs that alter licensing related files or headers. If you believe there's a problem with them, file an issue and we'll be happy to discuss it.
+* DO use the `com.ibm.wala.util.debug.Assertions` class liberally. All
+  calls to `assert()` must be guarded by
+  `Assertions.verifyAssertions`. Use the `productionAssert`
+  entrypoints for assertions that should be enabled in production, and
+  thus not guarded.
 
+* DO make code deterministic.  Construct `HashMap`s and `HashSet`s
+  using `com.ibm.wala.util.collections.HashMapFactory.make()` and
+  `com.ibm.wala.util.collections.HashSetFactory.make()` respectively.
+  Avoid use of `System.identityHashCode()` and finalizers.
+
+* DON'T write to `System.out` or `System.err`. Use the
+  `com.ibm.wala.util.debug.Trace` facility to write debugging and
+  trace messages.
+
+* DON'T submit PRs that alter licensing related files or headers. If
+  you believe there's a problem with them, file an issue and we'll be
+  happy to discuss it.
 
 Guiding Principles
 ------------------
 
-* We allow anyone to participate in our projects. Tasks can be carried out by anyone that demonstrates the capability to complete them.
-* Always be respectful of one another. Assume the best in others and act with empathy at all times
-* Collaborate closely with individuals maintaining the project or experienced users. Getting ideas out in the open and seeing a proposal before it's a pull request helps reduce redundancy and ensures we're all connected to the decision making process
+* We allow anyone to participate in our projects. Tasks can be carried
+  out by anyone that demonstrates the capability to complete them.
+
+* Always be respectful of one another. Assume the best in others and
+  act with empathy at all times
+
+* Collaborate closely with individuals maintaining the project or
+  experienced users. Getting ideas out in the open and seeing a
+  proposal before it's a pull request helps reduce redundancy and
+  ensures we're all connected to the decision making process

--- a/README-Gradle.md
+++ b/README-Gradle.md
@@ -38,9 +38,14 @@ to import WALA into Eclipse.** Select and import the topmost level of
 your WALA source tree.  On the “Import Options” page of the import
 wizard, leave all settings at their defaults: the “Override workspace
 settings” option should be off, and the grayed-out “Gradle
-distribution” choice should be set to “Gradle wrapper”.  It is also recommended that you clear the "Gradle user home" dialog box in the **Gradle Preferences** (not the one in the import wizard) prior to importing ([one issue](https://github.com/wala/WALA/issues/731#issuecomment-604465043) was resolved this way). You do not
-need to select each of WALA’s sub-projects; import only the top-level
-WALA source tree, and the rest will follow.
+distribution” choice should be set to “Gradle wrapper”.  It is also
+recommended that you clear the "Gradle user home" dialog box in the
+**Gradle Preferences** (not the one in the import wizard) prior to
+importing ([one
+issue](https://github.com/wala/WALA/issues/731#issuecomment-604465043)
+was resolved this way). You do not need to select each of WALA’s
+sub-projects; import only the top-level WALA source tree, and the rest
+will follow.
 
 The first time you import the WALA project, Eclipse will synchronize
 its project model with the Gradle build configuration, including

--- a/README.md
+++ b/README.md
@@ -1,10 +1,22 @@
 ![WALA logo](http://wala.sourceforge.net/wiki/images/9/94/WALA-banner.png)
 
-[![GitHub Actions status](https://github.com/wala/WALA/workflows/Continuous%20integration/badge.svg)](https://github.com/wala/WALA/actions?query=workflow%3A%22Continuous+integration%22) [![Join the chat at https://gitter.im/WALAHelp/Lobby](https://badges.gitter.im/WALAHelp/Lobby.svg)](https://gitter.im/WALAHelp/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![GitHub Actions
+status](https://github.com/wala/WALA/workflows/Continuous%20integration/badge.svg)](https://github.com/wala/WALA/actions?query=workflow%3A%22Continuous+integration%22)
+[![Join the chat at
+https://gitter.im/WALAHelp/Lobby](https://badges.gitter.im/WALAHelp/Lobby.svg)](https://gitter.im/WALAHelp/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 -------------------------
 
-The T. J. Watson Libraries for Analysis (WALA) provide static analysis capabilities for Java bytecode and related languages and for JavaScript. The system is licensed under the [Eclipse Public License](http://www.eclipse.org/legal/epl-v10.html), which has been approved by the [OSI](http://www.opensource.org/) (Open Source Initiative) as a fully certified open source license. The initial WALA infrastructure was independently developed as part of the DOMO research project at the [IBM T.J. Watson Research Center](http://www.research.ibm.com/). In 2006, [IBM](http://www.ibm.com/us/) donated the software to the community.
+The T. J. Watson Libraries for Analysis (WALA) provide static analysis
+capabilities for Java bytecode and related languages and for
+JavaScript. The system is licensed under the [Eclipse Public
+License](http://www.eclipse.org/legal/epl-v10.html), which has been
+approved by the [OSI](http://www.opensource.org/) (Open Source
+Initiative) as a fully certified open source license. The initial WALA
+infrastructure was independently developed as part of the DOMO
+research project at the [IBM T.J. Watson Research
+Center](http://www.research.ibm.com/). In 2006,
+[IBM](http://www.ibm.com/us/) donated the software to the community.
 
 For recent updates on WALA, join the [mailing list](http://sourceforge.net/p/wala/mailman/).
 
@@ -14,7 +26,8 @@ WALA features include:
 
 * Java type system and class hierarchy analysis
 * Source language framework supporting Java and JavaScript
-* Interprocedural dataflow analysis ([RHS](http://www.cs.wisc.edu/~reps/#popl95) solver)
+* Interprocedural dataflow analysis
+  ([RHS](http://www.cs.wisc.edu/~reps/#popl95) solver)
 * Context-sensitive tabulation-based slicer
 * Pointer analysis and call graph construction
 * SSA-based register-transfer language IR
@@ -24,35 +37,71 @@ WALA features include:
 
 ## Getting Started
 
-The fastest way to get started with WALA is to use the packages in Maven Central, as noted [here](https://github.com/wala/WALA/wiki/Getting-Started#quick-start-using-maven-central-packages).  See the [WALA-start](https://github.com/wala/WALA-start) repo for a Gradle-based example.  We are actively re-organizing the deeper wiki technical documentation.  In the meantime, you can check out tutorial slides to get an overview of WALA:
+The fastest way to get started with WALA is to use the packages in
+Maven Central, as noted
+[here](https://github.com/wala/WALA/wiki/Getting-Started#quick-start-using-maven-central-packages).
+See the [WALA-start](https://github.com/wala/WALA-start) repo for a
+Gradle-based example.  We are actively re-organizing the deeper wiki
+technical documentation.  In the meantime, you can check out tutorial
+slides to get an overview of WALA:
 
 * [Core WALA](http://wala.sourceforge.net/files/PLDI_WALA_Tutorial.pdf) (PDF)
-* [WALA JavaScript](http://wala.sourceforge.net/files/WALAJavaScriptTutorial.pdf) (PDF)
+* [WALA
+  JavaScript](http://wala.sourceforge.net/files/WALAJavaScriptTutorial.pdf)
+  (PDF)
 
 You can also watch screencasts of the WALA JavaScript tutorial [here](https://www.youtube.com/user/WALALibraries/videos).
 
-Finally, for now, to search the wiki documentation, we recommend a site-specific search on Google, e.g., [a search for "call graph"](https://www.google.com/search?q=call+graph+site%3Ahttps%3A%2F%2Fgithub.com%2Fwala%2FWALA%2Fwiki&oq=call+graph+site%3Ahttps%3A%2F%2Fgithub.com%2Fwala%2FWALA%2Fwiki).
+Finally, for now, to search the wiki documentation, we recommend a
+site-specific search on Google, e.g., [a search for "call
+graph"](https://www.google.com/search?q=call+graph+site%3Ahttps%3A%2F%2Fgithub.com%2Fwala%2FWALA%2Fwiki&oq=call+graph+site%3Ahttps%3A%2F%2Fgithub.com%2Fwala%2FWALA%2Fwiki).
 
 ## Documentation
 
-We're hosting documentation for WALA on [the GitHub wiki](https://github.com/wala/WALA/wiki).  **We've chosen a wiki format just so that _you_ can contribute.** Don't be shy!
+We're hosting documentation for WALA on [the GitHub
+wiki](https://github.com/wala/WALA/wiki).  **We've chosen a wiki
+format just so that _you_ can contribute.** Don't be shy!
 
-The WALA publications department is populating this wiki with technical documentation on a demand-driven basis, driven by questions posted to the [wala-wala](http://sourceforge.net/p/wala/mailman/) mailing list and also [Gitter](https://gitter.im/WALAHelp/Lobby). We recommend [this page](https://groups.google.com/forum/#!forum/wala-sourceforge-net) for searching the mailing list archives.
+The WALA publications department is populating this wiki with
+technical documentation on a demand-driven basis, driven by questions
+posted to the [wala-wala](http://sourceforge.net/p/wala/mailman/)
+mailing list and also [Gitter](https://gitter.im/WALAHelp/Lobby). We
+recommend [this
+page](https://groups.google.com/forum/#!forum/wala-sourceforge-net)
+for searching the mailing list archives.
 
-Currently, we have the [JavaDoc documentation for the WALA code](https://wala.github.io/javadoc) being updated continuously. If you think a particular file deserves better javadoc, please [open a feature request](https://github.com/wala/WALA/issues).
+Currently, we have the [JavaDoc documentation for the WALA
+code](https://wala.github.io/javadoc) being updated continuously. If
+you think a particular file deserves better javadoc, please [open a
+feature request](https://github.com/wala/WALA/issues).
 
 ## Getting Help
 
-To get help with WALA, please either [email the mailing list](http://sourceforge.net/p/wala/mailman/), [ask a question on Gitter](https://gitter.im/WALAHelp/Lobby), or [open an issue](https://github.com/wala/WALA/issues).
+To get help with WALA, please either [email the mailing
+list](http://sourceforge.net/p/wala/mailman/), [ask a question on
+Gitter](https://gitter.im/WALAHelp/Lobby), or [open an
+issue](https://github.com/wala/WALA/issues).
 
 ## Building from Source
 
-WALA uses Gradle as its build system.  If you intend to modify or build WALA yourself, then see [the Gradle-specific README](README-Gradle.md) for more instructions and helpful tips.
+WALA uses Gradle as its build system.  If you intend to modify or
+build WALA yourself, then see [the Gradle-specific
+README](README-Gradle.md) for more instructions and helpful tips.
 
 ## WALA Tools in JavaScript
 
-Recently, we have been expanding the set of WALA tools implemented in JavaScript. We have released a normalizer and some basic program analyses for JavaScript in the [JS_WALA GitHub repository](https://github.com/wala/JS_WALA). We have also made available [jsdelta](https://github.com/wala/jsdelta) and [WALA Delta](https://github.com/wala/WALADelta), delta debuggers for JavaScript-processing tools. Please see the linked GitHub repositories for further details on these tools.
+Recently, we have been expanding the set of WALA tools implemented in
+JavaScript. We have released a normalizer and some basic program
+analyses for JavaScript in the [JS_WALA GitHub
+repository](https://github.com/wala/JS_WALA). We have also made
+available [jsdelta](https://github.com/wala/jsdelta) and [WALA
+Delta](https://github.com/wala/WALADelta), delta debuggers for
+JavaScript-processing tools. Please see the linked GitHub repositories
+for further details on these tools.
 
 ## WALA-Based Tools
 
-Several groups have built open-source tools that enhance or build on WALA that may be useful to other WALA users. For details, see the [Wala-based tools](https://github.com/wala/WALA/wiki/WALA-Based-Tools) page.
+Several groups have built open-source tools that enhance or build on
+WALA that may be useful to other WALA users. For details, see the
+[Wala-based tools](https://github.com/wala/WALA/wiki/WALA-Based-Tools)
+page.

--- a/markdownlint-wala.rb
+++ b/markdownlint-wala.rb
@@ -1,0 +1,3 @@
+all
+exclude_rule 'MD002'
+exclude_rule 'MD041'


### PR DESCRIPTION
The `mdl` configuration describes how WALA's use of Markdown differs from the default style that `mdl` checks.  Specifically, we disable the following rules:

* [MD002](https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md002---first-header-should-be-a-top-level-header): First header should be a top level header
* [MD041](https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md041---first-line-in-file-should-be-a-top-level-header): First line in file should be a top level header

Nothing actually runs `mdl` to validate Markdown during a standard build.  I'd like to do that, but doing so would add nontrivial extra dependencies, given that `mdl` is written in Ruby.