### PR TITLE
Use Kotlin DSL type-safe accessors

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/NullAway.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/NullAway.gradle.kts
@@ -9,8 +9,7 @@ plugins {
 }
 
 dependencies {
-  annotationProcessor(
-      rootProject.the<VersionCatalogsExtension>().named("libs").findLibrary("nullaway").get())
+  annotationProcessor(rootProject.versionCatalogs.named("libs").findLibrary("nullaway").get())
 }
 
 tasks.withType<JavaCompile>().configureEach {

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/eclipse-maven-central.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/eclipse-maven-central.gradle.kts
@@ -1,9 +1,10 @@
 package com.ibm.wala.gradle
 
-import com.diffplug.gradle.eclipse.MavenCentralExtension
 import com.diffplug.gradle.eclipse.MavenCentralExtension.ReleaseConfigurer
 import com.diffplug.gradle.eclipse.MavenCentralPlugin
 import com.diffplug.gradle.pde.EclipseRelease
+
+plugins { id("com.diffplug.eclipse.mavencentral") }
 
 /**
  * WALA-specialized adaptation of
@@ -48,8 +49,7 @@ open class WalaMavenCentralReleaseConfigurerExtension @Inject constructor(projec
    */
   private val configurer by lazy {
     project.run {
-      the<MavenCentralExtension>()
-          .ReleaseConfigurer(rootProject.extra["eclipseVersion"] as EclipseRelease)
+      eclipseMavenCentral.ReleaseConfigurer(rootProject.extra["eclipseVersion"] as EclipseRelease)
     }
   }
 

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -6,7 +6,6 @@ package com.ibm.wala.gradle
 
 import com.diffplug.spotless.LineEnding.PLATFORM_NATIVE
 import net.ltgt.gradle.errorprone.errorprone
-import org.gradle.plugins.ide.eclipse.model.EclipseModel
 
 plugins {
   eclipse
@@ -26,17 +25,14 @@ repositories {
   maven { url = uri("https://storage.googleapis.com/r8-releases/raw") }
 }
 
-the<BasePluginExtension>().archivesName = "com.ibm.wala${project.path.replace(':', '.')}"
-
-val sourceSets = the<SourceSetContainer>()
+base.archivesName = "com.ibm.wala${project.path.replace(':', '.')}"
 
 configurations {
   resolvable("ecj")
   named("javadocClasspath") { extendsFrom(compileClasspath.get()) }
 }
 
-fun findLibrary(alias: String) =
-    rootProject.the<VersionCatalogsExtension>().named("libs").findLibrary(alias).get()
+fun findLibrary(alias: String) = rootProject.versionCatalogs.named("libs").findLibrary(alias).get()
 
 dependencies {
   "ecj"(findLibrary("eclipse-ecj"))
@@ -86,8 +82,7 @@ configurations {
       substitute(module("org.hamcrest:hamcrest-core"))
           .using(
               module(
-                  rootProject
-                      .the<VersionCatalogsExtension>()
+                  rootProject.versionCatalogs
                       .named("libs")
                       .findLibrary("hamcrest")
                       .get()
@@ -108,7 +103,7 @@ configurations {
   }
 }
 
-the<EclipseModel>().synchronizationTasks("processTestResources")
+eclipse.synchronizationTasks("processTestResources")
 
 tasks.named<Test>("test") {
   useJUnitPlatform()
@@ -190,8 +185,7 @@ spotless {
 
   java {
     googleJavaFormat(
-        rootProject
-            .the<VersionCatalogsExtension>()
+        rootProject.versionCatalogs
             .named("libs")
             .findVersion("google-java-format")
             .get()

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/project.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/project.gradle.kts
@@ -3,7 +3,6 @@ package com.ibm.wala.gradle
 import com.diffplug.spotless.LineEnding.PLATFORM_NATIVE
 import org.gradle.plugins.ide.eclipse.model.AbstractClasspathEntry
 import org.gradle.plugins.ide.eclipse.model.Classpath
-import org.gradle.plugins.ide.eclipse.model.EclipseModel
 
 // Build configuration shared by all projects *including* the root project.
 
@@ -20,7 +19,7 @@ repositories.mavenCentral()
 //
 
 // workaround for <https://github.com/gradle/gradle/issues/4802>
-the<EclipseModel>().classpath.file.whenMerged {
+eclipse.classpath.file.whenMerged {
   (this as Classpath).run {
     entries.forEach {
       if (it is AbstractClasspathEntry && it.entryAttributes["gradle_used_by_scope"] == "test")
@@ -52,12 +51,6 @@ spotless {
   findProperty("spotless.ratchet.from")?.let { ratchetFrom(it as String) }
 
   kotlinGradle {
-    ktfmt(
-        rootProject
-            .the<VersionCatalogsExtension>()
-            .named("libs")
-            .findVersion("ktfmt")
-            .get()
-            .toString())
+    ktfmt(rootProject.versionCatalogs.named("libs").findVersion("ktfmt").get().toString())
   }
 }

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
@@ -14,12 +14,10 @@ val isSnapshot = "SNAPSHOT" in version as String
 
 val javaComponent = components["java"] as AdhocComponentWithVariants
 
-val allTestFixturesSource = the<SourceSetContainer>()["testFixtures"].allSource
+val allTestFixturesSource: SourceDirectorySet = sourceSets.testFixtures.get().allSource
 
 val testFixturesJavadoc by
-    tasks.existing(Javadoc::class) {
-      setDestinationDir(project.the<JavaPluginExtension>().docsDir.get().dir(name).asFile)
-    }
+    tasks.existing(Javadoc::class) { setDestinationDir(java.docsDir.get().dir(name).asFile) }
 
 val testFixturesJavadocJar by
     tasks.registering(Jar::class) {
@@ -40,7 +38,7 @@ val mavenPublication =
       from(javaComponent)
 
       groupId = "com.ibm.wala"
-      artifactId = the<BasePluginExtension>().archivesName.get()
+      artifactId = base.archivesName.get()
 
       val testFixturesCodeElementsNames =
           listOf("testFixturesApiElements", "testFixturesRuntimeElements")
@@ -149,7 +147,7 @@ repositories.maven {
   setUrl(rootProject.layout.buildDirectory.dir("maven-fake-remote-repository"))
 }
 
-configure<SigningExtension> {
+signing {
   sign(mavenPublication)
   setRequired {
     // Signatures are a hard requirement if publishing a non-snapshot to a real, remote repository.
@@ -160,7 +158,7 @@ configure<SigningExtension> {
   }
 }
 
-configure<JavaPluginExtension> {
+java {
   withJavadocJar()
   withSourcesJar()
 }

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/subproject.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/subproject.gradle.kts
@@ -1,7 +1,5 @@
 package com.ibm.wala.gradle
 
-import org.gradle.plugins.ide.idea.model.IdeaModel
-
 // Build configuration shared by all projects *except* for the root project.
 
 plugins {
@@ -31,4 +29,4 @@ tasks.register("downloads") {
 //
 
 // workaround for <https://youtrack.jetbrains.com/issue/IDEA-140714>
-the<IdeaModel>().module.excludeDirs.add(file("bin"))
+idea.module.excludeDirs.add(file("bin"))


### PR DESCRIPTION
I find these to be a bit more readable than `the<T>` and `configure<T>`.