### PR TITLE
Avoid memory leak for thread-local values

### DIFF
--- a/shrike/src/main/java/com/ibm/wala/shrike/cg/Runtime.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/cg/Runtime.java
@@ -124,7 +124,7 @@ public class Runtime {
   }
 
   public static void execution(String klass, String method, Object receiver) {
-    runtime.currentSite.set(null);
+    runtime.currentSite.remove();
     if (runtime.filter == null || !runtime.filter.contains(bashToDescriptor(klass))) {
       if (runtime.output != null) {
         String caller = runtime.callStacks.get().peek();
@@ -183,7 +183,7 @@ public class Runtime {
         }
       }
 
-      runtime.currentSite.set(null);
+      runtime.currentSite.remove();
     }
   }
 


### PR DESCRIPTION
Setting a thread-local value to `null` is not the same as removing it. The former retains an entry mapping the current thread's value to `null` in a hidden global map.  The latter removes the current thread's entry entirely.