### PR TITLE
Improve source locations for constructor calls for JS function statements

### DIFF
--- a/cast/js/src/main/java/com/ibm/wala/cast/js/translator/JSAstTranslator.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/translator/JSAstTranslator.java
@@ -262,6 +262,8 @@ public class JSAstTranslator extends AstTranslator {
     int tmp = super.doGlobalRead(n, context, "Function", JavaScriptTypes.Function);
     Position old = null;
     if (n.getKind() == CAstNode.FUNCTION_STMT) {
+      // For function statements, set the current position (used for the constructor invocation
+      // instruction added below) to be the location of the statement itself.
       old = getCurrentPosition();
       CAstEntity entity = (CAstEntity) n.getChild(0).getValue();
       currentPosition = entity.getPosition();
@@ -280,6 +282,7 @@ public class JSAstTranslator extends AstTranslator {
                       new DynamicCallSiteReference(
                           JavaScriptMethods.ctorReference, context.cfg().getCurrentInstruction())));
     } finally {
+      // Reset the current position if it was temporarily updated for a function statement
       if (old != null) {
         currentPosition = old;
       }

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/translator/JSAstTranslator.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/translator/JSAstTranslator.java
@@ -260,18 +260,30 @@ public class JSAstTranslator extends AstTranslator {
     int nm = context.currentScope().getConstantValue('L' + composeEntityName(context, fn));
     // "Function" is the name we use to model the constructor of function values
     int tmp = super.doGlobalRead(n, context, "Function", JavaScriptTypes.Function);
-    context
-        .cfg()
-        .addInstruction(
-            ((JSInstructionFactory) insts)
-                .Invoke(
-                    context.cfg().getCurrentInstruction(),
-                    tmp,
-                    result,
-                    new int[] {nm},
-                    exception,
-                    new DynamicCallSiteReference(
-                        JavaScriptMethods.ctorReference, context.cfg().getCurrentInstruction())));
+    Position old = null;
+    if (n.getKind() == CAstNode.FUNCTION_STMT) {
+      old = getCurrentPosition();
+      CAstEntity entity = (CAstEntity) n.getChild(0).getValue();
+      currentPosition = entity.getPosition();
+    }
+    try {
+      context
+          .cfg()
+          .addInstruction(
+              ((JSInstructionFactory) insts)
+                  .Invoke(
+                      context.cfg().getCurrentInstruction(),
+                      tmp,
+                      result,
+                      new int[] {nm},
+                      exception,
+                      new DynamicCallSiteReference(
+                          JavaScriptMethods.ctorReference, context.cfg().getCurrentInstruction())));
+    } finally {
+      if (old != null) {
+        currentPosition = old;
+      }
+    }
   }
 
   @Override


### PR DESCRIPTION
This PR improves the source location used for the WALA IR instruction that performs a constructor invocation corresponding to a JS function statement.  Previously, the location used was the location of the closest enclosing function / script, which was both too coarse and led to duplicate locations when there were multiple function statements in a scope.  Now, we use the location of the function statement itself.

The implementation here is a bit hacky, but the source location code has complex invariants spread across multiple files and passes, so I think a local change is safest.