### PR TITLE
Update Gradle Goomph plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ eclipse-osgi = "org.eclipse.platform:org.eclipse.osgi:3.17.0"
 eclipse-wst-jsdt-core = { module = "org.eclipse.wst.jsdt:core", version.ref = "eclipse-wst-jsdt" }
 eclipse-wst-jsdt-ui = { module = "org.eclipse.wst.jsdt:ui", version.ref = "eclipse-wst-jsdt" }
 errorprone-core = "com.google.errorprone:error_prone_core:2.18.0"
-gradle-goomph-plugin = "com.diffplug.gradle:goomph:3.40.0"
+gradle-goomph-plugin = "com.diffplug.gradle:goomph:3.42.2"
 gradle-download-task = "de.undercouch:gradle-download-task:5.3.1"
 gradle-errorprone-plugin = "net.ltgt.gradle:gradle-errorprone-plugin:3.0.1"
 gradle-spotless-plugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }


### PR DESCRIPTION
This update seems to fix the problem of #1278 on JDK 11, but not on JDK 17.  Still it's good to update.