### PR TITLE
Port soft assertions from JUnit 4 to JUnit 5 + AssertJ

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
   api(projects.util) { because("public interface CallGraph extends interface NumberedGraph") }
   testFixturesImplementation(libs.ant)
   testFixturesImplementation(libs.junit.platform.launcher)
+  testImplementation(libs.assertj.core)
   testImplementation(libs.hamcrest)
   testRuntimeOnly(sourceSets["testSubjects"].output.classesDirs)
   // add the testSubjects source files to enable SourceMapTest to pass

--- a/core/src/test/java/com/ibm/wala/core/tests/exceptionpruning/ExceptionAnalysis2EdgeFilterTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/exceptionpruning/ExceptionAnalysis2EdgeFilterTest.java
@@ -1,7 +1,7 @@
 package com.ibm.wala.core.tests.exceptionpruning;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.ibm.wala.analysis.exceptionanalysis.ExceptionAnalysis;
 import com.ibm.wala.analysis.exceptionanalysis.ExceptionAnalysis2EdgeFilter;
@@ -42,10 +42,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ErrorCollector;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * This Test checks, if the number of deleted edges is correct for TestPruning, it is also doing a
@@ -64,9 +62,7 @@ public class ExceptionAnalysis2EdgeFilterTest {
   private static PointerAnalysis<InstanceKey> pointerAnalysis;
   private static CombinedInterproceduralExceptionFilter<SSAInstruction> filter;
 
-  @Rule public ErrorCollector collector = new ErrorCollector();
-
-  @BeforeClass
+  @BeforeAll
   public static void init()
       throws IOException, ClassHierarchyException, IllegalArgumentException,
           CallGraphBuilderCancelException {
@@ -180,27 +176,27 @@ public class ExceptionAnalysis2EdgeFilterTest {
       }
     }
 
-    assertEquals("Number of normal edges deleted wrong:", 0, deletedNormal);
+    assertEquals(0, deletedNormal, "Number of normal edges deleted wrong:");
     for (Map.Entry<String, Integer> entry : deletedExceptional.entrySet()) {
       final String key = entry.getKey();
       final int value = entry.getValue();
       String text = "Number of exceptional edges deleted wrong for " + key + ":";
       switch (key) {
         case "testTryCatchMultipleExceptions":
-          assertEquals(text, 12, value);
+          assertEquals(12, value, text);
           break;
         case "testTryCatchOwnException":
         case "testTryCatchImplicitException":
-          assertEquals(text, 5, value);
+          assertEquals(5, value, text);
           break;
         case "testTryCatchSuper":
-          assertEquals(text, 3, value);
+          assertEquals(3, value, text);
           break;
         case "main":
-          assertEquals(text, 4, value);
+          assertEquals(4, value, text);
           break;
         default:
-          assertEquals(text, 0, value);
+          assertEquals(0, value, text);
           break;
       }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ spotless = "6.13.0"
 [libraries]
 android-tools = "com.android.tools:r8:2.2.42"
 ant = "org.apache.ant:ant:1.10.12"
+assertj-core = "org.assertj:assertj-core:3.24.2"
 commons-cli = "commons-cli:commons-cli:1.5.0"
 commons-io = "commons-io:commons-io:2.11.0"
 dexlib2 = "org.smali:dexlib2:2.5.2"


### PR DESCRIPTION
JUnit 5 itself offers only a very limited API for soft assertions. The rigid structure of this API does not align well with ways that WALA already uses soft assertions. AssertJ offers much more flexibility, if we're willing to pick that up as an additional dependency.