### PR TITLE
Add explicit Kotlin types

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
@@ -121,9 +121,9 @@ val mavenPublication =
       }
     }
 
-val repositories = publishing.repositories
+val repositories: RepositoryHandler = publishing.repositories
 
-val mavenRepository =
+val mavenRepository: MavenArtifactRepository =
     repositories.maven {
       url =
           uri(


### PR DESCRIPTION
These values are returned from Java code without nullability information.  Kotlin needs a little extra help to know whether those Java APIs can return `null` here or not.