### PR TITLE
Always use static imports for org.junit.Assert

### DIFF
--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
@@ -13,6 +13,10 @@
  */
 package com.ibm.wala.cast.java.test;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import com.ibm.wala.cast.java.client.JavaSourceAnalysisEngine;
 import com.ibm.wala.cast.java.ipa.callgraph.JavaSourceAnalysisScope;
 import com.ibm.wala.cast.loader.AstClass;
@@ -59,7 +63,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.jar.JarFile;
-import org.junit.Assert;
 
 public abstract class IRTests {
 
@@ -231,7 +234,7 @@ public abstract class IRTests {
       MethodReference mref = descriptorToMethodRef(method, cg.getClassHierarchy());
 
       for (CGNode cgNode : cg.getNodes(mref)) {
-        Assert.assertTrue(
+        assertTrue(
             "failed for " + this.variableName + " in " + cgNode + "\n" + cgNode.getIR(),
             this.check(cgNode.getMethod(), cgNode.getIR()));
       }
@@ -312,7 +315,7 @@ public abstract class IRTests {
           }
         }
 
-        Assert.assertFalse("cannot find " + at + " in " + cls, false);
+        assertFalse("cannot find " + at + " in " + cls, false);
       }
 
       annot:
@@ -330,7 +333,7 @@ public abstract class IRTests {
               }
             }
 
-            Assert.assertFalse("cannot find " + at, false);
+            assertFalse("cannot find " + at, false);
           }
         }
       }
@@ -442,7 +445,7 @@ public abstract class IRTests {
     }
 
     if (assertReachable) {
-      Assert.assertTrue("unreachable methods: " + unreachable, unreachable.isEmpty());
+      assertTrue("unreachable methods: " + unreachable, unreachable.isEmpty());
     }
   }
 
@@ -495,7 +498,7 @@ public abstract class IRTests {
         try {
           engine.addSystemModule(new JarFileModule(new JarFile(libFile, false)));
         } catch (IOException e) {
-          Assert.fail(e.getMessage());
+          fail(e.getMessage());
         }
       }
     }
@@ -504,7 +507,7 @@ public abstract class IRTests {
     for (String srcFilePath : sources) {
       String srcFileName = srcFilePath.substring(srcFilePath.lastIndexOf(File.separator) + 1);
       File f = new File(srcFilePath);
-      Assert.assertTrue("couldn't find " + srcFilePath, f.exists());
+      assertTrue("couldn't find " + srcFilePath, f.exists());
       if (f.isDirectory()) {
         engine.addSourceModule(new SourceDirectoryTreeModule(f));
       } else {

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/JavaIRTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/JavaIRTests.java
@@ -14,6 +14,11 @@
 package com.ibm.wala.cast.java.test;
 
 import static com.ibm.wala.ipa.slicer.SlicerUtil.dumpSlice;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.ibm.wala.cast.java.ipa.callgraph.JavaSourceAnalysisScope;
 import com.ibm.wala.cast.java.ipa.modref.AstJavaModRef;
@@ -61,7 +66,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import org.junit.Assert;
 import org.junit.Test;
 
 public abstract class JavaIRTests extends IRTests {
@@ -99,7 +103,7 @@ public abstract class JavaIRTests extends IRTests {
         singleTestSrc(),
         rtJar,
         simpleTestEntryPoint(),
-        Collections.singletonList(
+        List.of(
             cg -> {
               final String typeStr = singleInputForTest();
 
@@ -107,13 +111,13 @@ public abstract class JavaIRTests extends IRTests {
                   findOrCreateTypeReference("Source", typeStr, cg.getClassHierarchy());
 
               final IClass iClass = cg.getClassHierarchy().lookupClass(type);
-              Assert.assertNotNull("Could not find class " + typeStr, iClass);
+              assertNotNull("Could not find class " + typeStr, iClass);
 
               /*
-              Assert.assertEquals("Expected two classes.", iClass.getClassLoader().getNumberOfClasses(), 2);
+              assertEquals("Expected two classes.", iClass.getClassLoader().getNumberOfClasses(), 2);
 
               for (IClass cls : Iterator2Iterable.make(iClass.getClassLoader().iterateAllClasses())) {
-                Assert.assertTrue("Expected class to be either " + typeStr + " or " + "Bar", cls.getName().getClassName().toString()
+                assertTrue("Expected class to be either " + typeStr + " or " + "Bar", cls.getName().getClassName().toString()
                     .equals(typeStr)
                     || cls.getName().getClassName().toString().equals("Bar"));
               }
@@ -137,9 +141,9 @@ public abstract class JavaIRTests extends IRTests {
                   findOrCreateTypeReference("Source", typeStr, cg.getClassHierarchy());
 
               final IClass iClass = cg.getClassHierarchy().lookupClass(type);
-              Assert.assertNotNull("Could not find class " + typeStr, iClass);
+              assertNotNull("Could not find class " + typeStr, iClass);
 
-              Assert.assertTrue("Expected IFoo to be an interface.", iClass.isInterface());
+              assertTrue("Expected IFoo to be an interface.", iClass.isInterface());
             },
             cg -> {
               final String typeStr = "FooIT1";
@@ -148,13 +152,13 @@ public abstract class JavaIRTests extends IRTests {
                   findOrCreateTypeReference("Source", typeStr, cg.getClassHierarchy());
 
               final IClass iClass = cg.getClassHierarchy().lookupClass(type);
-              Assert.assertNotNull("Could not find class " + typeStr, iClass);
+              assertNotNull("Could not find class " + typeStr, iClass);
 
               final Collection<? extends IClass> interfaces = iClass.getDirectInterfaces();
 
-              Assert.assertEquals("Expected one single interface.", interfaces.size(), 1);
+              assertEquals("Expected one single interface.", interfaces.size(), 1);
 
-              Assert.assertTrue(
+              assertTrue(
                   "Expected Foo to implement IFoo",
                   interfaces.contains(
                       cg.getClassHierarchy()
@@ -180,20 +184,20 @@ public abstract class JavaIRTests extends IRTests {
                   findOrCreateTypeReference("Source", typeStr, cg.getClassHierarchy());
 
               final IClass derivedClass = cg.getClassHierarchy().lookupClass(type);
-              Assert.assertNotNull("Could not find class " + typeStr, derivedClass);
+              assertNotNull("Could not find class " + typeStr, derivedClass);
 
               final TypeReference baseType =
                   findOrCreateTypeReference("Source", "Base", cg.getClassHierarchy());
               final IClass baseClass = cg.getClassHierarchy().lookupClass(baseType);
 
-              Assert.assertEquals(
+              assertEquals(
                   "Expected 'Base' to be the superclass of 'Derived'",
                   derivedClass.getSuperclass(),
                   baseClass);
 
               Collection<IClass> subclasses = cg.getClassHierarchy().computeSubClasses(baseType);
 
-              Assert.assertTrue(
+              assertTrue(
                   "Expected subclasses of 'Base' to be 'Base' and 'Derived'.",
                   subclasses.contains(derivedClass) && subclasses.contains(baseClass));
             }),
@@ -228,7 +232,7 @@ public abstract class JavaIRTests extends IRTests {
                   }
                 }
 
-                Assert.assertEquals("Unexpected number of array instructions in 'foo'.", count, 4);
+                assertEquals("Unexpected number of array instructions in 'foo'.", count, 4);
               }
 
               private boolean isArrayInstruction(SSAInstruction s) {
@@ -254,10 +258,8 @@ public abstract class JavaIRTests extends IRTests {
 
               CGNode node = cg.getNodes(mref).iterator().next();
               SSAInstruction s = node.getIR().getInstructions()[2];
-              Assert.assertTrue(
-                  "Did not find new array instruction.", s instanceof SSANewInstruction);
-              Assert.assertTrue(
-                  "", ((SSANewInstruction) s).getNewSite().getDeclaredType().isArrayType());
+              assertTrue("Did not find new array instruction.", s instanceof SSANewInstruction);
+              assertTrue("", ((SSANewInstruction) s).getNewSite().getDeclaredType().isArrayType());
             }),
         true,
         null);
@@ -282,33 +284,33 @@ public abstract class JavaIRTests extends IRTests {
               {
                 SSAInstruction s1 = instructions[2];
                 if (s1 instanceof SSANewInstruction) {
-                  Assert.assertTrue(
+                  assertTrue(
                       "", ((SSANewInstruction) s1).getNewSite().getDeclaredType().isArrayType());
                 } else {
-                  Assert.fail("Expected 3rd to be a new array instruction.");
+                  fail("Expected 3rd to be a new array instruction.");
                 }
               }
               // test 2
               {
                 SSAInstruction s2 = instructions[3];
                 if (s2 instanceof SSANewInstruction) {
-                  Assert.assertTrue(
+                  assertTrue(
                       "", ((SSANewInstruction) s2).getNewSite().getDeclaredType().isArrayType());
                 } else {
-                  Assert.fail("Expected 4th to be a new array instruction.");
+                  fail("Expected 4th to be a new array instruction.");
                 }
               }
               // test 3: the last 4 instructions are of the form y[i] = i+1;
               {
                 final SymbolTable symbolTable = node.getIR().getSymbolTable();
                 for (int i = 4; i <= 7; i++) {
-                  Assert.assertTrue(
+                  assertTrue(
                       "Expected only array stores.",
                       instructions[i] instanceof SSAArrayStoreInstruction);
 
                   SSAArrayStoreInstruction as = (SSAArrayStoreInstruction) instructions[i];
 
-                  Assert.assertEquals(
+                  assertEquals(
                       "Expected an array store to 'y'.",
                       node.getIR().getLocalNames(i, as.getArrayRef())[0],
                       "y");
@@ -318,7 +320,7 @@ public abstract class JavaIRTests extends IRTests {
                   final Integer valueAssigned =
                       (Integer) symbolTable.getConstantValue(as.getValue());
 
-                  Assert.assertEquals(
+                  assertEquals(
                       "Expected an array store to 'y' with value " + (valueOfArrayIndex + 1),
                       valueAssigned.intValue(),
                       valueOfArrayIndex + 1);
@@ -355,13 +357,13 @@ public abstract class JavaIRTests extends IRTests {
               CGNode node = cg.getNodes(mref).iterator().next();
               SSAInstruction s = node.getIR().getInstructions()[4];
 
-              Assert.assertTrue(
+              assertTrue(
                   "Did not find a getstatic instruction.",
                   s instanceof SSAGetInstruction && ((SSAGetInstruction) s).isStatic());
               final FieldReference field = ((SSAGetInstruction) s).getDeclaredField();
-              Assert.assertEquals(
+              assertEquals(
                   "Expected a getstatic for 'value'.", field.getName().toString(), "value");
-              Assert.assertEquals(
+              assertEquals(
                   "Expected a getstatic for 'value'.",
                   field.getDeclaringClass().getName().toString(),
                   "LFooQ");
@@ -384,9 +386,9 @@ public abstract class JavaIRTests extends IRTests {
                   findOrCreateTypeReference("Source", typeStr, cg.getClassHierarchy());
 
               final IClass iClass = cg.getClassHierarchy().lookupClass(type);
-              Assert.assertNotNull("Could not find class " + typeStr, iClass);
+              assertNotNull("Could not find class " + typeStr, iClass);
 
-              // todo: this fails: Assert.assertNotNull("Expected to be enclosed in
+              // todo: this fails: assertNotNull("Expected to be enclosed in
               // 'StaticNesting'.",
               // ((JavaSourceLoaderImpl.JavaClass)iClass).getEnclosingClass());
               // todo: is there the concept of CompilationUnit?
@@ -419,9 +421,9 @@ public abstract class JavaIRTests extends IRTests {
                   findOrCreateTypeReference("Source", typeStr + "$WhatsIt", cg.getClassHierarchy());
 
               final IClass iClass = cg.getClassHierarchy().lookupClass(type);
-              Assert.assertNotNull("Could not find class " + typeStr, iClass);
+              assertNotNull("Could not find class " + typeStr, iClass);
 
-              Assert.assertEquals(
+              assertEquals(
                   "Expected to be enclosed in 'InnerClass'.",
                   ((JavaSourceLoaderImpl.JavaClass) iClass)
                       .getEnclosingClass(), // todo is there another way?
@@ -474,7 +476,7 @@ public abstract class JavaIRTests extends IRTests {
         "LInnerClassA,",
       };
 
-      Assert.assertEquals("Buggy test", methodSigs.length, ikConcreteTypeStrings.length);
+      assertEquals("Buggy test", methodSigs.length, ikConcreteTypeStrings.length);
       for (int i = 0; i < methodSigs.length; i++) {
         if (n.getMethod().getSignature().equals(methodSigs[i])) {
           // find enclosing instruction
@@ -487,7 +489,7 @@ public abstract class JavaIRTests extends IRTests {
               // System.out.printf("in method %s, got ik %s\n", methodSigs[i], allIks);
 
               final String allIks = allIksBuilder.toString();
-              Assert.assertEquals(
+              assertEquals(
                   "assertion failed: expecting ik "
                       + ikConcreteTypeStrings[i]
                       + " in method "
@@ -527,7 +529,7 @@ public abstract class JavaIRTests extends IRTests {
               allIksBuilder.append(ik.getConcreteType().getName()).append(',');
             }
             final String allIks = allIksBuilder.toString();
-            Assert.assertEquals(
+            assertEquals(
                 "assertion failed: expecting ik \"LSub,\" in method, got \"" + allIks + "\"\n",
                 "LSub,",
                 allIks);
@@ -559,26 +561,26 @@ public abstract class JavaIRTests extends IRTests {
 
               // Observe the descriptor for a class local to a method.
               final IClass mainFooClass = cg.getClassHierarchy().lookupClass(mainFooType);
-              Assert.assertNotNull("Could not find class " + mainFooType, mainFooClass);
+              assertNotNull("Could not find class " + mainFooType, mainFooClass);
 
               final TypeReference methodFooType =
                   findOrCreateTypeReference(
                       "Source", typeStr + "/method()V/" + localClassStr, cg.getClassHierarchy());
 
               final IClass methodFooClass = cg.getClassHierarchy().lookupClass(methodFooType);
-              Assert.assertNotNull("Could not find class " + methodFooType, methodFooClass);
+              assertNotNull("Could not find class " + methodFooType, methodFooClass);
 
               final IClass localClass =
                   cg.getClassHierarchy()
                       .lookupClass(
                           findOrCreateTypeReference("Source", typeStr, cg.getClassHierarchy()));
 
-              Assert.assertSame(
+              assertSame(
                   "'Foo' is enclosed in 'Local'",
                   ((JavaSourceLoaderImpl.JavaClass) methodFooClass).getEnclosingClass(),
                   localClass);
               // todo: is this failing because 'main' is static?
-              // Assert.assertSame("'Foo' is enclosed in 'Local'",
+              // assertSame("'Foo' is enclosed in 'Local'",
               // ((JavaSourceLoaderImpl.JavaClass)mainFooClass).getEnclosingClass(),
               // localClass);
             }),
@@ -600,7 +602,7 @@ public abstract class JavaIRTests extends IRTests {
                   findOrCreateTypeReference("Source", typeStr, cg.getClassHierarchy());
 
               final IClass iClass = cg.getClassHierarchy().lookupClass(type);
-              Assert.assertNotNull("Could not find class " + typeStr, iClass);
+              assertNotNull("Could not find class " + typeStr, iClass);
 
               // todo what to check?? could not find anything in the APIs for
               // anonymous
@@ -722,8 +724,8 @@ public abstract class JavaIRTests extends IRTests {
         AstJavaSlicer.computeAssertionSlice(cg, pa, roots, false);
     Collection<Statement> slice = y.fst;
     dumpSlice(slice);
-    Assert.assertEquals(0, SlicerUtil.countAllocations(slice, false));
-    Assert.assertEquals(1, SlicerUtil.countPutfields(slice));
+    assertEquals(0, SlicerUtil.countAllocations(slice, false));
+    assertEquals(1, SlicerUtil.countPutfields(slice));
 
     // test slice from main
     sliceRootRef = getSliceRootReference("MiniaturSliceBug", "main", "([Ljava/lang/String;)V");
@@ -731,8 +733,8 @@ public abstract class JavaIRTests extends IRTests {
     y = AstJavaSlicer.computeAssertionSlice(cg, pa, roots, false);
     slice = y.fst;
     // SlicerUtil.dumpSlice(slice);
-    Assert.assertEquals(2, SlicerUtil.countAllocations(slice, false));
-    Assert.assertEquals(2, SlicerUtil.countPutfields(slice));
+    assertEquals(2, SlicerUtil.countAllocations(slice, false));
+    assertEquals(2, SlicerUtil.countPutfields(slice));
   }
 
   @Test

--- a/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/test/TestRhinoSourceMap.java
+++ b/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/test/TestRhinoSourceMap.java
@@ -14,6 +14,7 @@ import static com.ibm.wala.cast.js.ipa.callgraph.JSCallGraphUtil.makeHierarchy;
 import static com.ibm.wala.cast.js.ipa.callgraph.JSCallGraphUtil.makeLoaders;
 import static com.ibm.wala.cast.js.ipa.callgraph.JSCallGraphUtil.setTranslatorFactory;
 import static com.ibm.wala.cast.js.util.JSCallGraphBuilderUtil.makeScriptScope;
+import static org.junit.Assert.assertEquals;
 
 import com.ibm.wala.cast.js.loader.JavaScriptLoaderFactory;
 import com.ibm.wala.cast.js.translator.CAstRhinoTranslatorFactory;
@@ -27,7 +28,6 @@ import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.util.collections.HashMapFactory;
 import java.io.IOException;
 import java.util.Map;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -175,8 +175,7 @@ public class TestRhinoSourceMap {
                   + fun.getDeclaringClass().getName()
                   + " at "
                   + fun.getSourcePosition());
-          Assert.assertEquals(
-              sources.get(fun.getDeclaringClass().getName().toString()), sb.toString());
+          assertEquals(sources.get(fun.getDeclaringClass().getName().toString()), sb.toString());
         }
       }
     }

--- a/cast/js/src/test/java/com/ibm/wala/cast/js/test/TestWebUtil.java
+++ b/cast/js/src/test/java/com/ibm/wala/cast/js/test/TestWebUtil.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.cast.js.test;
 
+import static org.junit.Assert.assertNotNull;
+
 import com.ibm.wala.cast.ir.translator.TranslatorToCAst.Error;
 import com.ibm.wala.cast.js.html.DefaultSourceExtractor;
 import com.ibm.wala.cast.js.html.MappedSourceModule;
@@ -17,7 +19,6 @@ import com.ibm.wala.cast.js.html.WebUtil;
 import com.ibm.wala.core.tests.util.WalaTestCase;
 import java.net.URL;
 import java.util.Set;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class TestWebUtil extends WalaTestCase {
@@ -25,18 +26,18 @@ public class TestWebUtil extends WalaTestCase {
   @Test
   public void testAjaxslt() throws Error {
     URL url = getClass().getClassLoader().getResource("ajaxslt/test/xslt.html");
-    Assert.assertNotNull(url);
+    assertNotNull(url);
     Set<MappedSourceModule> mod =
         WebUtil.extractScriptFromHTML(url, DefaultSourceExtractor.factory).fst;
-    Assert.assertNotNull(mod);
+    assertNotNull(mod);
   }
 
   @Test
   public void testAjaxpath() throws Error {
     URL url = getClass().getClassLoader().getResource("ajaxslt/test/xpath.html");
-    Assert.assertNotNull(url);
+    assertNotNull(url);
     Set<MappedSourceModule> mod =
         WebUtil.extractScriptFromHTML(url, DefaultSourceExtractor.factory).fst;
-    Assert.assertNotNull(mod);
+    assertNotNull(mod);
   }
 }

--- a/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestCorrelatedPairExtraction.java
+++ b/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestCorrelatedPairExtraction.java
@@ -11,6 +11,9 @@
 
 package com.ibm.wala.cast.js.test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import com.ibm.wala.cast.js.ipa.callgraph.correlations.CorrelationFinder;
 import com.ibm.wala.cast.js.ipa.callgraph.correlations.CorrelationSummary;
 import com.ibm.wala.cast.js.ipa.callgraph.correlations.extraction.ClosureExtractor;
@@ -29,7 +32,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
-import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -63,7 +65,7 @@ public abstract class TestCorrelatedPairExtraction {
             public ExtractionPolicy createPolicy(CAstEntity entity) {
               CorrelatedPairExtractionPolicy policy =
                   CorrelatedPairExtractionPolicy.make(entity, summaries);
-              Assert.assertNotNull(policy);
+              assertNotNull(policy);
               return policy;
             }
           };
@@ -79,7 +81,7 @@ public abstract class TestCorrelatedPairExtraction {
       FileUtil.writeFile(new File("build/actual.dump"), actual);
 
       if (ASSERT_EQUALS) {
-        Assert.assertEquals(testName, expected, actual);
+        assertEquals(testName, expected, actual);
       }
 
     } catch (IOException | ClassHierarchyException e) {

--- a/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestForInBodyExtraction.java
+++ b/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestForInBodyExtraction.java
@@ -11,6 +11,8 @@
 
 package com.ibm.wala.cast.js.test;
 
+import static org.junit.Assert.assertEquals;
+
 import com.ibm.wala.cast.js.ipa.callgraph.correlations.extraction.ClosureExtractor;
 import com.ibm.wala.cast.js.ipa.callgraph.correlations.extraction.ForInBodyExtractionPolicy;
 import com.ibm.wala.cast.tree.CAstEntity;
@@ -21,7 +23,6 @@ import com.ibm.wala.util.io.FileUtil;
 import java.io.File;
 import java.io.IOException;
 import java.util.regex.Pattern;
-import org.junit.Assert;
 import org.junit.ComparisonFailure;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -66,7 +67,7 @@ public abstract class TestForInBodyExtraction {
       expected = new CAstDumper().dump(parseJS(tmp, ast));
       expected = eraseGeneratedNames(expected);
 
-      Assert.assertEquals(testName, expected, actual);
+      assertEquals(testName, expected, actual);
     } catch (IOException e) {
       e.printStackTrace();
     } catch (ComparisonFailure e) {

--- a/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestJavaScriptSlicer.java
+++ b/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestJavaScriptSlicer.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.cast.js.test;
 
+import static org.junit.Assert.assertEquals;
+
 import com.ibm.wala.cast.js.ipa.callgraph.JSCFABuilder;
 import com.ibm.wala.cast.js.ipa.modref.JavaScriptModRef;
 import com.ibm.wala.cast.js.util.JSCallGraphBuilderUtil;
@@ -30,7 +32,6 @@ import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.collections.Iterator2Iterable;
 import java.io.IOException;
 import java.util.Collection;
-import org.junit.Assert;
 import org.junit.Test;
 
 public abstract class TestJavaScriptSlicer extends TestJSCallGraphShape {
@@ -45,7 +46,7 @@ public abstract class TestJavaScriptSlicer extends TestJSCallGraphShape {
       System.err.println(r);
     }
 
-    Assert.assertEquals(0, SlicerUtil.countConditionals(result));
+    assertEquals(0, SlicerUtil.countConditionals(result));
   }
 
   @Test
@@ -58,7 +59,7 @@ public abstract class TestJavaScriptSlicer extends TestJSCallGraphShape {
       System.err.println(r);
     }
 
-    Assert.assertEquals(2, SlicerUtil.countConditionals(result));
+    assertEquals(2, SlicerUtil.countConditionals(result));
   }
 
   @Test
@@ -71,7 +72,7 @@ public abstract class TestJavaScriptSlicer extends TestJSCallGraphShape {
       System.err.println(r);
     }
 
-    Assert.assertEquals(1, SlicerUtil.countConditionals(result));
+    assertEquals(1, SlicerUtil.countConditionals(result));
   }
 
   private Collection<Statement> slice(

--- a/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestLexicalModRef.java
+++ b/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestLexicalModRef.java
@@ -10,6 +10,9 @@
  */
 package com.ibm.wala.cast.js.test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.cast.ipa.lexical.LexicalModRef;
 import com.ibm.wala.cast.js.ipa.callgraph.JSCFABuilder;
 import com.ibm.wala.cast.js.util.JSCallGraphBuilderUtil;
@@ -21,7 +24,6 @@ import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.io.IOException;
 import java.util.Map;
-import org.junit.Assert;
 import org.junit.Test;
 
 public abstract class TestLexicalModRef {
@@ -40,14 +42,14 @@ public abstract class TestLexicalModRef {
           .contains("Node: <Code body of function Ltests/simple-lexical.js/outer/inner>")) {
         // function "inner" reads exactly x and z
         OrdinalSet<Pair<CGNode, String>> readVars = entry.getValue();
-        Assert.assertEquals(2, readVars.size());
-        Assert.assertEquals(
+        assertEquals(2, readVars.size());
+        assertEquals(
             "[[Node: <Code body of function Ltests/simple-lexical.js/outer> Context: Everywhere,x], [Node: <Code body of function Ltests/simple-lexical.js/outer> Context: Everywhere,z]]",
             readVars.toString());
         // writes x and z as well
         OrdinalSet<Pair<CGNode, String>> writtenVars = writeResult.get(n);
-        Assert.assertEquals(2, writtenVars.size());
-        Assert.assertEquals(
+        assertEquals(2, writtenVars.size());
+        assertEquals(
             "[[Node: <Code body of function Ltests/simple-lexical.js/outer> Context: Everywhere,x], [Node: <Code body of function Ltests/simple-lexical.js/outer> Context: Everywhere,z]]",
             writtenVars.toString());
       }
@@ -55,9 +57,9 @@ public abstract class TestLexicalModRef {
           .contains("Node: <Code body of function Ltests/simple-lexical.js/outer/inner2>")) {
         // function "inner3" reads exactly innerName, inner3, and x and z via callees
         OrdinalSet<Pair<CGNode, String>> readVars = entry.getValue();
-        Assert.assertEquals(4, readVars.size());
+        assertEquals(4, readVars.size());
         for (Pair<CGNode, String> rv : readVars) {
-          Assert.assertTrue(
+          assertTrue(
               rv.toString(),
               "[Node: <Code body of function Ltests/simple-lexical.js/outer> Context: Everywhere,x]"
                       .equals(rv.toString())

--- a/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestPointerAnalyses.java
+++ b/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestPointerAnalyses.java
@@ -10,6 +10,9 @@
  */
 package com.ibm.wala.cast.js.test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.analysis.pointers.HeapGraph;
 import com.ibm.wala.cast.ipa.callgraph.GlobalObjectKey;
 import com.ibm.wala.cast.ir.ssa.AstGlobalWrite;
@@ -62,7 +65,6 @@ import java.util.Iterator;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import org.junit.Assert;
 import org.junit.Test;
 
 public abstract class TestPointerAnalyses {
@@ -263,7 +265,7 @@ public abstract class TestPointerAnalyses {
         Set<Pair<CGNode, NewSiteReference>> propPtrs =
             map(propCG, ptrs(propNodes, i, propCG, propPA));
 
-        Assert.assertEquals(
+        assertEquals(
             "analysis should agree on global object for " + i + " of " + ir,
             isGlobal(fbNodes, i, fbPA),
             isGlobal(propNodes, i, propPA));
@@ -273,7 +275,7 @@ public abstract class TestPointerAnalyses {
               "checking local " + i + " of " + function + ": " + fbPtrs + " vs " + propPtrs);
         }
 
-        Assert.assertTrue(
+        assertTrue(
             fbPtrs + " should intersect  " + propPtrs + " for " + i + " of " + ir,
             test.test(Pair.make(fbPtrs, propPtrs)));
       }
@@ -299,14 +301,13 @@ public abstract class TestPointerAnalyses {
                               o.getConcreteType(),
                               Atom.findOrCreateUnicodeAtom(p),
                               JavaScriptTypes.Root));
-              Assert.assertTrue(
-                  "object " + o + " should have field " + propKey, hg.hasEdge(o, propKey));
+              assertTrue("object " + o + " should have field " + propKey, hg.hasEdge(o, propKey));
 
               int val = ((AstPropertyWrite) inst).getValue();
               PointerKey valKey = fbPA.getHeapModel().getPointerKeyForLocal(node, val);
               OrdinalSet<ObjectVertex> valPtrs = fbPA.getPointsToSet(valKey);
               for (ObjectVertex v : valPtrs) {
-                Assert.assertTrue(
+                assertTrue(
                     "field " + propKey + " should point to object " + valKey + "(" + v + ")",
                     hg.hasEdge(propKey, v));
               }
@@ -326,7 +327,7 @@ public abstract class TestPointerAnalyses {
                           null,
                           Atom.findOrCreateUnicodeAtom(propName),
                           JavaScriptTypes.Root));
-          Assert.assertTrue(
+          assertTrue(
               "global " + propName + " should exist", hg.hasEdge(GlobalVertex.instance(), propKey));
 
           System.err.println("heap graph models instruction " + inst);
@@ -337,7 +338,7 @@ public abstract class TestPointerAnalyses {
               getFbPrototypes(fbPA, hg, fbCG, node, vn);
           Set<Pair<CGNode, NewSiteReference>> propPrototypes =
               getPropPrototypes(propPA, propCG, node, vn);
-          Assert.assertTrue(
+          assertTrue(
               "should have prototype overlap for "
                   + fbPrototypes
                   + " and "

--- a/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestSimpleCallGraphShape.java
+++ b/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestSimpleCallGraphShape.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.cast.js.test;
 
+import static org.junit.Assert.assertEquals;
+
 import com.ibm.wala.cast.ipa.callgraph.CAstCallGraphUtil;
 import com.ibm.wala.cast.js.ipa.callgraph.JSCFABuilder;
 import com.ibm.wala.cast.js.ipa.callgraph.PropertyNameContextSelector;
@@ -29,7 +31,6 @@ import com.ibm.wala.util.WalaException;
 import com.ibm.wala.util.collections.Iterator2Collection;
 import java.io.IOException;
 import java.util.List;
-import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -499,10 +500,10 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
     CallGraph cg = JSCallGraphBuilderUtil.makeScriptCG("tests", "function_call.js");
     for (CGNode n : cg) {
       if (n.getMethod().getName().toString().equals("call4")) {
-        Assert.assertEquals(2, cg.getSuccNodeCount(n));
+        assertEquals(2, cg.getSuccNodeCount(n));
         // ugh
         List<CGNode> succs = Iterator2Collection.toList(cg.getSuccNodes(n));
-        Assert.assertEquals(
+        assertEquals(
             "[Node: <Code body of function Lfunction_call.js/foo> Context: Everywhere, Node: <Code body of function Lfunction_call.js/bar> Context: Everywhere]",
             succs.toString());
       }

--- a/cast/src/test/java/com/ibm/wala/cast/test/TestCAstPattern.java
+++ b/cast/src/test/java/com/ibm/wala/cast/test/TestCAstPattern.java
@@ -10,6 +10,10 @@
  */
 package com.ibm.wala.cast.test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
 import com.ibm.wala.cast.tree.CAstNode;
 import com.ibm.wala.cast.tree.impl.CAstImpl;
 import com.ibm.wala.cast.util.CAstPattern;
@@ -19,7 +23,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class TestCAstPattern {
@@ -63,16 +66,16 @@ public class TestCAstPattern {
     System.err.println(("testing with input " + CAstPrinter.print(n)));
 
     if (names == null) {
-      Assert.assertFalse(p.match(n, null));
+      assertFalse(p.match(n, null));
     } else {
       Segments s = CAstPattern.match(p, n);
-      Assert.assertNotNull(s);
+      assertNotNull(s);
       for (Map.Entry<String, Object> entry : names.entrySet()) {
         Object o = entry.getValue();
         final String nm = entry.getKey();
         if (o instanceof CAstNode) {
           System.err.println(("found " + CAstPrinter.print(s.getSingle(nm)) + " for " + nm));
-          Assert.assertEquals(
+          assertEquals(
               "for name " + nm + ": expected " + entry.getValue() + " but got " + s.getSingle(nm),
               entry.getValue(),
               s.getSingle(nm));
@@ -80,7 +83,7 @@ public class TestCAstPattern {
           for (CAstNode node : s.getMultiple(nm)) {
             System.err.println(("found " + CAstPrinter.print(node) + " for " + nm));
           }
-          Assert.assertEquals(
+          assertEquals(
               "for name " + nm + ": expected " + entry.getValue() + " but got " + s.getMultiple(nm),
               entry.getValue(),
               s.getMultiple(nm));

--- a/cast/src/test/java/com/ibm/wala/cast/test/TestCAstTranslator.java
+++ b/cast/src/test/java/com/ibm/wala/cast/test/TestCAstTranslator.java
@@ -10,6 +10,12 @@
  */
 package com.ibm.wala.cast.test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import com.ibm.wala.cast.ipa.callgraph.CAstCallGraphUtil;
 import com.ibm.wala.cast.ir.ssa.AstIRFactory;
 import com.ibm.wala.cast.loader.SingleClassLoaderFactory;
@@ -32,7 +38,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import org.junit.Assert;
 
 public abstract class TestCAstTranslator {
 
@@ -170,14 +175,13 @@ public abstract class TestCAstTranslator {
     for (Object name : cha) {
       IClass cls = (IClass) name;
       clsCount++;
-      Assert.assertTrue(
+      assertTrue(
           "found class " + cls.getName().toString(), classes.contains(cls.getName().toString()));
 
       if (cls.getSuperclass() == null) {
-        Assert.assertNull(
-            cls.getName() + " has no superclass", supers.get(cls.getName().toString()));
+        assertNull(cls.getName() + " has no superclass", supers.get(cls.getName().toString()));
       } else {
-        Assert.assertEquals(
+        assertEquals(
             "super of " + cls.getName() + " is " + cls.getSuperclass().getName(),
             supers.get(cls.getName().toString()),
             cls.getSuperclass().getName().toString());
@@ -185,14 +189,14 @@ public abstract class TestCAstTranslator {
 
       for (Object name2 : cls.getDeclaredInstanceFields()) {
         IField fld = (IField) name2;
-        Assert.assertTrue(
+        assertTrue(
             cls.getName() + " has field " + fld.getName(),
             instanceFields.contains(Pair.make(cls.getName().toString(), fld.getName().toString())));
       }
 
       for (Object name2 : cls.getDeclaredStaticFields()) {
         IField fld = (IField) name2;
-        Assert.assertTrue(
+        assertTrue(
             cls.getName() + " has static field " + fld.getName(),
             staticFields.contains(Pair.make(cls.getName().toString(), fld.getName().toString())));
       }
@@ -203,17 +207,17 @@ public abstract class TestCAstTranslator {
         Pair<String, String> key = Pair.make(cls.getName().toString(), mth.getName().toString());
 
         if (mth.isStatic()) {
-          Assert.assertTrue(
+          assertTrue(
               cls.getName() + " has static method " + mth.getName(),
               staticMethods.containsKey(key));
-          Assert.assertEquals(
+          assertEquals(
               cls.getName() + "::" + mth.getName() + " has " + np + " parameters",
               staticMethods.get(key),
               np);
         } else {
-          Assert.assertTrue(
+          assertTrue(
               cls.getName() + " has method " + mth.getName(), instanceMethods.containsKey(key));
-          Assert.assertEquals(
+          assertEquals(
               cls.getName() + "::" + mth.getName() + " has " + np + " parameters",
               instanceMethods.get(key),
               np);
@@ -221,7 +225,7 @@ public abstract class TestCAstTranslator {
       }
     }
 
-    Assert.assertEquals("want " + classes.size() + " classes", clsCount, classes.size());
+    assertEquals("want " + classes.size() + " classes", clsCount, classes.size());
   }
 
   protected void testInternal(String[] args, TranslatorAssertions assertions) throws Exception {
@@ -239,7 +243,7 @@ public abstract class TestCAstTranslator {
         URL url = getClass().getClassLoader().getResource(args[i]);
         fileNames[i] = CAstCallGraphUtil.makeSourceModule(url, args[i]);
       }
-      Assert.assertNotNull(args[i], fileNames[i]);
+      assertNotNull(args[i], fileNames[i]);
     }
 
     ClassHierarchy cha = runTranslator(fileNames);
@@ -256,7 +260,7 @@ public abstract class TestCAstTranslator {
       testInternal(new String[] {arg}, assertions);
     } catch (Exception e) {
       e.printStackTrace();
-      Assert.fail(e.toString());
+      fail(e.toString());
     }
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/basic/FloydWarshallTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/basic/FloydWarshallTest.java
@@ -11,6 +11,7 @@
 package com.ibm.wala.core.tests.basic;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.ibm.wala.core.tests.util.WalaTestCase;
 import com.ibm.wala.util.graph.INodeWithNumberedEdges;
@@ -28,7 +29,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class FloydWarshallTest extends WalaTestCase {
@@ -206,7 +206,7 @@ public class FloydWarshallTest extends WalaTestCase {
 
     assertEquals(resultPaths.size(), expectedPaths.size());
     for (List<Node> rp : resultPaths) {
-      Assert.assertTrue(expectedPaths.contains(rp));
+      assertTrue(expectedPaths.contains(rp));
     }
   }
 

--- a/core/src/test/java/com/ibm/wala/core/tests/basic/GraphDataflowTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/basic/GraphDataflowTest.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.core.tests.basic;
 
+import static org.junit.Assert.assertEquals;
+
 import com.ibm.wala.core.tests.util.WalaTestCase;
 import com.ibm.wala.dataflow.graph.AbstractMeetOperator;
 import com.ibm.wala.dataflow.graph.BitVectorFilter;
@@ -28,7 +30,6 @@ import com.ibm.wala.util.graph.impl.SlowSparseNumberedGraph;
 import com.ibm.wala.util.intset.BitVector;
 import com.ibm.wala.util.intset.MutableMapping;
 import com.ibm.wala.util.intset.OrdinalSetMapping;
-import org.junit.Assert;
 import org.junit.Test;
 
 /** Simple Regression test for a graph-based dataflow problem. */
@@ -59,7 +60,7 @@ public class GraphDataflowTest extends WalaTestCase {
       System.err.println("Uh oh.");
       System.err.println(expectedStringNodeEdge());
     }
-    Assert.assertEquals(expectedStringNodeEdge(), result);
+    assertEquals(expectedStringNodeEdge(), result);
   }
 
   @Test
@@ -67,7 +68,7 @@ public class GraphDataflowTest extends WalaTestCase {
     Graph<String> G = buildGraph();
     String result = solveNodeOnly(G);
     System.err.println(result);
-    Assert.assertEquals(expectedStringNodeOnly(), result);
+    assertEquals(expectedStringNodeOnly(), result);
   }
 
   /** @return the expected dataflow result as a String */

--- a/core/src/test/java/com/ibm/wala/core/tests/basic/PathFinderTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/basic/PathFinderTest.java
@@ -10,11 +10,12 @@
  */
 package com.ibm.wala.core.tests.basic;
 
+import static org.junit.Assert.assertEquals;
+
 import com.ibm.wala.util.graph.Graph;
 import com.ibm.wala.util.graph.impl.SlowSparseNumberedGraph;
 import com.ibm.wala.util.graph.traverse.DFSAllPathsFinder;
 import java.util.List;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class PathFinderTest {
@@ -49,7 +50,7 @@ public class PathFinderTest {
       System.err.println(path);
       count++;
     }
-    Assert.assertEquals(expectedCount, count);
+    assertEquals(expectedCount, count);
   }
 
   private static final String edges1 = "ABBCBDCECFDGDHEIFIGJHJJKIKKL";

--- a/core/src/test/java/com/ibm/wala/core/tests/basic/PrimitivesTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/basic/PrimitivesTest.java
@@ -10,6 +10,13 @@
  */
 package com.ibm.wala.core.tests.basic;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.core.tests.util.WalaTestCase;
 import com.ibm.wala.util.collections.BimodalMap;
 import com.ibm.wala.util.collections.HashSetFactory;
@@ -50,7 +57,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import org.junit.Assert;
 import org.junit.Test;
 
 /** JUnit tests for some primitive operations. */
@@ -81,7 +87,7 @@ public class PrimitivesTest extends WalaTestCase {
     System.err.println(IntSetUtil.diff(v, z, factory)); // { 17 }
     System.err.println(IntSetUtil.diff(z, v, factory)); // { }
 
-    // Assert.assertTrue(x.union(z).intersection(y.union(z)).equals(x.intersection(y).union(z)));
+    // assertTrue(x.union(z).intersection(y.union(z)).equals(x.intersection(y).union(z)));
     MutableIntSet temp1 = factory.makeCopy(x);
     MutableIntSet temp2 = factory.makeCopy(x);
     MutableIntSet tempY = factory.makeCopy(y);
@@ -90,15 +96,15 @@ public class PrimitivesTest extends WalaTestCase {
     temp1.intersectWith(tempY);
     temp2.intersectWith(y);
     temp2.addAll(z);
-    Assert.assertTrue(temp1.sameValue(temp2));
+    assertTrue(temp1.sameValue(temp2));
 
-    // Assert.assertTrue(x.union(z).diff(z).equals(x));
-    Assert.assertTrue(w.isEmpty());
-    Assert.assertTrue(IntSetUtil.diff(x, x, factory).isEmpty());
-    Assert.assertTrue(IntSetUtil.diff(z, v, factory).isEmpty());
-    Assert.assertTrue(IntSetUtil.diff(v, z, factory).sameValue(SparseIntSet.singleton(17)));
-    Assert.assertTrue(IntSetUtil.diff(z, v, factory).isEmpty());
-    Assert.assertTrue(z.isSubset(v));
+    // assertTrue(x.union(z).diff(z).equals(x));
+    assertTrue(w.isEmpty());
+    assertTrue(IntSetUtil.diff(x, x, factory).isEmpty());
+    assertTrue(IntSetUtil.diff(z, v, factory).isEmpty());
+    assertTrue(IntSetUtil.diff(v, z, factory).sameValue(SparseIntSet.singleton(17)));
+    assertTrue(IntSetUtil.diff(z, v, factory).isEmpty());
+    assertTrue(z.isSubset(v));
     temp = factory.make();
     temp.add(4);
     System.err.println(temp); // { 4 }
@@ -107,7 +113,7 @@ public class PrimitivesTest extends WalaTestCase {
     temp.add(2);
     System.err.println(temp); // { 2 4 7 }
     System.err.println(x); // { 2 4 7 }
-    Assert.assertTrue(temp.sameValue(x));
+    assertTrue(temp.sameValue(x));
 
     MutableIntSet a =
         factory.parse(
@@ -115,71 +121,71 @@ public class PrimitivesTest extends WalaTestCase {
     System.err.println(a); // { 1 3 5 7 9 11 13 15 17 19 21 23 25 27 29 31 33
     // 35
     // 37 39 41 43 45 47 49 51 53 55 57 59 }
-    Assert.assertTrue(a.sameValue(a));
+    assertTrue(a.sameValue(a));
     IntSet i = a.intersection(temp);
-    Assert.assertTrue(i.sameValue(SparseIntSet.singleton(7)));
+    assertTrue(i.sameValue(SparseIntSet.singleton(7)));
     a.add(100);
-    Assert.assertTrue(a.sameValue(a));
+    assertTrue(a.sameValue(a));
 
     MutableIntSet b =
         factory.parse(
             "{1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59,100}");
-    Assert.assertTrue(a.sameValue(b));
-    Assert.assertTrue(a.isSubset(b));
+    assertTrue(a.sameValue(b));
+    assertTrue(a.isSubset(b));
 
     IntSet f = IntSetUtil.diff(b, factory.parse("{7,8,9}"), factory);
     System.err.println(f);
-    Assert.assertFalse(f.contains(7));
-    Assert.assertFalse(f.contains(8));
-    Assert.assertFalse(f.contains(9));
-    Assert.assertFalse(f.sameValue(b));
-    Assert.assertTrue(f.isSubset(b));
+    assertFalse(f.contains(7));
+    assertFalse(f.contains(8));
+    assertFalse(f.contains(9));
+    assertFalse(f.sameValue(b));
+    assertTrue(f.isSubset(b));
 
     IntSet tmp =
         factory.parse(
             "{2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48,50,51,53,55,57,59,61,63}");
     f = IntSetUtil.diff(b, tmp, factory);
     System.err.println(f);
-    Assert.assertFalse(f.sameValue(b));
-    Assert.assertTrue(f.isSubset(b));
-    Assert.assertFalse(f.contains(51));
-    Assert.assertFalse(f.contains(53));
-    Assert.assertFalse(f.contains(55));
-    Assert.assertFalse(f.contains(57));
-    Assert.assertFalse(f.contains(59));
-    Assert.assertTrue(f.contains(100));
+    assertFalse(f.sameValue(b));
+    assertTrue(f.isSubset(b));
+    assertFalse(f.contains(51));
+    assertFalse(f.contains(53));
+    assertFalse(f.contains(55));
+    assertFalse(f.contains(57));
+    assertFalse(f.contains(59));
+    assertTrue(f.contains(100));
 
     tmp =
         factory.parse(
             "{2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48,50,51,53,55,57,59,61,63,100}");
     f = IntSetUtil.diff(b, tmp, factory);
     System.err.println(f);
-    Assert.assertFalse(f.sameValue(b));
-    Assert.assertTrue(f.isSubset(b));
-    Assert.assertFalse(f.contains(51));
-    Assert.assertFalse(f.contains(53));
-    Assert.assertFalse(f.contains(55));
-    Assert.assertFalse(f.contains(57));
-    Assert.assertFalse(f.contains(59));
-    Assert.assertFalse(f.contains(100));
+    assertFalse(f.sameValue(b));
+    assertTrue(f.isSubset(b));
+    assertFalse(f.contains(51));
+    assertFalse(f.contains(53));
+    assertFalse(f.contains(55));
+    assertFalse(f.contains(57));
+    assertFalse(f.contains(59));
+    assertFalse(f.contains(100));
 
     b = factory.makeCopy(a);
-    Assert.assertTrue(a.sameValue(b));
+    assertTrue(a.sameValue(b));
     b.remove(1);
     b.add(0);
-    Assert.assertFalse(a.sameValue(b));
+    assertFalse(a.sameValue(b));
 
     a = factory.parse("{1}");
-    Assert.assertFalse(a.isSubset(b));
+    assertFalse(a.isSubset(b));
     b.remove(0);
-    Assert.assertFalse(a.isSubset(b));
+    assertFalse(a.isSubset(b));
     a.remove(1);
-    Assert.assertTrue(a.isEmpty());
+    assertTrue(a.isEmpty());
     IntSet ignored = a.intersection(temp);
-    Assert.assertTrue(a.isEmpty());
+    assertTrue(a.isEmpty());
 
     temp2 = factory.make();
-    Assert.assertTrue(temp2.sameValue(a));
+    assertTrue(temp2.sameValue(a));
 
     a =
         factory.parse(
@@ -193,62 +199,62 @@ public class PrimitivesTest extends WalaTestCase {
         factory.parse("{2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48,50}");
     MutableIntSet e = factory.parse("{2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34}");
 
-    Assert.assertTrue(e.isSubset(d));
+    assertTrue(e.isSubset(d));
     e.addAll(d);
-    Assert.assertTrue(e.isSubset(d));
+    assertTrue(e.isSubset(d));
     e.remove(12);
-    Assert.assertTrue(e.isSubset(d));
+    assertTrue(e.isSubset(d));
     e.add(105);
-    Assert.assertFalse(e.isSubset(d));
+    assertFalse(e.isSubset(d));
 
-    Assert.assertFalse(b.isSubset(a));
+    assertFalse(b.isSubset(a));
 
     b.add(53);
-    Assert.assertFalse(b.isSubset(a));
+    assertFalse(b.isSubset(a));
 
     a.add(52);
     a.remove(52);
-    Assert.assertFalse(b.isSubset(a));
+    assertFalse(b.isSubset(a));
 
     c.add(55);
-    Assert.assertFalse(c.isSubset(b));
+    assertFalse(c.isSubset(b));
 
     d.add(53);
-    Assert.assertTrue(d.isSubset(b));
+    assertTrue(d.isSubset(b));
 
     d = factory.make();
     d.copySet(c);
-    Assert.assertFalse(d.isSubset(b));
+    assertFalse(d.isSubset(b));
 
     a = factory.parse("{2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48,50}");
     b = factory.parse("{2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48}");
-    Assert.assertFalse(a.sameValue(b));
+    assertFalse(a.sameValue(b));
     b.add(50);
-    Assert.assertTrue(a.sameValue(b));
+    assertTrue(a.sameValue(b));
     a.add(11);
     b.add(11);
-    Assert.assertTrue(a.sameValue(b));
+    assertTrue(a.sameValue(b));
 
     a = factory.parse("{2,4,6,8,10,12,14,16,18,20,50}");
     b = factory.parse("{24,26,28,30,32,34,36,38,40,42,44,46,48}");
     c = factory.parse("{2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48,50}");
     a.addAll(b);
     a.add(22);
-    Assert.assertTrue(a.sameValue(c));
+    assertTrue(a.sameValue(c));
 
     a = factory.parse("{2,4,6,8,10,12,14,16,18,20,50}");
     b = factory.parse("{24,26,28,30,32,34,36,38,40,42,44,46,48}");
     c = factory.parse("{2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48,50}");
     b.addAll(factory.parse("{22}"));
     a.addAll(b);
-    Assert.assertTrue(a.sameValue(c));
+    assertTrue(a.sameValue(c));
 
     a = factory.parse("{2,4,6,8,10,12,14,16,18,20}");
     b = factory.parse("{22,24,26,28,30,32,34,36,38,40,42,44,46,48}");
     c = factory.parse("{2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48,50}");
     c.remove(22);
     a.addAll(b);
-    Assert.assertFalse(a.sameValue(c));
+    assertFalse(a.sameValue(c));
 
     a =
         factory.parse(
@@ -256,38 +262,38 @@ public class PrimitivesTest extends WalaTestCase {
     System.err.println(a); // { 1 3 5 7 9 11 13 15 17 19 21 23 25 27 29 31 33
     // 35
     // 37 39 41 43 45 47 49 51 53 55 57 59 }
-    Assert.assertTrue(a.sameValue(a));
+    assertTrue(a.sameValue(a));
     i = a.intersection(temp);
-    Assert.assertTrue(i.sameValue(SparseIntSet.singleton(7)));
+    assertTrue(i.sameValue(SparseIntSet.singleton(7)));
     a.add(100);
-    Assert.assertTrue(a.sameValue(a));
+    assertTrue(a.sameValue(a));
 
     b =
         factory.parse(
             "{1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59,100}");
-    Assert.assertTrue(a.sameValue(b));
-    Assert.assertTrue(a.isSubset(b));
+    assertTrue(a.sameValue(b));
+    assertTrue(a.isSubset(b));
 
     b = factory.makeCopy(a);
-    Assert.assertTrue(a.sameValue(b));
+    assertTrue(a.sameValue(b));
     b.remove(1);
     b.add(0);
-    Assert.assertFalse(a.sameValue(b));
+    assertFalse(a.sameValue(b));
 
     a.clear();
-    Assert.assertTrue(a.isEmpty());
+    assertTrue(a.isEmpty());
 
     a = factory.parse("{1}");
-    Assert.assertFalse(a.isSubset(b));
+    assertFalse(a.isSubset(b));
     b.remove(0);
-    Assert.assertFalse(a.isSubset(b));
+    assertFalse(a.isSubset(b));
     a.remove(1);
-    Assert.assertTrue(a.isEmpty());
+    assertTrue(a.isEmpty());
     ignored = a.intersection(temp);
-    Assert.assertTrue(a.isEmpty());
+    assertTrue(a.isEmpty());
 
     temp2 = factory.make();
-    Assert.assertTrue(temp2.sameValue(a));
+    assertTrue(temp2.sameValue(a));
 
     for (int idx = 500; idx < 550; ) {
       for (int xx = 0; xx < 50; xx++, idx++) {
@@ -304,10 +310,10 @@ public class PrimitivesTest extends WalaTestCase {
     }
 
     temp2.clear();
-    Assert.assertTrue(temp2.isEmpty());
+    assertTrue(temp2.isEmpty());
 
     temp2 = factory.make();
-    Assert.assertTrue(temp2.sameValue(a));
+    assertTrue(temp2.sameValue(a));
 
     for (int idx = 500; idx < 550; ) {
       for (int xx = 0; xx < 50; xx++, idx++) {
@@ -322,7 +328,7 @@ public class PrimitivesTest extends WalaTestCase {
     }
 
     temp2.clear();
-    Assert.assertTrue(temp2.isEmpty());
+    assertTrue(temp2.isEmpty());
   }
 
   /** Test the MutableSharedBitVectorIntSet implementation */
@@ -379,7 +385,7 @@ public class PrimitivesTest extends WalaTestCase {
     System.err.println(LongSetUtil.diff(v, z, factory)); // { 17 }
     System.err.println(LongSetUtil.diff(z, v, factory)); // { }
 
-    // Assert.assertTrue(x.union(z).intersection(y.union(z)).equals(x.intersection(y).union(z)));
+    // assertTrue(x.union(z).intersection(y.union(z)).equals(x.intersection(y).union(z)));
     MutableLongSet temp1 = factory.makeCopy(x);
     MutableLongSet temp2 = factory.makeCopy(x);
     MutableLongSet tempY = factory.makeCopy(y);
@@ -388,15 +394,15 @@ public class PrimitivesTest extends WalaTestCase {
     temp1.intersectWith(tempY);
     temp2.intersectWith(y);
     temp2.addAll(z);
-    Assert.assertTrue(temp1.sameValue(temp2));
+    assertTrue(temp1.sameValue(temp2));
 
-    // Assert.assertTrue(x.union(z).diff(z).equals(x));
-    Assert.assertTrue(w.isEmpty());
-    Assert.assertTrue(LongSetUtil.diff(x, x, factory).isEmpty());
-    Assert.assertTrue(LongSetUtil.diff(z, v, factory).isEmpty());
-    Assert.assertTrue(LongSetUtil.diff(v, z, factory).sameValue(SparseLongSet.singleton(17)));
-    Assert.assertTrue(LongSetUtil.diff(z, v, factory).isEmpty());
-    Assert.assertTrue(z.isSubset(v));
+    // assertTrue(x.union(z).diff(z).equals(x));
+    assertTrue(w.isEmpty());
+    assertTrue(LongSetUtil.diff(x, x, factory).isEmpty());
+    assertTrue(LongSetUtil.diff(z, v, factory).isEmpty());
+    assertTrue(LongSetUtil.diff(v, z, factory).sameValue(SparseLongSet.singleton(17)));
+    assertTrue(LongSetUtil.diff(z, v, factory).isEmpty());
+    assertTrue(z.isSubset(v));
     temp = factory.make();
     temp.add(4);
     System.err.println(temp); // { 4 }
@@ -405,7 +411,7 @@ public class PrimitivesTest extends WalaTestCase {
     temp.add(2);
     System.err.println(temp); // { 2 4 7 }
     System.err.println(x); // { 2 4 7 }
-    Assert.assertTrue(temp.sameValue(x));
+    assertTrue(temp.sameValue(x));
 
     MutableLongSet a =
         factory.parse(
@@ -413,71 +419,71 @@ public class PrimitivesTest extends WalaTestCase {
     System.err.println(a); // { 1 3 5 7 9 11 13 15 17 19 21 23 25 27 29 31 33
     // 35
     // 37 39 41 43 45 47 49 51 53 55 57 59 }
-    Assert.assertTrue(a.sameValue(a));
+    assertTrue(a.sameValue(a));
     LongSet i = a.intersection(temp);
-    Assert.assertTrue(i.sameValue(SparseLongSet.singleton(7)));
+    assertTrue(i.sameValue(SparseLongSet.singleton(7)));
     a.add(100);
-    Assert.assertTrue(a.sameValue(a));
+    assertTrue(a.sameValue(a));
 
     MutableLongSet b =
         factory.parse(
             "{1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59,100}");
-    Assert.assertTrue(a.sameValue(b));
-    Assert.assertTrue(a.isSubset(b));
+    assertTrue(a.sameValue(b));
+    assertTrue(a.isSubset(b));
 
     LongSet f = LongSetUtil.diff(b, factory.parse("{7,8,9}"), factory);
     System.err.println(f);
-    Assert.assertFalse(f.contains(7));
-    Assert.assertFalse(f.contains(8));
-    Assert.assertFalse(f.contains(9));
-    Assert.assertFalse(f.sameValue(b));
-    Assert.assertTrue(f.isSubset(b));
+    assertFalse(f.contains(7));
+    assertFalse(f.contains(8));
+    assertFalse(f.contains(9));
+    assertFalse(f.sameValue(b));
+    assertTrue(f.isSubset(b));
 
     LongSet tmp =
         factory.parse(
             "{2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48,50,51,53,55,57,59,61,63}");
     f = LongSetUtil.diff(b, tmp, factory);
     System.err.println(f);
-    Assert.assertFalse(f.sameValue(b));
-    Assert.assertTrue(f.isSubset(b));
-    Assert.assertFalse(f.contains(51));
-    Assert.assertFalse(f.contains(53));
-    Assert.assertFalse(f.contains(55));
-    Assert.assertFalse(f.contains(57));
-    Assert.assertFalse(f.contains(59));
-    Assert.assertTrue(f.contains(100));
+    assertFalse(f.sameValue(b));
+    assertTrue(f.isSubset(b));
+    assertFalse(f.contains(51));
+    assertFalse(f.contains(53));
+    assertFalse(f.contains(55));
+    assertFalse(f.contains(57));
+    assertFalse(f.contains(59));
+    assertTrue(f.contains(100));
 
     tmp =
         factory.parse(
             "{2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48,50,51,53,55,57,59,61,63,100}");
     f = LongSetUtil.diff(b, tmp, factory);
     System.err.println(f);
-    Assert.assertFalse(f.sameValue(b));
-    Assert.assertTrue(f.isSubset(b));
-    Assert.assertFalse(f.contains(51));
-    Assert.assertFalse(f.contains(53));
-    Assert.assertFalse(f.contains(55));
-    Assert.assertFalse(f.contains(57));
-    Assert.assertFalse(f.contains(59));
-    Assert.assertFalse(f.contains(100));
+    assertFalse(f.sameValue(b));
+    assertTrue(f.isSubset(b));
+    assertFalse(f.contains(51));
+    assertFalse(f.contains(53));
+    assertFalse(f.contains(55));
+    assertFalse(f.contains(57));
+    assertFalse(f.contains(59));
+    assertFalse(f.contains(100));
 
     b = factory.makeCopy(a);
-    Assert.assertTrue(a.sameValue(b));
+    assertTrue(a.sameValue(b));
     b.remove(1);
     b.add(0);
-    Assert.assertFalse(a.sameValue(b));
+    assertFalse(a.sameValue(b));
 
     a = factory.parse("{1}");
-    Assert.assertFalse(a.isSubset(b));
+    assertFalse(a.isSubset(b));
     b.remove(0);
-    Assert.assertFalse(a.isSubset(b));
+    assertFalse(a.isSubset(b));
     a.remove(1);
-    Assert.assertTrue(a.isEmpty());
+    assertTrue(a.isEmpty());
     LongSet ignored = a.intersection(temp);
-    Assert.assertTrue(a.isEmpty());
+    assertTrue(a.isEmpty());
 
     temp2 = factory.make();
-    Assert.assertTrue(temp2.sameValue(a));
+    assertTrue(temp2.sameValue(a));
 
     a =
         factory.parse(
@@ -491,62 +497,62 @@ public class PrimitivesTest extends WalaTestCase {
         factory.parse("{2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48,50}");
     MutableLongSet e = factory.parse("{2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34}");
 
-    Assert.assertTrue(e.isSubset(d));
+    assertTrue(e.isSubset(d));
     e.addAll(d);
-    Assert.assertTrue(e.isSubset(d));
+    assertTrue(e.isSubset(d));
     e.remove(12);
-    Assert.assertTrue(e.isSubset(d));
+    assertTrue(e.isSubset(d));
     e.add(105);
-    Assert.assertFalse(e.isSubset(d));
+    assertFalse(e.isSubset(d));
 
-    Assert.assertFalse(b.isSubset(a));
+    assertFalse(b.isSubset(a));
 
     b.add(53);
-    Assert.assertFalse(b.isSubset(a));
+    assertFalse(b.isSubset(a));
 
     a.add(52);
     a.remove(52);
-    Assert.assertFalse(b.isSubset(a));
+    assertFalse(b.isSubset(a));
 
     c.add(55);
-    Assert.assertFalse(c.isSubset(b));
+    assertFalse(c.isSubset(b));
 
     d.add(53);
-    Assert.assertTrue(d.isSubset(b));
+    assertTrue(d.isSubset(b));
 
     d = factory.make();
     d.copySet(c);
-    Assert.assertFalse(d.isSubset(b));
+    assertFalse(d.isSubset(b));
 
     a = factory.parse("{2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48,50}");
     b = factory.parse("{2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48}");
-    Assert.assertFalse(a.sameValue(b));
+    assertFalse(a.sameValue(b));
     b.add(50);
-    Assert.assertTrue(a.sameValue(b));
+    assertTrue(a.sameValue(b));
     a.add(11);
     b.add(11);
-    Assert.assertTrue(a.sameValue(b));
+    assertTrue(a.sameValue(b));
 
     a = factory.parse("{2,4,6,8,10,12,14,16,18,20,50}");
     b = factory.parse("{24,26,28,30,32,34,36,38,40,42,44,46,48}");
     c = factory.parse("{2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48,50}");
     a.addAll(b);
     a.add(22);
-    Assert.assertTrue(a.sameValue(c));
+    assertTrue(a.sameValue(c));
 
     a = factory.parse("{2,4,6,8,10,12,14,16,18,20,50}");
     b = factory.parse("{24,26,28,30,32,34,36,38,40,42,44,46,48}");
     c = factory.parse("{2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48,50}");
     b.addAll(factory.parse("{22}"));
     a.addAll(b);
-    Assert.assertTrue(a.sameValue(c));
+    assertTrue(a.sameValue(c));
 
     a = factory.parse("{2,4,6,8,10,12,14,16,18,20}");
     b = factory.parse("{22,24,26,28,30,32,34,36,38,40,42,44,46,48}");
     c = factory.parse("{2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48,50}");
     c.remove(22);
     a.addAll(b);
-    Assert.assertFalse(a.sameValue(c));
+    assertFalse(a.sameValue(c));
 
     a =
         factory.parse(
@@ -554,35 +560,35 @@ public class PrimitivesTest extends WalaTestCase {
     System.err.println(a); // { 1 3 5 7 9 11 13 15 17 19 21 23 25 27 29 31 33
     // 35
     // 37 39 41 43 45 47 49 51 53 55 57 59 }
-    Assert.assertTrue(a.sameValue(a));
+    assertTrue(a.sameValue(a));
     i = a.intersection(temp);
-    Assert.assertTrue(i.sameValue(SparseLongSet.singleton(7)));
+    assertTrue(i.sameValue(SparseLongSet.singleton(7)));
     a.add(100);
-    Assert.assertTrue(a.sameValue(a));
+    assertTrue(a.sameValue(a));
 
     b =
         factory.parse(
             "{1,3,5,7,9,11,13,15,17,19,21,23,25,27,29,31,33,35,37,39,41,43,45,47,49,51,53,55,57,59,100}");
-    Assert.assertTrue(a.sameValue(b));
-    Assert.assertTrue(a.isSubset(b));
+    assertTrue(a.sameValue(b));
+    assertTrue(a.isSubset(b));
 
     b = factory.makeCopy(a);
-    Assert.assertTrue(a.sameValue(b));
+    assertTrue(a.sameValue(b));
     b.remove(1);
     b.add(0);
-    Assert.assertFalse(a.sameValue(b));
+    assertFalse(a.sameValue(b));
 
     a = factory.parse("{1}");
-    Assert.assertFalse(a.isSubset(b));
+    assertFalse(a.isSubset(b));
     b.remove(0);
-    Assert.assertFalse(a.isSubset(b));
+    assertFalse(a.isSubset(b));
     a.remove(1);
-    Assert.assertTrue(a.isEmpty());
+    assertTrue(a.isEmpty());
     ignored = a.intersection(temp);
-    Assert.assertTrue(a.isEmpty());
+    assertTrue(a.isEmpty());
 
     temp2 = factory.make();
-    Assert.assertTrue(temp2.sameValue(a));
+    assertTrue(temp2.sameValue(a));
 
     for (int idx = 500; idx < 550; ) {
       for (int xx = 0; xx < 50; xx++, idx++) {
@@ -599,7 +605,7 @@ public class PrimitivesTest extends WalaTestCase {
     }
 
     temp2 = factory.make();
-    Assert.assertTrue(temp2.sameValue(a));
+    assertTrue(temp2.sameValue(a));
 
     for (int idx = 500; idx < 550; ) {
       for (int xx = 0; xx < 50; xx++, idx++) {
@@ -631,16 +637,16 @@ public class PrimitivesTest extends WalaTestCase {
     M.put(I3, I3);
 
     Integer I = M.get(Integer.valueOf(2));
-    Assert.assertNotNull(I);
-    Assert.assertEquals(I, I2);
+    assertNotNull(I);
+    assertEquals(I, I2);
 
     I = M.get(Integer.valueOf(4));
-    Assert.assertNull(I);
+    assertNull(I);
 
     I = M.put(Integer.valueOf(2), Integer.valueOf(3));
-    Assert.assertEquals(I, I2);
+    assertEquals(I, I2);
     I = M.get(I2);
-    Assert.assertEquals(I, I3);
+    assertEquals(I, I3);
   }
 
   @Test
@@ -657,31 +663,31 @@ public class PrimitivesTest extends WalaTestCase {
     M.put(I3, I3);
 
     Integer I = M.get(Integer.valueOf(2));
-    Assert.assertNotNull(I);
-    Assert.assertEquals(I, I2);
+    assertNotNull(I);
+    assertEquals(I, I2);
 
     I = M.get(Integer.valueOf(4));
-    Assert.assertNull(I);
+    assertNull(I);
 
     I = M.put(Integer.valueOf(2), Integer.valueOf(3));
-    Assert.assertEquals(I, I2);
+    assertEquals(I, I2);
     I = M.get(I2);
-    Assert.assertEquals(I, I3);
+    assertEquals(I, I3);
 
     M.put(I4, I4);
     M.put(I5, I5);
     M.put(I6, I6);
     I = M.get(Integer.valueOf(4));
-    Assert.assertNotNull(I);
-    Assert.assertEquals(I, I4);
+    assertNotNull(I);
+    assertEquals(I, I4);
 
     I = M.get(Integer.valueOf(7));
-    Assert.assertNull(I);
+    assertNull(I);
 
     I = M.put(Integer.valueOf(2), Integer.valueOf(6));
-    Assert.assertEquals(I, I3);
+    assertEquals(I, I3);
     I = M.get(I2);
-    Assert.assertEquals(I, I6);
+    assertEquals(I, I6);
   }
 
   @Test
@@ -695,7 +701,7 @@ public class PrimitivesTest extends WalaTestCase {
     // path should be 8, 6, 4, 2, 0
     System.err.println("Path is " + p);
     for (int i = 0; i < p.size(); i++) {
-      Assert.assertEquals((int) p.get(i), new int[] {8, 6, 4, 2, 0}[i]);
+      assertEquals((int) p.get(i), new int[] {8, 6, 4, 2, 0}[i]);
     }
   }
 
@@ -705,31 +711,31 @@ public class PrimitivesTest extends WalaTestCase {
 
     BoundedBFSIterator<Integer> bfs = new BoundedBFSIterator<>(G, G.getNode(0), 0);
     Collection<Integer> c = Iterator2Collection.toSet(bfs);
-    Assert.assertEquals(1, c.size());
+    assertEquals(1, c.size());
 
     bfs = new BoundedBFSIterator<>(G, G.getNode(0), 1);
     c = Iterator2Collection.toSet(bfs);
-    Assert.assertEquals(3, c.size());
+    assertEquals(3, c.size());
 
     bfs = new BoundedBFSIterator<>(G, G.getNode(0), 2);
     c = Iterator2Collection.toSet(bfs);
-    Assert.assertEquals(5, c.size());
+    assertEquals(5, c.size());
 
     bfs = new BoundedBFSIterator<>(G, G.getNode(0), 3);
     c = Iterator2Collection.toSet(bfs);
-    Assert.assertEquals(7, c.size());
+    assertEquals(7, c.size());
 
     bfs = new BoundedBFSIterator<>(G, G.getNode(0), 4);
     c = Iterator2Collection.toSet(bfs);
-    Assert.assertEquals(9, c.size());
+    assertEquals(9, c.size());
 
     bfs = new BoundedBFSIterator<>(G, G.getNode(0), 5);
     c = Iterator2Collection.toSet(bfs);
-    Assert.assertEquals(10, c.size());
+    assertEquals(10, c.size());
 
     bfs = new BoundedBFSIterator<>(G, G.getNode(0), 500);
     c = Iterator2Collection.toSet(bfs);
-    Assert.assertEquals(10, c.size());
+    assertEquals(10, c.size());
   }
 
   private static NumberedGraph<Integer> makeBFSTestGraph() {
@@ -785,8 +791,7 @@ public class PrimitivesTest extends WalaTestCase {
     // Assert.assertions
     int i = 0;
     Object[] desired4 = new Object[] {nodes[4], nodes[7], nodes[8], nodes[5], nodes[10]};
-    for (Object d4 : Iterator2Iterable.make(D.dominators(nodes[4])))
-      Assert.assertSame(d4, desired4[i++]);
+    for (Object d4 : Iterator2Iterable.make(D.dominators(nodes[4]))) assertSame(d4, desired4[i++]);
 
     int j = 0;
     Object[] desired5 = new Object[] {nodes[8]};
@@ -796,11 +801,11 @@ public class PrimitivesTest extends WalaTestCase {
       if (!ok) {
         System.err.println("O4: " + o4);
         System.err.println("desired " + d);
-        Assert.assertEquals(o4, d);
+        assertEquals(o4, d);
       }
     }
 
-    Assert.assertEquals(5, D.dominatorTree().getSuccNodeCount(nodes[10]));
+    assertEquals(5, D.dominatorTree().getSuccNodeCount(nodes[10]));
   }
 
   @Test
@@ -820,37 +825,37 @@ public class PrimitivesTest extends WalaTestCase {
       System.err.println(intPair);
       count++;
     }
-    Assert.assertEquals(5, count);
+    assertEquals(5, count);
 
     IntSet x = R.getRelated(3);
-    Assert.assertEquals(4, x.size());
+    assertEquals(4, x.size());
 
     x = R.getRelated(5);
-    Assert.assertEquals(1, x.size());
+    assertEquals(1, x.size());
 
     R.remove(5, 1);
     x = R.getRelated(5);
-    Assert.assertNull(x);
+    assertNull(x);
 
     R.add(2, 1);
     R.add(2, 2);
     R.remove(2, 1);
     x = R.getRelated(2);
-    Assert.assertEquals(1, x.size());
+    assertEquals(1, x.size());
 
     R.removeAll(3);
     x = R.getRelated(3);
-    Assert.assertNull(x);
+    assertNull(x);
 
     x = R.getRelated(0);
-    Assert.assertNull(x);
+    assertNull(x);
 
     for (int i = 0; i < 100; i++) {
       R.add(1, i);
     }
-    Assert.assertEquals(100, R.getRelated(1).size());
+    assertEquals(100, R.getRelated(1).size());
     R.remove(1, 1);
-    Assert.assertEquals(99, R.getRelated(1).size());
+    assertEquals(99, R.getRelated(1).size());
   }
 
   @Test
@@ -858,15 +863,15 @@ public class PrimitivesTest extends WalaTestCase {
     int SIZE = 10000;
     IntegerUnionFind uf = new IntegerUnionFind(SIZE);
     int count = countEquivalenceClasses(uf);
-    Assert.assertEquals("Got count " + count, count, SIZE);
+    assertEquals("Got count " + count, count, SIZE);
 
     uf.union(3, 7);
-    Assert.assertEquals(uf.find(3), uf.find(7));
-    Assert.assertTrue("Got uf.find(3)=" + uf.find(3), uf.find(3) == 3 || uf.find(3) == 7);
+    assertEquals(uf.find(3), uf.find(7));
+    assertTrue("Got uf.find(3)=" + uf.find(3), uf.find(3) == 3 || uf.find(3) == 7);
 
     uf.union(7, SIZE - 1);
-    Assert.assertEquals(uf.find(3), uf.find(SIZE - 1));
-    Assert.assertTrue(
+    assertEquals(uf.find(3), uf.find(SIZE - 1));
+    assertTrue(
         "Got uf.find(3)=" + uf.find(3),
         uf.find(3) == 3 || uf.find(3) == 7 || uf.find(3) == SIZE - 1);
 
@@ -874,7 +879,7 @@ public class PrimitivesTest extends WalaTestCase {
       uf.union(i, i + 1);
     }
     count = countEquivalenceClasses(uf);
-    Assert.assertEquals("Got count " + count, 1, count);
+    assertEquals("Got count " + count, 1, count);
 
     uf = new IntegerUnionFind(SIZE);
     for (int i = 0; i < SIZE; i++) {
@@ -885,7 +890,7 @@ public class PrimitivesTest extends WalaTestCase {
       }
     }
     count = countEquivalenceClasses(uf);
-    Assert.assertEquals("Got count " + count, 2, count);
+    assertEquals("Got count " + count, 2, count);
   }
 
   private static int countEquivalenceClasses(IntegerUnionFind uf) {
@@ -931,43 +936,43 @@ public class PrimitivesTest extends WalaTestCase {
     // a reasonable size?
     bv.set(55);
 
-    Assert.assertEquals("bv.max() is " + bv.max(), 55, bv.max());
-    Assert.assertTrue(bv.get(55));
+    assertEquals("bv.max() is " + bv.max(), 55, bv.max());
+    assertTrue(bv.get(55));
 
     bv.set(59);
-    Assert.assertEquals(59, bv.max());
-    Assert.assertTrue(bv.get(55));
-    Assert.assertTrue(bv.get(59));
+    assertEquals(59, bv.max());
+    assertTrue(bv.get(55));
+    assertTrue(bv.get(59));
 
     {
       boolean[] gets = new boolean[] {false, true, true};
       int[] bits = new int[] {0, 55, 59};
       for (int i = 0, j = 0; i != -1; i = bv.nextSetBit(i + 1), j++) {
-        Assert.assertEquals(i, bits[j]);
-        Assert.assertEquals(bv.get(i), gets[j]);
+        assertEquals(i, bits[j]);
+        assertEquals(bv.get(i), gets[j]);
       }
     }
 
     bv.set(77);
 
-    Assert.assertEquals("bv.max() is " + bv.max(), 77, bv.max());
+    assertEquals("bv.max() is " + bv.max(), 77, bv.max());
     {
       boolean[] gets = new boolean[] {false, true, true, true};
       int[] bits = new int[] {0, 55, 59, 77};
       for (int i = 0, j = 0; i != -1; i = bv.nextSetBit(i + 1), j++) {
-        Assert.assertEquals(i, bits[j]);
-        Assert.assertEquals(bv.get(i), gets[j]);
+        assertEquals(i, bits[j]);
+        assertEquals(bv.get(i), gets[j]);
       }
     }
 
     bv.set(3);
-    Assert.assertEquals("bv.max() is " + bv.max(), 77, bv.max());
+    assertEquals("bv.max() is " + bv.max(), 77, bv.max());
     {
       boolean[] gets = new boolean[] {false, true, true, true, true};
       int[] bits = new int[] {0, 3, 55, 59, 77};
       for (int i = 0, j = 0; i != -1; i = bv.nextSetBit(i + 1), j++) {
-        Assert.assertEquals(i, bits[j]);
-        Assert.assertEquals(bv.get(i), gets[j]);
+        assertEquals(i, bits[j]);
+        assertEquals(bv.get(i), gets[j]);
       }
     }
 
@@ -1003,29 +1008,29 @@ public class PrimitivesTest extends WalaTestCase {
     v1.set(100);
     v1.set(101);
     v1.set(102);
-    Assert.assertEquals("v1.max() is " + v1.max(), 102, v1.max());
+    assertEquals("v1.max() is " + v1.max(), 102, v1.max());
 
     v2.set(200);
     v2.set(201);
     v2.set(202);
-    Assert.assertEquals("v2.max() is " + v2.max(), 202, v2.max());
+    assertEquals("v2.max() is " + v2.max(), 202, v2.max());
 
-    Assert.assertTrue(v1.intersectionEmpty(v2));
-    Assert.assertTrue(v2.intersectionEmpty(v1));
+    assertTrue(v1.intersectionEmpty(v2));
+    assertTrue(v2.intersectionEmpty(v1));
 
     v1.or(v2);
 
     System.err.println("v1 = " + v1 + ", v2 = " + v2);
-    Assert.assertFalse("v1 = " + v1 + ", v2 = " + v2, v1.intersectionEmpty(v2));
-    Assert.assertFalse("v1 = " + v1 + ", v2 = " + v2, v2.intersectionEmpty(v1));
-    Assert.assertEquals("v1.max() is " + v1.max(), 202, v1.max());
+    assertFalse("v1 = " + v1 + ", v2 = " + v2, v1.intersectionEmpty(v2));
+    assertFalse("v1 = " + v1 + ", v2 = " + v2, v2.intersectionEmpty(v1));
+    assertEquals("v1.max() is " + v1.max(), 202, v1.max());
 
     {
       boolean[] gets = new boolean[] {false, true, true, true, true, true, true};
       int[] bits = new int[] {0, 100, 101, 102, 200, 201, 202};
       for (int i = 0, j = 0; i != -1; i = v1.nextSetBit(i + 1), j++) {
-        Assert.assertEquals(i, bits[j]);
-        Assert.assertEquals(v1.get(i), gets[j]);
+        assertEquals(i, bits[j]);
+        assertEquals(v1.get(i), gets[j]);
       }
     }
 
@@ -1038,23 +1043,23 @@ public class PrimitivesTest extends WalaTestCase {
     v1.set(103);
     v1.set(104);
     v1.set(105);
-    Assert.assertEquals("v1.max() is " + v1.max(), 105, v1.max());
+    assertEquals("v1.max() is " + v1.max(), 105, v1.max());
 
     v2.set(103);
     v2.set(104);
     v2.set(200);
     v2.set(201);
-    Assert.assertEquals("v2.max() is " + v2.max(), 201, v2.max());
+    assertEquals("v2.max() is " + v2.max(), 201, v2.max());
 
     v1.and(v2);
-    Assert.assertEquals("v1.max() is " + v1.max(), 104, v1.max());
+    assertEquals("v1.max() is " + v1.max(), 104, v1.max());
 
     {
       boolean[] gets = new boolean[] {false, true, true};
       int[] bits = new int[] {0, 103, 104};
       for (int i = 0, j = 0; i != -1; i = v1.nextSetBit(i + 1), j++) {
-        Assert.assertEquals(i, bits[j]);
-        Assert.assertEquals(v1.get(i), gets[j]);
+        assertEquals(i, bits[j]);
+        assertEquals(v1.get(i), gets[j]);
       }
     }
 
@@ -1062,14 +1067,14 @@ public class PrimitivesTest extends WalaTestCase {
     v1.set(101);
     v1.set(102);
     v1.set(105);
-    Assert.assertEquals("v1.max() is " + v1.max(), 105, v1.max());
+    assertEquals("v1.max() is " + v1.max(), 105, v1.max());
 
     {
       boolean[] gets = new boolean[] {false, true, true, true, true, true, true};
       int[] bits = new int[] {0, 100, 101, 102, 103, 104, 105};
       for (int i = 0, j = 0; i != -1; i = v1.nextSetBit(i + 1), j++) {
-        Assert.assertEquals(i, bits[j]);
-        Assert.assertEquals(v1.get(i), gets[j]);
+        assertEquals(i, bits[j]);
+        assertEquals(v1.get(i), gets[j]);
       }
     }
 
@@ -1081,8 +1086,8 @@ public class PrimitivesTest extends WalaTestCase {
       boolean[] gets = new boolean[] {false, true, true, true, true, true, true};
       int[] bits = new int[] {0, 100, 101, 102, 103, 104, 105};
       for (int i = 0, j = 0; i != -1; i = v1.nextSetBit(i + 1), j++) {
-        Assert.assertEquals(i, bits[j]);
-        Assert.assertEquals(v1.get(i), gets[j]);
+        assertEquals(i, bits[j]);
+        assertEquals(v1.get(i), gets[j]);
       }
     }
 
@@ -1096,8 +1101,8 @@ public class PrimitivesTest extends WalaTestCase {
       boolean[] gets = new boolean[] {false, true, true, true, true};
       int[] bits = new int[] {0, 100, 103, 104, 105};
       for (int i = 0, j = 0; i != -1; i = v1.nextSetBit(i + 1), j++) {
-        Assert.assertEquals(i, bits[j]);
-        Assert.assertEquals(v1.get(i), gets[j]);
+        assertEquals(i, bits[j]);
+        assertEquals(v1.get(i), gets[j]);
       }
     }
 
@@ -1123,8 +1128,8 @@ public class PrimitivesTest extends WalaTestCase {
       boolean[] gets = new boolean[] {false, true, true, true, true};
       int[] bits = new int[] {0, 35, 103, 105, 206};
       for (int i = 0, j = 0; i != -1; i = v1.nextSetBit(i + 1), j++) {
-        Assert.assertEquals(i, bits[j]);
-        Assert.assertEquals(v1.get(i), gets[j]);
+        assertEquals(i, bits[j]);
+        assertEquals(v1.get(i), gets[j]);
       }
     }
 
@@ -1133,16 +1138,16 @@ public class PrimitivesTest extends WalaTestCase {
     v2.set(105);
 
     System.err.println("v1 = " + v1 + ", v2 = " + v2);
-    Assert.assertTrue(v1.isSubset(v2));
+    assertTrue(v1.isSubset(v2));
 
     v2.clearAll();
     v2.set(111);
     v2.or(v1);
-    Assert.assertTrue(v1.isSubset(v2));
+    assertTrue(v1.isSubset(v2));
 
     v2.and(v1);
 
-    Assert.assertTrue(v1.sameBits(v2));
+    assertTrue(v1.sameBits(v2));
 
     v1.clearAll();
   }
@@ -1340,14 +1345,14 @@ public class PrimitivesTest extends WalaTestCase {
 
     v1.andNot(v2);
     System.err.println(v1);
-    Assert.assertTrue(v1.intersectionEmpty(v2));
+    assertTrue(v1.intersectionEmpty(v2));
 
     v1 = makeBigTestOffsetVector();
     v1.and(v2);
     System.err.println(v1);
-    Assert.assertTrue(v1.sameBits(v2));
-    Assert.assertTrue(v1.isSubset(v2));
-    Assert.assertTrue(v2.isSubset(v1));
+    assertTrue(v1.sameBits(v2));
+    assertTrue(v1.isSubset(v2));
+    assertTrue(v2.isSubset(v1));
   }
 
   @Test

--- a/core/src/test/java/com/ibm/wala/core/tests/basic/WelshPowellTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/basic/WelshPowellTest.java
@@ -10,6 +10,9 @@
  */
 package com.ibm.wala.core.tests.basic;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.collections.Iterator2Iterable;
 import com.ibm.wala.util.graph.Graph;
@@ -19,7 +22,6 @@ import com.ibm.wala.util.graph.impl.NodeWithNumberedEdges;
 import com.ibm.wala.util.graph.traverse.WelshPowell;
 import com.ibm.wala.util.graph.traverse.WelshPowell.ColoredVertices;
 import java.util.Map;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class WelshPowellTest {
@@ -30,7 +32,7 @@ public class WelshPowellTest {
         if (!fullColor && (!colors.containsKey(n) || !colors.containsKey(succ))) {
           continue;
         }
-        Assert.assertTrue(
+        assertTrue(
             n + " and succ: " + succ + " have same color: " + colors.get(n),
             colors.get(n).intValue() != colors.get(succ).intValue());
       }
@@ -38,7 +40,7 @@ public class WelshPowellTest {
         if (!fullColor && (!colors.containsKey(n) || !colors.containsKey(pred))) {
           continue;
         }
-        Assert.assertTrue(
+        assertTrue(
             n + " and pred: " + pred + " have same color:" + colors.get(n),
             colors.get(n).intValue() != colors.get(pred).intValue());
       }
@@ -92,7 +94,7 @@ public class WelshPowellTest {
     ColoredVertices<TypedNode<Integer>> colors = new WelshPowell<TypedNode<Integer>>().color(G);
     System.err.println(colors.getColors());
     assertColoring(G, colors.getColors(), true);
-    Assert.assertTrue(colors.getNumColors() <= 4);
+    assertTrue(colors.getNumColors() <= 4);
   }
 
   @Test
@@ -114,6 +116,6 @@ public class WelshPowellTest {
     ColoredVertices<TypedNode<String>> colors = new WelshPowell<TypedNode<String>>().color(G);
     System.err.println(colors.getColors());
     assertColoring(G, colors.getColors(), true);
-    Assert.assertEquals(3, colors.getNumColors());
+    assertEquals(3, colors.getNumColors());
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/AcyclicCallGraphTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/AcyclicCallGraphTest.java
@@ -1,5 +1,8 @@
 package com.ibm.wala.core.tests.callGraph;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.core.tests.util.TestConstants;
 import com.ibm.wala.core.tests.util.WalaTestCase;
 import com.ibm.wala.ipa.callgraph.AnalysisCacheImpl;
@@ -22,7 +25,6 @@ import com.ibm.wala.util.intset.IntPair;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class AcyclicCallGraphTest extends WalaTestCase {
@@ -42,7 +44,7 @@ public class AcyclicCallGraphTest extends WalaTestCase {
 
     IBinaryNaturalRelation backEdges = Acyclic.computeBackEdges(cg, cg.getFakeRootNode());
 
-    Assert.assertTrue("NList should have cycles", backEdges.iterator().hasNext());
+    assertTrue("NList should have cycles", backEdges.iterator().hasNext());
 
     Map<CGNode, Set<CGNode>> cgBackEdges = HashMapFactory.make();
     for (IntPair p : backEdges) {
@@ -56,7 +58,7 @@ public class AcyclicCallGraphTest extends WalaTestCase {
     PrunedCallGraph pcg =
         new PrunedCallGraph(cg, Iterator2Collection.toSet(cg.iterator()), cgBackEdges);
 
-    Assert.assertFalse(
+    assertFalse(
         "cycles should be gone",
         Acyclic.computeBackEdges(pcg, pcg.getFakeRootNode()).iterator().hasNext());
   }

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/CHACallGraphTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/CHACallGraphTest.java
@@ -10,6 +10,9 @@
  */
 package com.ibm.wala.core.tests.callGraph;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.core.tests.util.TestConstants;
 import com.ibm.wala.ipa.callgraph.AnalysisScope;
 import com.ibm.wala.ipa.callgraph.CGNode;
@@ -25,7 +28,6 @@ import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.intset.IntSet;
 import java.io.IOException;
 import java.util.function.Function;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class CHACallGraphTest {
@@ -64,10 +66,10 @@ public class CHACallGraphTest {
               succNum -> {
                 CGNode succNode = CG.getNode(succNum);
                 IntSet predNodeNumbers = CG.getPredNodeNumbers(succNode);
-                Assert.assertNotNull(
+                assertNotNull(
                     "no predecessors for " + succNode + " which is called by " + node,
                     predNodeNumbers);
-                Assert.assertTrue(predNodeNumbers.contains(nodeNum));
+                assertTrue(predNodeNumbers.contains(nodeNum));
               });
     }
     return CG;

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/CPATest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/CPATest.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.core.tests.callGraph;
 
+import static org.junit.Assert.assertEquals;
+
 import com.ibm.wala.classLoader.Language;
 import com.ibm.wala.core.tests.util.TestConstants;
 import com.ibm.wala.core.tests.util.WalaTestCase;
@@ -33,7 +35,6 @@ import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.CancelException;
 import java.io.IOException;
 import java.util.Set;
-import org.junit.Assert;
 import org.junit.Test;
 
 /** Check properties of a call to clone() in RTA */
@@ -76,6 +77,6 @@ public class CPATest extends WalaTestCase {
 
     System.err.println(cg);
 
-    Assert.assertEquals(2, idNodes.size());
+    assertEquals(2, idNodes.size());
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/CallGraphTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/CallGraphTest.java
@@ -10,6 +10,11 @@
  */
 package com.ibm.wala.core.tests.callGraph;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.classLoader.Language;
@@ -62,7 +67,6 @@ import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-import org.junit.Assert;
 import org.junit.Test;
 
 /** Tests for Call Graph construction */
@@ -134,12 +138,11 @@ public class CallGraphTest extends WalaTestCase {
     // we expect a warning or two about class Abstract1, which has no concrete
     // subclasses
     String ws = Warnings.asString();
-    Assert.assertTrue(
-        "failed to report a warning about Abstract1", ws.contains("cornerCases/Abstract1"));
+    assertTrue("failed to report a warning about Abstract1", ws.contains("cornerCases/Abstract1"));
 
     // we do not expect a warning about class Abstract2, which has a concrete
     // subclasses
-    Assert.assertFalse("reported a warning about Abstract2", ws.contains("cornerCases/Abstract2"));
+    assertFalse("reported a warning about Abstract2", ws.contains("cornerCases/Abstract2"));
   }
 
   @Test
@@ -174,11 +177,11 @@ public class CallGraphTest extends WalaTestCase {
         break;
       }
     }
-    Assert.assertTrue(foundDoNothing);
+    assertTrue(foundDoNothing);
     options.setHandleStaticInit(false);
     cg = CallGraphTestUtil.buildZeroCFA(options, new AnalysisCacheImpl(), cha, false);
     for (CGNode n : cg) {
-      Assert.assertFalse(n.toString().contains("doNothing"));
+      assertFalse(n.toString().contains("doNothing"));
     }
   }
 
@@ -199,7 +202,7 @@ public class CallGraphTest extends WalaTestCase {
         foundSortForward = true;
       }
     }
-    Assert.assertTrue("expected for sortForward", foundSortForward);
+    assertTrue("expected for sortForward", foundSortForward);
   }
 
   @Test
@@ -227,7 +230,7 @@ public class CallGraphTest extends WalaTestCase {
             break;
           }
         }
-        Assert.assertTrue(foundToCharArray);
+        assertTrue(foundToCharArray);
         break;
       }
     }
@@ -327,7 +330,7 @@ public class CallGraphTest extends WalaTestCase {
     CGNode mainMethod = AbstractPtrTest.findMainMethod(cg);
     PointerKey keyToQuery = AbstractPtrTest.getParam(mainMethod, "testThisVar", pa.getHeapModel());
     OrdinalSet<InstanceKey> pointsToSet = pa.getPointsToSet(keyToQuery);
-    Assert.assertEquals(1, pointsToSet.size());
+    assertEquals(1, pointsToSet.size());
   }
 
   @Test
@@ -344,7 +347,7 @@ public class CallGraphTest extends WalaTestCase {
         Util.makeZeroOneContainerCFABuilder(options, cache, cha);
     CallGraph cg = builder.makeCallGraph(options, null);
     CGNode mainMethod = CallGraphSearchUtil.findMainMethod(cg);
-    Assert.assertTrue(
+    assertTrue(
         "did not find call to valueOf",
         StreamSupport.stream(
                 Spliterators.spliteratorUnknownSize(
@@ -395,7 +398,7 @@ public class CallGraphTest extends WalaTestCase {
       GraphIntegrity.check(cg);
     } catch (UnsoundGraphException e1) {
       e1.printStackTrace();
-      Assert.fail(e1.getMessage());
+      fail(e1.getMessage());
     }
 
     Set<MethodReference> rtaMethods = CallGraphStats.collectMethods(cg);
@@ -462,7 +465,7 @@ public class CallGraphTest extends WalaTestCase {
       GraphIntegrity.check(icfg);
     } catch (UnsoundGraphException e) {
       e.printStackTrace();
-      Assert.fail();
+      fail();
     }
 
     // perform a little icfg exercise
@@ -485,7 +488,7 @@ public class CallGraphTest extends WalaTestCase {
     try {
       GraphIntegrity.check(cg);
     } catch (UnsoundGraphException e1) {
-      Assert.fail(e1.getMessage());
+      fail(e1.getMessage());
     }
     Set<MethodReference> callGraphMethods = CallGraphStats.collectMethods(cg);
     System.err.println(thisAlgorithm + " methods reached: " + callGraphMethods.size());

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/ClassConstantTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/ClassConstantTest.java
@@ -10,6 +10,10 @@
  */
 package com.ibm.wala.core.tests.callGraph;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.core.tests.util.TestConstants;
 import com.ibm.wala.core.tests.util.WalaTestCase;
 import com.ibm.wala.ipa.callgraph.AnalysisCacheImpl;
@@ -28,7 +32,6 @@ import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.CancelException;
 import java.io.IOException;
 import java.util.Set;
-import org.junit.Assert;
 import org.junit.Test;
 
 /** Check handling of class constants (test for part of 1.5 support) */
@@ -47,7 +50,7 @@ public class ClassConstantTest extends WalaTestCase {
     TypeReference mainClassRef =
         TypeReference.findOrCreate(
             ClassLoaderReference.Application, TestConstants.CLASSCONSTANT_MAIN);
-    Assert.assertNotNull(cha.lookupClass(mainClassRef));
+    assertNotNull(cha.lookupClass(mainClassRef));
 
     // make call graph
     Iterable<Entrypoint> entrypoints =
@@ -61,7 +64,7 @@ public class ClassConstantTest extends WalaTestCase {
     MethodReference mainMethodRef =
         MethodReference.findOrCreate(mainClassRef, "main", "([Ljava/lang/String;)V");
     Set<CGNode> mainMethodNodes = cg.getNodes(mainMethodRef);
-    Assert.assertFalse(mainMethodNodes.isEmpty());
+    assertFalse(mainMethodNodes.isEmpty());
     CGNode mainMethodNode = mainMethodNodes.iterator().next();
     // Trace.println("main IR:");
     // Trace.println(mainMethodNode.getIR());
@@ -71,9 +74,9 @@ public class ClassConstantTest extends WalaTestCase {
         TypeReference.findOrCreate(ClassLoaderReference.Primordial, "Ljava/lang/Class");
     MethodReference hashCodeRef = MethodReference.findOrCreate(classRef, "hashCode", "()I");
     Set<CGNode> hashCodeNodes = cg.getNodes(hashCodeRef);
-    Assert.assertFalse(hashCodeNodes.isEmpty());
+    assertFalse(hashCodeNodes.isEmpty());
 
     // make sure call to hashCode from main
-    Assert.assertTrue(cg.hasEdge(mainMethodNode, hashCodeNodes.iterator().next()));
+    assertTrue(cg.hasEdge(mainMethodNode, hashCodeNodes.iterator().next()));
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/DefaultMethodsTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/DefaultMethodsTest.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.core.tests.callGraph;
 
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.core.tests.util.TestConstants;
@@ -29,7 +31,6 @@ import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.CancelException;
 import java.io.IOException;
 import java.util.Collection;
-import org.junit.Assert;
 import org.junit.Test;
 
 /** Check properties of a call to clone() in RTA */
@@ -55,18 +56,18 @@ public class DefaultMethodsTest extends WalaTestCase {
         TypeReference.findOrCreate(
             ClassLoaderReference.Application, "LdefaultMethods/DefaultMethods");
     MethodReference mm = MethodReference.findOrCreate(tm, "main", "([Ljava/lang/String;)V");
-    Assert.assertTrue("expect main node", cg.getNodes(mm).iterator().hasNext());
+    assertTrue("expect main node", cg.getNodes(mm).iterator().hasNext());
     CGNode mnode = cg.getNodes(mm).iterator().next();
 
     // Find node corresponding to Interface1.silly
     TypeReference t1s =
         TypeReference.findOrCreate(ClassLoaderReference.Application, "LdefaultMethods/Interface1");
     MethodReference t1m = MethodReference.findOrCreate(t1s, "silly", "()I");
-    Assert.assertTrue("expect Interface1.silly node", cg.getNodes(t1m).iterator().hasNext());
+    assertTrue("expect Interface1.silly node", cg.getNodes(t1m).iterator().hasNext());
     CGNode t1node = cg.getNodes(t1m).iterator().next();
 
     // Check call from main to Interface1.silly
-    Assert.assertTrue(
+    assertTrue(
         "should have call site from main to Interface1.silly",
         cg.getPossibleSites(mnode, t1node).hasNext());
 
@@ -74,11 +75,11 @@ public class DefaultMethodsTest extends WalaTestCase {
     TypeReference t2s =
         TypeReference.findOrCreate(ClassLoaderReference.Application, "LdefaultMethods/Interface2");
     MethodReference t2m = MethodReference.findOrCreate(t2s, "silly", "()I");
-    Assert.assertTrue("expect Interface2.silly node", cg.getNodes(t2m).iterator().hasNext());
+    assertTrue("expect Interface2.silly node", cg.getNodes(t2m).iterator().hasNext());
     CGNode t2node = cg.getNodes(t1m).iterator().next();
 
     // Check call from main to Interface2.silly
-    Assert.assertTrue(
+    assertTrue(
         "should have call site from main to Interface2.silly",
         cg.getPossibleSites(mnode, t2node).hasNext());
 
@@ -87,11 +88,11 @@ public class DefaultMethodsTest extends WalaTestCase {
         TypeReference.findOrCreate(
             ClassLoaderReference.Application, "LdefaultMethods/DefaultMethods$Test3");
     MethodReference ttm = MethodReference.findOrCreate(tts, "silly", "()I");
-    Assert.assertTrue("expect Interface1.silly node", cg.getNodes(ttm).iterator().hasNext());
+    assertTrue("expect Interface1.silly node", cg.getNodes(ttm).iterator().hasNext());
     CGNode ttnode = cg.getNodes(ttm).iterator().next();
 
     // Check call from main to Test3.silly
-    Assert.assertTrue(
+    assertTrue(
         "should have call site from main to Test3.silly",
         cg.getPossibleSites(mnode, ttnode).hasNext());
 
@@ -103,7 +104,7 @@ public class DefaultMethodsTest extends WalaTestCase {
 
     Collection<? extends IMethod> allMethods = test1Class.getAllMethods();
     IMethod defaultMethod = test1Class.getMethod(t1m.getSelector());
-    Assert.assertTrue(
+    assertTrue(
         "Expecting default methods to show up in IClass.allMethods()",
         allMethods.contains(defaultMethod));
   }

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/FinalizerTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/FinalizerTest.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.core.tests.callGraph;
 
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.core.tests.util.TestConstants;
 import com.ibm.wala.core.tests.util.WalaTestCase;
 import com.ibm.wala.ipa.callgraph.AnalysisCacheImpl;
@@ -26,7 +28,6 @@ import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.CancelException;
 import java.io.IOException;
-import org.junit.Assert;
 import org.junit.Test;
 
 /** Check properties of a call to clone() in RTA */
@@ -50,11 +51,11 @@ public class FinalizerTest extends WalaTestCase {
     TypeReference t =
         TypeReference.findOrCreate(ClassLoaderReference.Application, "Lfinalizers/Finalizers");
     MethodReference m = MethodReference.findOrCreate(t, "finalize", "()V");
-    Assert.assertTrue("expect finalizer node", cg.getNodes(m).iterator().hasNext());
+    assertTrue("expect finalizer node", cg.getNodes(m).iterator().hasNext());
     CGNode node = cg.getNodes(m).iterator().next();
 
     // Check it's reachable from root
-    Assert.assertTrue(
+    assertTrue(
         "should have call site from root",
         cg.getPossibleSites(cg.getFakeRootNode(), node).hasNext());
   }

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/LambdaTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/LambdaTest.java
@@ -10,6 +10,9 @@
  */
 package com.ibm.wala.core.tests.callGraph;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.classLoader.CallSiteReference;
 import com.ibm.wala.core.tests.util.TestConstants;
 import com.ibm.wala.core.tests.util.WalaTestCase;
@@ -35,7 +38,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import org.junit.Assert;
 import org.junit.Test;
 
 /** Check properties of a call to clone() in RTA */
@@ -75,7 +77,7 @@ public class LambdaTest extends WalaTestCase {
         MethodReference.findOrCreate(
             A, Atom.findOrCreateUnicodeAtom("<init>"), Descriptor.findOrCreateUTF8("()V"));
     Set<CGNode> ctnodes = cg.getNodes(ct);
-    Assert.assertEquals(1, ctnodes.size());
+    assertEquals(1, ctnodes.size());
 
     MethodReference ts =
         MethodReference.findOrCreate(
@@ -83,7 +85,7 @@ public class LambdaTest extends WalaTestCase {
             Atom.findOrCreateUnicodeAtom("toString"),
             Descriptor.findOrCreateUTF8("()Ljava/lang/String;"));
     Set<CGNode> tsnodes = cg.getNodes(ts);
-    Assert.assertEquals(1, tsnodes.size());
+    assertEquals(1, tsnodes.size());
   }
 
   @Test
@@ -121,7 +123,7 @@ public class LambdaTest extends WalaTestCase {
     TypeReference tid1 =
         TypeReference.findOrCreate(ClassLoaderReference.Application, "Llambda/SortingExample");
     MethodReference mid1 = MethodReference.findOrCreate(tid1, x, "(I)I");
-    Assert.assertTrue("expect " + x + " node", cg.getNodes(mid1).iterator().hasNext());
+    assertTrue("expect " + x + " node", cg.getNodes(mid1).iterator().hasNext());
     CGNode id1node = cg.getNodes(mid1).iterator().next();
 
     // caller of id1 is dynamic from sortForward, and has 1 compareTo
@@ -132,7 +134,7 @@ public class LambdaTest extends WalaTestCase {
         count++;
       }
     }
-    Assert.assertEquals("expected one call to compareTo", expected, count);
+    assertEquals("expected one call to compareTo", expected, count);
     System.err.println("found " + count + " compareTo calls in " + sfnode);
   }
 
@@ -159,15 +161,15 @@ public class LambdaTest extends WalaTestCase {
                 Descriptor.findOrCreateUTF8("()V"));
 
     System.out.println(cg);
-    Assert.assertEquals(
+    assertEquals(
         "expected C1.target() to be reachable", 1, cg.getNodes(getTargetRef.apply("C1")).size());
-    Assert.assertEquals(
+    assertEquals(
         "expected C2.target() to be reachable", 1, cg.getNodes(getTargetRef.apply("C2")).size());
-    Assert.assertEquals(
+    assertEquals(
         "expected C3.target() to be reachable", 1, cg.getNodes(getTargetRef.apply("C3")).size());
-    Assert.assertEquals(
+    assertEquals(
         "expected C4.target() to be reachable", 1, cg.getNodes(getTargetRef.apply("C4")).size());
-    Assert.assertEquals(
+    assertEquals(
         "expected C5.target() to *not* be reachable",
         0,
         cg.getNodes(getTargetRef.apply("C5")).size());
@@ -199,18 +201,17 @@ public class LambdaTest extends WalaTestCase {
     Consumer<String> checkCalledFromOneSite =
         (klassName) -> {
           Set<CGNode> nodes = cg.getNodes(getTargetRef.apply(klassName));
-          Assert.assertEquals(
-              "expected " + klassName + ".target() to be reachable", 1, nodes.size());
+          assertEquals("expected " + klassName + ".target() to be reachable", 1, nodes.size());
           CGNode node = nodes.iterator().next();
           List<CGNode> predNodes = Iterator2Collection.toList(cg.getPredNodes(node));
-          Assert.assertEquals(
+          assertEquals(
               "expected " + klassName + ".target() to be invoked from one calling method",
               1,
               predNodes.size());
           CGNode pred = predNodes.get(0);
           List<CallSiteReference> sites =
               Iterator2Collection.toList(cg.getPossibleSites(pred, node));
-          Assert.assertEquals(
+          assertEquals(
               "expected " + klassName + ".target() to be invoked from one call site",
               1,
               sites.size());
@@ -238,6 +239,6 @@ public class LambdaTest extends WalaTestCase {
     // shouldn't crash
     CallGraph cg = CallGraphTestUtil.buildZeroCFA(options, new AnalysisCacheImpl(), cha, false);
     // exceedingly unlikely to fail, but ensures that optimizer won't remove buildZeroCFA call
-    Assert.assertTrue(cg.getNumberOfNodes() > 0);
+    assertTrue(cg.getNumberOfNodes() > 0);
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/LibModelsTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/LibModelsTest.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.core.tests.callGraph;
 
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.core.tests.util.TestConstants;
 import com.ibm.wala.core.tests.util.WalaTestCase;
 import com.ibm.wala.ipa.callgraph.AnalysisCacheImpl;
@@ -25,7 +27,6 @@ import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.CancelException;
 import java.io.IOException;
-import org.junit.Assert;
 import org.junit.Test;
 
 /** Check properties of a call to clone() in RTA */
@@ -52,10 +53,9 @@ public class LibModelsTest extends WalaTestCase {
     TypeReference t =
         TypeReference.findOrCreate(ClassLoaderReference.Application, libModelsTestClass);
     MethodReference m = MethodReference.findOrCreate(t, "reachable1", "()V");
-    Assert.assertTrue(
-        "expect reachable1 from addShutdownHook", cg.getNodes(m).iterator().hasNext());
+    assertTrue("expect reachable1 from addShutdownHook", cg.getNodes(m).iterator().hasNext());
     MethodReference m2 = MethodReference.findOrCreate(t, "reachable2", "()V");
-    Assert.assertTrue(
+    assertTrue(
         "expect reachable2 from uncaught exception handler", cg.getNodes(m2).iterator().hasNext());
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/PiNodeCallGraphTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/PiNodeCallGraphTest.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.core.tests.callGraph;
 
+import static org.junit.Assert.assertEquals;
+
 import com.ibm.wala.classLoader.CallSiteReference;
 import com.ibm.wala.core.tests.util.TestConstants;
 import com.ibm.wala.core.tests.util.WalaTestCase;
@@ -37,7 +39,6 @@ import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.collections.Iterator2Iterable;
 import java.io.IOException;
 import java.util.Set;
-import org.junit.Assert;
 import org.junit.Test;
 
 /** */
@@ -128,7 +129,7 @@ public class PiNodeCallGraphTest extends WalaTestCase {
             .iterator()
             .next();
     int actualLocalCastCallees = cg.getSuccNodeCount(localCastNode);
-    Assert.assertEquals(numLocalCastCallees, actualLocalCastCallees);
+    assertEquals(numLocalCastCallees, actualLocalCastCallees);
   }
 
   @Test

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/ReflectionTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/ReflectionTest.java
@@ -10,6 +10,12 @@
  */
 package com.ibm.wala.core.tests.callGraph;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.core.tests.util.TestConstants;
@@ -52,7 +58,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.Test;
 
 /** Tests for Call Graph construction */
@@ -106,7 +111,7 @@ public class ReflectionTest extends WalaTestCase {
         continue;
       }
       if (w.toString().contains("Integer")) {
-        Assert.fail(w.toString());
+        fail(w.toString());
       }
     }
   }
@@ -130,7 +135,7 @@ public class ReflectionTest extends WalaTestCase {
         TypeReference.findOrCreate(ClassLoaderReference.Application, "Ljava/lang/Integer");
     MethodReference mr = MethodReference.findOrCreate(tr, "<clinit>", "()V");
     Set<CGNode> nodes = cg.getNodes(mr);
-    Assert.assertFalse(nodes.isEmpty());
+    assertFalse(nodes.isEmpty());
   }
 
   /**
@@ -165,7 +170,7 @@ public class ReflectionTest extends WalaTestCase {
     MethodReference extraneousMR = MethodReference.findOrCreate(extraneousTR, "<init>", "()V");
     Set<CGNode> extraneousNodes = cg.getNodes(extraneousMR);
     succNodes.retainAll(extraneousNodes);
-    Assert.assertTrue(succNodes.isEmpty());
+    assertTrue(succNodes.isEmpty());
   }
 
   /**
@@ -200,7 +205,7 @@ public class ReflectionTest extends WalaTestCase {
             extraneousTR, "<init>", "(Ljava/lang/String;Ljava/lang/String;)V");
     Set<CGNode> extraneousNodes = cg.getNodes(extraneousMR);
     succNodes.retainAll(extraneousNodes);
-    Assert.assertTrue(succNodes.isEmpty());
+    assertTrue(succNodes.isEmpty());
   }
 
   /**
@@ -232,7 +237,7 @@ public class ReflectionTest extends WalaTestCase {
     MethodReference extraneousMR = MethodReference.findOrCreate(extraneousTR, "<init>", "()V");
     Set<CGNode> extraneousNodes = cg.getNodes(extraneousMR);
     succNodes.retainAll(extraneousNodes);
-    Assert.assertTrue(succNodes.isEmpty());
+    assertTrue(succNodes.isEmpty());
   }
 
   /**
@@ -264,7 +269,7 @@ public class ReflectionTest extends WalaTestCase {
     MethodReference extraneousMR = MethodReference.findOrCreate(extraneousTR, "<init>", "(I)V");
     Set<CGNode> extraneousNodes = cg.getNodes(extraneousMR);
     succNodes.retainAll(extraneousNodes);
-    Assert.assertTrue(succNodes.isEmpty());
+    assertTrue(succNodes.isEmpty());
   }
 
   @Test
@@ -312,7 +317,7 @@ public class ReflectionTest extends WalaTestCase {
         }
       }
     }
-    Assert.assertNotNull(filePermConstrNewInstanceNode);
+    assertNotNull(filePermConstrNewInstanceNode);
 
     // Now verify that this node has FilePermission.<init> children
     CGNode filePermInitNode = null;
@@ -326,7 +331,7 @@ public class ReflectionTest extends WalaTestCase {
         break;
       }
     }
-    Assert.assertNotNull(filePermInitNode);
+    assertNotNull(filePermInitNode);
 
     // Furthermore, verify that main has a FilePermission.toString child
     CGNode filePermToStringNode = null;
@@ -337,7 +342,7 @@ public class ReflectionTest extends WalaTestCase {
       }
     }
 
-    Assert.assertNotNull(filePermToStringNode);
+    assertNotNull(filePermToStringNode);
   }
 
   private static Collection<CGNode> getSuccNodes(CallGraph cg, Collection<CGNode> nodes) {
@@ -368,7 +373,7 @@ public class ReflectionTest extends WalaTestCase {
         TypeReference.findOrCreate(ClassLoaderReference.Primordial, "Ljava/lang/Integer");
     MethodReference mr = MethodReference.findOrCreate(tr, "toString", "()Ljava/lang/String;");
     Set<CGNode> nodes = cg.getNodes(mr);
-    Assert.assertFalse(nodes.isEmpty());
+    assertFalse(nodes.isEmpty());
   }
 
   /**
@@ -388,7 +393,7 @@ public class ReflectionTest extends WalaTestCase {
         TypeReference.findOrCreate(ClassLoaderReference.Primordial, "Ljava/lang/Integer");
     MethodReference mr = MethodReference.findOrCreate(tr, "toString", "()Ljava/lang/String;");
     Set<CGNode> nodes = cg.getNodes(mr);
-    Assert.assertFalse(nodes.isEmpty());
+    assertFalse(nodes.isEmpty());
   }
 
   /**
@@ -409,7 +414,7 @@ public class ReflectionTest extends WalaTestCase {
     MethodReference mr = MethodReference.findOrCreate(tr, "toString", "()Ljava/lang/String;");
     Set<CGNode> nodes = cg.getNodes(mr);
     System.err.println(cg);
-    Assert.assertFalse(nodes.isEmpty());
+    assertFalse(nodes.isEmpty());
   }
 
   /**
@@ -428,7 +433,7 @@ public class ReflectionTest extends WalaTestCase {
         TypeReference.findOrCreate(ClassLoaderReference.Primordial, "Ljava/lang/Object");
     MethodReference mr = MethodReference.findOrCreate(tr, "wait", "()V");
     Set<CGNode> nodes = cg.getNodes(mr);
-    Assert.assertFalse(nodes.isEmpty());
+    assertFalse(nodes.isEmpty());
   }
 
   /**
@@ -450,10 +455,10 @@ public class ReflectionTest extends WalaTestCase {
         MethodReference.findOrCreate(
             tr, "m", "(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V");
     Set<CGNode> nodes = cg.getNodes(mr);
-    Assert.assertFalse(nodes.isEmpty());
+    assertFalse(nodes.isEmpty());
     mr = MethodReference.findOrCreate(tr, "n", "(Ljava/lang/Object;Ljava/lang/Object;)V");
     nodes = cg.getNodes(mr);
-    Assert.assertTrue(nodes.isEmpty());
+    assertTrue(nodes.isEmpty());
   }
 
   /**
@@ -475,10 +480,10 @@ public class ReflectionTest extends WalaTestCase {
         MethodReference.findOrCreate(
             tr, "m", "(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V");
     Set<CGNode> nodes = cg.getNodes(mr);
-    Assert.assertFalse(nodes.isEmpty());
+    assertFalse(nodes.isEmpty());
     mr = MethodReference.findOrCreate(tr, "n", "(Ljava/lang/Object;Ljava/lang/Object;)V");
     nodes = cg.getNodes(mr);
-    Assert.assertFalse(nodes.isEmpty());
+    assertFalse(nodes.isEmpty());
   }
 
   /**
@@ -499,10 +504,10 @@ public class ReflectionTest extends WalaTestCase {
     MethodReference mr =
         MethodReference.findOrCreate(tr, "s", "(Ljava/lang/Object;Ljava/lang/Object;)V");
     Set<CGNode> nodes = cg.getNodes(mr);
-    Assert.assertFalse(nodes.isEmpty());
+    assertFalse(nodes.isEmpty());
     mr = MethodReference.findOrCreate(tr, "n", "(Ljava/lang/Object;Ljava/lang/Object;)V");
     nodes = cg.getNodes(mr);
-    Assert.assertTrue(nodes.isEmpty());
+    assertTrue(nodes.isEmpty());
   }
 
   /**
@@ -524,16 +529,16 @@ public class ReflectionTest extends WalaTestCase {
     MethodReference mr =
         MethodReference.findOrCreate(tr, "<init>", "(Ljava/lang/Object;Ljava/lang/Object;)V");
     Set<CGNode> nodes = cg.getNodes(mr);
-    Assert.assertFalse(nodes.isEmpty());
+    assertFalse(nodes.isEmpty());
     mr = MethodReference.findOrCreate(tr, "<init>", "(Ljava/lang/Object;)V");
     nodes = cg.getNodes(mr);
-    Assert.assertTrue(nodes.isEmpty());
+    assertTrue(nodes.isEmpty());
     mr = MethodReference.findOrCreate(tr, "<init>", "()V");
     nodes = cg.getNodes(mr);
-    Assert.assertTrue(nodes.isEmpty());
+    assertTrue(nodes.isEmpty());
     mr = MethodReference.findOrCreate(tr, "n", "(Ljava/lang/Object;Ljava/lang/Object;)V");
     nodes = cg.getNodes(mr);
-    Assert.assertFalse(nodes.isEmpty());
+    assertFalse(nodes.isEmpty());
   }
 
   /**
@@ -553,7 +558,7 @@ public class ReflectionTest extends WalaTestCase {
         TypeReference.findOrCreate(ClassLoaderReference.Primordial, "Ljava/lang/Integer");
     MethodReference mr = MethodReference.findOrCreate(tr, "toString", "()Ljava/lang/String;");
     Set<CGNode> nodes = cg.getNodes(mr);
-    Assert.assertFalse(nodes.isEmpty());
+    assertFalse(nodes.isEmpty());
   }
 
   /**
@@ -573,7 +578,7 @@ public class ReflectionTest extends WalaTestCase {
         TypeReference.findOrCreate(ClassLoaderReference.Application, "Lreflection/Helper");
     MethodReference mr = MethodReference.findOrCreate(tr, "t", "(Ljava/lang/Integer;)V");
     CGNode node = cg.getNode(cg.getClassHierarchy().resolveMethod(mr), Everywhere.EVERYWHERE);
-    Assert.assertEquals(0, cg.getSuccNodeCount(node));
+    assertEquals(0, cg.getSuccNodeCount(node));
   }
 
   /**
@@ -593,9 +598,9 @@ public class ReflectionTest extends WalaTestCase {
         TypeReference.findOrCreate(ClassLoaderReference.Application, "Lreflection/Helper");
     MethodReference mr = MethodReference.findOrCreate(tr, "t", "(Ljava/lang/Integer;)V");
     CGNode node = cg.getNode(cg.getClassHierarchy().resolveMethod(mr), Everywhere.EVERYWHERE);
-    Assert.assertEquals(1, cg.getSuccNodeCount(node));
+    assertEquals(1, cg.getSuccNodeCount(node));
     CGNode succ = cg.getSuccNodes(node).next();
-    Assert.assertEquals(
+    assertEquals(
         "Node: < Primordial, Ljava/lang/Integer, toString()Ljava/lang/String; > Context: Everywhere",
         succ.toString());
   }
@@ -617,7 +622,7 @@ public class ReflectionTest extends WalaTestCase {
         TypeReference.findOrCreate(ClassLoaderReference.Primordial, "Ljava/lang/Integer");
     MethodReference mr = MethodReference.findOrCreate(tr, "toString", "()Ljava/lang/String;");
     Set<CGNode> nodes = cg.getNodes(mr);
-    Assert.assertFalse(nodes.isEmpty());
+    assertFalse(nodes.isEmpty());
   }
 
   /** Test that when analyzing Reflect20, the call graph includes a node for Helper.o. */
@@ -635,7 +640,7 @@ public class ReflectionTest extends WalaTestCase {
     MethodReference mr =
         MethodReference.findOrCreate(tr, "o", "(Ljava/lang/Object;Ljava/lang/Object;)V");
     Set<CGNode> nodes = cg.getNodes(mr);
-    Assert.assertFalse(nodes.isEmpty());
+    assertFalse(nodes.isEmpty());
   }
 
   /**
@@ -657,7 +662,7 @@ public class ReflectionTest extends WalaTestCase {
     MethodReference mr =
         MethodReference.findOrCreate(tr, "<init>", "(Ljava/lang/Object;Ljava/lang/Object;)V");
     Set<CGNode> nodes = cg.getNodes(mr);
-    Assert.assertFalse(nodes.isEmpty());
+    assertFalse(nodes.isEmpty());
   }
 
   /**
@@ -678,7 +683,7 @@ public class ReflectionTest extends WalaTestCase {
         TypeReference.findOrCreate(ClassLoaderReference.Application, "Lreflection/Helper");
     MethodReference mr = MethodReference.findOrCreate(tr, "<init>", "(Ljava/lang/Integer;)V");
     Set<CGNode> nodes = cg.getNodes(mr);
-    Assert.assertFalse(nodes.isEmpty());
+    assertFalse(nodes.isEmpty());
   }
 
   /**
@@ -699,7 +704,7 @@ public class ReflectionTest extends WalaTestCase {
         TypeReference.findOrCreate(ClassLoaderReference.Application, "Lreflection/Helper");
     MethodReference mr = MethodReference.findOrCreate(tr, "u", "(Ljava/lang/Integer;)V");
     Set<CGNode> nodes = cg.getNodes(mr);
-    Assert.assertFalse(nodes.isEmpty());
+    assertFalse(nodes.isEmpty());
   }
 
   /**
@@ -729,28 +734,28 @@ public class ReflectionTest extends WalaTestCase {
     TypeReference helperTr =
         TypeReference.findOrCreate(ClassLoaderReference.Application, "Lreflection/Helper");
     IClass helperClass = cha.lookupClass(helperTr);
-    Assert.assertNotNull(helperClass);
+    assertNotNull(helperClass);
 
     TypeReference reflect24Tr =
         TypeReference.findOrCreate(ClassLoaderReference.Application, "Lreflection/Reflect24");
     MethodReference mr =
         MethodReference.findOrCreate(reflect24Tr, "doNothing", "(Ljava/lang/Class;)V");
     Set<CGNode> nodes = cg.getNodes(mr);
-    Assert.assertEquals(1, nodes.size());
+    assertEquals(1, nodes.size());
 
     // get the pts corresponding to the 0th parameter of the Reflect24#doNothing() method
     Optional<CGNode> firstMatched = nodes.stream().findFirst();
-    Assert.assertTrue(firstMatched.isPresent());
+    assertTrue(firstMatched.isPresent());
     CGNode cgNode = firstMatched.get();
 
     LocalPointerKey localPointerKey = new LocalPointerKey(cgNode, cgNode.getIR().getParameter(0));
     OrdinalSet<InstanceKey> pts = pointerAnalysis.getPointsToSet(localPointerKey);
-    Assert.assertEquals(1, pts.size());
+    assertEquals(1, pts.size());
 
     for (InstanceKey mappedObject : pts) {
       // the type corresponding to the 0th parameter should be Helper
-      Assert.assertTrue(mappedObject instanceof ConstantKey);
-      Assert.assertEquals(((ConstantKey<?>) mappedObject).getValue(), helperClass);
+      assertTrue(mappedObject instanceof ConstantKey);
+      assertEquals(((ConstantKey<?>) mappedObject).getValue(), helperClass);
     }
   }
 
@@ -808,27 +813,27 @@ public class ReflectionTest extends WalaTestCase {
     CallGraph cg = CallGraphTestUtil.buildZeroOneCFA(options, new AnalysisCacheImpl(), cha, false);
     Set<CGNode> cgn;
     cgn = cg.getNodes(mabar);
-    Assert.assertTrue(cgn.isEmpty());
+    assertTrue(cgn.isEmpty());
     cgn = cg.getNodes(mabaz);
-    Assert.assertTrue(cgn.isEmpty());
+    assertTrue(cgn.isEmpty());
     cgn = cg.getNodes(mafoo);
-    Assert.assertTrue(cgn.isEmpty());
+    assertTrue(cgn.isEmpty());
 
     cgn = cg.getNodes(mbbar);
-    Assert.assertTrue(cgn.isEmpty());
+    assertTrue(cgn.isEmpty());
     cgn = cg.getNodes(mbbaz);
-    Assert.assertTrue(cgn.isEmpty());
+    assertTrue(cgn.isEmpty());
 
     cgn = cg.getNodes(mcbaz);
-    Assert.assertTrue(cgn.isEmpty());
+    assertTrue(cgn.isEmpty());
     cgn = cg.getNodes(mcfoo);
-    Assert.assertTrue(cgn.isEmpty());
+    assertTrue(cgn.isEmpty());
 
     cgn = cg.getNodes(mbfoo);
-    Assert.assertEquals(1, cgn.size());
+    assertEquals(1, cgn.size());
 
     cgn = cg.getNodes(mcbar);
-    Assert.assertEquals(1, cgn.size());
+    assertEquals(1, cgn.size());
   }
 
   @Test
@@ -845,12 +850,12 @@ public class ReflectionTest extends WalaTestCase {
     IMethod mainMethod = entrypoints.iterator().next().getMethod();
     List<CGNode> mainCallees =
         Iterator2Collection.toList(cg.getSuccNodes(cg.getNode(mainMethod, Everywhere.EVERYWHERE)));
-    Assert.assertTrue(mainCallees.stream().anyMatch(n -> n.toString().contains("getMessage")));
+    assertTrue(mainCallees.stream().anyMatch(n -> n.toString().contains("getMessage")));
     options.setReflectionOptions(ReflectionOptions.STRING_ONLY);
     cg = CallGraphTestUtil.buildZeroCFA(options, new AnalysisCacheImpl(), cha, false);
     mainCallees =
         Iterator2Collection.toList(cg.getSuccNodes(cg.getNode(mainMethod, Everywhere.EVERYWHERE)));
     // getMessage() should _not_ be a callee with reflection handling enabled
-    Assert.assertFalse(mainCallees.stream().anyMatch(n -> n.toString().contains("getMessage")));
+    assertFalse(mainCallees.stream().anyMatch(n -> n.toString().contains("getMessage")));
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/StaticInterfaceMethodTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/StaticInterfaceMethodTest.java
@@ -1,5 +1,7 @@
 package com.ibm.wala.core.tests.callGraph;
 
+import static org.junit.Assert.assertEquals;
+
 import com.ibm.wala.core.tests.util.TestConstants;
 import com.ibm.wala.ipa.callgraph.AnalysisCacheImpl;
 import com.ibm.wala.ipa.callgraph.AnalysisOptions;
@@ -16,7 +18,6 @@ import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.CancelException;
 import java.io.IOException;
 import java.util.List;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class StaticInterfaceMethodTest {
@@ -42,6 +43,6 @@ public class StaticInterfaceMethodTest {
 
     CallGraph cg = CallGraphTestUtil.buildZeroCFA(options, new AnalysisCacheImpl(), cha, false);
 
-    Assert.assertEquals(1, cg.getNodes(staticInterfaceMethodRef).size());
+    assertEquals(1, cg.getNodes(staticInterfaceMethodRef).size());
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/SyntheticTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/SyntheticTest.java
@@ -10,6 +10,9 @@
  */
 package com.ibm.wala.core.tests.callGraph;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.core.tests.util.TestConstants;
 import com.ibm.wala.core.tests.util.WalaTestCase;
@@ -30,7 +33,6 @@ import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.CancelException;
 import java.io.IOException;
 import java.util.Collections;
-import org.junit.Assert;
 import org.junit.Test;
 
 /** Tests for synthetic methods */
@@ -60,11 +62,11 @@ public class SyntheticTest extends WalaTestCase {
     TypeReference tB =
         TypeReference.findOrCreate(ClassLoaderReference.Application, "LmultiTypes/Foo$B");
     MethodReference barB = MethodReference.findOrCreate(tB, "bar", "()V");
-    Assert.assertEquals(1, cg.getNodes(barA).size());
-    Assert.assertEquals(1, cg.getNodes(barB).size());
+    assertEquals(1, cg.getNodes(barA).size());
+    assertEquals(1, cg.getNodes(barB).size());
 
     CGNode root = cg.getFakeRootNode();
     IR ir = root.getIR();
-    Assert.assertTrue(ir.iteratePhis().hasNext());
+    assertTrue(ir.iteratePhis().hasNext());
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/cfg/exc/inter/NullPointerExceptionInterTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/cfg/exc/inter/NullPointerExceptionInterTest.java
@@ -10,6 +10,10 @@
  */
 package com.ibm.wala.core.tests.cfg.exc.inter;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.cfg.exc.ExceptionPruningAnalysis;
 import com.ibm.wala.cfg.exc.InterprocAnalysisResult;
 import com.ibm.wala.cfg.exc.NullPointerAnalysis;
@@ -44,7 +48,6 @@ import com.ibm.wala.util.NullProgressMonitor;
 import com.ibm.wala.util.WalaException;
 import com.ibm.wala.util.graph.GraphIntegrity.UnsoundGraphException;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -107,13 +110,13 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
     InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG =
         NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
 
-    Assert.assertEquals(1, cg.getNodes(mr).size());
+    assertEquals(1, cg.getNodes(mr).size());
     final CGNode callNode = cg.getNodes(mr).iterator().next();
 
     ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
         interExplodedCFG.getResult(callNode);
 
-    Assert.assertTrue(intraExplodedCFG.hasExceptions());
+    assertTrue(intraExplodedCFG.hasExceptions());
   }
 
   @Test
@@ -123,7 +126,7 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
         StringStuff.makeMethodReference(
             "cfg.exc.inter.CallFieldAccess.callDynamicIfException()Lcfg/exc/intra/B");
 
-    Assert.assertEquals(1, cg.getNodes(mr).size());
+    assertEquals(1, cg.getNodes(mr).size());
     final CGNode callNode = cg.getNodes(mr).iterator().next();
 
     InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG =
@@ -132,7 +135,7 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
     ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
         interExplodedCFG.getResult(callNode);
 
-    Assert.assertTrue(intraExplodedCFG.hasExceptions());
+    assertTrue(intraExplodedCFG.hasExceptions());
   }
 
   @Test
@@ -144,12 +147,12 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
     InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG =
         NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
 
-    Assert.assertEquals(1, cg.getNodes(mr).size());
+    assertEquals(1, cg.getNodes(mr).size());
     final CGNode callNode = cg.getNodes(mr).iterator().next();
 
     ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
         interExplodedCFG.getResult(callNode);
-    Assert.assertFalse(intraExplodedCFG.hasExceptions());
+    assertFalse(intraExplodedCFG.hasExceptions());
   }
 
   @Test
@@ -162,12 +165,12 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
     InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG =
         NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
 
-    Assert.assertEquals(1, cg.getNodes(mr).size());
+    assertEquals(1, cg.getNodes(mr).size());
     final CGNode callNode = cg.getNodes(mr).iterator().next();
 
     ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
         interExplodedCFG.getResult(callNode);
-    Assert.assertFalse(intraExplodedCFG.hasExceptions());
+    assertFalse(intraExplodedCFG.hasExceptions());
   }
 
   @Test
@@ -179,13 +182,13 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
     InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG =
         NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
 
-    Assert.assertEquals(1, cg.getNodes(mr).size());
+    assertEquals(1, cg.getNodes(mr).size());
     final CGNode callNode = cg.getNodes(mr).iterator().next();
 
     ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
         interExplodedCFG.getResult(callNode);
 
-    Assert.assertTrue(intraExplodedCFG.hasExceptions());
+    assertTrue(intraExplodedCFG.hasExceptions());
   }
 
   @Test
@@ -195,7 +198,7 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
         StringStuff.makeMethodReference(
             "cfg.exc.inter.CallFieldAccess.callDynamicIf2Exception()Lcfg/exc/intra/B");
 
-    Assert.assertEquals(1, cg.getNodes(mr).size());
+    assertEquals(1, cg.getNodes(mr).size());
     final CGNode callNode = cg.getNodes(mr).iterator().next();
 
     InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG =
@@ -204,7 +207,7 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
     ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
         interExplodedCFG.getResult(callNode);
 
-    Assert.assertTrue(intraExplodedCFG.hasExceptions());
+    assertTrue(intraExplodedCFG.hasExceptions());
   }
 
   @Test
@@ -216,12 +219,12 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
     InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG =
         NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
 
-    Assert.assertEquals(1, cg.getNodes(mr).size());
+    assertEquals(1, cg.getNodes(mr).size());
     final CGNode callNode = cg.getNodes(mr).iterator().next();
 
     ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
         interExplodedCFG.getResult(callNode);
-    Assert.assertFalse(intraExplodedCFG.hasExceptions());
+    assertFalse(intraExplodedCFG.hasExceptions());
   }
 
   @Test
@@ -234,12 +237,12 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
     InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG =
         NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
 
-    Assert.assertEquals(1, cg.getNodes(mr).size());
+    assertEquals(1, cg.getNodes(mr).size());
     final CGNode callNode = cg.getNodes(mr).iterator().next();
 
     ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
         interExplodedCFG.getResult(callNode);
-    Assert.assertFalse(intraExplodedCFG.hasExceptions());
+    assertFalse(intraExplodedCFG.hasExceptions());
   }
 
   @Test
@@ -251,13 +254,13 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
     InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG =
         NullPointerAnalysis.computeInterprocAnalysis(cg, new NullProgressMonitor());
 
-    Assert.assertEquals(1, cg.getNodes(mr).size());
+    assertEquals(1, cg.getNodes(mr).size());
     final CGNode callNode = cg.getNodes(mr).iterator().next();
 
     ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
         interExplodedCFG.getResult(callNode);
 
-    Assert.assertTrue(intraExplodedCFG.hasExceptions());
+    assertTrue(intraExplodedCFG.hasExceptions());
   }
 
   @Test
@@ -267,7 +270,7 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
         StringStuff.makeMethodReference(
             "cfg.exc.inter.CallFieldAccess.callDynamicGetException()Lcfg/exc/intra/B");
 
-    Assert.assertEquals(1, cg.getNodes(mr).size());
+    assertEquals(1, cg.getNodes(mr).size());
     final CGNode callNode = cg.getNodes(mr).iterator().next();
 
     InterprocAnalysisResult<SSAInstruction, IExplodedBasicBlock> interExplodedCFG =
@@ -276,6 +279,6 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
     ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
         interExplodedCFG.getResult(callNode);
 
-    Assert.assertTrue(intraExplodedCFG.hasExceptions());
+    assertTrue(intraExplodedCFG.hasExceptions());
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/cfg/exc/intra/NullPointerExceptionIntraTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/cfg/exc/intra/NullPointerExceptionIntraTest.java
@@ -10,6 +10,10 @@
  */
 package com.ibm.wala.core.tests.cfg.exc.intra;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.fail;
+
 import com.ibm.wala.cfg.ControlFlowGraph;
 import com.ibm.wala.cfg.exc.ExceptionPruningAnalysis;
 import com.ibm.wala.cfg.exc.NullPointerAnalysis;
@@ -42,7 +46,6 @@ import com.ibm.wala.util.collections.Iterator2Iterable;
 import com.ibm.wala.util.graph.GraphIntegrity.UnsoundGraphException;
 import java.util.Collection;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -106,19 +109,19 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
           returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
       final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
 
-      Assert.assertEquals(State.NULL, returnState.getState(returnVal));
+      assertEquals(State.NULL, returnState.getState(returnVal));
     }
     {
       ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
           NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
       intraSSACFG.compute(new NullProgressMonitor());
 
-      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
-      Assert.assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
+      assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
 
       final NullPointerState returnState = intraSSACFG.getState(returnNode);
 
-      Assert.assertEquals(State.NULL, returnState.getState(returnVal));
+      assertEquals(State.NULL, returnState.getState(returnVal));
     }
   }
 
@@ -143,19 +146,19 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
           returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
       final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
 
-      Assert.assertEquals(State.NULL, returnState.getState(returnVal));
+      assertEquals(State.NULL, returnState.getState(returnVal));
     }
     {
       ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
           NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
       intraSSACFG.compute(new NullProgressMonitor());
 
-      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
-      Assert.assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
+      assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
 
       final NullPointerState returnState = intraSSACFG.getState(returnNode);
 
-      Assert.assertEquals(State.NULL, returnState.getState(returnVal));
+      assertEquals(State.NULL, returnState.getState(returnVal));
     }
   }
 
@@ -180,19 +183,19 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
           returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
       final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
 
-      Assert.assertEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertEquals(State.NOT_NULL, returnState.getState(returnVal));
     }
     {
       ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
           NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
       intraSSACFG.compute(new NullProgressMonitor());
 
-      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
-      Assert.assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
+      assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
 
       final NullPointerState returnState = intraSSACFG.getState(returnNode);
 
-      Assert.assertEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertEquals(State.NOT_NULL, returnState.getState(returnVal));
     }
   }
 
@@ -218,19 +221,19 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
           returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
       final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
 
-      Assert.assertEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertEquals(State.NOT_NULL, returnState.getState(returnVal));
     }
     {
       ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
           NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
       intraSSACFG.compute(new NullProgressMonitor());
 
-      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
-      Assert.assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
+      assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
 
       final NullPointerState returnState = intraSSACFG.getState(returnNode);
 
-      Assert.assertEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertEquals(State.NOT_NULL, returnState.getState(returnVal));
     }
   }
 
@@ -255,19 +258,19 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
           returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
       final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
 
-      Assert.assertEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertEquals(State.NOT_NULL, returnState.getState(returnVal));
     }
     {
       ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
           NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
       intraSSACFG.compute(new NullProgressMonitor());
 
-      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
-      Assert.assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
+      assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
 
       final NullPointerState returnState = intraSSACFG.getState(returnNode);
 
-      Assert.assertEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertEquals(State.NOT_NULL, returnState.getState(returnVal));
     }
   }
 
@@ -292,19 +295,19 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
           returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
       final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
 
-      Assert.assertEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertEquals(State.NOT_NULL, returnState.getState(returnVal));
     }
     {
       ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
           NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
       intraSSACFG.compute(new NullProgressMonitor());
 
-      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
-      Assert.assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
+      assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
 
       final NullPointerState returnState = intraSSACFG.getState(returnNode);
 
-      Assert.assertEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertEquals(State.NOT_NULL, returnState.getState(returnVal));
     }
   }
 
@@ -329,21 +332,21 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
           returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
       final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
 
-      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
-      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NULL, returnState.getState(returnVal));
     }
     {
       ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
           NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
       intraSSACFG.compute(new NullProgressMonitor());
 
-      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
-      Assert.assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
+      assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
 
       final NullPointerState returnState = intraSSACFG.getState(returnNode);
 
-      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
-      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NULL, returnState.getState(returnVal));
     }
   }
 
@@ -368,21 +371,21 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
           returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
       final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
 
-      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
-      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NULL, returnState.getState(returnVal));
     }
     {
       ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
           NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
       intraSSACFG.compute(new NullProgressMonitor());
 
-      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
-      Assert.assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
+      assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
 
       final NullPointerState returnState = intraSSACFG.getState(returnNode);
 
-      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
-      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NULL, returnState.getState(returnVal));
     }
   }
 
@@ -407,21 +410,21 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
           returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
       final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
 
-      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
-      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NULL, returnState.getState(returnVal));
     }
     {
       ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
           NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
       intraSSACFG.compute(new NullProgressMonitor());
 
-      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
-      Assert.assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
+      assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
 
       final NullPointerState returnState = intraSSACFG.getState(returnNode);
 
-      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
-      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NULL, returnState.getState(returnVal));
     }
   }
 
@@ -446,21 +449,21 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
           returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
       final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
 
-      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
-      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NULL, returnState.getState(returnVal));
     }
     {
       ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
           NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
       intraSSACFG.compute(new NullProgressMonitor());
 
-      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
-      Assert.assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
+      assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
 
       final NullPointerState returnState = intraSSACFG.getState(returnNode);
 
-      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
-      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NULL, returnState.getState(returnVal));
     }
   }
 
@@ -485,21 +488,21 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
           returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
       final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
 
-      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
-      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NULL, returnState.getState(returnVal));
     }
     {
       ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
           NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
       intraSSACFG.compute(new NullProgressMonitor());
 
-      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
-      Assert.assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
+      assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
 
       final NullPointerState returnState = intraSSACFG.getState(returnNode);
 
-      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
-      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NULL, returnState.getState(returnVal));
     }
   }
 
@@ -524,21 +527,21 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
           returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
       final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
 
-      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
-      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NULL, returnState.getState(returnVal));
     }
     {
       ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
           NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
       intraSSACFG.compute(new NullProgressMonitor());
 
-      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
-      Assert.assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
+      assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
 
       final NullPointerState returnState = intraSSACFG.getState(returnNode);
 
-      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
-      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NULL, returnState.getState(returnVal));
     }
   }
 
@@ -563,21 +566,21 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
           returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
       final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
 
-      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
-      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NULL, returnState.getState(returnVal));
     }
     {
       ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
           NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
       intraSSACFG.compute(new NullProgressMonitor());
 
-      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
-      Assert.assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
+      assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
 
       final NullPointerState returnState = intraSSACFG.getState(returnNode);
 
-      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
-      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NULL, returnState.getState(returnVal));
     }
   }
 
@@ -602,21 +605,21 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
           returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
       final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
 
-      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
-      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NULL, returnState.getState(returnVal));
     }
     {
       ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
           NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
       intraSSACFG.compute(new NullProgressMonitor());
 
-      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
-      Assert.assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
+      assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
 
       final NullPointerState returnState = intraSSACFG.getState(returnNode);
 
-      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
-      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NULL, returnState.getState(returnVal));
     }
   }
 
@@ -641,19 +644,19 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
           returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
       final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
 
-      Assert.assertEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertEquals(State.NOT_NULL, returnState.getState(returnVal));
     }
     {
       ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
           NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
       intraSSACFG.compute(new NullProgressMonitor());
 
-      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
-      Assert.assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
+      assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
 
       final NullPointerState returnState = intraSSACFG.getState(returnNode);
 
-      Assert.assertEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertEquals(State.NOT_NULL, returnState.getState(returnVal));
     }
   }
 
@@ -678,19 +681,19 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
           returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
       final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
 
-      Assert.assertEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertEquals(State.NOT_NULL, returnState.getState(returnVal));
     }
     {
       ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
           NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
       intraSSACFG.compute(new NullProgressMonitor());
 
-      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
-      Assert.assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
+      assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
 
       final NullPointerState returnState = intraSSACFG.getState(returnNode);
 
-      Assert.assertEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertEquals(State.NOT_NULL, returnState.getState(returnVal));
     }
   }
 
@@ -715,21 +718,21 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
           returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
       final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
 
-      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
-      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NULL, returnState.getState(returnVal));
     }
     {
       ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
           NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
       intraSSACFG.compute(new NullProgressMonitor());
 
-      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
-      Assert.assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
+      assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
 
       final NullPointerState returnState = intraSSACFG.getState(returnNode);
 
-      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
-      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NULL, returnState.getState(returnVal));
     }
   }
 
@@ -754,33 +757,33 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
           returnNodeExploded(returnNode, intraExplodedCFG.getCFG());
       final NullPointerState returnState = intraExplodedCFG.getState(returnNodeExploded);
 
-      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
-      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NULL, returnState.getState(returnVal));
     }
     {
       ExceptionPruningAnalysis<SSAInstruction, ISSABasicBlock> intraSSACFG =
           NullPointerAnalysis.createIntraproceduralSSACFGAnalyis(ir);
       intraSSACFG.compute(new NullProgressMonitor());
 
-      Assert.assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
-      Assert.assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
+      assertEquals(ir.getControlFlowGraph().exit(), intraSSACFG.getCFG().exit());
+      assertEquals(returnNode, returnNode(intraSSACFG.getCFG()));
 
       final NullPointerState returnState = intraSSACFG.getState(returnNode);
 
-      Assert.assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
-      Assert.assertNotEquals(State.NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NOT_NULL, returnState.getState(returnVal));
+      assertNotEquals(State.NULL, returnState.getState(returnVal));
     }
   }
 
   public static ISSABasicBlock returnNode(ControlFlowGraph<SSAInstruction, ISSABasicBlock> cfg) {
     Collection<ISSABasicBlock> returnNodes = cfg.getNormalPredecessors(cfg.exit());
-    Assert.assertEquals(1, returnNodes.size());
+    assertEquals(1, returnNodes.size());
     return (ISSABasicBlock) returnNodes.toArray()[0];
   }
 
   public static int returnVal(ISSABasicBlock returnNode) {
     final SSAReturnInstruction returnInst = (SSAReturnInstruction) returnNode.getLastInstruction();
-    Assert.assertEquals(1, returnInst.getNumberOfUses());
+    assertEquals(1, returnInst.getNumberOfUses());
     return returnInst.getUse(0);
   }
 
@@ -793,7 +796,7 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
         return candidate;
       }
     }
-    Assert.fail();
+    fail();
     return null;
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/cha/AnalysisScopeTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/cha/AnalysisScopeTest.java
@@ -1,5 +1,8 @@
 package com.ibm.wala.core.tests.cha;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import com.ibm.wala.core.tests.util.TestConstants;
 import com.ibm.wala.core.util.config.AnalysisScopeReader;
 import com.ibm.wala.core.util.io.FileProvider;
@@ -13,7 +16,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class AnalysisScopeTest {
@@ -30,7 +32,7 @@ public class AnalysisScopeTest {
     scope.addInputStreamForJarToScope(
         ClassLoaderReference.Application, new FileInputStream(bcelJarPath.toString()));
     ClassHierarchy cha = ClassHierarchyFactory.make(scope);
-    Assert.assertNotNull(
+    assertNotNull(
         "couldn't find expected class",
         cha.lookupClass(
             TypeReference.findOrCreate(
@@ -43,11 +45,11 @@ public class AnalysisScopeTest {
         AnalysisScopeReader.instance.readJavaScope(
             "primordial-base.txt", null, AnalysisScopeTest.class.getClassLoader());
     ClassHierarchy cha = ClassHierarchyFactory.make(scope);
-    Assert.assertNotNull(
+    assertNotNull(
         "couldn't find expected class",
         cha.lookupClass(
             TypeReference.findOrCreate(ClassLoaderReference.Application, "Ljava/util/ArrayList")));
-    Assert.assertNull(
+    assertNull(
         "found unexpected class",
         cha.lookupClass(
             TypeReference.findOrCreate(

--- a/core/src/test/java/com/ibm/wala/core/tests/cha/DupFieldsTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/cha/DupFieldsTest.java
@@ -10,6 +10,9 @@
  */
 package com.ibm.wala.core.tests.cha;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IField;
 import com.ibm.wala.core.tests.util.TestConstants;
@@ -25,7 +28,6 @@ import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.FieldReference;
 import com.ibm.wala.types.TypeReference;
 import java.io.IOException;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class DupFieldsTest extends WalaTestCase {
@@ -48,15 +50,15 @@ public class DupFieldsTest extends WalaTestCase {
     } catch (IllegalStateException e) {
       threwException = true;
     }
-    Assert.assertTrue(threwException);
+    assertTrue(threwException);
     IField f =
         cha.resolveField(
             FieldReference.findOrCreate(ref, Atom.findOrCreateUnicodeAtom("a"), TypeReference.Int));
-    Assert.assertEquals(f.getFieldTypeReference(), TypeReference.Int);
+    assertEquals(f.getFieldTypeReference(), TypeReference.Int);
     f =
         cha.resolveField(
             FieldReference.findOrCreate(
                 ref, Atom.findOrCreateUnicodeAtom("a"), TypeReference.Boolean));
-    Assert.assertEquals(f.getFieldTypeReference(), TypeReference.Boolean);
+    assertEquals(f.getFieldTypeReference(), TypeReference.Boolean);
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/cha/ExclusionsTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/cha/ExclusionsTest.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.core.tests.cha;
 
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.core.tests.util.TestConstants;
 import com.ibm.wala.core.util.config.AnalysisScopeReader;
 import com.ibm.wala.core.util.io.FileProvider;
@@ -18,7 +20,6 @@ import com.ibm.wala.ipa.callgraph.AnalysisScope;
 import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.TypeReference;
 import java.io.IOException;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class ExclusionsTest {
@@ -34,6 +35,6 @@ public class ExclusionsTest {
         TypeReference.findOrCreate(
             ClassLoaderReference.Application,
             StringStuff.deployment2CanonicalTypeString("java.awt.Button"));
-    Assert.assertTrue(scope.getExclusions().contains(buttonRef.getName().toString().substring(1)));
+    assertTrue(scope.getExclusions().contains(buttonRef.getName().toString().substring(1)));
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/cha/GetTargetsTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/cha/GetTargetsTest.java
@@ -10,6 +10,9 @@
  */
 package com.ibm.wala.core.tests.cha;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import com.ibm.wala.classLoader.ClassLoaderFactory;
 import com.ibm.wala.classLoader.ClassLoaderFactoryImpl;
 import com.ibm.wala.classLoader.IClass;
@@ -28,7 +31,6 @@ import com.ibm.wala.types.Selector;
 import com.ibm.wala.types.TypeReference;
 import java.util.Collection;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -82,7 +84,7 @@ public class GetTargetsTest extends WalaTestCase {
     for (IMethod method : c) {
       System.err.println(method);
     }
-    Assert.assertEquals(1, c.size());
+    assertEquals(1, c.size());
   }
 
   /** test that calls to &lt;init&gt; methods are treated specially */
@@ -94,7 +96,7 @@ public class GetTargetsTest extends WalaTestCase {
     for (IMethod method : c) {
       System.err.println(method);
     }
-    Assert.assertEquals(1, c.size());
+    assertEquals(1, c.size());
   }
 
   @Test
@@ -104,6 +106,6 @@ public class GetTargetsTest extends WalaTestCase {
             TypeReference.findOrCreate(
                 ClassLoaderReference.Application, "LmethodLookup/MethodLookupStuff$B"));
     IMethod m = testKlass.getMethod(Selector.make("<init>(I)V"));
-    Assert.assertNull(m);
+    assertNull(m);
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/cha/InnerClassesTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/cha/InnerClassesTest.java
@@ -10,6 +10,9 @@
  */
 package com.ibm.wala.core.tests.cha;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.classLoader.ClassLoaderFactory;
 import com.ibm.wala.classLoader.ClassLoaderFactoryImpl;
 import com.ibm.wala.classLoader.IClass;
@@ -27,7 +30,6 @@ import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.TypeName;
 import com.ibm.wala.types.TypeReference;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -75,7 +77,7 @@ public class InnerClassesTest extends WalaTestCase {
     IClass klass = cha.lookupClass(t);
     assert klass != null;
     ShrikeClass s = (ShrikeClass) klass;
-    Assert.assertFalse(s.isInnerClass());
+    assertFalse(s.isInnerClass());
   }
 
   @Test
@@ -86,8 +88,8 @@ public class InnerClassesTest extends WalaTestCase {
     IClass klass = cha.lookupClass(t);
     assert klass != null;
     ShrikeClass s = (ShrikeClass) klass;
-    Assert.assertTrue(s.isInnerClass());
-    Assert.assertTrue(s.isStaticInnerClass());
+    assertTrue(s.isInnerClass());
+    assertTrue(s.isStaticInnerClass());
   }
 
   @Test
@@ -98,7 +100,7 @@ public class InnerClassesTest extends WalaTestCase {
     IClass klass = cha.lookupClass(t);
     assert klass != null;
     ShrikeClass s = (ShrikeClass) klass;
-    Assert.assertTrue(s.isInnerClass());
-    Assert.assertFalse(s.isStaticInnerClass());
+    assertTrue(s.isInnerClass());
+    assertFalse(s.isStaticInnerClass());
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/cha/InterfaceTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/cha/InterfaceTest.java
@@ -10,6 +10,10 @@
  */
 package com.ibm.wala.core.tests.cha;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.classLoader.ClassLoaderFactory;
 import com.ibm.wala.classLoader.ClassLoaderFactoryImpl;
 import com.ibm.wala.classLoader.IClass;
@@ -25,7 +29,6 @@ import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.TypeName;
 import com.ibm.wala.types.TypeReference;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -77,13 +80,13 @@ public class InterfaceTest extends WalaTestCase {
     IClass prep_stmt = cha.lookupClass(prep_stmt_type);
     IClass stmt = cha.lookupClass(stmt_type);
 
-    Assert.assertNotNull("did not find PreparedStatement", prep_stmt);
-    Assert.assertNotNull("did not find Statement", stmt);
+    assertNotNull("did not find PreparedStatement", prep_stmt);
+    assertNotNull("did not find Statement", stmt);
 
-    Assert.assertTrue(cha.implementsInterface(prep_stmt, stmt));
-    Assert.assertFalse(cha.implementsInterface(stmt, prep_stmt));
-    Assert.assertTrue(cha.isAssignableFrom(stmt, prep_stmt));
-    Assert.assertFalse(cha.isAssignableFrom(prep_stmt, stmt));
+    assertTrue(cha.implementsInterface(prep_stmt, stmt));
+    assertFalse(cha.implementsInterface(stmt, prep_stmt));
+    assertTrue(cha.isAssignableFrom(stmt, prep_stmt));
+    assertFalse(cha.isAssignableFrom(prep_stmt, stmt));
   }
 
   /** check that arrays implement Cloneable and Serializable */
@@ -96,9 +99,9 @@ public class InterfaceTest extends WalaTestCase {
     IClass cloneableClass = cha.lookupClass(TypeReference.JavaLangCloneable);
     IClass serializableClass = cha.lookupClass(TypeReference.JavaIoSerializable);
 
-    Assert.assertTrue(cha.implementsInterface(objArrayClass, cloneableClass));
-    Assert.assertTrue(cha.implementsInterface(objArrayClass, serializableClass));
-    Assert.assertTrue(cha.implementsInterface(stringArrayClass, cloneableClass));
-    Assert.assertTrue(cha.implementsInterface(stringArrayClass, serializableClass));
+    assertTrue(cha.implementsInterface(objArrayClass, cloneableClass));
+    assertTrue(cha.implementsInterface(objArrayClass, serializableClass));
+    assertTrue(cha.implementsInterface(stringArrayClass, cloneableClass));
+    assertTrue(cha.implementsInterface(stringArrayClass, serializableClass));
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/cha/LibraryVersionTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/cha/LibraryVersionTest.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.core.tests.cha;
 
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.core.tests.ir.DeterministicIRTest;
 import com.ibm.wala.core.tests.util.TestConstants;
 import com.ibm.wala.core.tests.util.WalaTestCase;
@@ -17,7 +19,6 @@ import com.ibm.wala.core.util.config.AnalysisScopeReader;
 import com.ibm.wala.core.util.io.FileProvider;
 import com.ibm.wala.ipa.callgraph.AnalysisScope;
 import java.io.IOException;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -37,7 +38,7 @@ public class LibraryVersionTest extends WalaTestCase {
             new FileProvider().getFile("J2SEClassHierarchyExclusions.txt"),
             MY_CLASSLOADER);
     System.err.println("java library version is " + scope.getJavaLibraryVersion());
-    Assert.assertTrue(
+    assertTrue(
         scope.isJava18Libraries()
             || scope.isJava17Libraries()
             || scope.isJava16Libraries()

--- a/core/src/test/java/com/ibm/wala/core/tests/cha/MissingSuperTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/cha/MissingSuperTest.java
@@ -10,6 +10,11 @@
  */
 package com.ibm.wala.core.tests.cha;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.classLoader.PhantomClass;
@@ -27,7 +32,6 @@ import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.TypeReference;
 import java.io.IOException;
 import java.util.Collection;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class MissingSuperTest extends WalaTestCase {
@@ -49,22 +53,22 @@ public class MissingSuperTest extends WalaTestCase {
 
     // without phantom classes, won't be able to resolve
     ClassHierarchy cha = ClassHierarchyFactory.make(scope);
-    Assert.assertNull("lookup should not work", cha.lookupClass(ref));
+    assertNull("lookup should not work", cha.lookupClass(ref));
 
     // with makeWithRoot lookup should succeed and
     // unresolvable super class "Super" should be replaced by hierarchy root
     cha = ClassHierarchyFactory.makeWithRoot(scope);
     IClass klass = cha.lookupClass(ref);
-    Assert.assertNotNull("expected class MissingSuper to load", klass);
-    Assert.assertEquals(cha.getRootClass(), klass.getSuperclass());
+    assertNotNull("expected class MissingSuper to load", klass);
+    assertEquals(cha.getRootClass(), klass.getSuperclass());
 
     // with phantom classes, lookup and IR construction should work
     cha = ClassHierarchyFactory.makeWithPhantom(scope);
     klass = cha.lookupClass(ref);
-    Assert.assertNotNull("expected class MissingSuper to load", klass);
+    assertNotNull("expected class MissingSuper to load", klass);
     IAnalysisCacheView cache = new AnalysisCacheImpl();
     Collection<? extends IMethod> declaredMethods = klass.getDeclaredMethods();
-    Assert.assertEquals(declaredMethods.toString(), 2, declaredMethods.size());
+    assertEquals(declaredMethods.toString(), 2, declaredMethods.size());
     for (IMethod m : declaredMethods) {
       // should succeed
       cache.getIR(m);
@@ -74,10 +78,10 @@ public class MissingSuperTest extends WalaTestCase {
     for (IClass klass2 : cha) {
       if (klass2 instanceof PhantomClass
           && klass2.getReference().getClassLoader().equals(ClassLoaderReference.Application)) {
-        Assert.assertEquals("Lmissingsuper/Super", klass2.getReference().getName().toString());
+        assertEquals("Lmissingsuper/Super", klass2.getReference().getName().toString());
         found = true;
       }
     }
-    Assert.assertTrue(found);
+    assertTrue(found);
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/cha/SourceMapTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/cha/SourceMapTest.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.core.tests.cha;
 
+import static org.junit.Assert.assertNotNull;
+
 import com.ibm.wala.classLoader.BytecodeClass;
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.Module;
@@ -22,7 +24,6 @@ import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.ipa.cha.ClassHierarchyFactory;
 import com.ibm.wala.types.TypeReference;
 import java.io.IOException;
-import org.junit.Assert;
 import org.junit.Test;
 
 /** A test of support for source file mapping */
@@ -42,10 +43,10 @@ public class SourceMapTest extends WalaTestCase {
     TypeReference t =
         TypeReference.findOrCreate(scope.getApplicationLoader(), TestConstants.HELLO_MAIN);
     IClass klass = cha.lookupClass(t);
-    Assert.assertNotNull("failed to load " + t, klass);
+    assertNotNull("failed to load " + t, klass);
     String sourceFile = klass.getSourceFileName();
     System.err.println("Source file: " + sourceFile);
-    Assert.assertNotNull(sourceFile);
+    assertNotNull(sourceFile);
   }
 
   @Test
@@ -59,12 +60,12 @@ public class SourceMapTest extends WalaTestCase {
     TypeReference t =
         TypeReference.findOrCreate(scope.getPrimordialLoader(), CLASS_IN_PRIMORDIAL_JAR);
     IClass klass = cha.lookupClass(t);
-    Assert.assertNotNull(klass);
+    assertNotNull(klass);
     String sourceFile = klass.getSourceFileName();
-    Assert.assertNotNull(sourceFile);
+    assertNotNull(sourceFile);
     System.err.println("Source file: " + sourceFile);
     Module container = ((BytecodeClass<?>) klass).getContainer();
-    Assert.assertNotNull(container);
+    assertNotNull(container);
     System.err.println("container: " + container);
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/collections/TwoLevelVectorTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/collections/TwoLevelVectorTest.java
@@ -18,10 +18,12 @@
  */
 package com.ibm.wala.core.tests.collections;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import com.ibm.wala.core.tests.util.WalaTestCase;
 import com.ibm.wala.util.collections.TwoLevelVector;
 import java.util.Iterator;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -42,7 +44,7 @@ public final class TwoLevelVectorTest extends WalaTestCase {
     final TwoLevelVector<Integer> tlVector = new TwoLevelVector<>();
     Iterator<Integer> ignored = tlVector.iterator();
     tlVector.set(2147483647, 56);
-    Assert.assertNotNull(tlVector.iterator());
-    Assert.assertEquals(Integer.valueOf(56), tlVector.get(2147483647));
+    assertNotNull(tlVector.iterator());
+    assertEquals(Integer.valueOf(56), tlVector.get(2147483647));
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/demandpa/AbstractPtrTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/demandpa/AbstractPtrTest.java
@@ -37,6 +37,8 @@
  */
 package com.ibm.wala.core.tests.demandpa;
 
+import static org.junit.Assert.assertEquals;
+
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.Language;
 import com.ibm.wala.classLoader.NewSiteReference;
@@ -81,7 +83,6 @@ import com.ibm.wala.util.intset.IntSet;
 import java.io.IOException;
 import java.util.Collection;
 import org.junit.AfterClass;
-import org.junit.Assert;
 
 public abstract class AbstractPtrTest {
 
@@ -163,7 +164,7 @@ public abstract class AbstractPtrTest {
     if (debug) {
       System.err.println("flows-to for " + mainClass + ": " + flowsTo);
     }
-    Assert.assertEquals(size, flowsTo.size());
+    assertEquals(size, flowsTo.size());
   }
 
   private Collection<PointerKey> getFlowsToSetToTest(String mainClass)
@@ -204,7 +205,7 @@ public abstract class AbstractPtrTest {
     if (debug) {
       System.err.println("points-to for " + mainClass + ": " + pointsTo);
     }
-    Assert.assertEquals(expectedSize, pointsTo.size());
+    assertEquals(expectedSize, pointsTo.size());
   }
 
   private Collection<InstanceKey> getPointsToSetToTest(String mainClass)

--- a/core/src/test/java/com/ibm/wala/core/tests/demandpa/ContextSensitiveTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/demandpa/ContextSensitiveTest.java
@@ -37,6 +37,8 @@
  */
 package com.ibm.wala.core.tests.demandpa;
 
+import static org.junit.Assert.assertEquals;
+
 import com.ibm.wala.core.util.strings.Atom;
 import com.ibm.wala.demandpa.alg.ContextSensitiveStateMachine;
 import com.ibm.wala.demandpa.alg.DemandRefinementPointsTo;
@@ -56,7 +58,6 @@ import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.CancelException;
 import java.io.IOException;
 import java.util.Collection;
-import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -113,7 +114,7 @@ public class ContextSensitiveTest extends AbstractPtrTest {
     if (debug) {
       System.err.println("points-to for " + mainClass + ": " + pointsTo);
     }
-    Assert.assertEquals(1, pointsTo.size());
+    assertEquals(1, pointsTo.size());
   }
 
   @Test
@@ -132,7 +133,7 @@ public class ContextSensitiveTest extends AbstractPtrTest {
     if (debug) {
       System.err.println("points-to for " + mainClass + ": " + pointsTo);
     }
-    Assert.assertEquals(1, pointsTo.size());
+    assertEquals(1, pointsTo.size());
   }
 
   @Test

--- a/core/src/test/java/com/ibm/wala/core/tests/demandpa/TunedRefinementTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/demandpa/TunedRefinementTest.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.core.tests.demandpa;
 
+import static org.junit.Assert.assertEquals;
+
 import com.ibm.wala.core.util.strings.Atom;
 import com.ibm.wala.demandpa.alg.ContextSensitiveStateMachine;
 import com.ibm.wala.demandpa.alg.DemandRefinementPointsTo;
@@ -25,7 +27,6 @@ import com.ibm.wala.types.Descriptor;
 import com.ibm.wala.util.CancelException;
 import java.io.IOException;
 import java.util.Collection;
-import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -99,7 +100,7 @@ public class TunedRefinementTest extends AbstractPtrTest {
     if (debug) {
       System.err.println("points-to for " + mainClass + ": " + pointsTo);
     }
-    Assert.assertEquals(1, pointsTo.size());
+    assertEquals(1, pointsTo.size());
   }
 
   @Test

--- a/core/src/test/java/com/ibm/wala/core/tests/ir/CFGSanitizerTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/ir/CFGSanitizerTest.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.core.tests.ir;
 
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.cfg.CFGSanitizer;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.core.tests.callGraph.CallGraphTestUtil;
@@ -33,7 +35,6 @@ import com.ibm.wala.util.graph.Graph;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
-import org.junit.Assert;
 import org.junit.Test;
 
 /** Test integrity of CFGs */
@@ -73,7 +74,7 @@ public class CFGSanitizerTest extends WalaTestCase {
       System.out.println(graph);
       BasicBlock exit = ir.getControlFlowGraph().exit();
       if (!exit.equals(ir.getControlFlowGraph().entry())) {
-        Assert.assertTrue(graph.getPredNodeCount(exit) > 0);
+        assertTrue(graph.getPredNodeCount(exit) > 0);
       }
     }
   }

--- a/core/src/test/java/com/ibm/wala/core/tests/ir/CFGTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/ir/CFGTest.java
@@ -10,6 +10,10 @@
  */
 package com.ibm.wala.core.tests.ir;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import com.ibm.wala.cfg.ControlFlowGraph;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.classLoader.Language;
@@ -31,7 +35,6 @@ import com.ibm.wala.util.graph.GraphIntegrity;
 import com.ibm.wala.util.graph.GraphIntegrity.UnsoundGraphException;
 import com.ibm.wala.util.intset.IntSet;
 import java.io.IOException;
-import org.junit.Assert;
 import org.junit.Test;
 
 /** Test integrity of CFGs */
@@ -71,7 +74,7 @@ public abstract class CFGTest extends WalaTestCase {
       } catch (UnsoundGraphException e) {
         e.printStackTrace();
         System.err.println(ir);
-        Assert.fail(" failed cfg integrity check for " + methodSig);
+        fail(" failed cfg integrity check for " + methodSig);
       }
 
       try {
@@ -80,7 +83,7 @@ public abstract class CFGTest extends WalaTestCase {
         e.printStackTrace();
         System.err.println(ir);
         System.err.println(cfg);
-        Assert.fail(" failed 2-exit cfg integrity check for " + methodSig);
+        fail(" failed 2-exit cfg integrity check for " + methodSig);
       }
     } catch (Exception e) {
       e.printStackTrace();
@@ -109,7 +112,7 @@ public abstract class CFGTest extends WalaTestCase {
     for (int i = 0; i < irBefore.getInstructions().length; i++) {
       System.out.println(irBefore.getInstructions()[i]);
       System.out.println(irAfter.getInstructions()[i]);
-      Assert.assertEquals(irAfter.getInstructions()[i], irBefore.getInstructions()[i]);
+      assertEquals(irAfter.getInstructions()[i], irBefore.getInstructions()[i]);
     }
   }
 
@@ -122,8 +125,7 @@ public abstract class CFGTest extends WalaTestCase {
     IR ir = cache.getIR(m);
     System.out.println(ir);
     SSACFG controlFlowGraph = ir.getControlFlowGraph();
-    Assert.assertEquals(
-        1, controlFlowGraph.getSuccNodeCount(controlFlowGraph.getBlockForInstruction(21)));
+    assertEquals(1, controlFlowGraph.getSuccNodeCount(controlFlowGraph.getBlockForInstruction(21)));
   }
 
   @Test
@@ -136,9 +138,9 @@ public abstract class CFGTest extends WalaTestCase {
     System.out.println(ir);
     SSACFG controlFlowGraph = ir.getControlFlowGraph();
     IntSet succs = controlFlowGraph.getSuccNodeNumbers(controlFlowGraph.getBlockForInstruction(13));
-    Assert.assertEquals(2, succs.size());
-    Assert.assertTrue(succs.contains(6));
-    Assert.assertTrue(succs.contains(7));
+    assertEquals(2, succs.size());
+    assertTrue(succs.contains(6));
+    assertTrue(succs.contains(7));
   }
 
   @Test
@@ -149,16 +151,15 @@ public abstract class CFGTest extends WalaTestCase {
     IAnalysisCacheView cache = makeAnalysisCache();
     IR ir = cache.getIR(m);
     SSACFG controlFlowGraph = ir.getControlFlowGraph();
-    Assert.assertEquals(
-        1, controlFlowGraph.getSuccNodeCount(controlFlowGraph.getBlockForInstruction(33)));
+    assertEquals(1, controlFlowGraph.getSuccNodeCount(controlFlowGraph.getBlockForInstruction(33)));
   }
 
   public static void testCFG(SSACFG cfg, int[][] assertions) {
     for (int i = 0; i < assertions.length; i++) {
       SSACFG.BasicBlock bb = cfg.getNode(i);
-      Assert.assertEquals("basic block " + i, assertions[i].length, cfg.getSuccNodeCount(bb));
+      assertEquals("basic block " + i, assertions[i].length, cfg.getSuccNodeCount(bb));
       for (int j = 0; j < assertions[i].length; j++) {
-        Assert.assertTrue(cfg.hasEdge(bb, cfg.getNode(assertions[i][j])));
+        assertTrue(cfg.hasEdge(bb, cfg.getNode(assertions[i][j])));
       }
     }
   }

--- a/core/src/test/java/com/ibm/wala/core/tests/ir/CornerCasesTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/ir/CornerCasesTest.java
@@ -10,6 +10,9 @@
  */
 package com.ibm.wala.core.tests.ir;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import com.ibm.wala.analysis.typeInference.TypeInference;
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IMethod;
@@ -32,7 +35,6 @@ import com.ibm.wala.types.Descriptor;
 import com.ibm.wala.types.Selector;
 import com.ibm.wala.types.TypeReference;
 import java.io.IOException;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -58,11 +60,11 @@ public class CornerCasesTest extends WalaTestCase {
         TypeReference.findOrCreateClass(
             scope.getApplicationLoader(), "cornerCases", "YuckyInterface");
     IClass klass = cha.lookupClass(t);
-    Assert.assertNotNull(klass);
+    assertNotNull(klass);
     IMethod m =
         klass.getMethod(
             new Selector(Atom.findOrCreateAsciiAtom("x"), Descriptor.findOrCreateUTF8("()V")));
-    Assert.assertNull(m);
+    assertNull(m);
   }
 
   /**
@@ -82,14 +84,14 @@ public class CornerCasesTest extends WalaTestCase {
     TypeReference t =
         TypeReference.findOrCreateClass(scope.getApplicationLoader(), "cornerCases", "Main");
     IClass klass = cha.lookupClass(t);
-    Assert.assertNotNull(klass);
+    assertNotNull(klass);
     ShrikeCTMethod m =
         (ShrikeCTMethod)
             klass.getMethod(
                 new Selector(
                     Atom.findOrCreateAsciiAtom("foo"),
                     Descriptor.findOrCreateUTF8("()Ljava/lang/Object;")));
-    Assert.assertNotNull(m);
+    assertNotNull(m);
     IR ir =
         new AnalysisCacheImpl()
             .getSSACache()

--- a/core/src/test/java/com/ibm/wala/core/tests/ir/DeterministicIRTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/ir/DeterministicIRTest.java
@@ -10,6 +10,10 @@
  */
 package com.ibm.wala.core.tests.ir;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.core.tests.util.WalaTestCase;
 import com.ibm.wala.core.util.strings.Atom;
@@ -28,7 +32,6 @@ import com.ibm.wala.util.graph.GraphIntegrity;
 import com.ibm.wala.util.graph.GraphIntegrity.UnsoundGraphException;
 import java.io.IOException;
 import java.util.Iterator;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -57,9 +60,9 @@ public abstract class DeterministicIRTest extends WalaTestCase {
 
   private IR doMethod(MethodReference method) {
     IAnalysisCacheView cache = makeAnalysisCache();
-    Assert.assertNotNull("method not found", method);
+    assertNotNull("method not found", method);
     IMethod imethod = cha.resolveMethod(method);
-    Assert.assertNotNull("imethod not found", imethod);
+    assertNotNull("imethod not found", imethod);
     IR ir1 = cache.getIRFactory().makeIR(imethod, Everywhere.EVERYWHERE, options.getSSAOptions());
     cache.clear();
 
@@ -70,7 +73,7 @@ public abstract class DeterministicIRTest extends WalaTestCase {
     } catch (UnsoundGraphException e) {
       System.err.println(ir1);
       e.printStackTrace();
-      Assert.fail("unsound CFG for ir1");
+      fail("unsound CFG for ir1");
     }
 
     IR ir2 = cache.getIRFactory().makeIR(imethod, Everywhere.EVERYWHERE, options.getSSAOptions());
@@ -81,10 +84,10 @@ public abstract class DeterministicIRTest extends WalaTestCase {
     } catch (UnsoundGraphException e1) {
       System.err.println(ir2);
       e1.printStackTrace();
-      Assert.fail("unsound CFG for ir2");
+      fail("unsound CFG for ir2");
     }
 
-    Assert.assertEquals(ir1.toString(), ir2.toString());
+    assertEquals(ir1.toString(), ir2.toString());
     return ir1;
   }
 
@@ -92,7 +95,7 @@ public abstract class DeterministicIRTest extends WalaTestCase {
 
   private static void checkNoneNull(Iterator<?> iterator) {
     while (iterator.hasNext()) {
-      Assert.assertNotNull(iterator.next());
+      assertNotNull(iterator.next());
     }
   }
 
@@ -102,7 +105,7 @@ public abstract class DeterministicIRTest extends WalaTestCase {
         return;
       }
     }
-    Assert.fail("no instructions generated");
+    fail("no instructions generated");
   }
 
   @Test

--- a/core/src/test/java/com/ibm/wala/core/tests/ir/LocalNamesTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/ir/LocalNamesTest.java
@@ -10,6 +10,11 @@
  */
 package com.ibm.wala.core.tests.ir;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
 import com.ibm.wala.classLoader.ClassLoaderFactory;
 import com.ibm.wala.classLoader.ClassLoaderFactoryImpl;
 import com.ibm.wala.classLoader.IClass;
@@ -39,7 +44,6 @@ import com.ibm.wala.types.Selector;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.debug.Assertions;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -103,7 +107,7 @@ public class LocalNamesTest extends WalaTestCase {
           TypeReference.findOrCreateClass(
               scope.getApplicationLoader(), "cornerCases", "AliasNames");
       IClass klass = cha.lookupClass(t);
-      Assert.assertNotNull(klass);
+      assertNotNull(klass);
       IMethod m =
           klass.getMethod(
               new Selector(
@@ -123,7 +127,7 @@ public class LocalNamesTest extends WalaTestCase {
           String[] localNames = ir.getLocalNames(offsetIndex, instr.getDef());
           if (localNames != null && localNames.length > 0 && localNames[0] == null) {
             System.err.println(ir);
-            Assert.fail(
+            fail(
                 " getLocalNames() returned [null,...] for the def of instruction at offset "
                     + offsetIndex
                     + "\n\tinstr");
@@ -146,30 +150,28 @@ public class LocalNamesTest extends WalaTestCase {
             "LcornerCases/Locals",
             Atom.findOrCreateUnicodeAtom("foo"),
             new ImmutableByteArray(UTF8Convert.toUTF8("([Ljava/lang/String;)V")));
-    Assert.assertNotNull("method not found", mref);
+    assertNotNull("method not found", mref);
     IMethod imethod = cha.resolveMethod(mref);
-    Assert.assertNotNull("imethod not found", imethod);
+    assertNotNull("imethod not found", imethod);
     IAnalysisCacheView cache = new AnalysisCacheImpl(options.getSSAOptions());
     IR ir = cache.getIRFactory().makeIR(imethod, Everywhere.EVERYWHERE, options.getSSAOptions());
     options.getSSAOptions().setPiNodePolicy(save);
 
     // v1 should be the parameter "a" at pc 0
     String[] names = ir.getLocalNames(0, 1);
-    Assert.assertNotNull("failed local name resolution for v1@0", names);
-    Assert.assertEquals(
-        "incorrect number of local names for v1@0: " + names.length, 1, names.length);
-    Assert.assertEquals("incorrect local name resolution for v1@0: " + names[0], "a", names[0]);
+    assertNotNull("failed local name resolution for v1@0", names);
+    assertEquals("incorrect number of local names for v1@0: " + names.length, 1, names.length);
+    assertEquals("incorrect local name resolution for v1@0: " + names[0], "a", names[0]);
 
     // v2 is a compiler-induced temporary
-    Assert.assertNull("didn't expect name for v2 at pc 2", ir.getLocalNames(2, 2));
+    assertNull("didn't expect name for v2 at pc 2", ir.getLocalNames(2, 2));
 
     // at pc 5, v1 should represent the locals "a" and "b"
     names = ir.getLocalNames(5, 1);
-    Assert.assertNotNull("failed local name resolution for v1@5", names);
-    Assert.assertEquals(
-        "incorrect number of local names for v1@5: " + names.length, 2, names.length);
-    Assert.assertEquals("incorrect local name resolution #0 for v1@5: " + names[0], "a", names[0]);
-    Assert.assertEquals("incorrect local name resolution #1 for v1@5: " + names[1], "b", names[1]);
+    assertNotNull("failed local name resolution for v1@5", names);
+    assertEquals("incorrect number of local names for v1@5: " + names.length, 2, names.length);
+    assertEquals("incorrect local name resolution #0 for v1@5: " + names[0], "a", names[0]);
+    assertEquals("incorrect local name resolution #1 for v1@5: " + names[1], "b", names[1]);
   }
 
   @Test
@@ -182,29 +184,27 @@ public class LocalNamesTest extends WalaTestCase {
             "LcornerCases/Locals",
             Atom.findOrCreateUnicodeAtom("foo"),
             new ImmutableByteArray(UTF8Convert.toUTF8("([Ljava/lang/String;)V")));
-    Assert.assertNotNull("method not found", mref);
+    assertNotNull("method not found", mref);
     IMethod imethod = cha.resolveMethod(mref);
-    Assert.assertNotNull("imethod not found", imethod);
+    assertNotNull("imethod not found", imethod);
     IAnalysisCacheView cache = new AnalysisCacheImpl(options.getSSAOptions());
     IR ir = cache.getIRFactory().makeIR(imethod, Everywhere.EVERYWHERE, options.getSSAOptions());
     options.getSSAOptions().setPiNodePolicy(save);
 
     // v1 should be the parameter "a" at pc 0
     String[] names = ir.getLocalNames(0, 1);
-    Assert.assertNotNull("failed local name resolution for v1@0", names);
-    Assert.assertEquals(
-        "incorrect number of local names for v1@0: " + names.length, 1, names.length);
-    Assert.assertEquals("incorrect local name resolution for v1@0: " + names[0], "a", names[0]);
+    assertNotNull("failed local name resolution for v1@0", names);
+    assertEquals("incorrect number of local names for v1@0: " + names.length, 1, names.length);
+    assertEquals("incorrect local name resolution for v1@0: " + names[0], "a", names[0]);
 
     // v2 is a compiler-induced temporary
-    Assert.assertNull("didn't expect name for v2 at pc 2", ir.getLocalNames(2, 2));
+    assertNull("didn't expect name for v2 at pc 2", ir.getLocalNames(2, 2));
 
     // at pc 5, v1 should represent the locals "a" and "b"
     names = ir.getLocalNames(5, 1);
-    Assert.assertNotNull("failed local name resolution for v1@5", names);
-    Assert.assertEquals(
-        "incorrect number of local names for v1@5: " + names.length, 2, names.length);
-    Assert.assertEquals("incorrect local name resolution #0 for v1@5: " + names[0], "a", names[0]);
-    Assert.assertEquals("incorrect local name resolution #1 for v1@5: " + names[1], "b", names[1]);
+    assertNotNull("failed local name resolution for v1@5", names);
+    assertEquals("incorrect number of local names for v1@5: " + names.length, 2, names.length);
+    assertEquals("incorrect local name resolution #0 for v1@5: " + names[0], "a", names[0]);
+    assertEquals("incorrect local name resolution #1 for v1@5: " + names[1], "b", names[1]);
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/ir/MultiNewArrayTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/ir/MultiNewArrayTest.java
@@ -10,6 +10,9 @@
  */
 package com.ibm.wala.core.tests.ir;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.classLoader.Language;
@@ -32,7 +35,6 @@ import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.Selector;
 import com.ibm.wala.types.TypeReference;
 import java.io.IOException;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class MultiNewArrayTest extends WalaTestCase {
@@ -52,19 +54,19 @@ public class MultiNewArrayTest extends WalaTestCase {
         cha.lookupClass(
             TypeReference.findOrCreate(
                 ClassLoaderReference.Application, TestConstants.MULTI_DIM_MAIN));
-    Assert.assertNotNull(klass);
+    assertNotNull(klass);
     IMethod m = klass.getMethod(Selector.make(Language.JAVA, "testNewMultiArray()V"));
-    Assert.assertNotNull(m);
+    assertNotNull(m);
     IAnalysisCacheView cache = new AnalysisCacheImpl();
     IR ir = cache.getIRFactory().makeIR(m, Everywhere.EVERYWHERE, new SSAOptions());
-    Assert.assertNotNull(ir);
+    assertNotNull(ir);
     SSAInstruction[] instructions = ir.getInstructions();
     for (SSAInstruction instr : instructions) {
       if (instr instanceof SSANewInstruction) {
         System.err.println(instr.toString(ir.getSymbolTable()));
-        Assert.assertEquals(2, instr.getNumberOfUses());
-        Assert.assertEquals(3, ir.getSymbolTable().getIntValue(instr.getUse(0)));
-        Assert.assertEquals(4, ir.getSymbolTable().getIntValue(instr.getUse(1)));
+        assertEquals(2, instr.getNumberOfUses());
+        assertEquals(3, ir.getSymbolTable().getIntValue(instr.getUse(0)));
+        assertEquals(4, ir.getSymbolTable().getIntValue(instr.getUse(1)));
       }
     }
   }

--- a/core/src/test/java/com/ibm/wala/core/tests/jdk11/nestmates/NestmatesTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/jdk11/nestmates/NestmatesTest.java
@@ -10,6 +10,9 @@
  */
 package com.ibm.wala.core.tests.jdk11.nestmates;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.core.tests.callGraph.CallGraphTestUtil;
 import com.ibm.wala.core.tests.util.WalaTestCase;
 import com.ibm.wala.ipa.callgraph.*;
@@ -21,7 +24,6 @@ import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.CancelException;
 import java.io.IOException;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class NestmatesTest extends WalaTestCase {
@@ -43,23 +45,23 @@ public class NestmatesTest extends WalaTestCase {
     TypeReference tm =
         TypeReference.findOrCreate(ClassLoaderReference.Application, "Lnestmates/TestNestmates");
     MethodReference mm = MethodReference.findOrCreate(tm, "main", "([Ljava/lang/String;)V");
-    Assert.assertTrue("expect main node", cg.getNodes(mm).iterator().hasNext());
+    assertTrue("expect main node", cg.getNodes(mm).iterator().hasNext());
     CGNode mnode = cg.getNodes(mm).iterator().next();
 
     // should be from main to Triple()
     TypeReference t1s =
         TypeReference.findOrCreate(ClassLoaderReference.Application, "Lnestmates/Outer$Inner");
     MethodReference t1m = MethodReference.findOrCreate(t1s, "triple", "()I");
-    Assert.assertTrue("expect Outer.Inner.triple node", cg.getNodes(t1m).iterator().hasNext());
+    assertTrue("expect Outer.Inner.triple node", cg.getNodes(t1m).iterator().hasNext());
     CGNode t1node = cg.getNodes(t1m).iterator().next();
 
     // Check call from main to Triple()
-    Assert.assertTrue(
+    assertTrue(
         "should have call site from main to TestNestmates.triple()",
         cg.getPossibleSites(mnode, t1node).hasNext());
 
     // check that triple() does not call an accessor method
-    Assert.assertFalse(
+    assertFalse(
         "there should not be a call from triple() to an accessor method",
         cg.getSuccNodes(t1node).hasNext());
   }

--- a/core/src/test/java/com/ibm/wala/core/tests/jdk11/privateInterfaceMethods/PrivateInterfaceMethodsTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/jdk11/privateInterfaceMethods/PrivateInterfaceMethodsTest.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.core.tests.jdk11.privateInterfaceMethods;
 
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.core.tests.callGraph.CallGraphTestUtil;
@@ -29,7 +31,6 @@ import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.CancelException;
 import java.io.IOException;
 import java.util.Collection;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class PrivateInterfaceMethodsTest extends WalaTestCase {
@@ -54,7 +55,7 @@ public class PrivateInterfaceMethodsTest extends WalaTestCase {
             ClassLoaderReference.Application,
             "LprivateInterfaceMethods/testArrayReturn/TestArrayReturn");
     MethodReference mm = MethodReference.findOrCreate(tm, "main", "([Ljava/lang/String;)V");
-    Assert.assertTrue("expect main node", cg.getNodes(mm).iterator().hasNext());
+    assertTrue("expect main node", cg.getNodes(mm).iterator().hasNext());
     CGNode mnode = cg.getNodes(mm).iterator().next();
 
     // should be from main to RetT
@@ -63,11 +64,11 @@ public class PrivateInterfaceMethodsTest extends WalaTestCase {
             ClassLoaderReference.Application,
             "LprivateInterfaceMethods/testArrayReturn/ReturnArray");
     MethodReference t2m = MethodReference.findOrCreate(t2s, "RetT", "(Ljava/lang/Object;)V");
-    Assert.assertTrue("expect RetT node", cg.getNodes(t2m).iterator().hasNext());
+    assertTrue("expect RetT node", cg.getNodes(t2m).iterator().hasNext());
     CGNode t2node = cg.getNodes(t2m).iterator().next();
 
     // Check call from main to RetT(string)
-    Assert.assertTrue(
+    assertTrue(
         "should have call site from main to TestArrayRetur.retT",
         cg.getPossibleSites(mnode, t2node).hasNext());
 
@@ -79,11 +80,11 @@ public class PrivateInterfaceMethodsTest extends WalaTestCase {
     MethodReference t3m =
         MethodReference.findOrCreate(t3s, "GetT", "(Ljava/lang/Object;)Ljava/lang/Object;");
 
-    Assert.assertTrue("expect ReturnArray.GetT() node", cg.getNodes(t3m).iterator().hasNext());
+    assertTrue("expect ReturnArray.GetT() node", cg.getNodes(t3m).iterator().hasNext());
     CGNode t3node = cg.getNodes(t3m).iterator().next();
 
     // Check call from RetT to GetT
-    Assert.assertTrue(
+    assertTrue(
         "should have call site from RetT to ReturnArray.GetT()",
         cg.getPossibleSites(t2node, t3node).hasNext());
 
@@ -98,10 +99,10 @@ public class PrivateInterfaceMethodsTest extends WalaTestCase {
     IMethod defaultMethod = test1Class.getMethod(t2m.getSelector());
     IMethod privateMethod = test1Class.getMethod(t3m.getSelector());
 
-    Assert.assertTrue(
+    assertTrue(
         "Expecting default methods to show up in IClass.allMethods()",
         allMethods.contains(defaultMethod));
-    Assert.assertTrue(
+    assertTrue(
         "Expecting private methods to show up in IClass.allMethods()",
         allMethods.contains(privateMethod));
   }

--- a/core/src/test/java/com/ibm/wala/core/tests/jdk11/stringConcat/JDK11StringConcatTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/jdk11/stringConcat/JDK11StringConcatTest.java
@@ -1,5 +1,8 @@
 package com.ibm.wala.core.tests.jdk11.stringConcat;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.core.tests.callGraph.CallGraphTestUtil;
 import com.ibm.wala.core.tests.util.WalaTestCase;
 import com.ibm.wala.ipa.callgraph.*;
@@ -11,7 +14,6 @@ import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.CancelException;
 import java.io.IOException;
-import org.junit.Assert;
 import org.junit.Test;
 
 /** Tests string concatenation on JDK 11+, which uses invokedynamic at the bytecode level */
@@ -34,25 +36,24 @@ public class JDK11StringConcatTest extends WalaTestCase {
     TypeReference tm =
         TypeReference.findOrCreate(ClassLoaderReference.Application, "LstringConcat/StringConcat");
     MethodReference mm = MethodReference.findOrCreate(tm, "main", "([Ljava/lang/String;)V");
-    Assert.assertTrue("expect main node", cg.getNodes(mm).iterator().hasNext());
+    assertTrue("expect main node", cg.getNodes(mm).iterator().hasNext());
     CGNode mnode = cg.getNodes(mm).iterator().next();
 
     // should be from main to testConcat()
     TypeReference t1s =
         TypeReference.findOrCreate(ClassLoaderReference.Application, "LstringConcat/StringConcat");
     MethodReference t1m = MethodReference.findOrCreate(t1s, "testConcat", "()Ljava/lang/String;");
-    Assert.assertTrue("expect testConcat node", cg.getNodes(t1m).iterator().hasNext());
+    assertTrue("expect testConcat node", cg.getNodes(t1m).iterator().hasNext());
     CGNode t1node = cg.getNodes(t1m).iterator().next();
 
     // Check call from main to testConcat()
-    Assert.assertTrue(
+    assertTrue(
         "should have call site from main to StringConcat.testConcat()",
         cg.getPossibleSites(mnode, t1node).hasNext());
 
     // For now, we will see no call edges from the testConcat method, as we have not added
     // support for invokedynamic-based string concatenation yet
     // TODO add support and change this assertion
-    Assert.assertFalse(
-        "did not expect call nodes from testConcat", cg.getSuccNodes(t1node).hasNext());
+    assertFalse("did not expect call nodes from testConcat", cg.getSuccNodes(t1node).hasNext());
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/ptrs/MultiDimArrayTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/ptrs/MultiDimArrayTest.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.core.tests.ptrs;
 
+import static org.junit.Assert.assertEquals;
+
 import com.ibm.wala.classLoader.Language;
 import com.ibm.wala.core.tests.callGraph.CallGraphTestUtil;
 import com.ibm.wala.core.tests.util.TestConstants;
@@ -32,7 +34,6 @@ import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.debug.Assertions;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.io.IOException;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -67,7 +68,7 @@ public class MultiDimArrayTest extends WalaTestCase {
     CGNode node = findDoNothingNode(cg);
     PointerKey pk = pa.getHeapModel().getPointerKeyForLocal(node, 1);
     OrdinalSet<InstanceKey> ptsTo = pa.getPointsToSet(pk);
-    Assert.assertEquals(1, ptsTo.size());
+    assertEquals(1, ptsTo.size());
   }
 
   private static final CGNode findDoNothingNode(CallGraph cg) {

--- a/core/src/test/java/com/ibm/wala/core/tests/ptrs/ObjectSensitiveTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/ptrs/ObjectSensitiveTest.java
@@ -10,6 +10,9 @@
  */
 package com.ibm.wala.core.tests.ptrs;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.core.tests.callGraph.CallGraphTestUtil;
 import com.ibm.wala.core.tests.util.TestConstants;
 import com.ibm.wala.ipa.callgraph.AnalysisCacheImpl;
@@ -35,7 +38,6 @@ import com.ibm.wala.util.intset.OrdinalSet;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.Set;
-import org.junit.Assert;
 import org.junit.Test;
 
 /** test case for nObjBuilder */
@@ -69,7 +71,7 @@ public class ObjectSensitiveTest {
         new LocalPointerKey(doNothing, doNothing.getIR().getParameter(0));
     OrdinalSet<InstanceKey> pts = pa.getPointsToSet(localPointerKey);
 
-    Assert.assertEquals(pts.size(), expectedSize);
+    assertEquals(pts.size(), expectedSize);
   }
 
   private static Pair<CallGraph, PointerAnalysis<InstanceKey>> initCallGraph(
@@ -97,10 +99,10 @@ public class ObjectSensitiveTest {
     MethodReference mr =
         MethodReference.findOrCreate(mainClassTr, "doNothing", "(Ljava/lang/Object;)V");
     Set<CGNode> nodes = cg.getNodes(mr);
-    Assert.assertEquals(1, nodes.size());
+    assertEquals(1, nodes.size());
 
     Optional<CGNode> firstMatched = nodes.stream().findFirst();
-    Assert.assertTrue(firstMatched.isPresent());
+    assertTrue(firstMatched.isPresent());
     return firstMatched.get();
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/ptrs/TypeBasedArrayAliasTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/ptrs/TypeBasedArrayAliasTest.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.core.tests.ptrs;
 
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.core.tests.callGraph.CallGraphTestUtil;
 import com.ibm.wala.core.tests.util.TestConstants;
 import com.ibm.wala.core.tests.util.WalaTestCase;
@@ -31,7 +33,6 @@ import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.debug.Assertions;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.io.IOException;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class TypeBasedArrayAliasTest extends WalaTestCase {
@@ -57,17 +58,17 @@ public class TypeBasedArrayAliasTest extends WalaTestCase {
     CGNode node = findNode(cg, "testMayAlias1");
     PointerKey pk1 = pa.getHeapModel().getPointerKeyForLocal(node, 1);
     PointerKey pk2 = pa.getHeapModel().getPointerKeyForLocal(node, 2);
-    Assert.assertTrue(mayAliased(pk1, pk2, pa));
+    assertTrue(mayAliased(pk1, pk2, pa));
 
     node = findNode(cg, "testMayAlias2");
     pk1 = pa.getHeapModel().getPointerKeyForLocal(node, 1);
     pk2 = pa.getHeapModel().getPointerKeyForLocal(node, 2);
-    Assert.assertTrue(mayAliased(pk1, pk2, pa));
+    assertTrue(mayAliased(pk1, pk2, pa));
 
     node = findNode(cg, "testMayAlias3");
     pk1 = pa.getHeapModel().getPointerKeyForLocal(node, 1);
     pk2 = pa.getHeapModel().getPointerKeyForLocal(node, 2);
-    Assert.assertTrue(mayAliased(pk1, pk2, pa));
+    assertTrue(mayAliased(pk1, pk2, pa));
   }
 
   private static final CGNode findNode(CallGraph cg, String methodName) {

--- a/core/src/test/java/com/ibm/wala/core/tests/ptrs/ZeroLengthArrayTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/ptrs/ZeroLengthArrayTest.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.core.tests.ptrs;
 
+import static org.junit.Assert.assertEquals;
+
 import com.ibm.wala.classLoader.Language;
 import com.ibm.wala.core.tests.callGraph.CallGraphTestUtil;
 import com.ibm.wala.core.tests.util.TestConstants;
@@ -35,7 +37,6 @@ import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.intset.OrdinalSet;
 import java.io.IOException;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class ZeroLengthArrayTest {
@@ -69,11 +70,11 @@ public class ZeroLengthArrayTest {
             Everywhere.EVERYWHERE);
     OrdinalSet<InstanceKey> pointsToSet =
         pa.getPointsToSet(heapModel.getPointerKeyForLocal(mainNode, 4));
-    Assert.assertEquals(1, pointsToSet.size());
+    assertEquals(1, pointsToSet.size());
     InstanceKey arrayKey = pointsToSet.iterator().next();
     OrdinalSet<InstanceKey> arrayContents =
         pa.getPointsToSet(heapModel.getPointerKeyForArrayContents(arrayKey));
     System.err.println(arrayContents);
-    Assert.assertEquals(0, arrayContents.size());
+    assertEquals(0, arrayContents.size());
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/shrike/FloatingPointsTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/shrike/FloatingPointsTest.java
@@ -1,5 +1,9 @@
 package com.ibm.wala.core.tests.shrike;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import com.ibm.wala.core.tests.util.WalaTestCase;
 import com.ibm.wala.shrike.shrikeBT.ConstantInstruction;
 import com.ibm.wala.shrike.shrikeBT.Constants;
@@ -18,7 +22,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -104,7 +107,7 @@ public class FloatingPointsTest extends WalaTestCase {
         (double) getConstantInstructionValue(signature, index, Constants.TYPE_double);
 
     // And finally (and most important) compare the value
-    Assert.assertEquals(newValue, readValue, 0d);
+    assertEquals(newValue, readValue, 0d);
   }
 
   @Test
@@ -148,7 +151,7 @@ public class FloatingPointsTest extends WalaTestCase {
     float readValue = (float) getConstantInstructionValue(signature, index, Constants.TYPE_float);
 
     // And finally (and most important) compare the value
-    Assert.assertEquals(newValue, readValue, 0d);
+    assertEquals(newValue, readValue, 0d);
   }
 
   private void write() throws IllegalStateException, IOException, InvalidClassFileException {
@@ -192,11 +195,11 @@ public class FloatingPointsTest extends WalaTestCase {
     IInstruction instruction = instructions[index];
 
     // Check that the instruction type has not been changed
-    Assert.assertTrue(instruction instanceof ConstantInstruction);
+    assertTrue(instruction instanceof ConstantInstruction);
 
     // The type type should be the same as well
     ConstantInstruction instruction2 = (ConstantInstruction) instruction;
-    Assert.assertTrue(type.contentEquals(instruction2.getType()));
+    assertTrue(type.contentEquals(instruction2.getType()));
 
     return instruction2.getValue();
   }
@@ -214,7 +217,7 @@ public class FloatingPointsTest extends WalaTestCase {
         }
       }
     }
-    Assert.fail("No ConstantInstruction with type '" + type + "' found");
+    fail("No ConstantInstruction with type '" + type + "' found");
     return null;
   }
 
@@ -233,7 +236,7 @@ public class FloatingPointsTest extends WalaTestCase {
         }
       }
     }
-    Assert.fail("Method data not found. Check the signature");
+    fail("Method data not found. Check the signature");
     return null;
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/slicer/SlicerTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/slicer/SlicerTest.java
@@ -10,6 +10,9 @@
  */
 package com.ibm.wala.core.tests.slicer;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.classLoader.Language;
 import com.ibm.wala.core.tests.callGraph.CallGraphTestUtil;
 import com.ibm.wala.core.tests.util.TestConstants;
@@ -66,7 +69,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class SlicerTest {
@@ -155,7 +157,7 @@ public class SlicerTest {
         i++;
       }
     }
-    Assert.assertEquals(16, i);
+    assertEquals(16, i);
   }
 
   @Test
@@ -183,7 +185,7 @@ public class SlicerTest {
     Collection<Statement> slice = computeBackwardSlice;
     SlicerUtil.dumpSlice(slice);
 
-    Assert.assertEquals(slice.toString(), 9, SlicerUtil.countNormals(slice));
+    assertEquals(slice.toString(), 9, SlicerUtil.countNormals(slice));
   }
 
   @Test
@@ -209,7 +211,7 @@ public class SlicerTest {
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     SlicerUtil.dumpSlice(slice);
-    Assert.assertEquals(slice.toString(), 1, SlicerUtil.countAllocations(slice, false));
+    assertEquals(slice.toString(), 1, SlicerUtil.countAllocations(slice, false));
   }
 
   @Test
@@ -236,7 +238,7 @@ public class SlicerTest {
         Slicer.computeForwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     SlicerUtil.dumpSlice(slice);
-    Assert.assertEquals(slice.toString(), 4, slice.size());
+    assertEquals(slice.toString(), 4, slice.size());
   }
 
   @Test
@@ -263,7 +265,7 @@ public class SlicerTest {
         Slicer.computeForwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     SlicerUtil.dumpSlice(slice);
-    Assert.assertEquals(slice.toString(), 7, slice.size());
+    assertEquals(slice.toString(), 7, slice.size());
   }
 
   /** test unreproduced bug reported on mailing list by Sameer Madan, 7/3/2007 */
@@ -322,12 +324,12 @@ public class SlicerTest {
             DataDependenceOptions.FULL,
             ControlDependenceOptions.NO_EXCEPTIONAL_EDGES);
     SlicerUtil.dumpSlice(slice);
-    Assert.assertEquals(4, SlicerUtil.countInvokes(slice));
+    assertEquals(4, SlicerUtil.countInvokes(slice));
     // should only get 4 statements total when ignoring control dependences completely
     slice =
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
-    Assert.assertEquals(slice.toString(), 4, slice.size());
+    assertEquals(slice.toString(), 4, slice.size());
   }
 
   @Test
@@ -357,7 +359,7 @@ public class SlicerTest {
             DataDependenceOptions.FULL,
             ControlDependenceOptions.NO_EXCEPTIONAL_EDGES);
     // dumpSlice(slice);
-    Assert.assertEquals(/*slice.toString(), */ 5, SlicerUtil.countApplicationNormals(slice));
+    assertEquals(/*slice.toString(), */ 5, SlicerUtil.countApplicationNormals(slice));
   }
 
   @Test
@@ -384,7 +386,7 @@ public class SlicerTest {
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.NONE, ControlDependenceOptions.FULL);
     SlicerUtil.dumpSlice(slice);
-    Assert.assertEquals(slice.toString(), 2, SlicerUtil.countConditionals(slice));
+    assertEquals(slice.toString(), 2, SlicerUtil.countConditionals(slice));
   }
 
   @Test
@@ -411,7 +413,7 @@ public class SlicerTest {
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.NONE, ControlDependenceOptions.FULL);
     SlicerUtil.dumpSlice(slice);
-    Assert.assertEquals(slice.toString(), 1, SlicerUtil.countConditionals(slice));
+    assertEquals(slice.toString(), 1, SlicerUtil.countConditionals(slice));
   }
 
   @Test
@@ -438,7 +440,7 @@ public class SlicerTest {
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.NONE, ControlDependenceOptions.FULL);
     SlicerUtil.dumpSlice(slice);
-    Assert.assertEquals(slice.toString(), 0, SlicerUtil.countConditionals(slice));
+    assertEquals(slice.toString(), 0, SlicerUtil.countConditionals(slice));
   }
 
   @Test
@@ -466,14 +468,14 @@ public class SlicerTest {
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.NONE, ControlDependenceOptions.FULL);
     SlicerUtil.dumpSlice(slice);
-    Assert.assertEquals(0, SlicerUtil.countConditionals(slice));
+    assertEquals(0, SlicerUtil.countConditionals(slice));
 
     // compute a full slice
     slice =
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.FULL);
     SlicerUtil.dumpSlice(slice);
-    Assert.assertEquals(slice.toString(), 1, SlicerUtil.countConditionals(slice));
+    assertEquals(slice.toString(), 1, SlicerUtil.countConditionals(slice));
   }
 
   @Test
@@ -505,8 +507,8 @@ public class SlicerTest {
             DataDependenceOptions.NONE,
             ControlDependenceOptions.NO_EXCEPTIONAL_EDGES);
     SlicerUtil.dumpSlice(slice);
-    Assert.assertEquals(10, slice.size());
-    Assert.assertEquals(3, SlicerUtil.countReturns(slice));
+    assertEquals(10, slice.size());
+    assertEquals(3, SlicerUtil.countReturns(slice));
   }
 
   @Test
@@ -538,8 +540,8 @@ public class SlicerTest {
             DataDependenceOptions.NONE,
             ControlDependenceOptions.NO_INTERPROC_NO_EXCEPTION);
     SlicerUtil.dumpSlice(slice);
-    Assert.assertEquals(8, slice.size());
-    Assert.assertEquals(2, SlicerUtil.countReturns(slice));
+    assertEquals(8, slice.size());
+    assertEquals(2, SlicerUtil.countReturns(slice));
   }
 
   @Test
@@ -571,7 +573,7 @@ public class SlicerTest {
             DataDependenceOptions.NONE,
             ControlDependenceOptions.NO_EXCEPTIONAL_EDGES);
     SlicerUtil.dumpSlice(slice);
-    Assert.assertEquals(slice.toString(), 2, SlicerUtil.countInvokes(slice));
+    assertEquals(slice.toString(), 2, SlicerUtil.countInvokes(slice));
   }
 
   @Test
@@ -598,7 +600,7 @@ public class SlicerTest {
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     SlicerUtil.dumpSlice(slice);
-    Assert.assertEquals(slice.toString(), 1, SlicerUtil.countAllocations(slice, false));
+    assertEquals(slice.toString(), 1, SlicerUtil.countAllocations(slice, false));
   }
 
   @Test
@@ -626,8 +628,8 @@ public class SlicerTest {
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     SlicerUtil.dumpSlice(slice);
-    Assert.assertEquals(slice.toString(), 2, SlicerUtil.countAllocations(slice, false));
-    Assert.assertEquals(slice.toString(), 1, SlicerUtil.countAloads(slice));
+    assertEquals(slice.toString(), 2, SlicerUtil.countAllocations(slice, false));
+    assertEquals(slice.toString(), 1, SlicerUtil.countAloads(slice));
   }
 
   @Test
@@ -655,8 +657,8 @@ public class SlicerTest {
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     SlicerUtil.dumpSlice(slice);
-    Assert.assertEquals(slice.toString(), 2, SlicerUtil.countAllocations(slice, false));
-    Assert.assertEquals(slice.toString(), 1, SlicerUtil.countPutfields(slice));
+    assertEquals(slice.toString(), 2, SlicerUtil.countAllocations(slice, false));
+    assertEquals(slice.toString(), 1, SlicerUtil.countPutfields(slice));
   }
 
   @Test
@@ -686,8 +688,8 @@ public class SlicerTest {
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     SlicerUtil.dumpSlice(slice);
-    Assert.assertEquals(3, SlicerUtil.countAllocations(slice, false));
-    Assert.assertEquals(2, SlicerUtil.countPutfields(slice));
+    assertEquals(3, SlicerUtil.countAllocations(slice, false));
+    assertEquals(2, SlicerUtil.countPutfields(slice));
 
     // compute thin slice .. ignore base pointers
     Collection<Statement> computeBackwardSlice =
@@ -699,8 +701,8 @@ public class SlicerTest {
             ControlDependenceOptions.NONE);
     slice = computeBackwardSlice;
     SlicerUtil.dumpSlice(slice);
-    Assert.assertEquals(slice.toString(), 2, SlicerUtil.countAllocations(slice, false));
-    Assert.assertEquals(slice.toString(), 1, SlicerUtil.countPutfields(slice));
+    assertEquals(slice.toString(), 2, SlicerUtil.countAllocations(slice, false));
+    assertEquals(slice.toString(), 1, SlicerUtil.countPutfields(slice));
   }
 
   @Test
@@ -728,9 +730,9 @@ public class SlicerTest {
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     SlicerUtil.dumpSlice(slice);
-    Assert.assertEquals(slice.toString(), 1, SlicerUtil.countAllocations(slice, false));
-    Assert.assertEquals(slice.toString(), 2, SlicerUtil.countPutstatics(slice));
-    Assert.assertEquals(slice.toString(), 2, SlicerUtil.countGetstatics(slice));
+    assertEquals(slice.toString(), 1, SlicerUtil.countAllocations(slice, false));
+    assertEquals(slice.toString(), 2, SlicerUtil.countPutstatics(slice));
+    assertEquals(slice.toString(), 2, SlicerUtil.countGetstatics(slice));
   }
 
   @Test
@@ -758,7 +760,7 @@ public class SlicerTest {
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     SlicerUtil.dumpSlice(slice);
-    Assert.assertEquals(slice.toString(), 2, SlicerUtil.countAllocations(slice, false));
+    assertEquals(slice.toString(), 2, SlicerUtil.countAllocations(slice, false));
   }
 
   @Test
@@ -787,8 +789,8 @@ public class SlicerTest {
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     SlicerUtil.dumpSlice(slice);
-    Assert.assertEquals(slice.toString(), 3, SlicerUtil.countAllocations(slice, false));
-    Assert.assertEquals(slice.toString(), 2, SlicerUtil.countPutfields(slice));
+    assertEquals(slice.toString(), 3, SlicerUtil.countAllocations(slice, false));
+    assertEquals(slice.toString(), 2, SlicerUtil.countPutfields(slice));
   }
 
   @Test
@@ -819,8 +821,8 @@ public class SlicerTest {
         Slicer.computeBackwardSlice(
             s, pcg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.FULL);
     SlicerUtil.dumpSlice(slice);
-    Assert.assertEquals(slice.toString(), 0, SlicerUtil.countAllocations(slice, false));
-    Assert.assertEquals(slice.toString(), 1, SlicerUtil.countPutfields(slice));
+    assertEquals(slice.toString(), 0, SlicerUtil.countAllocations(slice, false));
+    assertEquals(slice.toString(), 1, SlicerUtil.countPutfields(slice));
   }
 
   /**
@@ -878,8 +880,8 @@ public class SlicerTest {
         Slicer.computeBackwardSlice(
             s, pcg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     SlicerUtil.dumpSlice(slice);
-    Assert.assertEquals(slice.toString(), 1, SlicerUtil.countAllocations(slice, false));
-    Assert.assertEquals(slice.toString(), 1, SlicerUtil.countPutfields(slice));
+    assertEquals(slice.toString(), 1, SlicerUtil.countAllocations(slice, false));
+    assertEquals(slice.toString(), 1, SlicerUtil.countPutfields(slice));
   }
 
   @Test
@@ -906,9 +908,9 @@ public class SlicerTest {
     Collection<Statement> slice =
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
-    Assert.assertEquals("wrong number of allocations", 1, SlicerUtil.countAllocations(slice, true));
-    Assert.assertEquals("wrong number of throws", 1, SlicerUtil.countThrows(slice, true));
-    Assert.assertEquals("wrong number of getfields", 1, SlicerUtil.countGetfields(slice, true));
+    assertEquals("wrong number of allocations", 1, SlicerUtil.countAllocations(slice, true));
+    assertEquals("wrong number of throws", 1, SlicerUtil.countThrows(slice, true));
+    assertEquals("wrong number of getfields", 1, SlicerUtil.countGetfields(slice, true));
   }
 
   @Test
@@ -1025,7 +1027,7 @@ public class SlicerTest {
             .filter(s -> s instanceof NormalStatement && s.getNode().equals(main))
             .collect(Collectors.toList());
     normalsInMain.stream().forEach(System.err::println);
-    Assert.assertEquals(7, normalsInMain.size());
+    assertEquals(7, normalsInMain.size());
   }
 
   @Test
@@ -1059,7 +1061,7 @@ public class SlicerTest {
     List<Statement> inMain =
         slice.stream().filter(s -> s.getNode().equals(main)).collect(Collectors.toList());
     // check that we are tracking the size field in a HeapReturnCaller statement for the add() call
-    Assert.assertTrue(
+    assertTrue(
         "couldn't find HeapReturnCaller for size field",
         inMain.stream()
             .filter(
@@ -1106,8 +1108,8 @@ public class SlicerTest {
     List<Statement> inMain =
         slice.stream().filter(st -> st.getNode().equals(main)).collect(Collectors.toList());
     inMain.stream().forEach(System.err::println);
-    Assert.assertEquals(4, inMain.size());
+    assertEquals(4, inMain.size());
     // returns for Integer.valueOf() and getInt()
-    Assert.assertEquals(2, inMain.stream().filter(st -> st instanceof NormalReturnCaller).count());
+    assertEquals(2, inMain.stream().filter(st -> st instanceof NormalReturnCaller).count());
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/typeInference/TypeInferenceTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/typeInference/TypeInferenceTest.java
@@ -10,6 +10,10 @@
  */
 package com.ibm.wala.core.tests.typeInference;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.analysis.typeInference.ConeType;
 import com.ibm.wala.analysis.typeInference.TypeAbstraction;
 import com.ibm.wala.analysis.typeInference.TypeInference;
@@ -35,7 +39,6 @@ import com.ibm.wala.ipa.cha.ClassHierarchyFactory;
 import com.ibm.wala.ssa.IR;
 import com.ibm.wala.types.MethodReference;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -98,9 +101,9 @@ public class TypeInferenceTest extends WalaTestCase {
             "LtypeInference/TI",
             Atom.findOrCreateUnicodeAtom("foo"),
             new ImmutableByteArray(UTF8Convert.toUTF8("()V")));
-    Assert.assertNotNull("method not found", method);
+    assertNotNull("method not found", method);
     IMethod imethod = cha.resolveMethod(method);
-    Assert.assertNotNull("imethod not found", imethod);
+    assertNotNull("imethod not found", imethod);
     IR ir = cache.getIRFactory().makeIR(imethod, Everywhere.EVERYWHERE, options.getSSAOptions());
     System.out.println(ir);
 
@@ -118,14 +121,14 @@ public class TypeInferenceTest extends WalaTestCase {
             "LtypeInference/TI",
             Atom.findOrCreateUnicodeAtom("bar"),
             new ImmutableByteArray(UTF8Convert.toUTF8("(I)V")));
-    Assert.assertNotNull("method not found", method);
+    assertNotNull("method not found", method);
     IMethod imethod = cha.resolveMethod(method);
-    Assert.assertNotNull("imethod not found", imethod);
+    assertNotNull("imethod not found", imethod);
     IR ir = cache.getIRFactory().makeIR(imethod, Everywhere.EVERYWHERE, options.getSSAOptions());
     System.out.println(ir);
 
     TypeInference ti = TypeInference.make(ir, true);
-    Assert.assertNotNull("null type abstraction for parameter", ti.getType(2));
+    assertNotNull("null type abstraction for parameter", ti.getType(2));
   }
 
   @Test
@@ -136,16 +139,16 @@ public class TypeInferenceTest extends WalaTestCase {
             "LtypeInference/TI",
             Atom.findOrCreateUnicodeAtom("inferInt"),
             new ImmutableByteArray(UTF8Convert.toUTF8("()V")));
-    Assert.assertNotNull("method not found", method);
+    assertNotNull("method not found", method);
     IMethod imethod = cha.resolveMethod(method);
-    Assert.assertNotNull("imethod not found", imethod);
+    assertNotNull("imethod not found", imethod);
     IR ir = cache.getIRFactory().makeIR(imethod, Everywhere.EVERYWHERE, options.getSSAOptions());
     System.out.println(ir);
 
     TypeInference ti = TypeInference.make(ir, true);
     TypeAbstraction type = ti.getType(7);
-    Assert.assertNotNull("null type abstraction", type);
-    Assert.assertEquals("inferred wrong type", "int", type.toString());
+    assertNotNull("null type abstraction", type);
+    assertEquals("inferred wrong type", "int", type.toString());
   }
 
   @Test
@@ -156,16 +159,16 @@ public class TypeInferenceTest extends WalaTestCase {
             "LtypeInference/TI",
             Atom.findOrCreateUnicodeAtom("useCast"),
             new ImmutableByteArray(UTF8Convert.toUTF8("(Ljava/lang/Object;)V")));
-    Assert.assertNotNull("method not found", method);
+    assertNotNull("method not found", method);
     IMethod imethod = cha.resolveMethod(method);
-    Assert.assertNotNull("imethod not found", imethod);
+    assertNotNull("imethod not found", imethod);
     IR ir = cache.getIRFactory().makeIR(imethod, Everywhere.EVERYWHERE, options.getSSAOptions());
     System.out.println(ir);
 
     TypeInference ti = TypeInference.make(ir, false);
     TypeAbstraction type = ti.getType(4);
-    Assert.assertNotNull("null type abstraction", type);
-    Assert.assertTrue(
+    assertNotNull("null type abstraction", type);
+    assertTrue(
         "inferred wrong type " + type,
         type instanceof ConeType
             && ((ConeType) type)

--- a/core/src/test/java/com/ibm/wala/examples/analysis/dataflow/DataflowTest.java
+++ b/core/src/test/java/com/ibm/wala/examples/analysis/dataflow/DataflowTest.java
@@ -10,6 +10,9 @@
  */
 package com.ibm.wala.examples.analysis.dataflow;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.classLoader.Language;
 import com.ibm.wala.core.tests.callGraph.CallGraphTestUtil;
@@ -51,7 +54,6 @@ import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -119,8 +121,8 @@ public class DataflowTest extends WalaTestCase {
     for (IExplodedBasicBlock ebb : ecfg) {
       if (ebb.getNumber() == 4) {
         IntSet out = solver.getOut(ebb).getValue();
-        Assert.assertEquals(1, out.size());
-        Assert.assertTrue(out.contains(1));
+        assertEquals(1, out.size());
+        assertTrue(out.contains(1));
       }
     }
   }
@@ -139,9 +141,9 @@ public class DataflowTest extends WalaTestCase {
     for (IExplodedBasicBlock ebb : ecfg) {
       if (ebb.getNumber() == 10) {
         IntSet out = solver.getOut(ebb).getValue();
-        Assert.assertEquals(2, out.size());
-        Assert.assertTrue(out.contains(0));
-        Assert.assertTrue(out.contains(2));
+        assertEquals(2, out.size());
+        assertTrue(out.contains(0));
+        assertTrue(out.contains(2));
       }
     }
   }
@@ -179,7 +181,7 @@ public class DataflowTest extends WalaTestCase {
               applicationDefs.add(def);
             }
           }
-          Assert.assertEquals(2, applicationDefs.size());
+          assertEquals(2, applicationDefs.size());
         }
       }
     }
@@ -219,7 +221,7 @@ public class DataflowTest extends WalaTestCase {
               applicationDefs.add(def);
             }
           }
-          Assert.assertEquals(1, applicationDefs.size());
+          assertEquals(1, applicationDefs.size());
         }
       }
     }

--- a/core/src/test/java/com/ibm/wala/examples/analysis/dataflow/InitializerTest.java
+++ b/core/src/test/java/com/ibm/wala/examples/analysis/dataflow/InitializerTest.java
@@ -11,6 +11,8 @@
 
 package com.ibm.wala.examples.analysis.dataflow;
 
+import static org.junit.Assert.assertEquals;
+
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.Language;
 import com.ibm.wala.core.tests.callGraph.CallGraphTestUtil;
@@ -37,7 +39,6 @@ import com.ibm.wala.ssa.analysis.IExplodedBasicBlock;
 import com.ibm.wala.util.intset.IntIterator;
 import com.ibm.wala.util.intset.IntSet;
 import java.io.IOException;
-import org.junit.Assert;
 
 public class InitializerTest {
 
@@ -95,7 +96,7 @@ public class InitializerTest {
             int next = intIterator.next();
             System.out.println(reachingDefs.getDomain().getMappedObject(next));
           }
-          Assert.assertEquals(3, solution.size());
+          assertEquals(3, solution.size());
         }
       }
     }

--- a/core/src/testFixtures/java/com/ibm/wala/core/tests/shrike/DynamicCallGraphTestBase.java
+++ b/core/src/testFixtures/java/com/ibm/wala/core/tests/shrike/DynamicCallGraphTestBase.java
@@ -11,6 +11,9 @@
 
 package com.ibm.wala.core.tests.shrike;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.core.tests.util.WalaTestCase;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.CallGraph;
@@ -40,7 +43,6 @@ import java.util.zip.GZIPInputStream;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Java;
 import org.apache.tools.ant.types.Path;
-import org.junit.Assert;
 
 public abstract class DynamicCallGraphTestBase extends WalaTestCase {
 
@@ -87,7 +89,7 @@ public abstract class DynamicCallGraphTestBase extends WalaTestCase {
         args.add("--patch-calls");
       }
       OfflineDynamicCallGraph.main(args.toArray(new String[0]));
-      Assert.assertTrue(
+      assertTrue(
           "expected to create " + instrumentedJarLocation, Files.exists(instrumentedJarLocation));
       instrumentedJarBuilt = true;
     }
@@ -139,7 +141,7 @@ public abstract class DynamicCallGraphTestBase extends WalaTestCase {
     Process x = Runtime.getRuntime().exec(commandLine, null, new File("build"));
     x.waitFor();
 
-    Assert.assertTrue("expected to create call graph", Files.exists(cgLocation));
+    assertTrue("expected to create call graph", Files.exists(cgLocation));
   }
 
   interface EdgesTest {
@@ -163,10 +165,10 @@ public abstract class DynamicCallGraphTestBase extends WalaTestCase {
         staticCG,
         (staticCG1, caller, calleeRef) -> {
           Set<CGNode> nodes = staticCG1.getNodes(calleeRef);
-          Assert.assertEquals("expected one node for " + calleeRef, 1, nodes.size());
+          assertEquals("expected one node for " + calleeRef, 1, nodes.size());
           CGNode callee = nodes.iterator().next();
 
-          Assert.assertTrue(
+          assertTrue(
               "no edge for " + caller + " --> " + callee,
               staticCG1.getPossibleSites(caller, callee).hasNext());
           Pair<CGNode, CGNode> x = Pair.make(caller, callee);
@@ -196,7 +198,7 @@ public abstract class DynamicCallGraphTestBase extends WalaTestCase {
         },
         filter);
 
-    Assert.assertTrue("could not find " + notFound, notFound.isEmpty());
+    assertTrue("could not find " + notFound, notFound.isEmpty());
   }
 
   protected void check(CallGraph staticCG, EdgesTest test, Predicate<MethodReference> filter)
@@ -236,7 +238,7 @@ public abstract class DynamicCallGraphTestBase extends WalaTestCase {
           if (!filter.test(callerRef)) {
             continue loop;
           }
-          Assert.assertEquals(callerRef.toString(), 1, nodes.size());
+          assertEquals(callerRef.toString(), 1, nodes.size());
           caller = nodes.iterator().next();
         }
 
@@ -250,6 +252,6 @@ public abstract class DynamicCallGraphTestBase extends WalaTestCase {
       }
     }
 
-    Assert.assertTrue("more than one edge", lines > 0);
+    assertTrue("more than one edge", lines > 0);
   }
 }

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/DroidBenchCGTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/DroidBenchCGTest.java
@@ -11,6 +11,7 @@
 package com.ibm.wala.dalvik.test.callGraph;
 
 import static com.ibm.wala.dalvik.test.util.Util.walaProperties;
+import static org.junit.Assert.assertTrue;
 
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IMethod;
@@ -35,7 +36,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.junit.Assert;
 import org.junit.Test;
 
 public abstract class DroidBenchCGTest extends DalvikCallGraphTestBase {
@@ -142,7 +142,7 @@ public abstract class DroidBenchCGTest extends DalvikCallGraphTestBase {
   }
 
   protected void assertion(String string, boolean empty) {
-    Assert.assertTrue(string, empty);
+    assertTrue(string, empty);
   }
 
   private static final Set<String> skipTests = HashSetFactory.make();

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/cha/MultiDexScopeTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/cha/MultiDexScopeTest.java
@@ -1,5 +1,8 @@
 package com.ibm.wala.dalvik.test.cha;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 
 import com.ibm.wala.classLoader.IClass;
@@ -41,7 +44,6 @@ import org.jf.dexlib2.DexFileFactory;
 import org.jf.dexlib2.Opcodes;
 import org.jf.dexlib2.dexbacked.DexBackedDexFile;
 import org.jf.dexlib2.iface.MultiDexContainer;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class MultiDexScopeTest {
@@ -104,7 +106,7 @@ public class MultiDexScopeTest {
     scope2 = DalvikCallGraphTestBase.makeDalvikScope(null, null, testAPK);
     cha2 = ClassHierarchyFactory.make(scope2);
 
-    Assert.assertEquals(
+    assertEquals(
         Integer.valueOf(getNumberOfAppClasses(cha)), Integer.valueOf(getNumberOfAppClasses(cha2)));
   }
 
@@ -147,8 +149,8 @@ public class MultiDexScopeTest {
     scope2 = DalvikCallGraphTestBase.makeDalvikScope(null, null, multidexApk);
     cha2 = ClassHierarchyFactory.make(scope2);
 
-    Assert.assertEquals(Integer.valueOf(getNumberOfAppClasses(cha)), Integer.valueOf(5));
-    Assert.assertEquals(
+    assertEquals(Integer.valueOf(getNumberOfAppClasses(cha)), Integer.valueOf(5));
+    assertEquals(
         Integer.valueOf(getNumberOfAppClasses(cha)), Integer.valueOf(getNumberOfAppClasses(cha2)));
   }
 
@@ -202,13 +204,13 @@ public class MultiDexScopeTest {
 
   public static void findEdge(CallGraph cg, MethodReference callerRef, MethodReference calleeRef) {
     Set<CGNode> callerNodes = cg.getNodes(callerRef);
-    Assert.assertFalse(callerNodes.isEmpty());
+    assertFalse(callerNodes.isEmpty());
     CGNode callerNode = callerNodes.iterator().next();
 
     Set<CGNode> calleeNodes = cg.getNodes(calleeRef);
-    Assert.assertFalse(calleeNodes.isEmpty());
+    assertFalse(calleeNodes.isEmpty());
     CGNode calleeNode = calleeNodes.iterator().next();
-    Assert.assertTrue(cg.hasEdge(callerNode, calleeNode));
+    assertTrue(cg.hasEdge(callerNode, calleeNode));
   }
 
   private static void extractFile(ZipInputStream zipIn, String outFileName) throws IOException {

--- a/ide/jsdt/tests/src/test/java/com/ibm/wala/ide/jsdt/tests/AbstractJSProjectScopeTest.java
+++ b/ide/jsdt/tests/src/test/java/com/ibm/wala/ide/jsdt/tests/AbstractJSProjectScopeTest.java
@@ -10,6 +10,10 @@
  */
 package com.ibm.wala.ide.jsdt.tests;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import com.ibm.wala.cast.ipa.callgraph.CAstAnalysisScope;
 import com.ibm.wala.cast.js.client.EclipseJavaScriptAnalysisEngine;
 import com.ibm.wala.cast.js.client.EclipseJavaScriptAnalysisEngine.BuilderType;
@@ -32,7 +36,6 @@ import java.util.Set;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Plugin;
 import org.eclipse.wst.jsdt.core.IJavaScriptProject;
-import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -49,7 +52,7 @@ public abstract class AbstractJSProjectScopeTest {
     IJavaScriptProject p =
         JavaScriptHeadlessUtil.getJavaScriptProjectFromWorkspace(project.projectName);
     System.err.println(p);
-    Assert.assertNotNull("cannot find project", p);
+    assertNotNull("cannot find project", p);
   }
 
   @Test
@@ -63,8 +66,8 @@ public abstract class AbstractJSProjectScopeTest {
                 new CAstAnalysisScope(
                     JSCallGraphUtil.makeLoaders(), Collections.singleton(JavaScriptLoader.JS)));
     System.err.println(s);
-    Assert.assertNotNull("cannot make scope", s);
-    Assert.assertFalse("cannot find files", s.getModules(JavaScriptTypes.jsLoader).isEmpty());
+    assertNotNull("cannot make scope", s);
+    assertFalse("cannot find files", s.getModules(JavaScriptTypes.jsLoader).isEmpty());
   }
 
   protected JavaScriptEclipseProjectPath makeProjectPath(IJavaScriptProject p)
@@ -80,8 +83,8 @@ public abstract class AbstractJSProjectScopeTest {
 
     System.err.println(info.calls.size());
     System.err.println("call graph:\n" + info.cg);
-    Assert.assertTrue("cannot find any function calls", info.calls.size() > 0);
-    Assert.assertTrue("cannot find any cg nodes", info.cg.getNumberOfNodes() > 0);
+    assertTrue("cannot find any function calls", info.calls.size() > 0);
+    assertTrue("cannot find any cg nodes", info.cg.getNumberOfNodes() > 0);
   }
 
   @Test
@@ -93,7 +96,7 @@ public abstract class AbstractJSProjectScopeTest {
     e.buildAnalysisScope();
     IClassHierarchy cha = e.getClassHierarchy();
     // System.err.println(cha);
-    Assert.assertNotNull(cha);
+    assertNotNull(cha);
   }
 
   protected EclipseJavaScriptAnalysisEngine makeAnalysisEngine(IJavaScriptProject p) {

--- a/util/src/test/java/com/ibm/wala/util/test/BasicGraphTest.java
+++ b/util/src/test/java/com/ibm/wala/util/test/BasicGraphTest.java
@@ -12,10 +12,10 @@ package com.ibm.wala.util.test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertTrue;
 
 import com.ibm.wala.util.collections.Iterator2Collection;
 import com.ibm.wala.util.graph.impl.BasicGraph;
-import org.junit.Assert;
 import org.junit.Test;
 
 /** Tests for {@link com.ibm.wala.util.graph.impl.BasicGraph}. */
@@ -29,8 +29,8 @@ public class BasicGraphTest {
     graph.addNode(root);
     graph.addNode(leaf);
     graph.addEdge(root, leaf);
-    Assert.assertTrue(graph.containsNode(root));
-    Assert.assertTrue(graph.containsNode(leaf));
+    assertTrue(graph.containsNode(root));
+    assertTrue(graph.containsNode(leaf));
     assertThat(Iterator2Collection.toList(graph.getPredNodes(leaf)), contains(root));
     assertThat(Iterator2Collection.toList(graph.getSuccNodes(root)), contains(leaf));
   }


### PR DESCRIPTION
`org.junit.Assert` provides static JUnit 4 assertion methods.  Many of these methods have JUnit 5 analogues in
`org.junit.jupiter.api.Assertions`, but we're not switching over to the latter yet.  Instead, we're just changing to using static imports to get the same `org.junit.Assert` methods we were already using.

By switching to static imports now, we make it easier to change from JUnit 4 to JUnit 5 later.  In most cases, we'll just have to change the top-of-file static imports, not the code that actually calls the imported methods.  That should make diffs in subsequent pull requests smaller and easier to review.