### PR TITLE
Let JUnit 5 manage tests' temporary files

### DIFF
--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/JavaIRTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/JavaIRTests.java
@@ -67,6 +67,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public abstract class JavaIRTests extends IRTests {
 
@@ -790,9 +791,11 @@ public abstract class JavaIRTests extends IRTests {
   }
 
   @Test
-  public void testExclusions() throws IllegalArgumentException, CancelException, IOException {
+  public void testExclusions(@TempDir final File tmpDir)
+      throws IllegalArgumentException, CancelException, IOException {
     File exclusions =
-        TemporaryFile.stringToFile(File.createTempFile("exl", "txt"), "Exclusions.Excluded\n");
+        TemporaryFile.stringToFile(
+            File.createTempFile("exl", "txt", tmpDir), "Exclusions.Excluded\n");
     Pair<CallGraph, CallGraphBuilder<? super InstanceKey>> x =
         runTest(
             singleTestSrc(),

--- a/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestCorrelatedPairExtraction.java
+++ b/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestCorrelatedPairExtraction.java
@@ -34,6 +34,7 @@ import java.util.Collections;
 import java.util.Map;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public abstract class TestCorrelatedPairExtraction {
   // set to "true" to use JUnit's assertEquals to check whether a test case passed;
@@ -42,14 +43,15 @@ public abstract class TestCorrelatedPairExtraction {
   // this is useful if the outputs are too big/too different for Eclipse's diff view to handle
   private static final boolean ASSERT_EQUALS = true;
 
+  @TempDir private File tmpDir;
+
   public void testRewriter(String in, String out) {
     testRewriter(null, in, out);
   }
 
   public void testRewriter(String testName, String in, String out) {
-    File tmp = null;
     try {
-      tmp = File.createTempFile("test", ".js");
+      final var tmp = File.createTempFile("test", ".js", tmpDir);
       FileUtil.writeFile(tmp, in);
 
       final Map<IMethod, CorrelationSummary> summaries =
@@ -86,8 +88,6 @@ public abstract class TestCorrelatedPairExtraction {
 
     } catch (IOException | ClassHierarchyException e) {
       e.printStackTrace();
-    } finally {
-      if (tmp != null && tmp.exists()) tmp.delete();
     }
   }
 

--- a/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestForInBodyExtraction.java
+++ b/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestForInBodyExtraction.java
@@ -26,8 +26,12 @@ import java.io.UncheckedIOException;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public abstract class TestForInBodyExtraction {
+
+  @TempDir private File tmpDir;
+
   public void testRewriter(String in, String out) {
     testRewriter(null, in, out);
   }
@@ -49,11 +53,10 @@ public abstract class TestForInBodyExtraction {
   }
 
   public void testRewriter(String testName, String in, String out) {
-    File tmp = null;
     String expected = null;
     String actual = null;
     try {
-      tmp = File.createTempFile("test", ".js");
+      final var tmp = File.createTempFile("test", ".js", tmpDir);
       FileUtil.writeFile(tmp, in);
       CAstImpl ast = new CAstImpl();
       actual =
@@ -70,8 +73,6 @@ public abstract class TestForInBodyExtraction {
       assertEquals(expected, actual, () -> "Comparison Failure in " + testName + '!');
     } catch (IOException e) {
       throw new UncheckedIOException(e);
-    } finally {
-      if (tmp != null && tmp.exists()) tmp.delete();
     }
   }
 

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/Java7CallGraphTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/Java7CallGraphTest.java
@@ -35,10 +35,19 @@ import com.ibm.wala.util.PlatformUtil;
 import com.ibm.wala.util.io.TemporaryFile;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.jar.JarFile;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class Java7CallGraphTest extends DynamicCallGraphTestBase {
+
+  private @TempDir Path temporaryDirectory;
+
+  @Override
+  protected Path getTemporaryDirectory() {
+    return temporaryDirectory;
+  }
 
   @Test
   public void testOcamlHelloHash()

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/KawaCallGraphTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/KawaCallGraphTest.java
@@ -38,12 +38,21 @@ import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.MonitorUtil.IProgressMonitor;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Set;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 @Tag("slow")
 public class KawaCallGraphTest extends DynamicCallGraphTestBase {
+
+  private @TempDir Path temporaryDirectory;
+
+  @Override
+  protected Path getTemporaryDirectory() {
+    return temporaryDirectory;
+  }
 
   @Test
   public void testKawaChess()

--- a/core/src/test/java/com/ibm/wala/core/tests/shrike/FloatingPointsTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/shrike/FloatingPointsTest.java
@@ -150,16 +150,18 @@ public class FloatingPointsTest extends WalaTestCase {
   }
 
   private void write() throws IllegalStateException, IOException, InvalidClassFileException {
-    // Write all modified classes
-    for (ClassInstrumenter ci2 : classInstrumenters) {
-      if (ci2.isChanged()) {
-        ClassWriter cw = ci2.emitClass();
-        instrumenter.outputModifiedClass(ci2, cw);
+    try {
+      // Write all modified classes
+      for (ClassInstrumenter ci2 : classInstrumenters) {
+        if (ci2.isChanged()) {
+          ClassWriter cw = ci2.emitClass();
+          instrumenter.outputModifiedClass(ci2, cw);
+        }
       }
+    } finally {
+      // Finally write the instrumented jar
+      instrumenter.close();
     }
-
-    // Finally write the instrumented jar
-    instrumenter.close();
   }
 
   private void setValidationInstrumenter() throws IOException {
@@ -169,11 +171,15 @@ public class FloatingPointsTest extends WalaTestCase {
     instrumenter.addInputJar(instrumentedJarLocation.toFile());
     instrumenter.beginTraversal();
 
-    // To be able to reuse all classes from shrike save them in a new list
-    classInstrumenters = new ArrayList<>();
-    ClassInstrumenter ci = null;
-    while ((ci = instrumenter.nextClass()) != null) {
-      classInstrumenters.add(ci);
+    try {
+      // To be able to reuse all classes from shrike save them in a new list
+      classInstrumenters = new ArrayList<>();
+      ClassInstrumenter ci = null;
+      while ((ci = instrumenter.nextClass()) != null) {
+        classInstrumenters.add(ci);
+      }
+    } finally {
+      instrumenter.close();
     }
   }
 

--- a/core/src/test/java/com/ibm/wala/core/tests/shrike/FloatingPointsTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/shrike/FloatingPointsTest.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 @SuppressWarnings("UnconstructableJUnitTestCase")
 public class FloatingPointsTest extends WalaTestCase {
@@ -38,10 +39,9 @@ public class FloatingPointsTest extends WalaTestCase {
   public FloatingPointsTest() {}
 
   @BeforeEach
-  public void setOfflineInstrumenter() throws IOException {
+  public void setOfflineInstrumenter(@TempDir final Path tmpDir) throws IOException {
     // Create a temporary file for the shrike instrumented output
-    instrumentedJarLocation = Files.createTempFile("wala-test", ".jar");
-    instrumentedJarLocation.toFile().deleteOnExit();
+    instrumentedJarLocation = Files.createTempFile(tmpDir, "wala-test", ".jar");
 
     // Initialize the OfflineInstrumenter loading the class file specified in
     // 'klass' above

--- a/core/src/testFixtures/java/com/ibm/wala/core/tests/shrike/DynamicCallGraphTestBase.java
+++ b/core/src/testFixtures/java/com/ibm/wala/core/tests/shrike/DynamicCallGraphTestBase.java
@@ -43,6 +43,7 @@ import java.util.zip.GZIPInputStream;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Java;
 import org.apache.tools.ant.types.Path;
+import org.junit.jupiter.api.BeforeEach;
 
 public abstract class DynamicCallGraphTestBase extends WalaTestCase {
 
@@ -50,19 +51,17 @@ public abstract class DynamicCallGraphTestBase extends WalaTestCase {
 
   private boolean instrumentedJarBuilt = false;
 
-  private final java.nio.file.Path instrumentedJarLocation;
+  private java.nio.file.Path instrumentedJarLocation;
 
-  private final java.nio.file.Path cgLocation;
+  private java.nio.file.Path cgLocation;
 
-  protected DynamicCallGraphTestBase() {
-    try {
-      instrumentedJarLocation = Files.createTempFile("wala-test", ".jar");
-      instrumentedJarLocation.toFile().deleteOnExit();
-      cgLocation = Files.createTempFile("cg", ".txt");
-      cgLocation.toFile().deleteOnExit();
-    } catch (IOException problem) {
-      throw new RuntimeException(problem);
-    }
+  protected abstract java.nio.file.Path getTemporaryDirectory();
+
+  @BeforeEach
+  protected void createTemporaryFiles() throws IOException {
+    final var temporaryDirectory = getTemporaryDirectory();
+    instrumentedJarLocation = Files.createTempFile(temporaryDirectory, "wala-test", ".jar");
+    cgLocation = Files.createTempFile(temporaryDirectory, "cg", ".txt");
   }
 
   protected void instrument(String testJarLocation)

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/DalvikCallGraphTestBase.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/DalvikCallGraphTestBase.java
@@ -54,14 +54,23 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.jar.JarFile;
+import org.junit.jupiter.api.io.TempDir;
 
 public class DalvikCallGraphTestBase extends DynamicCallGraphTestBase {
+
+  private @TempDir Path temporaryDirectory;
+
+  @Override
+  protected Path getTemporaryDirectory() {
+    return temporaryDirectory;
+  }
 
   protected static <T> Set<T> processCG(
       CallGraph cg, Predicate<CGNode> filter, Function<CGNode, T> map) {

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/DynamicDalvikComparisonJavaLibsTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/DynamicDalvikComparisonJavaLibsTest.java
@@ -7,9 +7,18 @@ import com.ibm.wala.shrike.shrikeCT.InvalidClassFileException;
 import com.ibm.wala.util.CancelException;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class DynamicDalvikComparisonJavaLibsTest extends DynamicDalvikComparisonTest {
+
+  private @TempDir Path temporaryDirectory;
+
+  @Override
+  protected Path getTemporaryDirectory() {
+    return temporaryDirectory;
+  }
 
   @Test
   public void testJLex()


### PR DESCRIPTION
This change implements [a suggestion previously made by @msridhar](https://github.com/wala/WALA/pull/1301#discussion_r1275297725), not just in the class originally under review, but in several other test (and test fixture) classes as well.