### PR TITLE
Suppress warnings about safe `this` leaks

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/VerifiedDownload.kt
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/VerifiedDownload.kt
@@ -38,11 +38,13 @@ abstract class VerifiedDownload : DefaultTask() {
 
   // plugin-provided extension for downloading a resource from some URL
   @Internal
+  @Suppress("LeakingThis")
   val downloadExtension: DownloadExtension =
       project.objects.newInstance(DownloadExtension::class.java, this)
 
   // plugin-provided extension for verifying that a file has the expected checksum
   @Internal
+  @Suppress("LeakingThis")
   val verifyExtension: VerifyExtension =
       project.objects.newInstance(VerifyExtension::class.java, this)
 


### PR DESCRIPTION
Leaking `this` before the constructor has completed can be dangerous in general, specifically if any methods are called or not-yet-initialized fields are used.  However, in the specific cases addressed here, the escaping `this` is merely recorded in fields of other objects for later use.  Members of `this` instance are not actually used during construction, so these escapes are safe.