### PR TITLE
Simplify Maven Eclipse configuration

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -12,6 +12,7 @@ repositories {
 dependencies {
   implementation(libs.gradle.download.task)
   implementation(libs.gradle.errorprone.plugin)
+  implementation(libs.gradle.goomph.plugin)
   implementation(libs.gradle.spotless.plugin)
 }
 

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/eclipse-maven-central.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/eclipse-maven-central.gradle.kts
@@ -1,0 +1,115 @@
+package com.ibm.wala.gradle
+
+import com.diffplug.gradle.eclipse.MavenCentralExtension
+import com.diffplug.gradle.eclipse.MavenCentralExtension.ReleaseConfigurer
+import com.diffplug.gradle.eclipse.MavenCentralPlugin
+import com.diffplug.gradle.pde.EclipseRelease
+
+/**
+ * WALA-specialized adaptation of
+ * [ReleaseConfigurer](https://javadoc.io/doc/com.diffplug.gradle/goomph/latest/com/diffplug/gradle/eclipse/MavenCentralExtension.ReleaseConfigurer.html).
+ *
+ * ## WALA-Specific Specializations
+ *
+ * ### Release Selection
+ *
+ * The standard
+ * [MavenCentralExtension](https://javadoc.io/doc/com.diffplug.gradle/goomph/latest/com/diffplug/gradle/eclipse/MavenCentralExtension.html)
+ * offers a few overloaded `release` methods to allow selecting the Eclipse release to configure.
+ * However, WALA does not need that flexibility. Instead, this extension always configures the
+ * Eclipse release identified by the `eclipseVersion` extra property on the root project.
+ *
+ * ### Default Configuration
+ *
+ * This extension always applies [ReleaseConfigurer.constrainTransitivesToThisRelease] and
+ * [ReleaseConfigurer.useNativesForRunningPlatform] to the selected release.
+ *
+ * ## Generally Useful Additions
+ *
+ * ### Variadic Configuration Methods
+ *
+ * This extension offers variadic analogs of standard unary [ReleaseConfigurer] dependency-declaring
+ * methods. For example, [implementation] accepts any number of `bundleId` arguments rather than
+ * just one as expected by [ReleaseConfigurer.implementation]
+ *
+ * ### Test Fixtures Configuration Methods
+ *
+ * This extension offers variadic methods for configuring dependencies for test fixtures:
+ * [testFixturesApi] and [testFixturesImplementation].
+ */
+open class WalaMavenCentralReleaseConfigurerExtension @Inject constructor(project: Project) {
+
+  /**
+   * Internal [ReleaseConfigurer] instance to which all dependency-declaring methods apply.
+   *
+   * This instance always operates on the Eclipse release identified by the `eclipseVersion` extra
+   * property on the root project. The instance is created lazily in case the root project itself
+   * loads this extension before setting that property.
+   */
+  private val configurer by lazy {
+    project.run {
+      the<MavenCentralExtension>()
+          .ReleaseConfigurer(rootProject.extra["eclipseVersion"] as EclipseRelease)
+    }
+  }
+
+  /**
+   * Delegates to [configurer] to apply default WALA configuration.
+   *
+   * @see ReleaseConfigurer.constrainTransitivesToThisRelease
+   * @see ReleaseConfigurer.useNativesForRunningPlatform
+   */
+  internal fun defaults() =
+      configurer.run {
+        constrainTransitivesToThisRelease()
+        useNativesForRunningPlatform()
+      }
+
+  /**
+   * Delegates to [configurer] to configure each argument as an `api` dependency.
+   *
+   * @see ReleaseConfigurer.api
+   */
+  fun api(vararg bundleIds: String) = bundleIds.forEach(configurer::api)
+
+  /**
+   * Delegates to [configurer] to configure each argument as an `implementation` dependency.
+   *
+   * @see ReleaseConfigurer.implementation
+   */
+  @Suppress("MemberVisibilityCanBePrivate")
+  fun implementation(vararg bundleIds: String) = bundleIds.forEach(configurer::implementation)
+
+  /**
+   * Delegates to [configurer] to configure each argument as a `testFixturesApi` dependency.
+   *
+   * @see ReleaseConfigurer.dep
+   */
+  @Suppress("MemberVisibilityCanBePrivate")
+  fun testFixturesApi(vararg bundleIds: String) =
+      bundleIds.forEach { configurer.dep("testFixturesApi", it) }
+
+  /**
+   * Delegates to [configurer] to configure each argument as a `testFixturesImplementation`
+   * dependency.
+   *
+   * @see ReleaseConfigurer.dep
+   */
+  @Suppress("MemberVisibilityCanBePrivate")
+  fun testFixturesImplementation(vararg bundleIds: String) =
+      bundleIds.forEach { configurer.dep("testFixturesImplementation", it) }
+
+  /**
+   * Delegates to [configurer] to configure each argument as a `testImplementation` dependency.
+   *
+   * @see ReleaseConfigurer.testImplementation
+   */
+  fun testImplementation(vararg bundleIds: String) =
+      bundleIds.forEach(configurer::testImplementation)
+}
+
+apply<MavenCentralPlugin>()
+
+extensions.create<WalaMavenCentralReleaseConfigurerExtension>("walaEclipseMavenCentral")
+
+afterEvaluate { configure(WalaMavenCentralReleaseConfigurerExtension::defaults) }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@
 //  plugin configuration must precede everything else
 //
 
+import com.diffplug.gradle.pde.EclipseRelease
 import com.diffplug.spotless.LineEnding.PLATFORM_NATIVE
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 
@@ -16,8 +17,8 @@ plugins {
   alias(libs.plugins.shellcheck)
   alias(libs.plugins.task.tree)
   alias(libs.plugins.versions)
-  id("com.diffplug.eclipse.mavencentral")
   id("com.ibm.wala.gradle.javadoc")
+  id("com.ibm.wala.gradle.eclipse-maven-central")
   id("com.ibm.wala.gradle.maven-eclipse-jsdt")
   id("com.ibm.wala.gradle.project")
 }
@@ -48,7 +49,9 @@ group = name
 version = properties["VERSION_NAME"] as String
 
 // version of Eclipse JARs to use for Eclipse-integrated WALA components.
-val eclipseVersion: String by extra(libs.versions.eclipse.asProvider()::get)
+val eclipseVersion: EclipseRelease by extra {
+  EclipseRelease.official(libs.versions.eclipse.asProvider().get())
+}
 
 ///////////////////////////////////////////////////////////////////////
 //
@@ -58,13 +61,6 @@ val eclipseVersion: String by extra(libs.versions.eclipse.asProvider()::get)
 val aggregatedJavadocClasspath: Configuration by configurations.creating { isCanBeConsumed = false }
 
 val aggregatedJavadocSource: Configuration by configurations.creating { isCanBeConsumed = false }
-
-eclipseMavenCentral {
-  release(eclipseVersion) {
-    useNativesForRunningPlatform()
-    constrainTransitivesToThisRelease()
-  }
-}
 
 dependencies {
   subprojects {

--- a/cast/java/ecj/build.gradle.kts
+++ b/cast/java/ecj/build.gradle.kts
@@ -1,19 +1,15 @@
 plugins {
   application
-  id("com.diffplug.eclipse.mavencentral")
+  id("com.ibm.wala.gradle.eclipse-maven-central")
   id("com.ibm.wala.gradle.java")
   id("com.ibm.wala.gradle.publishing")
 }
 
-eclipseMavenCentral {
-  release(rootProject.extra["eclipseVersion"] as String) {
-    listOf(
-            "org.eclipse.core.runtime",
-            "org.eclipse.jdt.core",
-        )
-        .forEach { implementation(it) }
-    constrainTransitivesToThisRelease()
-  }
+walaEclipseMavenCentral {
+  implementation(
+      "org.eclipse.core.runtime",
+      "org.eclipse.jdt.core",
+  )
 }
 
 val runSourceDirectory: Configuration by configurations.creating { isCanBeConsumed = false }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ eclipse-osgi = "org.eclipse.platform:org.eclipse.osgi:3.17.0"
 eclipse-wst-jsdt-core = { module = "org.eclipse.wst.jsdt:core", version.ref = "eclipse-wst-jsdt" }
 eclipse-wst-jsdt-ui = { module = "org.eclipse.wst.jsdt:ui", version.ref = "eclipse-wst-jsdt" }
 errorprone-core = "com.google.errorprone:error_prone_core:2.18.0"
+gradle-goomph-plugin = "com.diffplug.gradle:goomph:3.40.0"
 gradle-download-task = "de.undercouch:gradle-download-task:5.3.1"
 gradle-errorprone-plugin = "net.ltgt.gradle:gradle-errorprone-plugin:3.0.1"
 gradle-spotless-plugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }

--- a/ide/build.gradle.kts
+++ b/ide/build.gradle.kts
@@ -1,29 +1,24 @@
 plugins {
-  id("com.diffplug.eclipse.mavencentral")
+  id("com.ibm.wala.gradle.eclipse-maven-central")
   id("com.ibm.wala.gradle.java")
 }
 
 eclipse.project.natures("org.eclipse.pde.PluginNature")
 
-eclipseMavenCentral {
-  release(rootProject.extra["eclipseVersion"] as String) {
-    api("org.eclipse.pde.core")
-    listOf(
-            "org.eclipse.core.commands",
-            "org.eclipse.core.jobs",
-            "org.eclipse.core.resources",
-            "org.eclipse.core.runtime",
-            "org.eclipse.equinox.common",
-            "org.eclipse.jdt.core",
-            "org.eclipse.jface",
-            "org.eclipse.osgi",
-            "org.eclipse.swt",
-            "org.eclipse.ui.workbench",
-        )
-        .forEach { implementation(it) }
-    useNativesForRunningPlatform()
-    constrainTransitivesToThisRelease()
-  }
+walaEclipseMavenCentral {
+  api("org.eclipse.pde.core")
+  implementation(
+      "org.eclipse.core.commands",
+      "org.eclipse.core.jobs",
+      "org.eclipse.core.resources",
+      "org.eclipse.core.runtime",
+      "org.eclipse.equinox.common",
+      "org.eclipse.jdt.core",
+      "org.eclipse.jface",
+      "org.eclipse.osgi",
+      "org.eclipse.swt",
+      "org.eclipse.ui.workbench",
+  )
 }
 
 dependencies {

--- a/ide/jdt/build.gradle.kts
+++ b/ide/jdt/build.gradle.kts
@@ -1,25 +1,20 @@
 plugins {
-  id("com.diffplug.eclipse.mavencentral")
+  id("com.ibm.wala.gradle.eclipse-maven-central")
   id("com.ibm.wala.gradle.java")
 }
 
-eclipseMavenCentral {
-  release(rootProject.extra["eclipseVersion"] as String) {
-    api("org.eclipse.equinox.common")
-    listOf(
-            "org.eclipse.core.jobs",
-            "org.eclipse.core.resources",
-            "org.eclipse.core.runtime",
-            "org.eclipse.equinox.app",
-            "org.eclipse.jdt.core",
-            "org.eclipse.jface",
-            "org.eclipse.osgi",
-            "org.eclipse.ui.workbench",
-        )
-        .forEach { implementation(it) }
-    useNativesForRunningPlatform()
-    constrainTransitivesToThisRelease()
-  }
+walaEclipseMavenCentral {
+  api("org.eclipse.equinox.common")
+  implementation(
+      "org.eclipse.core.jobs",
+      "org.eclipse.core.resources",
+      "org.eclipse.core.runtime",
+      "org.eclipse.equinox.app",
+      "org.eclipse.jdt.core",
+      "org.eclipse.jface",
+      "org.eclipse.osgi",
+      "org.eclipse.ui.workbench",
+  )
 }
 
 dependencies {

--- a/ide/jdt/test/build.gradle.kts
+++ b/ide/jdt/test/build.gradle.kts
@@ -1,21 +1,16 @@
 plugins {
-  id("com.diffplug.eclipse.mavencentral")
+  id("com.ibm.wala.gradle.eclipse-maven-central")
   id("com.ibm.wala.gradle.java")
 }
 
-eclipseMavenCentral {
-  release(rootProject.extra["eclipseVersion"] as String) {
-    listOf(
-            "org.eclipse.core.contenttype",
-            "org.eclipse.core.runtime",
-            "org.eclipse.equinox.preferences",
-            "org.eclipse.jdt.core",
-            "org.eclipse.osgi",
-        )
-        .forEach { dep("testImplementation", it) }
-    useNativesForRunningPlatform()
-    constrainTransitivesToThisRelease()
-  }
+walaEclipseMavenCentral {
+  testImplementation(
+      "org.eclipse.core.contenttype",
+      "org.eclipse.core.runtime",
+      "org.eclipse.equinox.preferences",
+      "org.eclipse.jdt.core",
+      "org.eclipse.osgi",
+  )
 }
 
 dependencies {

--- a/ide/jsdt/build.gradle.kts
+++ b/ide/jsdt/build.gradle.kts
@@ -1,23 +1,18 @@
 plugins {
-  id("com.diffplug.eclipse.mavencentral")
+  id("com.ibm.wala.gradle.eclipse-maven-central")
   id("com.ibm.wala.gradle.java")
   id("com.ibm.wala.gradle.maven-eclipse-jsdt")
 }
 
-eclipseMavenCentral {
-  release(rootProject.extra["eclipseVersion"] as String) {
-    listOf(
-            "org.eclipse.core.jobs",
-            "org.eclipse.core.resources",
-            "org.eclipse.core.runtime",
-            "org.eclipse.equinox.common",
-            "org.eclipse.osgi",
-            "org.eclipse.ui.workbench",
-        )
-        .forEach { implementation(it) }
-    useNativesForRunningPlatform()
-    constrainTransitivesToThisRelease()
-  }
+walaEclipseMavenCentral {
+  implementation(
+      "org.eclipse.core.jobs",
+      "org.eclipse.core.resources",
+      "org.eclipse.core.runtime",
+      "org.eclipse.equinox.common",
+      "org.eclipse.osgi",
+      "org.eclipse.ui.workbench",
+  )
 }
 
 dependencies {

--- a/ide/jsdt/tests/build.gradle.kts
+++ b/ide/jsdt/tests/build.gradle.kts
@@ -1,20 +1,15 @@
 plugins {
-  id("com.diffplug.eclipse.mavencentral")
+  id("com.ibm.wala.gradle.eclipse-maven-central")
   id("com.ibm.wala.gradle.java")
   id("com.ibm.wala.gradle.maven-eclipse-jsdt")
 }
 
-eclipseMavenCentral {
-  release(rootProject.extra["eclipseVersion"] as String) {
-    listOf(
-            "org.eclipse.core.runtime",
-            "org.eclipse.equinox.common",
-            "org.eclipse.osgi",
-        )
-        .forEach { dep("testImplementation", it) }
-    useNativesForRunningPlatform()
-    constrainTransitivesToThisRelease()
-  }
+walaEclipseMavenCentral {
+  testImplementation(
+      "org.eclipse.core.runtime",
+      "org.eclipse.equinox.common",
+      "org.eclipse.osgi",
+  )
 }
 
 dependencies {

--- a/ide/tests/build.gradle.kts
+++ b/ide/tests/build.gradle.kts
@@ -4,21 +4,16 @@ import org.gradle.api.attributes.VerificationType.VERIFICATION_TYPE_ATTRIBUTE
 plugins {
   `java-library`
   `java-test-fixtures`
+  id("com.ibm.wala.gradle.eclipse-maven-central")
   id("com.ibm.wala.gradle.java")
-  id("com.diffplug.eclipse.mavencentral")
 }
 
 eclipse.project.natures("org.eclipse.pde.PluginNature")
 
-eclipseMavenCentral {
-  release(rootProject.extra["eclipseVersion"] as String) {
-    dep("testFixturesApi", "org.eclipse.core.resources")
-    dep("testFixturesApi", "org.eclipse.core.runtime")
-    dep("testFixturesImplementation", "org.eclipse.ui.ide")
-    dep("testImplementation", "org.eclipse.jface")
-    useNativesForRunningPlatform()
-    constrainTransitivesToThisRelease()
-  }
+walaEclipseMavenCentral {
+  testFixturesApi("org.eclipse.core.resources", "org.eclipse.core.runtime")
+  testFixturesImplementation("org.eclipse.ui.ide")
+  testImplementation("org.eclipse.jface")
 }
 
 val coreTestDataJar: Configuration by


### PR DESCRIPTION
A new `walaEclipseMavenCentral` Kotlin DSL extension allows configuring the diffplug MavenCentral plugin more easily by internalizing certain WALA-specific behaviors and adding a few convenience features.  See KDoc comments in
`build-logic/src/main/kotlin/com/ibm/wala/gradle/eclipse-maven-central.gradle.kts` for more details about what this new extension can do.

Resolves wala/WALA#1280.