### PR TITLE
Upgrade to Kotlin 1.9.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,7 @@ w3c-css-sac = "org.eclipse.birt.runtime:org.w3c.css.sac:1.3.1.v200903091627"
 [plugins]
 file-lister = "all.shared.gradle.file-lister:1.0.2"
 google-java-format = "com.github.sherter.google-java-format:0.9"
-kotlin-jvm = "org.jetbrains.kotlin.jvm:1.8.0"
+kotlin-jvm = "org.jetbrains.kotlin.jvm:1.9.0"
 ktfmt = "com.ncorti.ktfmt.gradle:0.11.0"
 shellcheck = "com.felipefzdz.gradle.shellcheck:1.4.6"
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }


### PR DESCRIPTION
This is a minor update; none of the [new Kotlin 1.9.0 features](https://kotlinlang.org/docs/whatsnew19.html) are particularly interesting for our use of Kotlin to drive Gradle.