### PR TITLE
Remove more debugging output produced during testing

### DIFF
--- a/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/examples/drivers/RunBuilder.java
+++ b/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/examples/drivers/RunBuilder.java
@@ -59,7 +59,6 @@ public class RunBuilder {
 
     System.err.println(CG.getClassHierarchy());
 
-    CAstCallGraphUtil.AVOID_DUMP = true;
     CAstCallGraphUtil.dumpCG(builder.getCFAContextInterpreter(), builder.getPointerAnalysis(), CG);
   }
 }

--- a/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/test/TestCPA.java
+++ b/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/test/TestCPA.java
@@ -12,7 +12,6 @@ package com.ibm.wala.cast.js.test;
 
 import com.ibm.wala.cast.ipa.callgraph.CAstCallGraphUtil;
 import com.ibm.wala.cast.js.ipa.callgraph.JSCFABuilder;
-import com.ibm.wala.cast.js.ipa.callgraph.JSCallGraphUtil;
 import com.ibm.wala.cast.js.translator.CAstRhinoTranslatorFactory;
 import com.ibm.wala.cast.js.util.JSCallGraphBuilderUtil;
 import com.ibm.wala.ipa.callgraph.CallGraph;
@@ -37,7 +36,6 @@ public class TestCPA {
     JSCFABuilder builder = JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "cpa.js");
     builder.setContextSelector(new CPAContextSelector(builder.getContextSelector()));
     CallGraph CG = builder.makeCallGraph(builder.getOptions());
-    JSCallGraphUtil.AVOID_DUMP = false;
     CAstCallGraphUtil.dumpCG(builder.getCFAContextInterpreter(), builder.getPointerAnalysis(), CG);
   }
 }

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/JSSSAPropagationCallGraphBuilder.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/JSSSAPropagationCallGraphBuilder.java
@@ -841,8 +841,6 @@ public class JSSSAPropagationCallGraphBuilder extends AstSSAPropagationCallGraph
                 }
               }
             }
-
-            System.err.println(instruction);
           }
 
           if (op == CAstBinaryOp.STRICT_EQ || op == CAstBinaryOp.STRICT_NE) {

--- a/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestArgumentSensitivity.java
+++ b/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestArgumentSensitivity.java
@@ -65,7 +65,6 @@ public abstract class TestArgumentSensitivity extends TestJSCallGraphShape {
         new ArgumentSpecialization.ArgumentSpecializationContextIntepreter(options, cache));
     CallGraph CG = builder.makeCallGraph(options);
 
-    CAstCallGraphUtil.AVOID_DUMP = true;
     CAstCallGraphUtil.dumpCG(builder.getCFAContextInterpreter(), builder.getPointerAnalysis(), CG);
 
     verifyGraphAssertions(CG, assertionsForArgs);

--- a/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestSimpleCallGraphShape.java
+++ b/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestSimpleCallGraphShape.java
@@ -236,7 +236,6 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
       throws IOException, IllegalArgumentException, CancelException, WalaException {
     JSCFABuilder B = JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "forin.js");
     CallGraph CG = B.makeCallGraph(B.getOptions());
-    //    JSCallGraphUtil.AVOID_DUMP = false;
     CAstCallGraphUtil.dumpCG(B.getCFAContextInterpreter(), B.getPointerAnalysis(), CG);
     verifyGraphAssertions(CG, assertionsForForin);
   }
@@ -321,11 +320,8 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
     PropagationCallGraphBuilder B = JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "try.js");
     CallGraph CG = B.makeCallGraph(B.getOptions());
 
-    boolean x = CAstCallGraphUtil.AVOID_DUMP;
-    CAstCallGraphUtil.AVOID_DUMP = true;
     CAstCallGraphUtil.dumpCG(
         (SSAContextInterpreter) B.getContextInterpreter(), B.getPointerAnalysis(), CG);
-    CAstCallGraphUtil.AVOID_DUMP = x;
 
     verifyGraphAssertions(CG, assertionsForTry);
   }
@@ -382,7 +378,6 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
         JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "string-prims.js");
     B.getOptions().setTraceStringConstants(true);
     CallGraph CG = B.makeCallGraph(B.getOptions());
-    //    JSCallGraphUtil.AVOID_DUMP = false;
     CAstCallGraphUtil.dumpCG(B.getCFAContextInterpreter(), B.getPointerAnalysis(), CG);
     verifyGraphAssertions(CG, assertionsForStringPrims);
   }
@@ -642,7 +637,6 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
     SSAPropagationCallGraphBuilder B =
         JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "return_this.js");
     CallGraph CG = B.makeCallGraph(B.getOptions());
-    //    JSCallGraphUtil.AVOID_DUMP = false;
     CAstCallGraphUtil.dumpCG(B.getCFAContextInterpreter(), B.getPointerAnalysis(), CG);
     verifyGraphAssertions(CG, assertionsForReturnThis);
   }
@@ -764,7 +758,6 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
     SSAPropagationCallGraphBuilder B =
         JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "dispatch.js");
     CallGraph CG = B.makeCallGraph(B.getOptions());
-    //    JSCallGraphUtil.AVOID_DUMP = false;
     CAstCallGraphUtil.dumpCG(B.getCFAContextInterpreter(), B.getPointerAnalysis(), CG);
     verifyGraphAssertions(CG, assertionsForDispatch);
   }
@@ -781,7 +774,6 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
     PropagationCallGraphBuilder B =
         JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "dispatch_same_target.js");
     CallGraph CG = B.makeCallGraph(B.getOptions());
-    //    JSCallGraphUtil.AVOID_DUMP = false;
     //    JSCallGraphUtil.dumpCG(B.getPointerAnalysis(), CG);
     verifyGraphAssertions(CG, assertionsForDispatchSameTarget);
   }
@@ -840,7 +832,6 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
     b.setContextSelector(
         new PropertyNameContextSelector(b.getAnalysisCache(), b.getContextSelector()));
     CallGraph cg = b.makeCallGraph(b.getOptions());
-    // JSCallGraphUtil.AVOID_DUMP = false;
     // JSCallGraphUtil.dumpCG(b.getPointerAnalysis(), cg);
     verifyGraphAssertions(cg, assertionsForArrayIndexConv2);
   }
@@ -857,7 +848,6 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
     PropagationCallGraphBuilder B =
         JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "date-property.js");
     CallGraph CG = B.makeCallGraph(B.getOptions());
-    // JSCallGraphUtil.AVOID_DUMP = false;
     // JSCallGraphUtil.dumpCG(B.getPointerAnalysis(), CG);
     verifyGraphAssertions(CG, assertionsForDateProperty);
   }
@@ -873,7 +863,6 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
       throws IllegalArgumentException, IOException, CancelException, WalaException {
     PropagationCallGraphBuilder B = JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "dead.js");
     CallGraph CG = B.makeCallGraph(B.getOptions());
-    // JSCallGraphUtil.AVOID_DUMP = false;
     // JSCallGraphUtil.dumpCG(B.getPointerAnalysis(), CG);
     verifyGraphAssertions(CG, assertionsForDeadCode);
   }
@@ -925,10 +914,7 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
       throws IllegalArgumentException, IOException, CancelException, WalaException {
     JSCFABuilder B = JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "try-finally-crash.js");
     CallGraph CG = B.makeCallGraph(B.getOptions());
-    boolean save = CAstCallGraphUtil.AVOID_DUMP;
-    CAstCallGraphUtil.AVOID_DUMP = true;
     CAstCallGraphUtil.dumpCG(B.getCFAContextInterpreter(), B.getPointerAnalysis(), CG);
-    CAstCallGraphUtil.AVOID_DUMP = save;
   }
 
   @Test(expected = CallGraphBuilderCancelException.class)
@@ -968,10 +954,7 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
     SSAPropagationCallGraphBuilder B =
         JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "loops.js");
     CallGraph CG = B.makeCallGraph(B.getOptions());
-    boolean x = CAstCallGraphUtil.AVOID_DUMP;
-    CAstCallGraphUtil.AVOID_DUMP = true;
     CAstCallGraphUtil.dumpCG(B.getCFAContextInterpreter(), B.getPointerAnalysis(), CG);
-    CAstCallGraphUtil.AVOID_DUMP = x;
     verifyGraphAssertions(CG, assertionsForLoops);
   }
 
@@ -997,10 +980,7 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
     SSAPropagationCallGraphBuilder B =
         JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "primitive_strings.js");
     CallGraph CG = B.makeCallGraph(B.getOptions());
-    boolean x = CAstCallGraphUtil.AVOID_DUMP;
-    CAstCallGraphUtil.AVOID_DUMP = true;
     CAstCallGraphUtil.dumpCG(B.getCFAContextInterpreter(), B.getPointerAnalysis(), CG);
-    CAstCallGraphUtil.AVOID_DUMP = x;
     verifyGraphAssertions(CG, assertionsForPrimitiveStrings);
   }
 
@@ -1035,10 +1015,7 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
       throws IllegalArgumentException, IOException, CancelException, WalaException {
     JSCFABuilder B = JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "badthrow.js");
     CallGraph CG = B.makeCallGraph(B.getOptions());
-    boolean save = CAstCallGraphUtil.AVOID_DUMP;
-    CAstCallGraphUtil.AVOID_DUMP = true;
     CAstCallGraphUtil.dumpCG(B.getCFAContextInterpreter(), B.getPointerAnalysis(), CG);
-    CAstCallGraphUtil.AVOID_DUMP = save;
   }
 
   @Test
@@ -1046,10 +1023,7 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
       throws IllegalArgumentException, IOException, CancelException, WalaException {
     JSCFABuilder B = JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "nrwrapper.js");
     CallGraph CG = B.makeCallGraph(B.getOptions());
-    boolean save = CAstCallGraphUtil.AVOID_DUMP;
-    CAstCallGraphUtil.AVOID_DUMP = true;
     CAstCallGraphUtil.dumpCG(B.getCFAContextInterpreter(), B.getPointerAnalysis(), CG);
-    CAstCallGraphUtil.AVOID_DUMP = save;
   }
 
   @Test
@@ -1057,10 +1031,7 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
       throws IllegalArgumentException, IOException, CancelException, WalaException {
     JSCFABuilder B = JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "finallycrash.js");
     CallGraph CG = B.makeCallGraph(B.getOptions());
-    boolean save = CAstCallGraphUtil.AVOID_DUMP;
-    CAstCallGraphUtil.AVOID_DUMP = true;
     CAstCallGraphUtil.dumpCG(B.getCFAContextInterpreter(), B.getPointerAnalysis(), CG);
-    CAstCallGraphUtil.AVOID_DUMP = save;
   }
 
   @Test
@@ -1068,10 +1039,7 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
       throws IllegalArgumentException, IOException, CancelException, WalaException {
     JSCFABuilder B = JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "for_in_expr.js");
     CallGraph CG = B.makeCallGraph(B.getOptions());
-    boolean save = CAstCallGraphUtil.AVOID_DUMP;
-    CAstCallGraphUtil.AVOID_DUMP = true;
     CAstCallGraphUtil.dumpCG(B.getCFAContextInterpreter(), B.getPointerAnalysis(), CG);
-    CAstCallGraphUtil.AVOID_DUMP = save;
   }
 
   private static final Object[][] assertionsForComplexFinally =
@@ -1097,9 +1065,6 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
     CallGraph CG = B.makeCallGraph(B.getOptions());
     verifyGraphAssertions(CG, assertionsForComplexFinally);
 
-    boolean save = CAstCallGraphUtil.AVOID_DUMP;
-    CAstCallGraphUtil.AVOID_DUMP = true;
     CAstCallGraphUtil.dumpCG(B.getCFAContextInterpreter(), B.getPointerAnalysis(), CG);
-    CAstCallGraphUtil.AVOID_DUMP = save;
   }
 }

--- a/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestSimplePageCallGraphShape.java
+++ b/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestSimplePageCallGraphShape.java
@@ -322,7 +322,6 @@ public abstract class TestSimplePageCallGraphShape extends TestJSCallGraphShape 
     URL url = getClass().getClassLoader().getResource("pages/list.html");
     JSCFABuilder builder = JSCallGraphBuilderUtil.makeHTMLCGBuilder(url);
     CallGraph CG = builder.makeCallGraph(builder.getOptions());
-    //    JSCallGraphBuilderUtil.AVOID_DUMP = false;
     CAstCallGraphUtil.dumpCG(builder.getCFAContextInterpreter(), builder.getPointerAnalysis(), CG);
     verifySourceAssertions(CG, sourceAssertionsForList);
   }

--- a/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/CAstCallGraphUtil.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/CAstCallGraphUtil.java
@@ -40,7 +40,7 @@ import org.apache.commons.io.input.BOMInputStream;
 public class CAstCallGraphUtil {
 
   /** flag to prevent dumping of verbose call graph / pointer analysis output */
-  public static boolean AVOID_DUMP = true;
+  public static final ThreadLocal<Boolean> AVOID_DUMP = ThreadLocal.withInitial(() -> true);
 
   public static SourceFileModule makeSourceModule(URL script, String dir, String name) {
     // DO NOT use File.separator here, since this name is matched against
@@ -128,7 +128,7 @@ public class CAstCallGraphUtil {
 
   public static void dumpCG(
       SSAContextInterpreter interp, PointerAnalysis<? extends InstanceKey> PA, CallGraph CG) {
-    if (AVOID_DUMP) return;
+    if (AVOID_DUMP.get()) return;
     for (CGNode N : CG) {
       System.err.print("callees of node " + getShortName(N) + " : [");
       boolean fst = true;

--- a/cast/src/testFixtures/java/com/ibm/wala/cast/util/test/TestCallGraphShape.java
+++ b/cast/src/testFixtures/java/com/ibm/wala/cast/util/test/TestCallGraphShape.java
@@ -68,8 +68,6 @@ public abstract class TestCallGraphShape {
                     if (pos.getFirstLine() >= (Integer) assertionDatum[2]
                         && (pos.getLastLine() != -1 ? pos.getLastLine() : pos.getFirstLine())
                             <= (Integer) assertionDatum[3]) {
-                      System.err.println(
-                          "found " + inst + " of " + M + " at expected position " + pos);
                       continue insts;
                     }
                   }
@@ -166,7 +164,6 @@ public abstract class TestCallGraphShape {
                     System.err.println(("found unexpected " + src + " --> " + dst + " at " + sr));
                     assert false : "found edge " + assertionDatum[0] + " ---> " + targetName;
                   } else {
-                    System.err.println(("found expected " + src + " --> " + dst + " at " + sr));
                     continue check_target;
                   }
                 }

--- a/core/src/testFixtures/java/com/ibm/wala/core/tests/shrike/DynamicCallGraphTestBase.java
+++ b/core/src/testFixtures/java/com/ibm/wala/core/tests/shrike/DynamicCallGraphTestBase.java
@@ -172,9 +172,7 @@ public abstract class DynamicCallGraphTestBase extends WalaTestCase {
               "no edge for " + caller + " --> " + callee,
               staticCG1.getPossibleSites(caller, callee).hasNext());
           Pair<CGNode, CGNode> x = Pair.make(caller, callee);
-          if (edges.add(x)) {
-            System.err.println("found expected edge " + caller + " --> " + callee);
-          }
+          edges.add(x);
         },
         filter);
   }
@@ -192,8 +190,6 @@ public abstract class DynamicCallGraphTestBase extends WalaTestCase {
           boolean checkForCallee = !staticCG1.getNodes(callee).isEmpty();
           if (!checkForCallee) {
             notFound.add(callee);
-          } else {
-            System.err.println("found expected node " + callee);
           }
         },
         filter);


### PR DESCRIPTION
Also, turn `com.ibm.wala.cast.ipa.callgraph.CAstCallGraphUtil.AVOID_DUMP` into a thread-local flag.  We should be able to turn it on or off without potential interference from different threads (e.g., during concurrent test execution) that have conflicting opinions.