### PR TITLE
Properly handle static interface methods as entrypoints

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@
 //  plugin configuration must precede everything else
 //
 
+import com.diffplug.spotless.LineEnding.PLATFORM_NATIVE
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 
 buildscript { dependencies.classpath(libs.commons.io) }
@@ -98,6 +99,11 @@ shellcheck {
 }
 
 tasks.named("shellcheck") { group = "verification" }
+
+// Workaround for <https://github.com/diffplug/spotless/issues/1644>
+// using idea found at
+// <https://github.com/diffplug/spotless/issues/1527#issuecomment-1409142798>.
+spotless.lineEndings = PLATFORM_NATIVE
 
 // install Java reformatter as git pre-commit hook
 tasks.register<Copy>("installGitHooks") {

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/Entrypoint.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/Entrypoint.java
@@ -70,6 +70,8 @@ public abstract class Entrypoint implements BytecodeConstants {
       return CallSiteReference.make(
           programCounter, method.getReference(), IInvokeInstruction.Dispatch.SPECIAL);
     } else {
+      // It is important to check for static methods before interface methods, since if an interface
+      // contains a static method, it should be called via static dispatch, not interface dispatch
       if (method.isStatic()) {
         return CallSiteReference.make(
             programCounter, method.getReference(), IInvokeInstruction.Dispatch.STATIC);

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/Entrypoint.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/Entrypoint.java
@@ -70,17 +70,15 @@ public abstract class Entrypoint implements BytecodeConstants {
       return CallSiteReference.make(
           programCounter, method.getReference(), IInvokeInstruction.Dispatch.SPECIAL);
     } else {
-      if (method.getDeclaringClass().isInterface()) {
+      if (method.isStatic()) {
+        return CallSiteReference.make(
+            programCounter, method.getReference(), IInvokeInstruction.Dispatch.STATIC);
+      } else if (method.getDeclaringClass().isInterface()) {
         return CallSiteReference.make(
             programCounter, method.getReference(), IInvokeInstruction.Dispatch.INTERFACE);
       } else {
-        if (method.isStatic()) {
-          return CallSiteReference.make(
-              programCounter, method.getReference(), IInvokeInstruction.Dispatch.STATIC);
-        } else {
-          return CallSiteReference.make(
-              programCounter, method.getReference(), IInvokeInstruction.Dispatch.VIRTUAL);
-        }
+        return CallSiteReference.make(
+            programCounter, method.getReference(), IInvokeInstruction.Dispatch.VIRTUAL);
       }
     }
   }

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/StaticInterfaceMethodTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/StaticInterfaceMethodTest.java
@@ -16,6 +16,7 @@ import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.CancelException;
 import java.io.IOException;
 import java.util.List;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class StaticInterfaceMethodTest {
@@ -39,66 +40,8 @@ public class StaticInterfaceMethodTest {
         List.of(new DefaultEntrypoint(staticInterfaceMethodRef, cha));
     AnalysisOptions options = CallGraphTestUtil.makeAnalysisOptions(scope, entrypoints);
 
-    CallGraph ignored =
-        CallGraphTestUtil.buildZeroCFA(options, new AnalysisCacheImpl(), cha, false);
-    //
-    //    // Find node corresponding to main
-    //    TypeReference tm =
-    //        TypeReference.findOrCreate(
-    //            ClassLoaderReference.Application, "LdefaultMethods/DefaultMethods");
-    //    MethodReference mm = MethodReference.findOrCreate(tm, "main", "([Ljava/lang/String;)V");
-    //    Assert.assertTrue("expect main node", cg.getNodes(mm).iterator().hasNext());
-    //    CGNode mnode = cg.getNodes(mm).iterator().next();
-    //
-    //    // Find node corresponding to Interface1.silly
-    //    TypeReference t1s =
-    //        TypeReference.findOrCreate(ClassLoaderReference.Application,
-    // "LdefaultMethods/Interface1");
-    //    MethodReference t1m = MethodReference.findOrCreate(t1s, "silly", "()I");
-    //    Assert.assertTrue("expect Interface1.silly node", cg.getNodes(t1m).iterator().hasNext());
-    //    CGNode t1node = cg.getNodes(t1m).iterator().next();
-    //
-    //    // Check call from main to Interface1.silly
-    //    Assert.assertTrue(
-    //        "should have call site from main to Interface1.silly",
-    //        cg.getPossibleSites(mnode, t1node).hasNext());
-    //
-    //    // Find node corresponding to Interface2.silly
-    //    TypeReference t2s =
-    //        TypeReference.findOrCreate(ClassLoaderReference.Application,
-    // "LdefaultMethods/Interface2");
-    //    MethodReference t2m = MethodReference.findOrCreate(t2s, "silly", "()I");
-    //    Assert.assertTrue("expect Interface2.silly node", cg.getNodes(t2m).iterator().hasNext());
-    //    CGNode t2node = cg.getNodes(t1m).iterator().next();
-    //
-    //    // Check call from main to Interface2.silly
-    //    Assert.assertTrue(
-    //        "should have call site from main to Interface2.silly",
-    //        cg.getPossibleSites(mnode, t2node).hasNext());
-    //
-    //    // Find node corresponding to Test.silly
-    //    TypeReference tts =
-    //        TypeReference.findOrCreate(
-    //            ClassLoaderReference.Application, "LdefaultMethods/DefaultMethods$Test3");
-    //    MethodReference ttm = MethodReference.findOrCreate(tts, "silly", "()I");
-    //    Assert.assertTrue("expect Interface1.silly node", cg.getNodes(ttm).iterator().hasNext());
-    //    CGNode ttnode = cg.getNodes(ttm).iterator().next();
-    //
-    //    // Check call from main to Test3.silly
-    //    Assert.assertTrue(
-    //        "should have call site from main to Test3.silly",
-    //        cg.getPossibleSites(mnode, ttnode).hasNext());
-    //
-    //    // Check that IClass.getAllMethods() returns default methods #219.
-    //    TypeReference test1Type =
-    //        TypeReference.findOrCreate(
-    //            ClassLoaderReference.Application, "LdefaultMethods/DefaultMethods$Test1");
-    //    IClass test1Class = cha.lookupClass(test1Type);
-    //
-    //    Collection<? extends IMethod> allMethods = test1Class.getAllMethods();
-    //    IMethod defaultMethod = test1Class.getMethod(t1m.getSelector());
-    //    Assert.assertTrue(
-    //        "Expecting default methods to show up in IClass.allMethods()",
-    //        allMethods.contains(defaultMethod));
+    CallGraph cg = CallGraphTestUtil.buildZeroCFA(options, new AnalysisCacheImpl(), cha, false);
+
+    Assert.assertEquals(1, cg.getNodes(staticInterfaceMethodRef).size());
   }
 }


### PR DESCRIPTION
When a static Interface method is selected as an Entrypoint, WALA creates an invokeinterface instead of an invokestatic instruction in FakeRootMethod. This will lead to an out-of-array read when resolving the receiver for an interface invocation.

A test can be simply an Android app generated by Android Studio for a Basic Activity demo (either Java or Kotlin). In my case, the problem occurs for handling:

40149 = invokeinterface < Application, Landroidx/window/layout/WindowMetricsCalculator, getOrCreate()Landroidx/window/layout/WindowMetricsCalculator; > @32353 exception:40150

And the exception is as follows:

java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
        at com.ibm.wala.ipa.callgraph.propagation.SSAPropagationCallGraphBuilder.lambda$getTargetsForCall$0(SSAPropagationCallGraphBuilder.java:2072)
        at com.ibm.wala.ipa.callgraph.propagation.SSAPropagationCallGraphBuilder$CrossProductRec.rec(SSAPropagationCallGraphBuilder.java:542)
        at com.ibm.wala.ipa.callgraph.propagation.SSAPropagationCallGraphBuilder.iterateCrossProduct(SSAPropagationCallGraphBuilder.java:2055)
        at com.ibm.wala.ipa.callgraph.propagation.SSAPropagationCallGraphBuilder.getTargetsForCall(SSAPropagationCallGraphBuilder.java:2079)
        at com.ibm.wala.ipa.callgraph.propagation.SSAPropagationCallGraphBuilder$ConstraintVisitor.visitInvokeInternal(SSAPropagationCallGraphBuilder.java:1159)
        at com.ibm.wala.ipa.callgraph.propagation.SSAPropagationCallGraphBuilder$ConstraintVisitor.visitInvoke(SSAPropagationCallGraphBuilder.java:1115)
        at com.ibm.wala.ssa.SSAInvokeInstruction.visit(SSAInvokeInstruction.java:94)
        at com.ibm.wala.ipa.callgraph.propagation.SSAPropagationCallGraphBuilder.addBlockInstructionConstraints(SSAPropagationCallGraphBuilder.java:273)
        at com.ibm.wala.ipa.callgraph.propagation.SSAPropagationCallGraphBuilder.addNodeInstructionConstraints(SSAPropagationCallGraphBuilder.java:250)
        at com.ibm.wala.ipa.callgraph.propagation.SSAPropagationCallGraphBuilder.unconditionallyAddConstraintsFromNode(SSAPropagationCallGraphBuilder.java:226)
        at com.ibm.wala.ipa.callgraph.propagation.SSAPropagationCallGraphBuilder.addConstraintsFromNode(SSAPropagationCallGraphBuilder.java:191)
        at com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder.addConstraintsFromNewNodes(PropagationCallGraphBuilder.java:308)
        at com.ibm.wala.ipa.callgraph.propagation.StandardSolver.solve(StandardSolver.java:53)
        at com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder.makeCallGraph(PropagationCallGraphBuilder.java:248)

This commit prioritizes a static method over an interface method and addresses the above problem.
