### PR TITLE
Migrate a few test classes from JUnit 4 to JUnit 5

### DIFF
--- a/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/test/TestSimpleCallGraphShapeRhino.java
+++ b/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/test/TestSimpleCallGraphShapeRhino.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.cast.js.test;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import com.ibm.wala.cast.js.ipa.callgraph.JSCFABuilder;
 import com.ibm.wala.cast.js.translator.CAstRhinoTranslatorFactory;
 import com.ibm.wala.cast.js.util.JSCallGraphBuilderUtil;
@@ -17,12 +19,12 @@ import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.WalaException;
 import java.io.IOException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestSimpleCallGraphShapeRhino extends TestSimpleCallGraphShape {
 
-  @Before
+  @BeforeEach
   public void setUp() {
     com.ibm.wala.cast.js.ipa.callgraph.JSCallGraphUtil.setTranslatorFactory(
         new CAstRhinoTranslatorFactory());
@@ -80,12 +82,15 @@ public class TestSimpleCallGraphShapeRhino extends TestSimpleCallGraphShape {
     JSCallGraphBuilderUtil.makeScriptCG("tests", "for_in_name.js");
   }
 
-  @Test(expected = WalaException.class)
-  public void testParseError()
-      throws IllegalArgumentException, IOException, CancelException, WalaException {
-    PropagationCallGraphBuilder B =
-        JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "portal-example-simple.html");
-    B.makeCallGraph(B.getOptions());
-    com.ibm.wala.cast.util.Util.checkForFrontEndErrors(B.getClassHierarchy());
+  @Test
+  public void testParseError() {
+    assertThrows(
+        WalaException.class,
+        () -> {
+          PropagationCallGraphBuilder B =
+              JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "portal-example-simple.html");
+          B.makeCallGraph(B.getOptions());
+          com.ibm.wala.cast.util.Util.checkForFrontEndErrors(B.getClassHierarchy());
+        });
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/cha/CodeDeletedTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/cha/CodeDeletedTest.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.core.tests.cha;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.core.tests.util.TestConstants;
@@ -20,13 +22,11 @@ import com.ibm.wala.ipa.callgraph.AnalysisCacheImpl;
 import com.ibm.wala.ipa.callgraph.AnalysisScope;
 import com.ibm.wala.ipa.callgraph.IAnalysisCacheView;
 import com.ibm.wala.ipa.cha.ClassHierarchy;
-import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.ipa.cha.ClassHierarchyFactory;
 import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.WalaRuntimeException;
-import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CodeDeletedTest extends WalaTestCase {
 
@@ -34,24 +34,27 @@ public class CodeDeletedTest extends WalaTestCase {
    * Test handling of an invalid class where a non-abstract method has no code. We want to throw an
    * exception rather than crash.
    */
-  @Test(expected = WalaRuntimeException.class)
-  public void testDeletedCode() throws IOException, ClassHierarchyException {
-
-    AnalysisScope scope =
-        AnalysisScopeReader.instance.readJavaScope(
-            TestConstants.WALA_TESTDATA,
-            new FileProvider().getFile("J2SEClassHierarchyExclusions.txt"),
-            DupFieldsTest.class.getClassLoader());
-    ClassHierarchy cha = ClassHierarchyFactory.make(scope);
-    TypeReference ref =
-        TypeReference.findOrCreate(ClassLoaderReference.Application, "LCodeDeleted");
-    IClass klass = cha.lookupClass(ref);
-    IAnalysisCacheView cache = new AnalysisCacheImpl();
-    for (IMethod m : klass.getDeclaredMethods()) {
-      if (m.toString().contains("foo")) {
-        // should throw WalaRuntimeException
-        cache.getIR(m);
-      }
-    }
+  @Test
+  public void testDeletedCode() {
+    assertThrows(
+        WalaRuntimeException.class,
+        () -> {
+          AnalysisScope scope =
+              AnalysisScopeReader.instance.readJavaScope(
+                  TestConstants.WALA_TESTDATA,
+                  new FileProvider().getFile("J2SEClassHierarchyExclusions.txt"),
+                  DupFieldsTest.class.getClassLoader());
+          ClassHierarchy cha = ClassHierarchyFactory.make(scope);
+          TypeReference ref =
+              TypeReference.findOrCreate(ClassLoaderReference.Application, "LCodeDeleted");
+          IClass klass = cha.lookupClass(ref);
+          IAnalysisCacheView cache = new AnalysisCacheImpl();
+          for (IMethod m : klass.getDeclaredMethods()) {
+            if (m.toString().contains("foo")) {
+              // should throw WalaRuntimeException
+              cache.getIR(m);
+            }
+          }
+        });
   }
 }


### PR DESCRIPTION
IntelliJ IDEA does not know how to migrate tests that are expected to fail, so these were ported by hand.