### PR TITLE
Remove JUnit 4 dependency

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -42,11 +42,9 @@ dependencies {
   "javadocSource"(sourceSets.main.get().allJava)
 
   testFixturesImplementation(platform(findLibrary("junit-bom")))
-  testFixturesImplementation(findLibrary("junit"))
   testFixturesImplementation(findLibrary("junit-jupiter-api"))
 
   testImplementation(platform(findLibrary("junit-bom")))
-  testImplementation(findLibrary("junit"))
   testImplementation(findLibrary("junit-jupiter-api"))
   testRuntimeOnly(findLibrary("junit-jupiter-engine"))
   testRuntimeOnly(findLibrary("junit-vintage-engine"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,6 @@ javax-annotation-api = { module = "javax.annotation:javax.annotation-api", versi
 jericho-html = "net.htmlparser.jericho:jericho-html:3.2"
 json = "org.json:json:20230618"
 jspecify = "org.jspecify:jspecify:0.3.0"
-junit = "junit:junit:4.13.2"
 junit-bom = "org.junit:junit-bom:5.9.3"
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }


### PR DESCRIPTION
All tests and test infrastructure have been migrated or ported to JUnit 5. Nothing remains that uses JUnit 4.