### PR TITLE
Avoid printing some call graphs during testing

### DIFF
--- a/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestSimplePageCallGraphShape.java
+++ b/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestSimplePageCallGraphShape.java
@@ -430,7 +430,6 @@ public abstract class TestSimplePageCallGraphShape extends TestJSCallGraphShape 
   public void testSkeleton2() throws IllegalArgumentException, CancelException, WalaException {
     URL url = getClass().getClassLoader().getResource("pages/skeleton2.html");
     CallGraph CG = JSCallGraphBuilderUtil.makeHTMLCG(url);
-    System.err.println(CG);
     verifyGraphAssertions(CG, assertionsForSkeleton2);
   }
 

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/ReflectionTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/ReflectionTest.java
@@ -413,7 +413,6 @@ public class ReflectionTest extends WalaTestCase {
         TypeReference.findOrCreate(ClassLoaderReference.Primordial, "Ljava/lang/Integer");
     MethodReference mr = MethodReference.findOrCreate(tr, "toString", "()Ljava/lang/String;");
     Set<CGNode> nodes = cg.getNodes(mr);
-    System.err.println(cg);
     assertFalse(nodes.isEmpty());
   }
 


### PR DESCRIPTION
Following up #1294 by removing a few more rarely examined graph dumps.