### PR TITLE
Stop using Project.getBuildDir()

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -122,7 +122,7 @@ tasks.named<Test>("test") {
     outputs.upToDateWhen { false }
     afterTest(
         KotlinClosure2<TestDescriptor, TestResult, Unit>({ descriptor, result ->
-          File("${rootProject.buildDir}/time-trials.csv").let {
+          rootProject.layout.buildDirectory.file("time-trials.csv").get().asFile.let {
             if (!it.exists()) {
               it.appendText("trial,className,name,resultType,startTime,endTime\n")
             }

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
@@ -144,7 +144,7 @@ val mavenRepository =
 
 repositories.maven {
   name = "fakeRemote"
-  url = uri("file://${rootProject.buildDir}/maven-fake-remote-repository")
+  setUrl(rootProject.layout.buildDirectory.dir("maven-fake-remote-repository"))
 }
 
 configure<SigningExtension> {


### PR DESCRIPTION
[`Project.getBuildDir()` will likely be deprecated in Gradle 8.3.](https://github.com/gradle/gradle/issues/20210)  Fortunately we only had a few remaining uses of this getter, all easily modernized.