### PR TITLE
Update to Guava 32.0.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ gradle-download-task = "de.undercouch:gradle-download-task:5.3.1"
 gradle-errorprone-plugin = "net.ltgt.gradle:gradle-errorprone-plugin:3.0.1"
 gradle-spotless-plugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 gson = "com.google.code.gson:gson:2.10"
-guava = "com.google.guava:guava:31.1-jre"
+guava = "com.google.guava:guava:32.0.1-jre"
 hamcrest = "org.hamcrest:hamcrest:2.2"
 htmlparser = "nu.validator.htmlparser:htmlparser:1.4"
 java_cup = "java_cup:java_cup:0.9e"


### PR DESCRIPTION
Just to stay up to date.  Also, Guava 32 fully fixed some CVEs: https://github.com/google/guava/releases/tag/v32.0.0