### PR TITLE
Avoid printing many call graphs during testing

### DIFF
--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/SyncDuplicatorTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/SyncDuplicatorTests.java
@@ -14,16 +14,12 @@ import com.ibm.wala.cast.java.ipa.callgraph.JavaSourceAnalysisScope;
 import com.ibm.wala.classLoader.CallSiteReference;
 import com.ibm.wala.classLoader.Language;
 import com.ibm.wala.core.util.strings.Atom;
-import com.ibm.wala.ipa.callgraph.CallGraph;
-import com.ibm.wala.ipa.callgraph.CallGraphBuilder;
-import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.shrike.shrikeBT.IInvokeInstruction;
 import com.ibm.wala.types.Descriptor;
 import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.TypeName;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.CancelException;
-import com.ibm.wala.util.collections.Pair;
 import java.io.IOException;
 import org.junit.Test;
 
@@ -45,8 +41,6 @@ public abstract class SyncDuplicatorTests extends IRTests {
 
   @Test
   public void testMonitor2() throws IllegalArgumentException, CancelException, IOException {
-    Pair<CallGraph, CallGraphBuilder<? super InstanceKey>> result =
-        runTest(singleTestSrc(), rtJar, simpleTestEntryPoint(), emptyList, true, null);
-    System.err.println(result.fst);
+    runTest(singleTestSrc(), rtJar, simpleTestEntryPoint(), emptyList, true, null);
   }
 }

--- a/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/examples/drivers/RunBuilder.java
+++ b/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/examples/drivers/RunBuilder.java
@@ -59,7 +59,7 @@ public class RunBuilder {
 
     System.err.println(CG.getClassHierarchy());
 
-    CAstCallGraphUtil.AVOID_DUMP = false;
+    CAstCallGraphUtil.AVOID_DUMP = true;
     CAstCallGraphUtil.dumpCG(builder.getCFAContextInterpreter(), builder.getPointerAnalysis(), CG);
   }
 }

--- a/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/AbstractFieldBasedTest.java
+++ b/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/AbstractFieldBasedTest.java
@@ -52,7 +52,6 @@ public abstract class AbstractFieldBasedTest extends TestJSCallGraphShape {
         cg =
             util.buildCG(url, builderType, monitor, false, DefaultSourceExtractor.factory)
                 .getCallGraph();
-        System.err.println(cg);
         verifyGraphAssertions(cg, assertions);
       } catch (AssertionError afe) {
         throw new AssertionError(builderType + ": " + afe.getMessage(), afe);
@@ -75,7 +74,6 @@ public abstract class AbstractFieldBasedTest extends TestJSCallGraphShape {
       cg =
           util.buildBoundedCG(loaders, scripts.toArray(new Module[0]), monitor, false, bound)
               .getCallGraph();
-      System.err.println(cg);
       verifyGraphAssertions(cg, assertions);
     } catch (AssertionError afe) {
       throw new AssertionError(builderType + ": " + afe.getMessage(), afe);

--- a/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestArgumentSensitivity.java
+++ b/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestArgumentSensitivity.java
@@ -65,7 +65,7 @@ public abstract class TestArgumentSensitivity extends TestJSCallGraphShape {
         new ArgumentSpecialization.ArgumentSpecializationContextIntepreter(options, cache));
     CallGraph CG = builder.makeCallGraph(options);
 
-    //    CAstCallGraphUtil.AVOID_DUMP = false;
+    CAstCallGraphUtil.AVOID_DUMP = true;
     CAstCallGraphUtil.dumpCG(builder.getCFAContextInterpreter(), builder.getPointerAnalysis(), CG);
 
     verifyGraphAssertions(CG, assertionsForArgs);

--- a/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestSimpleCallGraphShape.java
+++ b/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestSimpleCallGraphShape.java
@@ -322,7 +322,7 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
     CallGraph CG = B.makeCallGraph(B.getOptions());
 
     boolean x = CAstCallGraphUtil.AVOID_DUMP;
-    CAstCallGraphUtil.AVOID_DUMP = false;
+    CAstCallGraphUtil.AVOID_DUMP = true;
     CAstCallGraphUtil.dumpCG(
         (SSAContextInterpreter) B.getContextInterpreter(), B.getPointerAnalysis(), CG);
     CAstCallGraphUtil.AVOID_DUMP = x;
@@ -926,7 +926,7 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
     JSCFABuilder B = JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "try-finally-crash.js");
     CallGraph CG = B.makeCallGraph(B.getOptions());
     boolean save = CAstCallGraphUtil.AVOID_DUMP;
-    // CAstCallGraphUtil.AVOID_DUMP = false;
+    CAstCallGraphUtil.AVOID_DUMP = true;
     CAstCallGraphUtil.dumpCG(B.getCFAContextInterpreter(), B.getPointerAnalysis(), CG);
     CAstCallGraphUtil.AVOID_DUMP = save;
   }
@@ -969,7 +969,7 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
         JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "loops.js");
     CallGraph CG = B.makeCallGraph(B.getOptions());
     boolean x = CAstCallGraphUtil.AVOID_DUMP;
-    CAstCallGraphUtil.AVOID_DUMP = false;
+    CAstCallGraphUtil.AVOID_DUMP = true;
     CAstCallGraphUtil.dumpCG(B.getCFAContextInterpreter(), B.getPointerAnalysis(), CG);
     CAstCallGraphUtil.AVOID_DUMP = x;
     verifyGraphAssertions(CG, assertionsForLoops);
@@ -998,7 +998,7 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
         JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "primitive_strings.js");
     CallGraph CG = B.makeCallGraph(B.getOptions());
     boolean x = CAstCallGraphUtil.AVOID_DUMP;
-    CAstCallGraphUtil.AVOID_DUMP = false;
+    CAstCallGraphUtil.AVOID_DUMP = true;
     CAstCallGraphUtil.dumpCG(B.getCFAContextInterpreter(), B.getPointerAnalysis(), CG);
     CAstCallGraphUtil.AVOID_DUMP = x;
     verifyGraphAssertions(CG, assertionsForPrimitiveStrings);
@@ -1036,7 +1036,7 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
     JSCFABuilder B = JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "badthrow.js");
     CallGraph CG = B.makeCallGraph(B.getOptions());
     boolean save = CAstCallGraphUtil.AVOID_DUMP;
-    // CAstCallGraphUtil.AVOID_DUMP = false;
+    CAstCallGraphUtil.AVOID_DUMP = true;
     CAstCallGraphUtil.dumpCG(B.getCFAContextInterpreter(), B.getPointerAnalysis(), CG);
     CAstCallGraphUtil.AVOID_DUMP = save;
   }
@@ -1047,7 +1047,7 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
     JSCFABuilder B = JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "nrwrapper.js");
     CallGraph CG = B.makeCallGraph(B.getOptions());
     boolean save = CAstCallGraphUtil.AVOID_DUMP;
-    // CAstCallGraphUtil.AVOID_DUMP = false;
+    CAstCallGraphUtil.AVOID_DUMP = true;
     CAstCallGraphUtil.dumpCG(B.getCFAContextInterpreter(), B.getPointerAnalysis(), CG);
     CAstCallGraphUtil.AVOID_DUMP = save;
   }
@@ -1058,7 +1058,7 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
     JSCFABuilder B = JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "finallycrash.js");
     CallGraph CG = B.makeCallGraph(B.getOptions());
     boolean save = CAstCallGraphUtil.AVOID_DUMP;
-    // CAstCallGraphUtil.AVOID_DUMP = false;
+    CAstCallGraphUtil.AVOID_DUMP = true;
     CAstCallGraphUtil.dumpCG(B.getCFAContextInterpreter(), B.getPointerAnalysis(), CG);
     CAstCallGraphUtil.AVOID_DUMP = save;
   }
@@ -1069,7 +1069,7 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
     JSCFABuilder B = JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "for_in_expr.js");
     CallGraph CG = B.makeCallGraph(B.getOptions());
     boolean save = CAstCallGraphUtil.AVOID_DUMP;
-    // CAstCallGraphUtil.AVOID_DUMP = false;
+    CAstCallGraphUtil.AVOID_DUMP = true;
     CAstCallGraphUtil.dumpCG(B.getCFAContextInterpreter(), B.getPointerAnalysis(), CG);
     CAstCallGraphUtil.AVOID_DUMP = save;
   }
@@ -1098,7 +1098,7 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
     verifyGraphAssertions(CG, assertionsForComplexFinally);
 
     boolean save = CAstCallGraphUtil.AVOID_DUMP;
-    // CAstCallGraphUtil.AVOID_DUMP = false;
+    CAstCallGraphUtil.AVOID_DUMP = true;
     CAstCallGraphUtil.dumpCG(B.getCFAContextInterpreter(), B.getPointerAnalysis(), CG);
     CAstCallGraphUtil.AVOID_DUMP = save;
   }

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/Java7CallGraphTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/Java7CallGraphTest.java
@@ -82,8 +82,6 @@ public class Java7CallGraphTest extends DynamicCallGraphTestBase {
 
     CallGraph cg = builder.makeCallGraph(options, null);
 
-    System.err.println(cg);
-
     instrument(F.getAbsolutePath());
     run("pack.ocamljavaMain", null, args);
 

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/LambdaTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/LambdaTest.java
@@ -160,7 +160,6 @@ public class LambdaTest extends WalaTestCase {
                 Atom.findOrCreateUnicodeAtom("target"),
                 Descriptor.findOrCreateUTF8("()V"));
 
-    System.out.println(cg);
     assertEquals(
         "expected C1.target() to be reachable", 1, cg.getNodes(getTargetRef.apply("C1")).size());
     assertEquals(
@@ -197,7 +196,6 @@ public class LambdaTest extends WalaTestCase {
                 Atom.findOrCreateUnicodeAtom("target"),
                 Descriptor.findOrCreateUTF8("()V"));
 
-    System.out.println(cg);
     Consumer<String> checkCalledFromOneSite =
         (klassName) -> {
           Set<CGNode> nodes = cg.getNodes(getTargetRef.apply(klassName));


### PR DESCRIPTION
These graph dumps add hundreds of megabytes to test logs, and presumably are manually inspected approximately never.  Let's turn them off. Anyone chasing a specific bug or regression can add more debug output in their local working tree, as needed, but there's no benefit to dumping all of this data on every automated test run.

Furthermore, I'm exploring an option for getting a nice test summaries after each GitHub actions workflow run.  Unfortunately, the tool I am considering has some limits on the sizes `CDATA` sections it can read in JUnit's XML test logs.  When our test logs include call graph dumps, several of them exceed these limits.