### PR TITLE
Fix :ide:tests:runIFDSExplorerExample

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -305,7 +305,7 @@ val collectTestData by
 
 val collectTestDataJar: Configuration by configurations.creating { isCanBeResolved = false }
 
-artifacts.add(collectTestDataJar.name, collectTestData)
+artifacts.add(collectTestDataJar.name, collectTestData.map { it.destinationDirectory })
 
 ////////////////////////////////////////////////////////////////////////
 //

--- a/ide/tests/build.gradle.kts
+++ b/ide/tests/build.gradle.kts
@@ -38,10 +38,19 @@ val coreMainSource: Configuration by
       }
     }
 
+val ifdsExplorerExampleClasspath: Configuration by
+    configurations.creating {
+      isCanBeConsumed = false
+      isTransitive = false
+    }
+
 dependencies {
   coreMainSource(project(mapOf("path" to ":core")))
   coreTestDataJar(projects.core)
   coreTestResources(project(mapOf("path" to ":core", "configuration" to "testResources")))
+  ifdsExplorerExampleClasspath(sourceSets.test.map { it.runtimeClasspath })
+  ifdsExplorerExampleClasspath(
+      project(mapOf("path" to ":core", "configuration" to "collectTestDataJar")))
   testImplementation(libs.junit)
   testImplementation(projects.core)
   testImplementation(projects.ide)
@@ -81,7 +90,7 @@ tasks.named<Copy>("processTestResources") {
 tasks.register<JavaExec>("runIFDSExplorerExample") {
   group = "Execution"
   description = "Run the IFDSExplorerExample driver"
-  classpath = sourceSets.test.get().runtimeClasspath
+  classpath = ifdsExplorerExampleClasspath
   mainClass.set("com.ibm.wala.examples.drivers.IFDSExplorerExample")
   if (System.getProperty("os.name").startsWith("Mac OS X")) {
     jvmArgs = listOf("-XstartOnFirstThread")


### PR DESCRIPTION
The `:ide:tests:runIFDSExplorerExample` task uses the Java classloader to find a `com.ibm.wala.core.testdata_1.0.0.jar` resource. The `:core` subproject builds that resource using the `:core:collectTestData` task, and exports a consumable `collectTestDataJar` configuration containing it. However, we were not actually including that configuration's files in the `:ide:tests:runIFDSExplorerExample` task's classpath.  Now we do.

For extra subtlety, the `:ide:tests:runIFDSExplorerExample` task requires access to the complete `com.ibm.wala.core.testdata_1.0.0.jar` archive as a single file, not as a collection of files in which other resources can be found. Thus, the `collectTestDataJar` configuration should actually consist of the directory *containing* `com.ibm.wala.core.testdata_1.0.0.jar`, not the `com.ibm.wala.core.testdata_1.0.0.jar` file itself. Setup of the `collectTestDataJar` configuration has been adjusted accordingly.

Fixes #1263.