### PR TITLE
Migrate parameterized DroidBench tests from JUnit 4 to JUnit 5

### DIFF
--- a/dalvik/build.gradle.kts
+++ b/dalvik/build.gradle.kts
@@ -93,6 +93,7 @@ dependencies {
 
   testImplementation(libs.android.tools)
   testImplementation(libs.dexlib2)
+  testImplementation(libs.junit.jupiter.params)
   testImplementation(projects.core)
   testImplementation(projects.dalvik)
   testImplementation(projects.shrike)

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/droidbench/AliasingTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/droidbench/AliasingTest.java
@@ -3,26 +3,22 @@ package com.ibm.wala.dalvik.test.callGraph.droidbench;
 import static com.ibm.wala.dalvik.test.util.Util.androidJavaLib;
 
 import com.ibm.wala.dalvik.test.callGraph.DroidBenchCGTest;
-import com.ibm.wala.types.MethodReference;
-import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.util.Collection;
-import java.util.Set;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class AliasingTest extends DroidBenchCGTest {
 
-  public AliasingTest(
-      URI[] androidLibs, File androidJavaJar, String apkFile, Set<MethodReference> uncalled) {
-    super(androidLibs, androidJavaJar, apkFile, uncalled);
+  @MethodSource("generateData")
+  @Override
+  @ParameterizedTest
+  protected void runTest(final TestParameters testParameters) throws Exception {
+    super.runTest(testParameters);
   }
 
-  @Parameters(name = "DroidBench: {2}")
-  public static Collection<Object[]> generateData() throws IOException {
+  static Stream<Named<TestParameters>> generateData() throws IOException {
     return DroidBenchCGTest.generateData(null, androidJavaLib(), "Aliasing");
   }
 }

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/droidbench/AndroidSpecificTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/droidbench/AndroidSpecificTest.java
@@ -3,26 +3,22 @@ package com.ibm.wala.dalvik.test.callGraph.droidbench;
 import static com.ibm.wala.dalvik.test.util.Util.androidJavaLib;
 
 import com.ibm.wala.dalvik.test.callGraph.DroidBenchCGTest;
-import com.ibm.wala.types.MethodReference;
-import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.util.Collection;
-import java.util.Set;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class AndroidSpecificTest extends DroidBenchCGTest {
 
-  public AndroidSpecificTest(
-      URI[] androidLibs, File androidJavaJar, String apkFile, Set<MethodReference> uncalled) {
-    super(androidLibs, androidJavaJar, apkFile, uncalled);
+  @MethodSource("generateData")
+  @Override
+  @ParameterizedTest
+  protected void runTest(final TestParameters testParameters) throws Exception {
+    super.runTest(testParameters);
   }
 
-  @Parameters(name = "DroidBench: {2}")
-  public static Collection<Object[]> generateData() throws IOException {
+  static Stream<Named<TestParameters>> generateData() throws IOException {
     return DroidBenchCGTest.generateData(null, androidJavaLib(), "AndroidSpecific");
   }
 }

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/droidbench/ArraysAndListsTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/droidbench/ArraysAndListsTest.java
@@ -3,26 +3,22 @@ package com.ibm.wala.dalvik.test.callGraph.droidbench;
 import static com.ibm.wala.dalvik.test.util.Util.androidJavaLib;
 
 import com.ibm.wala.dalvik.test.callGraph.DroidBenchCGTest;
-import com.ibm.wala.types.MethodReference;
-import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.util.Collection;
-import java.util.Set;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class ArraysAndListsTest extends DroidBenchCGTest {
 
-  public ArraysAndListsTest(
-      URI[] androidLibs, File androidJavaJar, String apkFile, Set<MethodReference> uncalled) {
-    super(androidLibs, androidJavaJar, apkFile, uncalled);
+  @MethodSource("generateData")
+  @Override
+  @ParameterizedTest
+  protected void runTest(final TestParameters testParameters) throws Exception {
+    super.runTest(testParameters);
   }
 
-  @Parameters(name = "DroidBench: {2}")
-  public static Collection<Object[]> generateData() throws IOException {
+  static Stream<Named<TestParameters>> generateData() throws IOException {
     return DroidBenchCGTest.generateData(null, androidJavaLib(), "ArraysAndLists");
   }
 }

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/droidbench/CallbacksTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/droidbench/CallbacksTest.java
@@ -3,26 +3,22 @@ package com.ibm.wala.dalvik.test.callGraph.droidbench;
 import static com.ibm.wala.dalvik.test.util.Util.androidJavaLib;
 
 import com.ibm.wala.dalvik.test.callGraph.DroidBenchCGTest;
-import com.ibm.wala.types.MethodReference;
-import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.util.Collection;
-import java.util.Set;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class CallbacksTest extends DroidBenchCGTest {
 
-  public CallbacksTest(
-      URI[] androidLibs, File androidJavaJar, String apkFile, Set<MethodReference> uncalled) {
-    super(androidLibs, androidJavaJar, apkFile, uncalled);
+  @MethodSource("generateData")
+  @Override
+  @ParameterizedTest
+  protected void runTest(final TestParameters testParameters) throws Exception {
+    super.runTest(testParameters);
   }
 
-  @Parameters(name = "DroidBench: {2}")
-  public static Collection<Object[]> generateData() throws IOException {
+  static Stream<Named<TestParameters>> generateData() throws IOException {
     return DroidBenchCGTest.generateData(null, androidJavaLib(), "Callbacks");
   }
 }

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/droidbench/EmulatorDetectionTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/droidbench/EmulatorDetectionTest.java
@@ -3,25 +3,22 @@ package com.ibm.wala.dalvik.test.callGraph.droidbench;
 import static com.ibm.wala.dalvik.test.util.Util.androidJavaLib;
 
 import com.ibm.wala.dalvik.test.callGraph.DroidBenchCGTest;
-import com.ibm.wala.types.MethodReference;
-import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.util.Collection;
-import java.util.Set;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class EmulatorDetectionTest extends DroidBenchCGTest {
-  public EmulatorDetectionTest(
-      URI[] androidLibs, File androidJavaJar, String apkFile, Set<MethodReference> uncalled) {
-    super(androidLibs, androidJavaJar, apkFile, uncalled);
+
+  @MethodSource("generateData")
+  @Override
+  @ParameterizedTest
+  protected void runTest(final TestParameters testParameters) throws Exception {
+    super.runTest(testParameters);
   }
 
-  @Parameters(name = "DroidBench: {2}")
-  public static Collection<Object[]> generateData() throws IOException {
+  static Stream<Named<TestParameters>> generateData() throws IOException {
     return DroidBenchCGTest.generateData(null, androidJavaLib(), "EmulatorDetection");
   }
 }

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/droidbench/FieldAndObjectSensitivityTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/droidbench/FieldAndObjectSensitivityTest.java
@@ -3,26 +3,22 @@ package com.ibm.wala.dalvik.test.callGraph.droidbench;
 import static com.ibm.wala.dalvik.test.util.Util.androidJavaLib;
 
 import com.ibm.wala.dalvik.test.callGraph.DroidBenchCGTest;
-import com.ibm.wala.types.MethodReference;
-import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.util.Collection;
-import java.util.Set;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class FieldAndObjectSensitivityTest extends DroidBenchCGTest {
 
-  public FieldAndObjectSensitivityTest(
-      URI[] androidLibs, File androidJavaJar, String apkFile, Set<MethodReference> uncalled) {
-    super(androidLibs, androidJavaJar, apkFile, uncalled);
+  @MethodSource("generateData")
+  @Override
+  @ParameterizedTest
+  protected void runTest(final TestParameters testParameters) throws Exception {
+    super.runTest(testParameters);
   }
 
-  @Parameters(name = "DroidBench: {2}")
-  public static Collection<Object[]> generateData() throws IOException {
+  static Stream<Named<TestParameters>> generateData() throws IOException {
     return DroidBenchCGTest.generateData(null, androidJavaLib(), "FieldAndObjectSensitivity");
   }
 }

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/droidbench/GeneralJavaTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/droidbench/GeneralJavaTest.java
@@ -3,26 +3,22 @@ package com.ibm.wala.dalvik.test.callGraph.droidbench;
 import static com.ibm.wala.dalvik.test.util.Util.androidJavaLib;
 
 import com.ibm.wala.dalvik.test.callGraph.DroidBenchCGTest;
-import com.ibm.wala.types.MethodReference;
-import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.util.Collection;
-import java.util.Set;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class GeneralJavaTest extends DroidBenchCGTest {
 
-  public GeneralJavaTest(
-      URI[] androidLibs, File androidJavaJar, String apkFile, Set<MethodReference> uncalled) {
-    super(androidLibs, androidJavaJar, apkFile, uncalled);
+  @MethodSource("generateData")
+  @Override
+  @ParameterizedTest
+  protected void runTest(final TestParameters testParameters) throws Exception {
+    super.runTest(testParameters);
   }
 
-  @Parameters(name = "DroidBench: {2}")
-  public static Collection<Object[]> generateData() throws IOException {
+  static Stream<Named<TestParameters>> generateData() throws IOException {
     return DroidBenchCGTest.generateData(null, androidJavaLib(), "GeneralJava");
   }
 }

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/droidbench/ImplicitFlowsTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/droidbench/ImplicitFlowsTest.java
@@ -3,26 +3,22 @@ package com.ibm.wala.dalvik.test.callGraph.droidbench;
 import static com.ibm.wala.dalvik.test.util.Util.androidJavaLib;
 
 import com.ibm.wala.dalvik.test.callGraph.DroidBenchCGTest;
-import com.ibm.wala.types.MethodReference;
-import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.util.Collection;
-import java.util.Set;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class ImplicitFlowsTest extends DroidBenchCGTest {
 
-  public ImplicitFlowsTest(
-      URI[] androidLibs, File androidJavaJar, String apkFile, Set<MethodReference> uncalled) {
-    super(androidLibs, androidJavaJar, apkFile, uncalled);
+  @MethodSource("generateData")
+  @Override
+  @ParameterizedTest
+  protected void runTest(final TestParameters testParameters) throws Exception {
+    super.runTest(testParameters);
   }
 
-  @Parameters(name = "DroidBench: {2}")
-  public static Collection<Object[]> generateData() throws IOException {
+  static Stream<Named<TestParameters>> generateData() throws IOException {
     return DroidBenchCGTest.generateData(null, androidJavaLib(), "ImplicitFlows");
   }
 }

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/droidbench/InterAppCommunicationTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/droidbench/InterAppCommunicationTest.java
@@ -3,25 +3,22 @@ package com.ibm.wala.dalvik.test.callGraph.droidbench;
 import static com.ibm.wala.dalvik.test.util.Util.androidJavaLib;
 
 import com.ibm.wala.dalvik.test.callGraph.DroidBenchCGTest;
-import com.ibm.wala.types.MethodReference;
-import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.util.Collection;
-import java.util.Set;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class InterAppCommunicationTest extends DroidBenchCGTest {
-  public InterAppCommunicationTest(
-      URI[] androidLibs, File androidJavaJar, String apkFile, Set<MethodReference> uncalled) {
-    super(androidLibs, androidJavaJar, apkFile, uncalled);
+
+  @MethodSource("generateData")
+  @Override
+  @ParameterizedTest
+  protected void runTest(final TestParameters testParameters) throws Exception {
+    super.runTest(testParameters);
   }
 
-  @Parameters(name = "DroidBench: {2}")
-  public static Collection<Object[]> generateData() throws IOException {
+  static Stream<Named<TestParameters>> generateData() throws IOException {
     return DroidBenchCGTest.generateData(null, androidJavaLib(), "InterAppCommunication");
   }
 }

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/droidbench/InterComponentCommunicationTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/droidbench/InterComponentCommunicationTest.java
@@ -3,26 +3,22 @@ package com.ibm.wala.dalvik.test.callGraph.droidbench;
 import static com.ibm.wala.dalvik.test.util.Util.androidJavaLib;
 
 import com.ibm.wala.dalvik.test.callGraph.DroidBenchCGTest;
-import com.ibm.wala.types.MethodReference;
-import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.util.Collection;
-import java.util.Set;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class InterComponentCommunicationTest extends DroidBenchCGTest {
 
-  public InterComponentCommunicationTest(
-      URI[] androidLibs, File androidJavaJar, String apkFile, Set<MethodReference> uncalled) {
-    super(androidLibs, androidJavaJar, apkFile, uncalled);
+  @MethodSource("generateData")
+  @Override
+  @ParameterizedTest
+  protected void runTest(final TestParameters testParameters) throws Exception {
+    super.runTest(testParameters);
   }
 
-  @Parameters(name = "DroidBench: {2}")
-  public static Collection<Object[]> generateData() throws IOException {
+  static Stream<Named<TestParameters>> generateData() throws IOException {
     return DroidBenchCGTest.generateData(null, androidJavaLib(), "InterComponentCommunication");
   }
 }

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/droidbench/LifecycleTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/droidbench/LifecycleTest.java
@@ -3,26 +3,22 @@ package com.ibm.wala.dalvik.test.callGraph.droidbench;
 import static com.ibm.wala.dalvik.test.util.Util.androidJavaLib;
 
 import com.ibm.wala.dalvik.test.callGraph.DroidBenchCGTest;
-import com.ibm.wala.types.MethodReference;
-import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.util.Collection;
-import java.util.Set;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class LifecycleTest extends DroidBenchCGTest {
 
-  public LifecycleTest(
-      URI[] androidLibs, File androidJavaJar, String apkFile, Set<MethodReference> uncalled) {
-    super(androidLibs, androidJavaJar, apkFile, uncalled);
+  @MethodSource("generateData")
+  @Override
+  @ParameterizedTest
+  protected void runTest(final TestParameters testParameters) throws Exception {
+    super.runTest(testParameters);
   }
 
-  @Parameters(name = "DroidBench: {2}")
-  public static Collection<Object[]> generateData() throws IOException {
+  static Stream<Named<TestParameters>> generateData() throws IOException {
     return DroidBenchCGTest.generateData(null, androidJavaLib(), "Lifecycle");
   }
 }

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/droidbench/ReflectionTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/droidbench/ReflectionTest.java
@@ -3,26 +3,22 @@ package com.ibm.wala.dalvik.test.callGraph.droidbench;
 import static com.ibm.wala.dalvik.test.util.Util.androidJavaLib;
 
 import com.ibm.wala.dalvik.test.callGraph.DroidBenchCGTest;
-import com.ibm.wala.types.MethodReference;
-import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.util.Collection;
-import java.util.Set;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class ReflectionTest extends DroidBenchCGTest {
 
-  public ReflectionTest(
-      URI[] androidLibs, File androidJavaJar, String apkFile, Set<MethodReference> uncalled) {
-    super(androidLibs, androidJavaJar, apkFile, uncalled);
+  @MethodSource("generateData")
+  @Override
+  @ParameterizedTest
+  protected void runTest(final TestParameters testParameters) throws Exception {
+    super.runTest(testParameters);
   }
 
-  @Parameters(name = "DroidBench: {2}")
-  public static Collection<Object[]> generateData() throws IOException {
+  static Stream<Named<TestParameters>> generateData() throws IOException {
     return DroidBenchCGTest.generateData(null, androidJavaLib(), "Reflection");
   }
 }

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/droidbench/ThreadingTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/droidbench/ThreadingTest.java
@@ -3,26 +3,22 @@ package com.ibm.wala.dalvik.test.callGraph.droidbench;
 import static com.ibm.wala.dalvik.test.util.Util.androidJavaLib;
 
 import com.ibm.wala.dalvik.test.callGraph.DroidBenchCGTest;
-import com.ibm.wala.types.MethodReference;
-import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.util.Collection;
-import java.util.Set;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class ThreadingTest extends DroidBenchCGTest {
 
-  public ThreadingTest(
-      URI[] androidLibs, File androidJavaJar, String apkFile, Set<MethodReference> uncalled) {
-    super(androidLibs, androidJavaJar, apkFile, uncalled);
+  @MethodSource("generateData")
+  @Override
+  @ParameterizedTest
+  protected void runTest(final TestParameters testParameters) throws Exception {
+    super.runTest(testParameters);
   }
 
-  @Parameters(name = "DroidBench: {2}")
-  public static Collection<Object[]> generateData() throws IOException {
+  static Stream<Named<TestParameters>> generateData() throws IOException {
     return DroidBenchCGTest.generateData(null, androidJavaLib(), "Threading");
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ junit = "junit:junit:4.13.2"
 junit-bom = "org.junit:junit-bom:5.9.3"
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
+junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params" }
 junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine" }
 nullaway = "com.uber.nullaway:nullaway:0.10.10"
 rhino = "org.mozilla:rhino:1.7.14"


### PR DESCRIPTION
IntelliJ IDEA does not know how to migrate parameterized tests, so these test classes were migrated by hand.