### PR TITLE
Port WalaTestCase.justThisTest from JUnit 4 to JUnit 5

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
   }
   api(projects.util) { because("public interface CallGraph extends interface NumberedGraph") }
   testFixturesImplementation(libs.ant)
+  testFixturesImplementation(libs.junit.platform.launcher)
   testImplementation(libs.hamcrest)
   testRuntimeOnly(sourceSets["testSubjects"].output.classesDirs)
   // add the testSubjects source files to enable SourceMapTest to pass

--- a/core/src/testFixtures/java/com/ibm/wala/core/tests/util/WalaTestCase.java
+++ b/core/src/testFixtures/java/com/ibm/wala/core/tests/util/WalaTestCase.java
@@ -10,18 +10,23 @@
  */
 package com.ibm.wala.core.tests.util;
 
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
 import com.ibm.wala.core.util.warnings.Warnings;
 import com.ibm.wala.ipa.callgraph.AnalysisCacheImpl;
 import com.ibm.wala.ipa.callgraph.IAnalysisCacheView;
 import com.ibm.wala.ssa.SSAOptions;
 import com.ibm.wala.util.heapTrace.HeapTracer;
 import java.io.File;
+import java.io.PrintWriter;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.runner.JUnitCore;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
 
 /** Simple extension to JUnit test case. */
 public abstract class WalaTestCase {
@@ -62,7 +67,12 @@ public abstract class WalaTestCase {
    * test.
    */
   protected static void justThisTest(Class<?> testClass) {
-    JUnitCore.runClasses(testClass);
+    final var listener = new SummaryGeneratingListener();
+    LauncherFactory.create()
+        .execute(
+            LauncherDiscoveryRequestBuilder.request().selectors(selectClass(testClass)).build(),
+            listener);
+    listener.getSummary().printFailuresTo(new PrintWriter(System.err));
   }
 
   protected static String getClasspathEntry(String elt) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ junit-bom = "org.junit:junit-bom:5.9.3"
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine" }
 nullaway = "com.uber.nullaway:nullaway:0.10.10"
 rhino = "org.mozilla:rhino:1.7.14"


### PR DESCRIPTION
`WalaTestCase.justThisTest` offers a convenient way to run a single test class as a `main` application.  Previously this worked using JUnit 4; now it uses JUnit 5.