### PR TITLE
Update configuration-cache-for-platform-specific-build plugin

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,6 @@
 buildscript { dependencies { classpath("com.diffplug.spotless:spotless-lib-extra:2.34.1") } }
 
-plugins { id("com.diffplug.configuration-cache-for-platform-specific-build") version "3.40.0" }
+plugins { id("com.diffplug.configuration-cache-for-platform-specific-build") version "3.42.2" }
 
 enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
 


### PR DESCRIPTION
Follow up to #1311.  I didn't realize I had to update this version number in two places.  #1278 remains as an issue even after this update.