### PR TITLE
Don't call toString unless actually needed

### DIFF
--- a/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestLexicalModRef.java
+++ b/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestLexicalModRef.java
@@ -68,7 +68,7 @@ public abstract class TestLexicalModRef {
                       .equals(rv.toString())
                   || "[Node: <Code body of function Ltests/simple-lexical.js/outer> Context: Everywhere,z]"
                       .equals(rv.toString()),
-              rv.toString());
+              rv::toString);
         }
       }
     }

--- a/cast/src/test/java/com/ibm/wala/cast/test/TestCAstTranslator.java
+++ b/cast/src/test/java/com/ibm/wala/cast/test/TestCAstTranslator.java
@@ -184,7 +184,7 @@ public abstract class TestCAstTranslator {
         assertEquals(
             "super of " + cls.getName() + " is " + cls.getSuperclass().getName(),
             supers.get(cls.getName().toString()),
-            cls.getSuperclass().getName().toString());
+            () -> cls.getSuperclass().getName().toString());
       }
 
       for (Object name2 : cls.getDeclaredInstanceFields()) {

--- a/core/src/test/java/com/ibm/wala/core/tests/cha/MissingSuperTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/cha/MissingSuperTest.java
@@ -68,7 +68,7 @@ public class MissingSuperTest extends WalaTestCase {
     assertNotNull(klass, "expected class MissingSuper to load");
     IAnalysisCacheView cache = new AnalysisCacheImpl();
     Collection<? extends IMethod> declaredMethods = klass.getDeclaredMethods();
-    assertEquals(2, declaredMethods.size(), declaredMethods.toString());
+    assertEquals(2, declaredMethods.size(), declaredMethods::toString);
     for (IMethod m : declaredMethods) {
       // should succeed
       cache.getIR(m);

--- a/core/src/test/java/com/ibm/wala/core/tests/slicer/SlicerTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/slicer/SlicerTest.java
@@ -185,7 +185,7 @@ public class SlicerTest {
     Collection<Statement> slice = computeBackwardSlice;
     SlicerUtil.dumpSlice(slice);
 
-    assertEquals(9, SlicerUtil.countNormals(slice), slice.toString());
+    assertEquals(9, SlicerUtil.countNormals(slice), slice::toString);
   }
 
   @Test
@@ -211,7 +211,7 @@ public class SlicerTest {
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     SlicerUtil.dumpSlice(slice);
-    assertEquals(1, SlicerUtil.countAllocations(slice, false), slice.toString());
+    assertEquals(1, SlicerUtil.countAllocations(slice, false), slice::toString);
   }
 
   @Test
@@ -238,7 +238,7 @@ public class SlicerTest {
         Slicer.computeForwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     SlicerUtil.dumpSlice(slice);
-    assertEquals(4, slice.size(), slice.toString());
+    assertEquals(4, slice.size(), slice::toString);
   }
 
   @Test
@@ -265,7 +265,7 @@ public class SlicerTest {
         Slicer.computeForwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     SlicerUtil.dumpSlice(slice);
-    assertEquals(7, slice.size(), slice.toString());
+    assertEquals(7, slice.size(), slice::toString);
   }
 
   /** test unreproduced bug reported on mailing list by Sameer Madan, 7/3/2007 */
@@ -329,7 +329,7 @@ public class SlicerTest {
     slice =
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
-    assertEquals(4, slice.size(), slice.toString());
+    assertEquals(4, slice.size(), slice::toString);
   }
 
   @Test
@@ -386,7 +386,7 @@ public class SlicerTest {
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.NONE, ControlDependenceOptions.FULL);
     SlicerUtil.dumpSlice(slice);
-    assertEquals(2, SlicerUtil.countConditionals(slice), slice.toString());
+    assertEquals(2, SlicerUtil.countConditionals(slice), slice::toString);
   }
 
   @Test
@@ -413,7 +413,7 @@ public class SlicerTest {
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.NONE, ControlDependenceOptions.FULL);
     SlicerUtil.dumpSlice(slice);
-    assertEquals(1, SlicerUtil.countConditionals(slice), slice.toString());
+    assertEquals(1, SlicerUtil.countConditionals(slice), slice::toString);
   }
 
   @Test
@@ -440,7 +440,7 @@ public class SlicerTest {
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.NONE, ControlDependenceOptions.FULL);
     SlicerUtil.dumpSlice(slice);
-    assertEquals(0, SlicerUtil.countConditionals(slice), slice.toString());
+    assertEquals(0, SlicerUtil.countConditionals(slice), slice::toString);
   }
 
   @Test
@@ -475,7 +475,7 @@ public class SlicerTest {
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.FULL);
     SlicerUtil.dumpSlice(slice);
-    assertEquals(1, SlicerUtil.countConditionals(slice), slice.toString());
+    assertEquals(1, SlicerUtil.countConditionals(slice), slice::toString);
   }
 
   @Test
@@ -573,7 +573,7 @@ public class SlicerTest {
             DataDependenceOptions.NONE,
             ControlDependenceOptions.NO_EXCEPTIONAL_EDGES);
     SlicerUtil.dumpSlice(slice);
-    assertEquals(2, SlicerUtil.countInvokes(slice), slice.toString());
+    assertEquals(2, SlicerUtil.countInvokes(slice), slice::toString);
   }
 
   @Test
@@ -600,7 +600,7 @@ public class SlicerTest {
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     SlicerUtil.dumpSlice(slice);
-    assertEquals(1, SlicerUtil.countAllocations(slice, false), slice.toString());
+    assertEquals(1, SlicerUtil.countAllocations(slice, false), slice::toString);
   }
 
   @Test
@@ -628,8 +628,8 @@ public class SlicerTest {
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     SlicerUtil.dumpSlice(slice);
-    assertEquals(2, SlicerUtil.countAllocations(slice, false), slice.toString());
-    assertEquals(1, SlicerUtil.countAloads(slice), slice.toString());
+    assertEquals(2, SlicerUtil.countAllocations(slice, false), slice::toString);
+    assertEquals(1, SlicerUtil.countAloads(slice), slice::toString);
   }
 
   @Test
@@ -657,8 +657,8 @@ public class SlicerTest {
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     SlicerUtil.dumpSlice(slice);
-    assertEquals(2, SlicerUtil.countAllocations(slice, false), slice.toString());
-    assertEquals(1, SlicerUtil.countPutfields(slice), slice.toString());
+    assertEquals(2, SlicerUtil.countAllocations(slice, false), slice::toString);
+    assertEquals(1, SlicerUtil.countPutfields(slice), slice::toString);
   }
 
   @Test
@@ -701,8 +701,8 @@ public class SlicerTest {
             ControlDependenceOptions.NONE);
     slice = computeBackwardSlice;
     SlicerUtil.dumpSlice(slice);
-    assertEquals(2, SlicerUtil.countAllocations(slice, false), slice.toString());
-    assertEquals(1, SlicerUtil.countPutfields(slice), slice.toString());
+    assertEquals(2, SlicerUtil.countAllocations(slice, false), slice::toString);
+    assertEquals(1, SlicerUtil.countPutfields(slice), slice::toString);
   }
 
   @Test
@@ -730,9 +730,9 @@ public class SlicerTest {
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     SlicerUtil.dumpSlice(slice);
-    assertEquals(1, SlicerUtil.countAllocations(slice, false), slice.toString());
-    assertEquals(2, SlicerUtil.countPutstatics(slice), slice.toString());
-    assertEquals(2, SlicerUtil.countGetstatics(slice), slice.toString());
+    assertEquals(1, SlicerUtil.countAllocations(slice, false), slice::toString);
+    assertEquals(2, SlicerUtil.countPutstatics(slice), slice::toString);
+    assertEquals(2, SlicerUtil.countGetstatics(slice), slice::toString);
   }
 
   @Test
@@ -760,7 +760,7 @@ public class SlicerTest {
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     SlicerUtil.dumpSlice(slice);
-    assertEquals(2, SlicerUtil.countAllocations(slice, false), slice.toString());
+    assertEquals(2, SlicerUtil.countAllocations(slice, false), slice::toString);
   }
 
   @Test
@@ -789,8 +789,8 @@ public class SlicerTest {
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     SlicerUtil.dumpSlice(slice);
-    assertEquals(3, SlicerUtil.countAllocations(slice, false), slice.toString());
-    assertEquals(2, SlicerUtil.countPutfields(slice), slice.toString());
+    assertEquals(3, SlicerUtil.countAllocations(slice, false), slice::toString);
+    assertEquals(2, SlicerUtil.countPutfields(slice), slice::toString);
   }
 
   @Test
@@ -821,8 +821,8 @@ public class SlicerTest {
         Slicer.computeBackwardSlice(
             s, pcg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.FULL);
     SlicerUtil.dumpSlice(slice);
-    assertEquals(0, SlicerUtil.countAllocations(slice, false), slice.toString());
-    assertEquals(1, SlicerUtil.countPutfields(slice), slice.toString());
+    assertEquals(0, SlicerUtil.countAllocations(slice, false), slice::toString);
+    assertEquals(1, SlicerUtil.countPutfields(slice), slice::toString);
   }
 
   /**
@@ -880,8 +880,8 @@ public class SlicerTest {
         Slicer.computeBackwardSlice(
             s, pcg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
     SlicerUtil.dumpSlice(slice);
-    assertEquals(1, SlicerUtil.countAllocations(slice, false), slice.toString());
-    assertEquals(1, SlicerUtil.countPutfields(slice), slice.toString());
+    assertEquals(1, SlicerUtil.countAllocations(slice, false), slice::toString);
+    assertEquals(1, SlicerUtil.countPutfields(slice), slice::toString);
   }
 
   @Test

--- a/core/src/testFixtures/java/com/ibm/wala/core/tests/shrike/DynamicCallGraphTestBase.java
+++ b/core/src/testFixtures/java/com/ibm/wala/core/tests/shrike/DynamicCallGraphTestBase.java
@@ -233,7 +233,7 @@ public abstract class DynamicCallGraphTestBase extends WalaTestCase {
           if (!filter.test(callerRef)) {
             continue loop;
           }
-          assertEquals(1, nodes.size(), callerRef.toString());
+          assertEquals(1, nodes.size(), callerRef::toString);
           caller = nodes.iterator().next();
         }
 


### PR DESCRIPTION
For each of these assertions, if the check succeeds, then no diagnostic message will be formed and there's no need to call `toString`.