### PR TITLE
Update logo URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![WALA logo](http://wala.sourceforge.net/wiki/images/9/94/WALA-banner.png)
+![WALA logo](https://wala.github.io/logos/WALA-banner.png)
 
 [![GitHub Actions
 status](https://github.com/wala/WALA/workflows/Continuous%20integration/badge.svg)](https://github.com/wala/WALA/actions?query=workflow%3A%22Continuous+integration%22)


### PR DESCRIPTION
Fixes #1340.  I recovered the logo from the Internet Archive!  New URL is https://wala.github.io/logos/WALA-banner.png.

