### PR TITLE
Add IntelliJ IDEA run configuration for testing configuration cache

### DIFF
--- a/.idea/runConfigurations/Build_with_configuration_cache.xml
+++ b/.idea/runConfigurations/Build_with_configuration_cache.xml
@@ -1,0 +1,26 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Build with configuration cache" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="-PexcludeSlowTests --continue --exclude-task=:cast:java:ecj:signMavenPublication --exclude-task=:cast:java:signMavenPublication --exclude-task=:cast:js:rhino:signMavenPublication --exclude-task=:cast:js:signMavenPublication --exclude-task=:cast:cast:compileDebugCpp --exclude-task=:cast:cast:compileReleaseCpp --exclude-task=:cast:cast:stripSymbolsRelease --exclude-task=:cast:signMavenPublication --exclude-task=:cast:smoke_main:checkSmokeMain --exclude-task=:cast:smoke_main:compileDebugCpp --exclude-task=:cast:smoke_main:compileReleaseCpp --exclude-task=:cast:smoke_main:stripSymbolsRelease --exclude-task=:cast:test --exclude-task=:cast:xlator_test:compileDebugCpp --exclude-task=:cast:xlator_test:compileReleaseCpp --exclude-task=:cast:xlator_test:stripSymbolsRelease --exclude-task=:core:signMavenPublication --exclude-task=:dalvik:signMavenPublication --exclude-task=:scandroid:signMavenPublication --exclude-task=:shrike:signMavenPublication --exclude-task=:util:signMavenPublication" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="aggregatedJavadocs" />
+          <option value="build" />
+          <option value="publishAllPublicationsToFakeRemoteRepository" />
+          <option value="shellcheck" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
This new "Build with configuration cache" run configuration performs the same Gradle tasks as our GitHub Actions CI job when run on Ubuntu, except that:

1. it excludes slow tests, and

1. it excludes tasks relating to native code and code signing that we already know are not compatible with the Gradle configuration cache.

This run configuration can be useful for identifying other configuration-cache problems that we still need to work on.

Noe that this run configuration is not actually used by any GitHub Actions CI job.  It's only here to be run manually, in an interactive IntelliJ IDEA session.