### PR TITLE
Migrate slow tests from JUnit 4 to JUnit 5

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -139,7 +139,7 @@ tasks.named<Test>("test") {
 
 if (project.hasProperty("excludeSlowTests")) {
   dependencies { testImplementation(testFixtures(project(":core"))) }
-  tasks.named<Test>("test") { useJUnit { excludeCategories("com.ibm.wala.tests.util.SlowTests") } }
+  tasks.named<Test>("test") { useJUnitPlatform { excludeTags("slow") } }
 }
 
 val ecjCompileTaskProviders =

--- a/cast/build.gradle.kts
+++ b/cast/build.gradle.kts
@@ -46,7 +46,6 @@ dependencies {
   castJsPackageListDirectory(
       project(mapOf("path" to ":cast:js", "configuration" to "packageListDirectory")))
   javadocClasspath(projects.cast.js)
-  testRuntimeOnly(testFixtures(projects.core))
   xlatorTestSharedLibrary(project("xlator_test"))
 }
 

--- a/cast/java/ecj/build.gradle.kts
+++ b/cast/java/ecj/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
       project(
           mapOf("path" to ":cast:java:test:data", "configuration" to "testJavaSourceDirectory")))
   testImplementation(testFixtures(projects.cast.java))
-  testRuntimeOnly(testFixtures(projects.core))
 }
 
 application.mainClass = "com.ibm.wala.cast.java.ecj.util.SourceDirCallGraph"

--- a/cast/js/build.gradle.kts
+++ b/cast/js/build.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
   implementation(projects.util)
   javadocClasspath(projects.cast.js.rhino)
   testFixturesImplementation(testFixtures(projects.cast))
-  testFixturesImplementation(testFixtures(projects.core))
   testImplementation(testFixtures(projects.cast))
   testImplementation(testFixtures(projects.core))
 }

--- a/cast/js/nodejs/build.gradle.kts
+++ b/cast/js/nodejs/build.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
   implementation(projects.cast.js.rhino)
   implementation(projects.core)
   implementation(projects.util)
-  testRuntimeOnly(testFixtures(projects.core))
 }
 
 val downloadNodeJS by

--- a/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestSimpleCallGraphShape.java
+++ b/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestSimpleCallGraphShape.java
@@ -10,7 +10,8 @@
  */
 package com.ibm.wala.cast.js.test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.ibm.wala.cast.ipa.callgraph.CAstCallGraphUtil;
 import com.ibm.wala.cast.js.ipa.callgraph.JSCFABuilder;
@@ -23,7 +24,6 @@ import com.ibm.wala.ipa.callgraph.CallGraphBuilderCancelException;
 import com.ibm.wala.ipa.callgraph.propagation.PropagationCallGraphBuilder;
 import com.ibm.wala.ipa.callgraph.propagation.SSAContextInterpreter;
 import com.ibm.wala.ipa.callgraph.propagation.SSAPropagationCallGraphBuilder;
-import com.ibm.wala.tests.util.SlowTests;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.MonitorUtil.IProgressMonitor;
 import com.ibm.wala.util.NullProgressMonitor;
@@ -31,9 +31,9 @@ import com.ibm.wala.util.WalaException;
 import com.ibm.wala.util.collections.Iterator2Collection;
 import java.io.IOException;
 import java.util.List;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
 
@@ -474,8 +474,8 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
     verifyNoEdges(CG, "suffix:test2", "suffix:foo_of_A");
   }
 
+  @Tag("slow")
   @Test
-  @Category(SlowTests.class)
   public void testStackOverflowOnSsaConversionBug()
       throws IOException, IllegalArgumentException, CancelException, WalaException {
     JSCallGraphBuilderUtil.makeScriptCG("tests", "stack_overflow_on_ssa_conversion.js");
@@ -917,18 +917,21 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
     CAstCallGraphUtil.dumpCG(B.getCFAContextInterpreter(), B.getPointerAnalysis(), CG);
   }
 
-  @Test(expected = CallGraphBuilderCancelException.class)
-  @Category(SlowTests.class)
-  public void testManyStrings()
-      throws IllegalArgumentException, IOException, CancelException, WalaException {
+  @Tag("slow")
+  @Test
+  public void testManyStrings() throws IllegalArgumentException, IOException, WalaException {
     SSAPropagationCallGraphBuilder B =
         JSCallGraphBuilderUtil.makeScriptCGBuilder("tests", "many-strings.js");
     B.getOptions().setTraceStringConstants(true);
     IProgressMonitor monitor = ProgressMaster.make(new NullProgressMonitor(), 10000, false);
-    monitor.beginTask("build CG", 1);
-    CallGraph CG = B.makeCallGraph(B.getOptions(), monitor);
-    monitor.done();
-    CAstCallGraphUtil.dumpCG(B.getCFAContextInterpreter(), B.getPointerAnalysis(), CG);
+    assertThrows(
+        CallGraphBuilderCancelException.class,
+        () -> {
+          monitor.beginTask("build CG", 1);
+          CallGraph CG = B.makeCallGraph(B.getOptions(), monitor);
+          monitor.done();
+          CAstCallGraphUtil.dumpCG(B.getCFAContextInterpreter(), B.getPointerAnalysis(), CG);
+        });
   }
 
   @Test
@@ -947,7 +950,7 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
         new Object[] {"loops.js", new String[] {"loops.js/three", "loops.js/four"}}
       };
 
-  @Ignore("need to fix this.  bug from Sukyoung's group")
+  @Disabled("need to fix this.  bug from Sukyoung's group")
   @Test
   public void testLoops()
       throws IllegalArgumentException, IOException, CancelException, WalaException {
@@ -973,7 +976,7 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
         },
       };
 
-  @Ignore("need to fix this.  bug from Sukyoung's group")
+  @Disabled("need to fix this.  bug from Sukyoung's group")
   @Test
   public void testPrimitiveStrings()
       throws IllegalArgumentException, IOException, CancelException, WalaException {

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/KawaCallGraphTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/KawaCallGraphTest.java
@@ -32,7 +32,6 @@ import com.ibm.wala.ipa.callgraph.propagation.SSAPropagationCallGraphBuilder;
 import com.ibm.wala.ipa.cha.ClassHierarchy;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.ipa.cha.ClassHierarchyFactory;
-import com.ibm.wala.tests.util.SlowTests;
 import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.Descriptor;
 import com.ibm.wala.types.MethodReference;
@@ -40,10 +39,10 @@ import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.MonitorUtil.IProgressMonitor;
 import java.io.IOException;
 import java.util.Set;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
-@Category(SlowTests.class)
+@Tag("slow")
 public class KawaCallGraphTest extends DynamicCallGraphTestBase {
 
   @Test

--- a/core/src/testFixtures/java/com/ibm/wala/tests/util/SlowTests.java
+++ b/core/src/testFixtures/java/com/ibm/wala/tests/util/SlowTests.java
@@ -1,9 +1,0 @@
-package com.ibm.wala.tests.util;
-
-/**
- * JUnit category marker for slow tests
- *
- * <p>Add “{@code -PexcludeSlowTests}” to the Gradle command line for faster test turnaround at the
- * expense of worse test coverage.
- */
-public interface SlowTests {}

--- a/util/build.gradle.kts
+++ b/util/build.gradle.kts
@@ -10,7 +10,6 @@ dependencies {
   compileOnly(libs.jspecify)
   javadocClasspath(projects.core)
   testImplementation(libs.hamcrest)
-  testRuntimeOnly(testFixtures(projects.core))
 }
 
 tasks.named<Javadoc>("javadoc") {


### PR DESCRIPTION
These tests were all migrated by hand, including updating the Gradle logic for conditionally excluding them.