### PR TITLE
Correct redundant escaping

### DIFF
--- a/cast/js/src/main/java/com/ibm/wala/cast/js/html/DomLessSourceExtractor.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/html/DomLessSourceExtractor.java
@@ -199,11 +199,11 @@ public class DomLessSourceExtractor extends JSSourceExtractor {
         quote = '"';
       } else {
         quote = '"';
-        value = value.replaceAll("\"", "\\\"");
+        value = value.replaceAll("\"", "\\\\\"");
       }
 
       if (value.indexOf('\n') >= 0) {
-        value = value.replaceAll("\n", "\\n");
+        value = value.replaceAll("\n", "\\\\n");
       }
 
       return Pair.make(value, quote);

--- a/core/src/main/java/com/ibm/wala/types/generics/MethodTypeSignature.java
+++ b/core/src/main/java/com/ibm/wala/types/generics/MethodTypeSignature.java
@@ -43,7 +43,7 @@ public class MethodTypeSignature extends Signature {
    * @return null if no arguments
    */
   public TypeSignature[] getArguments() {
-    String typeSig = rawString().replaceAll(".*\\(", "\\(").replaceAll("\\).*", "\\)");
+    String typeSig = rawString().replaceAll(".*\\(", "(").replaceAll("\\).*", ")");
     String[] args = TypeSignature.parseForTypeSignatures(typeSig);
     if (args == null) {
       return null;

--- a/core/src/test/java/com/ibm/wala/types/generics/MethodTypeSignatureTest.java
+++ b/core/src/test/java/com/ibm/wala/types/generics/MethodTypeSignatureTest.java
@@ -1,0 +1,19 @@
+package com.ibm.wala.types.generics;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link MethodTypeSignature}. */
+class MethodTypeSignatureTest {
+
+  /** Unit test for {@link MethodTypeSignature#getArguments()}. */
+  @Test
+  void getArguments() {
+    assertThat(
+        MethodTypeSignature.make("(I)V").getArguments(),
+        arrayContaining(is(TypeSignature.make("I"))));
+  }
+}


### PR DESCRIPTION
Whoever wrote these `String.replaceAll` calls was a bit confused about how backslashes behave in the replacement text.  They actually behave less like backslashes in generic `String` literals, and more like backslashes in regular expressions.  For example, to replace a newline with a backslash followed by an `n`, the replacement text should be `\\\\n`, not `\\n`.

I've added a test for
`com.ibm.wala.types.generics.MethodTypeSignature.getArguments()` to affirm that my changes there leave us with an implementation that has the intended effects.  I haven't added a
`com.ibm.wala.cast.js.html.DomLessSourceExtractor.HtmlCallback.quotify(String)` test, though, because this method is buried too deep inside `protected` APIs that are difficult for a unit test to get access to.  Instead, to argue that the new code matches the original `quotify` authors' likely intent, contrast these two JShell approximations:

* old code:

  ```plain
  jshell> System.out.println("foo\n\"bar".replaceAll("\"", "\\\"").replaceAll("\n", "\\n"))
  foon"bar
  ```

* new code:

  ```plain
  System.out.println("foo\n\"bar".replaceAll("\"", "\\\\\"").replaceAll("\n", "\\\\n"))
  foo\n\"bar
  ```