### PR TITLE
Remove an unnecessary argument injection

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/CompileKawaScheme.kt
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/CompileKawaScheme.kt
@@ -1,7 +1,5 @@
 package com.ibm.wala.gradle
 
-import javax.inject.Inject
-import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.LogLevel
@@ -19,7 +17,7 @@ import org.gradle.api.tasks.PathSensitivity
 //
 
 @CacheableTask
-abstract class CompileKawaScheme @Inject constructor(project: Project) : JavaExec() {
+abstract class CompileKawaScheme : JavaExec() {
 
   @get:InputFile
   @get:PathSensitive(PathSensitivity.NONE)


### PR DESCRIPTION
We don't need to inject a `Project` argument into this custom task's constructor.  The `JavaExec` superclass already has a perfectly good `getProject` method, and the value that it returns will already have been initialized before we are initializing this custom task's fields.