### PR TITLE
Generate a summary test report for all builds

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -55,6 +55,31 @@ jobs:
         run: ./check-git-cleanliness.sh
         # not running in Borne or POSIX shell on Windows
         if: runner.os != 'Windows'
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: Test results for JDK ${{ matrix.java }} on ${{ runner.os }}
+          path: '**/build/test-results/test/TEST-*.xml'
+  publish_test_results:
+    name: Repoort test results
+    needs: build_gradle
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
+      contents: read
+      issues: read
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+      - name: Publish test results
+        uses: EnricoMi/publish-unit-test-result-action@v2.8.0
+        with:
+          files: 'artifacts/**/build/test-results/test/TEST-*.xml'
   generate_docs:
     name: 'Generate latest docs'
     needs: build_gradle


### PR DESCRIPTION
My intent is for this summary report to increase our confidence that we're not accidentally dropping any tests or dramatically hurting test performance as we [migrate from JUnit 4 to JUnit 5](https://github.com/orgs/wala/projects/2).  The summary report may also turn out to be useful if anyone posts a pull request that causes new test failures, though that's rare from what I've observed.

Full disclosure:  I do not actually understand all the instructions on configuring the report generator to [Support fork repositories and dependabot branches](https://github.com/EnricoMi/publish-unit-test-result-action#support-fork-repositories-and-dependabot-branches) or for [Running with multiple event types (pull_request, push, schedule, …)](https://github.com/EnricoMi/publish-unit-test-result-action#support-fork-repositories-and-dependabot-branches). I'm probably not doing everything correctly here.  It seems to be working just fine, though, even in my forked repository.  So let's just charge ahead and see what fails, if anything.