### PR TITLE
Suppress warnings about unstable Gradle APIs

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 import com.diffplug.spotless.LineEnding.PLATFORM_NATIVE
 
 plugins {

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 package com.ibm.wala.gradle
 
 // Build configuration for subprojects that include Java source code.

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 package com.ibm.wala.gradle
 
 plugins {

--- a/cast/java/ecj/build.gradle.kts
+++ b/cast/java/ecj/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 plugins {
   application
   id("com.ibm.wala.gradle.eclipse-maven-central")

--- a/cast/java/test/data/build.gradle.kts
+++ b/cast/java/test/data/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 import com.ibm.wala.gradle.VerifiedDownload
 import java.net.URI
 import net.ltgt.gradle.errorprone.errorprone

--- a/cast/js/build.gradle.kts
+++ b/cast/js/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 import com.ibm.wala.gradle.CreatePackageList
 import com.ibm.wala.gradle.VerifiedDownload
 import java.net.URI

--- a/cast/js/nodejs/build.gradle.kts
+++ b/cast/js/nodejs/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 import com.ibm.wala.gradle.VerifiedDownload
 import java.net.URI
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,3 +1,5 @@
+@file:Suppress("UnstableApiUsage")
+
 import com.ibm.wala.gradle.CompileKawaScheme
 import com.ibm.wala.gradle.JavaCompileUsingEcj
 import com.ibm.wala.gradle.VerifiedDownload


### PR DESCRIPTION
We're intentionally using [an unstable Gradle Kotlin feature that allows direct `... = ...` assignment to `Property` instances](https://blog.gradle.org/simpler-kotlin-dsl-property-assignment). This feature may be considered unstable, but it's stable enough to have been [enabled by default since Gradle 8.2](https://docs.gradle.org/8.2.1/release-notes.html#simple-property-assignment-in-kotlin-dsl-enabled-by-default).