### PR TITLE
Remove redundant initializers

### DIFF
--- a/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
+++ b/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
@@ -186,7 +186,7 @@ import org.eclipse.jdt.core.dom.WhileStatement;
 // possible)
 
 public abstract class JDTJava2CAstTranslator<T extends Position> {
-  protected boolean dump = false;
+  protected boolean dump;
 
   protected final CAst fFactory = new CAstImpl();
 
@@ -1083,7 +1083,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
       }
 
       if (fDecl != null) {
-        int i = 0; // index to start filling up with real params
+        int i; // index to start filling up with real params
         if ((fModifiers & Modifier.STATIC) != 0) {
           fParameterNames = new String[fDecl.parameters().size()];
           i = 0;

--- a/cast/java/src/main/java/com/ibm/wala/cast/java/translator/Java2IRTranslator.java
+++ b/cast/java/src/main/java/com/ibm/wala/cast/java/translator/Java2IRTranslator.java
@@ -31,7 +31,7 @@ public class Java2IRTranslator {
 
   protected final SetOfClasses exclusions;
 
-  CAstRewriterFactory<?, ?> castRewriterFactory = null;
+  CAstRewriterFactory<?, ?> castRewriterFactory;
 
   public Java2IRTranslator(JavaSourceLoaderImpl srcLoader, SetOfClasses exclusions) {
     this(srcLoader, null, exclusions);

--- a/cast/js/nodejs/src/main/java/com/ibm/wala/cast/js/nodejs/NodejsRequiredSourceModule.java
+++ b/cast/js/nodejs/src/main/java/com/ibm/wala/cast/js/nodejs/NodejsRequiredSourceModule.java
@@ -70,7 +70,7 @@ public class NodejsRequiredSourceModule extends SourceFileModule {
       Assertions.UNREACHABLE(e.getMessage());
     }
 
-    String wrapperSource = null;
+    final String wrapperSource;
     String ext = FilenameUtils.getExtension(getFile().toString()).toLowerCase();
     switch (ext) {
       case "js":

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/FlowGraph.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/FlowGraph.java
@@ -185,8 +185,7 @@ public class FlowGraph implements Iterable<Vertex> {
       private final Map<Pair<PrototypeField, ObjectVertex>, PrototypeFieldVertex> proto =
           HashMapFactory.make();
 
-      private GraphReachability<Vertex, ObjectVertex> pointerAnalysis =
-          computeClosure(graph, monitor, ObjectVertex.class);
+      private GraphReachability<Vertex, ObjectVertex> pointerAnalysis;
 
       private final ExtensionGraph<Vertex> dataflow = new ExtensionGraph<>(graph);
 
@@ -203,6 +202,9 @@ public class FlowGraph implements Iterable<Vertex> {
       }
 
       {
+        // This initial value of `pointerAnalysis` is used by the `getPointsToSet` call below.
+        pointerAnalysis = computeClosure(graph, monitor, ObjectVertex.class);
+
         PropVertex proto = factory.makePropVertex("prototype");
         if (graph.containsNode(proto)) {
           for (Vertex p : Iterator2Iterable.make(graph.getPredNodes(proto))) {

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/CorrelatedPairExtractionPolicy.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/CorrelatedPairExtractionPolicy.java
@@ -96,7 +96,7 @@ public class CorrelatedPairExtractionPolicy extends ExtractionPolicy {
 
     if (!entity.getPosition().getURL().toString().equals(startPos.getURL().toString())) return true;
     Set<ChildPos> startNodes = findNodesAtPos(CAstNode.OBJECT_REF, startPos, entity);
-    Set<ChildPos> endNodes = null;
+    final Set<ChildPos> endNodes;
     if (corr instanceof ReadWriteCorrelation) {
       endNodes = findNodesAtPos(CAstNode.ASSIGN, endPos, entity);
     } else if (corr instanceof EscapeCorrelation) {
@@ -207,9 +207,9 @@ public class CorrelatedPairExtractionPolicy extends ExtractionPolicy {
       String parmName,
       List<String> locals) {
     ChildPos pos = startNode;
-    CAstNode block = null;
-    int start = -1, end = 0;
-    int start_inner = -1, end_inner = -1;
+    CAstNode block;
+    int start, end;
+    int start_inner, end_inner = -1;
 
     do {
       if (pos != startNode && pos.getParentPos() instanceof ChildPos)

--- a/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/CAstDumper.java
+++ b/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/CAstDumper.java
@@ -24,7 +24,6 @@ import com.ibm.wala.cast.util.CAstPrinter;
 import com.ibm.wala.util.collections.HashMapFactory;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -63,7 +62,7 @@ public class CAstDumper {
   }
 
   private void dump(CAstEntity entity, int indent, StringBuilder buf) {
-    Collection<CAstEntity> scopedEntities = Collections.emptySet();
+    final Collection<CAstEntity> scopedEntities;
     if (entity.getKind() == CAstEntity.SCRIPT_ENTITY) {
       buf.append(indent(indent)).append(entity.getName()).append(":\n");
       scopedEntities = dumpScopedEntities(entity, indent + 2, buf);

--- a/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestForInBodyExtraction.java
+++ b/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestForInBodyExtraction.java
@@ -53,8 +53,8 @@ public abstract class TestForInBodyExtraction {
   }
 
   public void testRewriter(String testName, String in, String out) {
-    String expected = null;
-    String actual = null;
+    String expected;
+    String actual;
     try {
       final var tmp = File.createTempFile("test", ".js", tmpDir);
       FileUtil.writeFile(tmp, in);

--- a/cast/src/main/java/com/ibm/wala/cast/loader/CAstAbstractModuleLoader.java
+++ b/cast/src/main/java/com/ibm/wala/cast/loader/CAstAbstractModuleLoader.java
@@ -162,9 +162,8 @@ public abstract class CAstAbstractModuleLoader extends CAstAbstractLoader {
       } else {
         TranslatorToCAst xlatorToCAst = getTranslatorToCAst(ast, moduleEntry, modules);
 
-        CAstEntity fileEntity = null;
         try {
-          fileEntity = xlatorToCAst.translateToCAst();
+          final CAstEntity fileEntity = xlatorToCAst.translateToCAst();
 
           if (DEBUG) {
             CAstPrinter.printTo(fileEntity, new PrintWriter(System.err));

--- a/cast/src/main/java/com/ibm/wala/cast/util/SourceBuffer.java
+++ b/cast/src/main/java/com/ibm/wala/cast/util/SourceBuffer.java
@@ -103,7 +103,7 @@ public class SourceBuffer {
     try (Reader pr = p.getReader()) {
       try (BufferedReader reader = new BufferedReader(pr)) {
 
-        String currentLine = null;
+        String currentLine;
         List<String> lines = new ArrayList<>();
         int offset = 0, line = 0;
         do {
@@ -123,7 +123,7 @@ public class SourceBuffer {
         int endColumn = -1;
         int startOffset = -1;
         int startLine = line;
-        int startColumn = -1;
+        final int startColumn;
         if (p.getLastOffset() >= 0) {
           if (p.getFirstOffset() == offset) {
             startOffset = p.getFirstOffset();

--- a/core/src/main/java/com/ibm/wala/analysis/arraybounds/hypergraph/weight/NormalOrder.java
+++ b/core/src/main/java/com/ibm/wala/analysis/arraybounds/hypergraph/weight/NormalOrder.java
@@ -13,7 +13,7 @@ public class NormalOrder implements Comparator<Weight> {
 
   @Override
   public int compare(Weight o1, Weight o2) {
-    int result = 0;
+    final int result;
 
     if (o1.getType() == Type.NOT_SET || o2.getType() == Type.NOT_SET) {
       throw new IllegalArgumentException("Tried to compare weights, which are not set yet.");

--- a/core/src/main/java/com/ibm/wala/analysis/arraybounds/hypergraph/weight/Weight.java
+++ b/core/src/main/java/com/ibm/wala/analysis/arraybounds/hypergraph/weight/Weight.java
@@ -39,7 +39,7 @@ public class Weight {
    * @return this + other
    */
   public Weight add(Weight other) {
-    Weight result = null;
+    final Weight result;
     if (this.getType() == Type.NUMBER) {
       if (other.getType() == Type.NUMBER) {
         result = new Weight(Type.NUMBER, this.getNumber() + other.getNumber());

--- a/core/src/main/java/com/ibm/wala/analysis/exceptionanalysis/ExceptionTransferFunctionProvider.java
+++ b/core/src/main/java/com/ibm/wala/analysis/exceptionanalysis/ExceptionTransferFunctionProvider.java
@@ -71,7 +71,6 @@ public class ExceptionTransferFunctionProvider
      */
 
     Iterator<CallSiteReference> callsites = cg.getPossibleSites(src, dst);
-    BitVector filtered = new BitVector(transformer.getValues().getSize());
 
     if (callsites.hasNext()) {
 
@@ -84,7 +83,7 @@ public class ExceptionTransferFunctionProvider
         caught.retainAll(intraResult.getAnalysis(src).getCaughtExceptions(callsite));
       }
 
-      filtered = transformer.computeBitVector(caught);
+      BitVector filtered = transformer.computeBitVector(caught);
       return new BitVectorMinusVector(filtered);
     } else {
       // This case should not happen, as we should only get src, dst pairs,

--- a/core/src/main/java/com/ibm/wala/analysis/reflection/CloneInterpreter.java
+++ b/core/src/main/java/com/ibm/wala/analysis/reflection/CloneInterpreter.java
@@ -162,7 +162,7 @@ public class CloneInterpreter implements SSAContextInterpreter {
     int retValue = nextLocal++;
     // value number of the result of the clone()
     NewSiteReference ref = NewSiteReference.make(NEW_PC, klass.getReference());
-    SSANewInstruction N = null;
+    final SSANewInstruction N;
     if (klass.isArrayClass()) {
       int length = nextLocal++;
       statements.add(insts.ArrayLengthInstruction(statements.size(), length, 1));

--- a/core/src/main/java/com/ibm/wala/analysis/reflection/FactoryBypassInterpreter.java
+++ b/core/src/main/java/com/ibm/wala/analysis/reflection/FactoryBypassInterpreter.java
@@ -532,7 +532,7 @@ public class FactoryBypassInterpreter extends AbstractReflectionInterpreter {
         typesAllocated.add(T);
         int i = getLocalForType(T);
         NewSiteReference ref = NewSiteReference.make(getNewSiteForType(T), T);
-        SSANewInstruction a = null;
+        final SSANewInstruction a;
         if (T.isArrayType()) {
           int[] sizes = new int[((ArrayClass) klass).getDimensionality()];
           initValueNumberForConstantOne();

--- a/core/src/main/java/com/ibm/wala/analysis/reflection/ReflectiveInvocationInterpreter.java
+++ b/core/src/main/java/com/ibm/wala/analysis/reflection/ReflectiveInvocationInterpreter.java
@@ -175,7 +175,7 @@ public class ReflectiveInvocationInterpreter extends AbstractReflectionInterpret
     // pointer
     int args[] = new int[nargs];
     int pc = 0;
-    int parametersVn = -1; // parametersVn will hold the value number of parameters array
+    final int parametersVn; // parametersVn will hold the value number of parameters array
 
     if (method.getReference().equals(CTOR_NEW_INSTANCE)) {
       // allocate the new object constructed
@@ -239,7 +239,7 @@ public class ReflectiveInvocationInterpreter extends AbstractReflectionInterpret
     }
 
     int exceptions = nextLocal++;
-    int result = -1;
+    final int result;
 
     // emit the dispatch and return instructions
     if (method.getReference().equals(CTOR_NEW_INSTANCE)) {

--- a/core/src/main/java/com/ibm/wala/analysis/typeInference/TypeInference.java
+++ b/core/src/main/java/com/ibm/wala/analysis/typeInference/TypeInference.java
@@ -646,7 +646,7 @@ public class TypeInference extends SSAInference<TypeVariable> implements FixedPo
       Iterator<TypeReference> it = bb.getCaughtExceptionTypes();
       TypeReference t = it.next();
       IClass klass = cha.lookupClass(t);
-      TypeAbstraction result = null;
+      TypeAbstraction result;
       if (klass == null) {
         // a type that cannot be loaded.
         // be pessimistic

--- a/core/src/main/java/com/ibm/wala/classLoader/BytecodeClass.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/BytecodeClass.java
@@ -211,7 +211,7 @@ public abstract class BytecodeClass<T extends IClassLoader> implements IClass {
 
   @Override
   public IField getField(Atom name, TypeName type) {
-    boolean unresolved = false;
+    boolean unresolved;
     try {
       // typically, there will be at most one field with the name
       IField field = getField(name);
@@ -452,7 +452,7 @@ public abstract class BytecodeClass<T extends IClassLoader> implements IClass {
 
     // at this point result holds all interfaces the class directly extends.
     // now expand to a fixed point.
-    Set<IClass> last = null;
+    Set<IClass> last;
     do {
       last = HashSetFactory.make(result);
       for (IClass i : last) {
@@ -519,7 +519,7 @@ public abstract class BytecodeClass<T extends IClassLoader> implements IClass {
       Collection<Annotation> annotations,
       Collection<TypeAnnotation> typeAnnotations,
       TypeSignature sig) {
-    TypeName T = null;
+    final TypeName T;
     if (fieldType.get(fieldType.length() - 1) == ';') {
       T = TypeName.findOrCreate(fieldType, 0, fieldType.length() - 1);
     } else {

--- a/core/src/main/java/com/ibm/wala/classLoader/ClassLoaderImpl.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/ClassLoaderImpl.java
@@ -291,7 +291,7 @@ public class ClassLoaderImpl implements IClassLoader {
     Map<String, Object> result = HashMapFactory.make();
     try (final JarInputStream s =
         new JarInputStream(new ByteArrayInputStream(jarFileContents), false)) {
-      JarEntry entry = null;
+      JarEntry entry;
       while ((entry = s.getNextJarEntry()) != null) {
         byte[] entryBytes = getEntryBytes(entrySizesForFile.get(entry.getName()), s);
         if (entryBytes == null) {

--- a/core/src/main/java/com/ibm/wala/classLoader/ShrikeCTMethod.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/ShrikeCTMethod.java
@@ -269,7 +269,7 @@ public final class ShrikeCTMethod extends ShrikeBTMethod implements IBytecodeMet
 
   @Override
   public String getLocalVariableName(int bcIndex, int localNumber) {
-    int[][] map = null;
+    final int[][] map;
     try {
       map = getBCInfo().localVariableMap;
     } catch (InvalidClassFileException e1) {

--- a/core/src/main/java/com/ibm/wala/classLoader/ShrikeIRFactory.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/ShrikeIRFactory.java
@@ -46,7 +46,7 @@ public class ShrikeIRFactory implements IRFactory<IBytecodeMethod<IInstruction>>
     if (method == null) {
       throw new IllegalArgumentException("null method");
     }
-    com.ibm.wala.shrike.shrikeBT.IInstruction[] shrikeInstructions = null;
+    final com.ibm.wala.shrike.shrikeBT.IInstruction[] shrikeInstructions;
     try {
       shrikeInstructions = method.getInstructions();
     } catch (InvalidClassFileException e) {

--- a/core/src/main/java/com/ibm/wala/core/util/shrike/ShrikeUtil.java
+++ b/core/src/main/java/com/ibm/wala/core/util/shrike/ShrikeUtil.java
@@ -51,7 +51,7 @@ public class ShrikeUtil implements BytecodeConstants {
       return p;
     }
     ImmutableByteArray b = ImmutableByteArray.make(type);
-    TypeName T = null;
+    final TypeName T;
     /*if (b.get(0) != '[') {
       T = TypeName.findOrCreate(b, 0, b.length() - 1);
     } else {*/

--- a/core/src/main/java/com/ibm/wala/core/util/strings/StringStuff.java
+++ b/core/src/main/java/com/ibm/wala/core/util/strings/StringStuff.java
@@ -274,7 +274,7 @@ public class StringStuff {
             while (StringStuff.isTypeCodeChar(b, i)) {
               ++i;
             }
-            TypeName T = null;
+            final TypeName T;
             byte c = b.get(i++);
             if (c == TypeReference.ClassTypeCode || c == TypeReference.OtherPrimitiveTypeCode) {
               while (b.get(i++) != ';')

--- a/core/src/main/java/com/ibm/wala/dataflow/IFDS/TabulationSolver.java
+++ b/core/src/main/java/com/ibm/wala/dataflow/IFDS/TabulationSolver.java
@@ -550,7 +550,7 @@ public class TabulationSolver<T, P, F> {
       if (DEBUG_LEVEL > 0) {
         System.err.println(" process return site: " + returnSite);
       }
-      IUnaryFlowFunction f = null;
+      final IUnaryFlowFunction f;
       if (hasCallee) {
         f = flowFunctionMap.getCallToReturnFlowFunction(edge.target, returnSite);
       } else {

--- a/core/src/main/java/com/ibm/wala/demandpa/alg/ContextSensitiveStateMachine.java
+++ b/core/src/main/java/com/ibm/wala/demandpa/alg/ContextSensitiveStateMachine.java
@@ -175,7 +175,7 @@ public class ContextSensitiveStateMachine implements StateMachine<IFlowLabel> {
           System.err.println("FOUND RECURSION");
           System.err.println("stack " + prevStack + " contains " + callSite);
         }
-        CallerSiteContext topCallSite = null;
+        CallerSiteContext topCallSite;
         CallStack tmpStack = prevStack;
         // mark the appropriate call sites as recursive
         // and pop them

--- a/core/src/main/java/com/ibm/wala/demandpa/alg/DemandRefinementPointsTo.java
+++ b/core/src/main/java/com/ibm/wala/demandpa/alg/DemandRefinementPointsTo.java
@@ -330,12 +330,11 @@ public class DemandRefinementPointsTo extends AbstractDemandPointsTo {
       setNumNodesTraversed(0);
       setTraversalBudget(refinementPolicy.getBudgetForPass(passNum));
       Collection<InstanceKeyAndState> curP2Set = null;
-      PointsToComputer computer = null;
       boolean completedPassInBudget = false;
       try {
         while (true) {
           try {
-            computer = new PointsToComputer(queried);
+            final PointsToComputer computer = new PointsToComputer(queried);
             computer.compute();
             curP2Set = computer.getComputedP2Set(queried);
             // System.err.println("completed pass");
@@ -382,7 +381,7 @@ public class DemandRefinementPointsTo extends AbstractDemandPointsTo {
         break;
       }
     }
-    PointsToResult result = null;
+    final PointsToResult result;
     if (succeeded) {
       result = PointsToResult.SUCCESS;
     } else if (passNum == numPasses) {
@@ -491,7 +490,7 @@ public class DemandRefinementPointsTo extends AbstractDemandPointsTo {
         break;
       }
     }
-    PointsToResult result = null;
+    final PointsToResult result;
     if (succeeded) {
       result = PointsToResult.SUCCESS;
     } else if (passNum == numPasses) {
@@ -572,7 +571,7 @@ public class DemandRefinementPointsTo extends AbstractDemandPointsTo {
       setNumNodesTraversed(0);
       setTraversalBudget(refinementPolicy.getBudgetForPass(passNum));
       Collection<PointerKeyAndState> curFlowsToSet = null;
-      FlowsToComputer computer = null;
+      FlowsToComputer computer;
       try {
         while (true) {
           try {
@@ -619,7 +618,7 @@ public class DemandRefinementPointsTo extends AbstractDemandPointsTo {
         break;
       }
     }
-    PointsToResult result = null;
+    final PointsToResult result;
     if (succeeded) {
       result = PointsToResult.SUCCESS;
     } else if (passNum == numPasses) {
@@ -2433,7 +2432,7 @@ public class DemandRefinementPointsTo extends AbstractDemandPointsTo {
             return null;
           }
           IR ir = node.getIR();
-          PointerKey base = null, stored = null;
+          final PointerKey base, stored;
           if (field == ArrayContents.v()) {
             final SSAInstruction instruction =
                 ir.getInstructions()[fieldWrite.getInstructionIndex()];

--- a/core/src/main/java/com/ibm/wala/demandpa/flowgraph/AbstractDemandFlowGraph.java
+++ b/core/src/main/java/com/ibm/wala/demandpa/flowgraph/AbstractDemandFlowGraph.java
@@ -346,7 +346,7 @@ public abstract class AbstractDemandFlowGraph extends AbstractFlowGraph {
 
   @Override
   public Set<CallerSiteContext> getPotentialCallers(PointerKey formalPk) {
-    CGNode callee = null;
+    final CGNode callee;
     if (formalPk instanceof LocalPointerKey) {
       callee = ((LocalPointerKey) formalPk).getNode();
     } else if (formalPk instanceof ReturnValueKey) {

--- a/core/src/main/java/com/ibm/wala/examples/drivers/PDFSlice.java
+++ b/core/src/main/java/com/ibm/wala/examples/drivers/PDFSlice.java
@@ -170,7 +170,7 @@ public class PDFSlice {
       System.err.println("Statement: " + s);
 
       // compute the slice as a collection of statements
-      Collection<Statement> slice = null;
+      final Collection<Statement> slice;
       if (goBackward) {
         final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
         slice = Slicer.computeBackwardSlice(s, cg, pointerAnalysis, dOptions, cOptions);

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/AbstractRootMethod.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/AbstractRootMethod.java
@@ -149,7 +149,7 @@ public abstract class AbstractRootMethod extends SyntheticMethod {
     CallSiteReference newSite =
         CallSiteReference.make(
             statements.size(), site.getDeclaredTarget(), site.getInvocationCode());
-    SSAAbstractInvokeInstruction s = null;
+    final SSAAbstractInvokeInstruction s;
     if (newSite.getDeclaredTarget().getReturnType().equals(TypeReference.Void)) {
       s = insts.InvokeInstruction(statements.size(), params, nextLocal++, newSite, null);
     } else {
@@ -238,7 +238,7 @@ public abstract class AbstractRootMethod extends SyntheticMethod {
           // allocate an instance for the array contents
           NewSiteReference n = NewSiteReference.make(statements.size(), e);
           int alloc = nextLocal++;
-          SSANewInstruction ni = null;
+          final SSANewInstruction ni;
           if (e.isArrayType()) {
             int[] sizes = new int[((ArrayClass) cha.lookupClass(T)).getDimensionality()];
             Arrays.fill(sizes, getValueNumberForIntConstant(1));

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationCallGraphBuilder.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationCallGraphBuilder.java
@@ -1331,7 +1331,7 @@ public abstract class PropagationCallGraphBuilder implements CallGraphBuilder<In
    */
   @SuppressWarnings("unused")
   protected IntSet filterForClass(IntSet S, IClass klass) {
-    MutableIntSet filter = null;
+    final MutableIntSet filter;
     if (klass.getReference().equals(TypeReference.JavaLangObject)) {
       return S;
     } else {

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationGraph.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationGraph.java
@@ -103,7 +103,7 @@ public class PropagationGraph implements IFixedPointSystem<PointsToSetVariable> 
    * @return a Relation object to track implicit equations using the operator
    */
   private static IBinaryNaturalRelation makeRelation(AbstractOperator<PointsToSetVariable> op) {
-    byte[] implementation = null;
+    final byte[] implementation;
     if (op instanceof AssignOperator) {
       // lots of assignments.
       implementation =

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationSystem.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationSystem.java
@@ -470,8 +470,7 @@ public class PropagationSystem extends DefaultFixedPointSolver<PointsToSetVariab
 
     for (int i = 1; i < dim; i++) {
       TypeReference jlo = makeArray(TypeReference.JavaLangObject, i);
-      IClass jloClass = null;
-      jloClass = aClass.getClassLoader().lookupClass(jlo.getName());
+      final IClass jloClass = aClass.getClassLoader().lookupClass(jlo.getName());
       MutableIntSet set = findOrCreateSparseSetForClass(jloClass);
       set.add(index);
     }

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/TypeBasedPointerAnalysis.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/TypeBasedPointerAnalysis.java
@@ -102,7 +102,7 @@ public class TypeBasedPointerAnalysis extends AbstractPointerAnalysis {
 
   /** Compute the set of {@link InstanceKey}s which may represent a particular type. */
   private OrdinalSet<InstanceKey> computeOrdinalInstanceSet(IClass type) {
-    Collection<IClass> klasses = null;
+    final Collection<IClass> klasses;
     if (type.isInterface()) {
       klasses = getCallGraph().getClassHierarchy().getImplementors(type.getReference());
     } else {

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/BypassMethodTargetSelector.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/BypassMethodTargetSelector.java
@@ -160,7 +160,7 @@ public class BypassMethodTargetSelector implements MethodTargetSelector {
     if (syntheticMethods.containsKey(m)) {
       return syntheticMethods.get(m);
     } else {
-      MethodSummary summ = null;
+      final MethodSummary summ;
       if (canIgnore(m)) {
         TypeReference T = m.getDeclaringClass();
         IClass C = cha.lookupClass(T);
@@ -199,7 +199,7 @@ public class BypassMethodTargetSelector implements MethodTargetSelector {
     if (syntheticMethods.containsKey(ref)) {
       return syntheticMethods.get(ref);
     } else {
-      MethodSummary summ = null;
+      final MethodSummary summ;
       if (canIgnore(ref)) {
         summ = generateNoOp(ref, isStatic);
       } else {

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/XMLMethodSummaryReader.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/XMLMethodSummaryReader.java
@@ -538,7 +538,7 @@ public class XMLMethodSummaryReader implements BytecodeConstants {
       // create the allocation statement and add it to the method summary
       NewSiteReference ref = NewSiteReference.make(governingMethod.getNumberOfStatements(), type);
 
-      SSANewInstruction a = null;
+      final SSANewInstruction a;
       if (type.isArrayType()) {
         String size = atts.getValue(A_SIZE);
         Assertions.productionAssertion(size != null);

--- a/core/src/main/java/com/ibm/wala/properties/WalaProperties.java
+++ b/core/src/main/java/com/ibm/wala/properties/WalaProperties.java
@@ -71,7 +71,7 @@ public final class WalaProperties {
    * @see PlatformUtil#getJDKModules(boolean)
    */
   public static String[] getJDKLibraryFiles(boolean justBase) {
-    Properties p = null;
+    final Properties p;
     try {
       p = WalaProperties.loadProperties();
     } catch (WalaException e) {
@@ -97,7 +97,7 @@ public final class WalaProperties {
    * @throws IllegalStateException if the J2EE_DIR property is not set
    */
   public static String[] getJ2EEJarFiles() {
-    Properties p = null;
+    final Properties p;
     try {
       p = WalaProperties.loadProperties();
     } catch (WalaException e) {

--- a/core/src/main/java/com/ibm/wala/ssa/SSABuilder.java
+++ b/core/src/main/java/com/ibm/wala/ssa/SSABuilder.java
@@ -222,7 +222,7 @@ public class SSABuilder extends AbstractIntStackMachine {
     private boolean allTheSame(int[] rhs) {
       int x = -1;
       // set x := the first non-TOP value
-      int i = 0;
+      int i;
       for (i = 0; i < rhs.length; i++) {
         if (rhs[i] != TOP) {
           x = rhs[i];

--- a/core/src/main/java/com/ibm/wala/ssa/SSACFG.java
+++ b/core/src/main/java/com/ibm/wala/ssa/SSACFG.java
@@ -163,7 +163,7 @@ public class SSACFG
 
   private void recordExceptionTypes(Set<ExceptionHandler> set, IClassLoader loader) {
     for (ExceptionHandler handler : set) {
-      TypeReference t = null;
+      final TypeReference t;
       if (handler.getCatchClass() == null) {
         // by convention, in ShrikeCT this means catch everything
         t = TypeReference.JavaLangThrowable;

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexIMethod.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexIMethod.java
@@ -905,7 +905,7 @@ public class DexIMethod implements IBytecodeMethod<Instruction> {
     //  System.out.println("debug here");
 
     instructions = new InstructionArray();
-    int instLoc = 0;
+    int instLoc;
     int instCounter = -1;
     // int pc = 0;
     int currentCodeAddress = 0;

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexUtil.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexUtil.java
@@ -197,7 +197,7 @@ public class DexUtil {
 
   static TypeName getTypeName(String fieldType) {
     ImmutableByteArray fieldTypeArray = ImmutableByteArray.make(fieldType);
-    TypeName T = null;
+    final TypeName T;
     if (fieldTypeArray.get(fieldTypeArray.length() - 1) == ';') {
       T = TypeName.findOrCreate(fieldTypeArray, 0, fieldTypeArray.length() - 1);
     } else {

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/AndroidModelParameterManager.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/AndroidModelParameterManager.java
@@ -100,7 +100,7 @@ public class AndroidModelParameterManager {
   private int currentScope = 0;
 
   /** For checking if type is CREATE or REUSE (optional) */
-  private IInstantiationBehavior behaviour = null;
+  private final IInstantiationBehavior behaviour;
 
   /** Description only used for toString() */
   private String description;

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/AbstractAndroidModel.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/AbstractAndroidModel.java
@@ -76,10 +76,10 @@ public abstract class AbstractAndroidModel {
   private static final Logger logger = LoggerFactory.getLogger(AbstractAndroidModel.class);
 
   private ExecutionOrder currentSection = null;
-  protected VolatileMethodSummary body = null;
-  protected TypeSafeInstructionFactory insts = null;
-  protected SSAValueManager paramManager = null;
-  protected Iterable<? extends Entrypoint> entryPoints = null;
+  protected VolatileMethodSummary body;
+  protected TypeSafeInstructionFactory insts;
+  protected SSAValueManager paramManager;
+  protected Iterable<? extends Entrypoint> entryPoints;
   private IExecutionOrder lastQueriedMethod = null; // Used for sanity checks only
 
   //

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ssa/DexSSABuilder.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ssa/DexSSABuilder.java
@@ -245,7 +245,7 @@ public class DexSSABuilder extends AbstractIntRegisterMachine {
     private boolean allTheSame(int[] rhs) {
       int x = -1;
       // set x := the first non-TOP value
-      int i = 0;
+      int i;
       for (i = 0; i < rhs.length; i++) {
         if (rhs[i] != TOP) {
           x = rhs[i];

--- a/ide/jdt/src/main/java/com/ibm/wala/ide/util/JdtUtil.java
+++ b/ide/jdt/src/main/java/com/ibm/wala/ide/util/JdtUtil.java
@@ -290,7 +290,7 @@ public class JdtUtil {
     if (projects == null) {
       throw new IllegalArgumentException("null projects");
     }
-    IType type = null;
+    final IType type;
     try {
       type = findJavaClassInProjects(klass, projects);
     } catch (Throwable t) {

--- a/scandroid/src/main/java/org/scandroid/model/AppModelMethod.java
+++ b/scandroid/src/main/java/org/scandroid/model/AppModelMethod.java
@@ -311,7 +311,7 @@ public class AppModelMethod {
   private SSANewInstruction processAllocation(TypeReference tr, Integer i, boolean isInner) {
     // create the allocation statement and add it to the method summary
     NewSiteReference ref = NewSiteReference.make(methodSummary.getNumberOfStatements(), tr);
-    SSANewInstruction a = null;
+    final SSANewInstruction a;
 
     if (tr.isArrayType()) {
       int[] sizes = new int[((ArrayClass) cha.lookupClass(tr)).getDimensionality()];
@@ -335,7 +335,7 @@ public class AppModelMethod {
         // allocate an instance for the array contents
         NewSiteReference n = NewSiteReference.make(methodSummary.getNumberOfStatements(), e);
         int alloc = nextLocal++;
-        SSANewInstruction ni = null;
+        final SSANewInstruction ni;
         if (e.isArrayType()) {
           int[] sizes = new int[((ArrayClass) cha.lookupClass(tr)).getDimensionality()];
           Arrays.fill(sizes, getValueNumberForIntConstant(1));
@@ -432,7 +432,7 @@ public class AppModelMethod {
             methodSummary.getNumberOfStatements(),
             site.getDeclaredTarget(),
             site.getInvocationCode());
-    SSAAbstractInvokeInstruction s = null;
+    final SSAAbstractInvokeInstruction s;
     if (newSite.getDeclaredTarget().getReturnType().equals(TypeReference.Void)) {
       s =
           insts.InvokeInstruction(

--- a/scandroid/src/main/java/org/scandroid/prefixtransfer/PrefixTransferGraph.java
+++ b/scandroid/src/main/java/org/scandroid/prefixtransfer/PrefixTransferGraph.java
@@ -105,7 +105,7 @@ public class PrefixTransferGraph implements Graph<InstanceKeySite> {
         }
       }
     }
-    InstanceKeySite node = null;
+    InstanceKeySite node;
     for (InstanceKey k : instanceKeys) {
       // create a node for each InstanceKey of type string
       if (k.getConcreteType().getName().toString().equals("Ljava/lang/String")) {

--- a/scandroid/src/main/java/org/scandroid/util/DexDotUtil.java
+++ b/scandroid/src/main/java/org/scandroid/util/DexDotUtil.java
@@ -261,7 +261,7 @@ public class DexDotUtil extends DotUtil {
   }
 
   private static <T> String getLabel(T o, NodeDecorator<T> d) throws WalaException {
-    String result = null;
+    String result;
     if (d == null) {
       // result = o.toString();
       result = cleanUpString(o.toString());

--- a/scandroid/src/main/java/org/scandroid/util/EntryPoints.java
+++ b/scandroid/src/main/java/org/scandroid/util/EntryPoints.java
@@ -171,7 +171,6 @@ public class EntryPoints {
     // String pathToJava = new String(System.getProperty("java.home").replace(" ", "\\ ") +
     // File.separator + "bin" + File.separator);
     pathToJava = System.getProperty("java.home") + File.separator + "bin" + File.separator;
-    String s = null;
 
     // String command = new String(pathToJava + "java -jar " + pathToApkTool + "apktool.jar d -f " +
     // pathToApkFile + " " + pathToApkTool + tempFolder);
@@ -196,7 +195,7 @@ public class EntryPoints {
       BufferedReader stdError = new BufferedReader(new InputStreamReader(p.getErrorStream()));
 
       // read the output from the command
-
+      String s;
       while ((s = stdInput.readLine()) != null) {}
 
       // read any errors from the attempted command
@@ -291,8 +290,8 @@ public class EntryPoints {
 
   @SuppressWarnings("unused")
   private void populateEntryPoints(ClassHierarchy cha) {
-    String method = null;
-    IMethod im = null;
+    String method;
+    IMethod im;
     for (String[] intent : ActivityIntentList) {
       // method = IntentToMethod(intent[0]);
       method = "onCreate(Landroid/os/Bundle;)V";

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/shrikeCT/ClassInstrumenter.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/shrikeCT/ClassInstrumenter.java
@@ -351,7 +351,7 @@ public final class ClassInstrumenter {
 
   private LineNumberTableWriter makeNewLines(
       ClassWriter w, CodeReader oldCode, Compiler.Output output) throws InvalidClassFileException {
-    int[] newLineMap = null;
+    final int[] newLineMap;
     int[] oldLineMap = LineNumberTableReader.makeBytecodeToSourceMap(oldCode);
     if (oldLineMap != null) {
       // Map the old line number map onto the new bytecodes

--- a/util/src/main/java/com/ibm/wala/util/collections/ImmutableStack.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/ImmutableStack.java
@@ -114,7 +114,7 @@ public class ImmutableStack<T> implements Iterable<T> {
       return emptyStack();
     }
     int size = entries.length + 1;
-    T[] tmpEntries = null;
+    final T[] tmpEntries;
     if (isWithinSizeLimit(size)) {
       tmpEntries = makeInternalArray(size);
       System.arraycopy(entries, 0, tmpEntries, 0, entries.length);
@@ -237,7 +237,7 @@ public class ImmutableStack<T> implements Iterable<T> {
       throw new IllegalArgumentException("null other");
     }
     int size = entries.length + other.entries.length;
-    T[] tmpEntries = null;
+    final T[] tmpEntries;
     if (isWithinSizeLimit(size)) {
       tmpEntries = (T[]) new Object[size];
       System.arraycopy(entries, 0, tmpEntries, 0, entries.length);

--- a/util/src/main/java/com/ibm/wala/util/collections/SparseVector.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/SparseVector.java
@@ -34,7 +34,7 @@ public class SparseVector<T> implements IVector<T>, Serializable {
   private static final int DEF_INITIAL_SIZE = 5;
 
   /** if indices[i] = x, then data[i] == get(x) */
-  private MutableSparseIntSet indices = MutableSparseIntSet.makeEmpty();
+  private MutableSparseIntSet indices;
 
   private Object[] data;
 

--- a/util/src/main/java/com/ibm/wala/util/graph/GraphIntegrity.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/GraphIntegrity.java
@@ -101,11 +101,11 @@ public class GraphIntegrity {
 
   @SuppressWarnings("unused")
   private static <T> void checkNodeCount(Graph<T> G) throws UnsoundGraphException {
-    int n1 = 0;
-    int n2 = 0;
-    int n3 = 0;
-    int n4 = 0;
-    int n5 = 0;
+    final int n1;
+    int n2;
+    final int n3;
+    final int n4;
+    final int n5;
     try {
       n1 = G.getNumberOfNodes();
       n2 = 0;

--- a/util/src/main/java/com/ibm/wala/util/intset/BasicNaturalRelation.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/BasicNaturalRelation.java
@@ -233,7 +233,7 @@ public final class BasicNaturalRelation implements IBinaryNaturalRelation, Seria
     @NullUnmarked
     @Override
     public IntPair next() {
-      IntPair result = null;
+      final IntPair result;
       if (nextIndex == smallStore.length) {
         int y = delegateIterator.next();
         result = new IntPair(nextX, y);

--- a/util/src/main/java/com/ibm/wala/util/intset/BitVector.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/BitVector.java
@@ -349,9 +349,7 @@ public class BitVector extends BitVectorBase<BitVector> {
     if (vector == null) {
       throw new IllegalArgumentException("null vector");
     }
-    int ai = 0;
-    int bi = 0;
-    for (ai = 0, bi = 0; ai < bits.length && bi < vector.bits.length; ai++, bi++) {
+    for (int ai = 0, bi = 0; ai < bits.length && bi < vector.bits.length; ai++, bi++) {
       bits[ai] &= ~vector.bits[bi];
     }
   }

--- a/util/src/main/java/com/ibm/wala/util/intset/BitVectorBase.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/BitVectorBase.java
@@ -95,7 +95,7 @@ public abstract class BitVectorBase<T extends BitVectorBase> implements Cloneabl
   @Override
   @SuppressWarnings("unchecked")
   public Object clone() {
-    BitVectorBase<T> result = null;
+    final BitVectorBase<T> result;
     try {
       result = (BitVectorBase<T>) super.clone();
     } catch (CloneNotSupportedException e) {

--- a/util/src/main/java/com/ibm/wala/util/intset/FixedSizeBitVector.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/FixedSizeBitVector.java
@@ -300,7 +300,7 @@ public final class FixedSizeBitVector implements Cloneable, java.io.Serializable
   /** Clones the FixedSizeBitVector. */
   @Override
   public Object clone() {
-    FixedSizeBitVector result = null;
+    final FixedSizeBitVector result;
     try {
       result = (FixedSizeBitVector) super.clone();
     } catch (CloneNotSupportedException e) {

--- a/util/src/main/java/com/ibm/wala/util/intset/MutableMapping.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/MutableMapping.java
@@ -38,7 +38,7 @@ public class MutableMapping<T> implements OrdinalSetMapping<T>, Serializable {
 
   private Object[] array;
 
-  private int nextIndex = 0;
+  private int nextIndex;
 
   /** A mapping from object to Integer. */
   final HashMap<T, Integer> map = HashMapFactory.make();

--- a/util/src/main/java/com/ibm/wala/util/viz/DotUtil.java
+++ b/util/src/main/java/com/ibm/wala/util/viz/DotUtil.java
@@ -268,7 +268,7 @@ public class DotUtil {
   }
 
   private static <T> String getLabel(T n, NodeDecorator<T> d) throws WalaException {
-    String result = null;
+    String result;
     if (d == null) {
       result = n.toString();
     } else {


### PR DESCRIPTION
In most of these cases, the initializer is redundant because some other assignment to the same location appears after the initialization but before any use.

In a few cases involving fields, the explicit initialization value is identical to what would be used implicitly.