### PR TITLE
Migrate one test class from JUnit 4 to JUnit 5

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
   testImplementation(platform(findLibrary("junit-bom")))
   testImplementation(findLibrary("junit"))
   testImplementation(findLibrary("junit-jupiter-api"))
+  testRuntimeOnly(findLibrary("junit-jupiter-engine"))
   testRuntimeOnly(findLibrary("junit-vintage-engine"))
 }
 

--- a/core/src/test/java/com/ibm/wala/core/tests/basic/ExtensionGraphTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/basic/ExtensionGraphTest.java
@@ -11,13 +11,14 @@
 
 package com.ibm.wala.core.tests.basic;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.ibm.wala.util.collections.IteratorUtil;
 import com.ibm.wala.util.graph.NumberedGraph;
 import com.ibm.wala.util.graph.impl.ExtensionGraph;
 import com.ibm.wala.util.graph.impl.SlowSparseNumberedGraph;
 import com.ibm.wala.util.graph.traverse.SCCIterator;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ExtensionGraphTest {
 
@@ -68,24 +69,24 @@ public class ExtensionGraphTest {
   @Test
   public void testAugment() {
     NumberedGraph<String> base = makeBaseGraph();
-    Assert.assertEquals("base has 8 SCCs", 8, IteratorUtil.count(new SCCIterator<>(base)));
+    assertEquals(8, IteratorUtil.count(new SCCIterator<>(base)), "base has 8 SCCs");
 
     NumberedGraph<String> x = new ExtensionGraph<>(base);
     augmentA(x);
-    Assert.assertEquals("base+A has 5 SCCs", 5, IteratorUtil.count(new SCCIterator<>(x)));
-    Assert.assertEquals("base has 8 SCCs", 8, IteratorUtil.count(new SCCIterator<>(base)));
+    assertEquals(5, IteratorUtil.count(new SCCIterator<>(x)), "base+A has 5 SCCs");
+    assertEquals(8, IteratorUtil.count(new SCCIterator<>(base)), "base has 8 SCCs");
 
     NumberedGraph<String> y = new ExtensionGraph<>(x);
     augmentB(y);
-    Assert.assertEquals("base+A+B has 7 SCCs", 7, IteratorUtil.count(new SCCIterator<>(y)));
-    Assert.assertEquals("base+A has 5 SCCs", 5, IteratorUtil.count(new SCCIterator<>(x)));
-    Assert.assertEquals("base has 8 SCCs", 8, IteratorUtil.count(new SCCIterator<>(base)));
+    assertEquals(7, IteratorUtil.count(new SCCIterator<>(y)), "base+A+B has 7 SCCs");
+    assertEquals(5, IteratorUtil.count(new SCCIterator<>(x)), "base+A has 5 SCCs");
+    assertEquals(8, IteratorUtil.count(new SCCIterator<>(base)), "base has 8 SCCs");
 
     NumberedGraph<String> z = new ExtensionGraph<>(y);
     augmentC(z);
-    Assert.assertEquals("base+A+B+C has 3 SCCs", 3, IteratorUtil.count(new SCCIterator<>(z)));
-    Assert.assertEquals("base+A+B has 7 SCCs", 7, IteratorUtil.count(new SCCIterator<>(y)));
-    Assert.assertEquals("base+A has 5 SCCs", 5, IteratorUtil.count(new SCCIterator<>(x)));
-    Assert.assertEquals("base has 8 SCCs", 8, IteratorUtil.count(new SCCIterator<>(base)));
+    assertEquals(3, IteratorUtil.count(new SCCIterator<>(z)), "base+A+B+C has 3 SCCs");
+    assertEquals(7, IteratorUtil.count(new SCCIterator<>(y)), "base+A+B has 7 SCCs");
+    assertEquals(5, IteratorUtil.count(new SCCIterator<>(x)), "base+A has 5 SCCs");
+    assertEquals(8, IteratorUtil.count(new SCCIterator<>(base)), "base has 8 SCCs");
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ jspecify = "org.jspecify:jspecify:0.3.0"
 junit = "junit:junit:4.13.2"
 junit-bom = "org.junit:junit-bom:5.9.3"
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
 junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine" }
 nullaway = "com.uber.nullaway:nullaway:0.10.10"
 rhino = "org.mozilla:rhino:1.7.14"


### PR DESCRIPTION
The migration was mostly automated by IntelliJ IDEA.  We're starting with just a single test class so that we have a clear demonstration of the kinds of changes that will later be applied more broadly.

It's also good to verify here, by manual inspection, that we are correctly running a mix of `core` tests from JUnit 5 (`ExtensionGraphTest`) and JUnit 4 (all the rest).  This confirms that it's OK to use multiple `TestEngine`s at the same time, which in turn confirms that it's OK to migrate tests from JUnit 4 to JUnit 5 incrementally rather than in one giant batch.