### PR TITLE
Expose some types that are used in exposed APIs

### DIFF
--- a/cast/src/test/java/com/ibm/wala/cast/test/TestCAstTranslator.java
+++ b/cast/src/test/java/com/ibm/wala/cast/test/TestCAstTranslator.java
@@ -41,7 +41,7 @@ import java.util.Set;
 
 public abstract class TestCAstTranslator {
 
-  protected static class TranslatorAssertions {
+  public static class TranslatorAssertions {
     private final Set<String> classes = new HashSet<>();
 
     private final Map<String, String> supers = new HashMap<>();

--- a/core/src/testFixtures/java/com/ibm/wala/core/tests/shrike/DynamicCallGraphTestBase.java
+++ b/core/src/testFixtures/java/com/ibm/wala/core/tests/shrike/DynamicCallGraphTestBase.java
@@ -143,7 +143,7 @@ public abstract class DynamicCallGraphTestBase extends WalaTestCase {
     assertTrue(Files.exists(cgLocation), "expected to create call graph");
   }
 
-  interface EdgesTest {
+  protected interface EdgesTest {
     void edgesTest(CallGraph staticCG, CGNode caller, MethodReference callee);
   }
 


### PR DESCRIPTION
`com.ibm.wala.cast.test.TestCAstTranslator.checkAssertions` is a `public` method that takes an argument of type
`com.ibm.wala.cast.test.TestCAstTranslator.TranslatorAssertions`.  The latter, therefore, needs to be `public` as well or else the checkAssertions` method can never be called.

Similarly,
`com.ibm.wala.core.tests.shrike.DynamicCallGraphTestBase.check` is a `protected` method that takes an argument of type
`com.ibm.wala.core.tests.shrike.DynamicCallGraphTestBase.EdgesTest`. The latter must at least have `protected` visibility too, or else the `check` method can never be called.