### PR TITLE
Use JUnit 5 to find and run tests

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -33,15 +33,22 @@ configurations {
   named("javadocClasspath").get().extendsFrom(compileClasspath.get())
 }
 
+fun findLibrary(alias: String) =
+    rootProject.the<VersionCatalogsExtension>().named("libs").findLibrary(alias).get()
+
 dependencies {
-  "ecj"(rootProject.the<VersionCatalogsExtension>().named("libs").findLibrary("eclipse-ecj").get())
-  "errorprone"(
-      rootProject
-          .the<VersionCatalogsExtension>()
-          .named("libs")
-          .findLibrary("errorprone-core")
-          .get())
+  "ecj"(findLibrary("eclipse-ecj"))
+  "errorprone"(findLibrary("errorprone-core"))
   "javadocSource"(sourceSets.main.get().allJava)
+
+  testFixturesImplementation(platform(findLibrary("junit-bom")))
+  testFixturesImplementation(findLibrary("junit"))
+  testFixturesImplementation(findLibrary("junit-jupiter-api"))
+
+  testImplementation(platform(findLibrary("junit-bom")))
+  testImplementation(findLibrary("junit"))
+  testImplementation(findLibrary("junit-jupiter-api"))
+  testRuntimeOnly(findLibrary("junit-vintage-engine"))
 }
 
 tasks.withType<JavaCompile>().configureEach {
@@ -103,6 +110,8 @@ configurations {
 the<EclipseModel>().synchronizationTasks("processTestResources")
 
 tasks.named<Test>("test") {
+  useJUnitPlatform()
+
   include("**/*Test.class")
   include("**/*TestCase.class")
   include("**/*Tests.class")

--- a/cast/build.gradle.kts
+++ b/cast/build.gradle.kts
@@ -46,7 +46,6 @@ dependencies {
   castJsPackageListDirectory(
       project(mapOf("path" to ":cast:js", "configuration" to "packageListDirectory")))
   javadocClasspath(projects.cast.js)
-  testImplementation(libs.junit)
   testRuntimeOnly(testFixtures(projects.core))
   xlatorTestSharedLibrary(project("xlator_test"))
 }

--- a/cast/java/build.gradle.kts
+++ b/cast/java/build.gradle.kts
@@ -10,7 +10,6 @@ dependencies {
   implementation(projects.core)
   implementation(projects.shrike)
   implementation(projects.util)
-  testFixturesImplementation(libs.junit)
   testFixturesImplementation(projects.cast)
   testFixturesImplementation(projects.core)
 }

--- a/cast/java/ecj/build.gradle.kts
+++ b/cast/java/ecj/build.gradle.kts
@@ -25,7 +25,6 @@ dependencies {
   runSourceDirectory(
       project(
           mapOf("path" to ":cast:java:test:data", "configuration" to "testJavaSourceDirectory")))
-  testImplementation(libs.junit)
   testImplementation(testFixtures(projects.cast.java))
   testRuntimeOnly(testFixtures(projects.core))
 }

--- a/cast/js/build.gradle.kts
+++ b/cast/js/build.gradle.kts
@@ -16,10 +16,8 @@ dependencies {
   implementation(projects.shrike)
   implementation(projects.util)
   javadocClasspath(projects.cast.js.rhino)
-  testFixturesImplementation(libs.junit)
   testFixturesImplementation(testFixtures(projects.cast))
   testFixturesImplementation(testFixtures(projects.core))
-  testImplementation(libs.junit)
   testImplementation(testFixtures(projects.cast))
   testImplementation(testFixtures(projects.core))
 }

--- a/cast/js/nodejs/build.gradle.kts
+++ b/cast/js/nodejs/build.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
   implementation(projects.cast.js.rhino)
   implementation(projects.core)
   implementation(projects.util)
-  testImplementation(libs.junit)
   testRuntimeOnly(testFixtures(projects.core))
 }
 

--- a/cast/js/rhino/build.gradle.kts
+++ b/cast/js/rhino/build.gradle.kts
@@ -16,10 +16,8 @@ dependencies {
   implementation(projects.util)
   testImplementation(libs.gson)
   testImplementation(libs.hamcrest)
-  testImplementation(libs.junit)
   testImplementation(testFixtures(projects.cast))
   testImplementation(testFixtures(projects.cast.js))
-  testFixturesImplementation(libs.junit)
   testFixturesImplementation(testFixtures(projects.cast))
   testFixturesImplementation(testFixtures(projects.cast.js))
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -58,9 +58,7 @@ dependencies {
   }
   api(projects.util) { because("public interface CallGraph extends interface NumberedGraph") }
   testFixturesImplementation(libs.ant)
-  testFixturesImplementation(libs.junit)
   testImplementation(libs.hamcrest)
-  testImplementation(libs.junit)
   testRuntimeOnly(sourceSets["testSubjects"].output.classesDirs)
   // add the testSubjects source files to enable SourceMapTest to pass
   testRuntimeOnly(files(sourceSets["testSubjects"].java.srcDirs))

--- a/dalvik/build.gradle.kts
+++ b/dalvik/build.gradle.kts
@@ -92,7 +92,6 @@ dependencies {
   sampleCupSources(libs.java.cup.map { "$it:sources" })
 
   testImplementation(libs.android.tools)
-  testImplementation(libs.junit)
   testImplementation(libs.dexlib2)
   testImplementation(projects.core)
   testImplementation(projects.dalvik)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,9 @@ jericho-html = "net.htmlparser.jericho:jericho-html:3.2"
 json = "org.json:json:20220924"
 jspecify = "org.jspecify:jspecify:0.3.0"
 junit = "junit:junit:4.13.2"
+junit-bom = "org.junit:junit-bom:5.9.3"
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
+junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine" }
 nullaway = "com.uber.nullaway:nullaway:0.10.10"
 rhino = "org.mozilla:rhino:1.7.14"
 slf4j-api = "org.slf4j:slf4j-api:2.0.6"

--- a/ide/jdt/test/build.gradle.kts
+++ b/ide/jdt/test/build.gradle.kts
@@ -15,7 +15,6 @@ walaEclipseMavenCentral {
 
 dependencies {
   testImplementation(libs.eclipse.osgi)
-  testImplementation(libs.junit)
   testImplementation(projects.cast)
   testImplementation(projects.cast.java)
   testImplementation(projects.cast.java.ecj)

--- a/ide/jsdt/tests/build.gradle.kts
+++ b/ide/jsdt/tests/build.gradle.kts
@@ -16,7 +16,6 @@ dependencies {
   testImplementation(libs.eclipse.osgi)
   testImplementation(libs.eclipse.wst.jsdt.core)
   testImplementation(libs.javax.annotation.api)
-  testImplementation(libs.junit)
   testImplementation(projects.cast)
   testImplementation(projects.cast.js)
   testImplementation(projects.cast.js.rhino)

--- a/ide/tests/build.gradle.kts
+++ b/ide/tests/build.gradle.kts
@@ -45,7 +45,6 @@ dependencies {
   ifdsExplorerExampleClasspath(sourceSets.test.map { it.runtimeClasspath })
   ifdsExplorerExampleClasspath(
       project(mapOf("path" to ":core", "configuration" to "collectTestDataJar")))
-  testImplementation(libs.junit)
   testImplementation(projects.core)
   testImplementation(projects.ide)
   testImplementation(projects.util)

--- a/util/build.gradle.kts
+++ b/util/build.gradle.kts
@@ -10,7 +10,6 @@ dependencies {
   compileOnly(libs.jspecify)
   javadocClasspath(projects.core)
   testImplementation(libs.hamcrest)
-  testImplementation(libs.junit)
   testRuntimeOnly(testFixtures(projects.core))
 }
 


### PR DESCRIPTION
The tests themselves are still written using JUnit 4, so we're using JUnit 5's Vintage component to discover and run those tests.  Hooray for backward compatibility!

Eventually we can try porting JUnit 4 tests forward to JUnit 5, but this is a decent first step.