### PR TITLE
Tag additional slow tests

### DIFF
--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/CallGraphTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/CallGraphTest.java
@@ -67,6 +67,7 @@ import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /** Tests for Call Graph construction */
@@ -76,6 +77,7 @@ public class CallGraphTest extends WalaTestCase {
     justThisTest(CallGraphTest.class);
   }
 
+  @Tag("slow")
   @Test
   public void testJava_cup()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
@@ -90,6 +92,7 @@ public class CallGraphTest extends WalaTestCase {
     doCallGraphs(options, new AnalysisCacheImpl(), cha, useShortProfile());
   }
 
+  @Tag("slow")
   @Test
   public void testBcelVerifier()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/DebuggingBitsetCallGraphTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/DebuggingBitsetCallGraphTest.java
@@ -22,9 +22,11 @@ import com.ibm.wala.util.intset.MutableSharedBitVectorIntSetFactory;
 import com.ibm.wala.util.intset.MutableSparseIntSetFactory;
 import com.ibm.wala.util.intset.SemiSparseMutableIntSetFactory;
 import java.io.IOException;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 /** Run the call graph only test with paranoid debugging bit vectors */
+@Tag("slow")
 public class DebuggingBitsetCallGraphTest extends WalaTestCase {
 
   public static void main(String[] args) {


### PR DESCRIPTION
Empirically, these tests start but take a long time to finish on my personal laptop.  Some of them wedge the entire laptop, requiring that I cycle power to recover.  Granted, my laptop is a bit old and not the most powerful.  I think it's reasonable to skip a few tests to make development on this laptop feasible.  We still run the full test suite, including "slow"-tagged tests, in our GitHub Actions workflows.