### PR TITLE
Avoid using doFirst to postpone setting task inputs

### DIFF
--- a/cast/build.gradle.kts
+++ b/cast/build.gradle.kts
@@ -58,12 +58,12 @@ artifacts.add(
 tasks.named<Javadoc>("javadoc") {
   inputs.files(castJsPackageListDirectory)
 
-  inputs.property("extdocURL", castJsJavadocDestinationDirectory.singleFile)
-  inputs.property("packagelistLoc", castJsPackageListDirectory.singleFile)
-  doFirst {
-    (options as StandardJavadocDocletOptions).linksOffline(
-        inputs.properties["extdocURL"].toString(), inputs.properties["packagelistLoc"].toString())
-  }
+  val extdocURL = castJsJavadocDestinationDirectory.singleFile
+  val packagelistLoc = castJsPackageListDirectory.singleFile
+  inputs.property("extdocURL", extdocURL)
+  inputs.property("packagelistLoc", packagelistLoc)
+  (options as StandardJavadocDocletOptions).linksOffline(
+      extdocURL.toString(), packagelistLoc.toString())
 }
 
 tasks.named<Test>("test") {

--- a/cast/build.gradle.kts
+++ b/cast/build.gradle.kts
@@ -68,8 +68,7 @@ tasks.named<Javadoc>("javadoc") {
 
 tasks.named<Test>("test") {
   inputs.files(xlatorTestSharedLibrary)
-  val xlatorTestSharedLibrary = xlatorTestSharedLibrary.singleFile
-  doFirst { systemProperty("java.library.path", xlatorTestSharedLibrary.parent) }
+  systemProperty("java.library.path", xlatorTestSharedLibrary.singleFile.parent)
 
   if (rootProject.extra["isWindows"] as Boolean) {
 

--- a/cast/smoke_main/build.gradle.kts
+++ b/cast/smoke_main/build.gradle.kts
@@ -86,7 +86,12 @@ application {
 
                       // main executable to run for test
                       inputs.file(linkedFile)
-                      doFirst { executable(linkedFile.get().asFile) }
+                      executable(
+                          object {
+                            val toString by lazy { linkedFile.get().asFile.toString() }
+
+                            override fun toString() = toString
+                          })
 
                       // xlator Java bytecode + implementation of native methods
                       val pathElements = project.objects.listProperty<File>()


### PR DESCRIPTION
For precise caching, task inputs should be set during task configuration. If we use `doFirst` to postpone setting inputs until task execution, then we're preventing the cache from seeing an accurate representation of the task's real inputs.