### PR TITLE
Upgrade to Spotless 2.43.1 and Spotless Gradle 6.23.3

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,7 +1,5 @@
 @file:Suppress("UnstableApiUsage")
 
-import com.diffplug.spotless.LineEnding.PLATFORM_NATIVE
-
 plugins {
   `kotlin-dsl`
   `kotlin-dsl-precompiled-script-plugins`
@@ -23,11 +21,6 @@ dependencies {
 kotlin.jvmToolchain { languageVersion = JavaLanguageVersion.of(11) }
 
 spotless {
-  // Workaround for <https://github.com/diffplug/spotless/issues/1644>
-  // using idea found at
-  // <https://github.com/diffplug/spotless/issues/1527#issuecomment-1409142798>.
-  lineEndings = PLATFORM_NATIVE
-
   val ktfmtVersion = libs.versions.ktfmt.get()
 
   kotlin {

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -4,7 +4,6 @@ package com.ibm.wala.gradle
 
 // Build configuration for subprojects that include Java source code.
 
-import com.diffplug.spotless.LineEnding.PLATFORM_NATIVE
 import net.ltgt.gradle.errorprone.errorprone
 
 plugins {
@@ -178,11 +177,6 @@ if (project.gradle.parent != null) {
 }
 
 spotless {
-  // Workaround for <https://github.com/diffplug/spotless/issues/1644>
-  // using idea found at
-  // <https://github.com/diffplug/spotless/issues/1527#issuecomment-1409142798>.
-  lineEndings = PLATFORM_NATIVE
-
   java {
     googleJavaFormat(
         rootProject.versionCatalogs

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/project.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/project.gradle.kts
@@ -1,6 +1,5 @@
 package com.ibm.wala.gradle
 
-import com.diffplug.spotless.LineEnding.PLATFORM_NATIVE
 import org.gradle.plugins.ide.eclipse.model.AbstractClasspathEntry
 import org.gradle.plugins.ide.eclipse.model.Classpath
 
@@ -43,11 +42,6 @@ tasks.register<DependencyReportTask>("allDeps") {}
 //
 
 spotless {
-  // Workaround for <https://github.com/diffplug/spotless/issues/1644>
-  // using idea found at
-  // <https://github.com/diffplug/spotless/issues/1527#issuecomment-1409142798>.
-  lineEndings = PLATFORM_NATIVE
-
   findProperty("spotless.ratchet.from")?.let { ratchetFrom(it as String) }
 
   kotlinGradle {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,6 @@
 //
 
 import com.diffplug.gradle.pde.EclipseRelease
-import com.diffplug.spotless.LineEnding.PLATFORM_NATIVE
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 
 buildscript { dependencies.classpath(libs.commons.io) }
@@ -100,11 +99,6 @@ shellcheck {
 }
 
 tasks.named("shellcheck") { group = "verification" }
-
-// Workaround for <https://github.com/diffplug/spotless/issues/1644>
-// using idea found at
-// <https://github.com/diffplug/spotless/issues/1527#issuecomment-1409142798>.
-spotless.lineEndings = PLATFORM_NATIVE
 
 // install Java reformatter as git pre-commit hook
 tasks.register<Copy>("installGitHooks") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ eclipse = "4.21.0"
 eclipse-wst-jsdt = "1.0.201.v2010012803"
 google-java-format = "1.17.0"
 ktfmt = "0.44"
-spotless = "6.20.0"
+spotless = "6.23.3"
 
 [libraries]
 android-tools = "com.android.tools:r8:2.2.42"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-buildscript { dependencies { classpath("com.diffplug.spotless:spotless-lib-extra:2.34.1") } }
+buildscript { dependencies { classpath("com.diffplug.spotless:spotless-lib-extra:2.43.1") } }
 
 plugins { id("com.diffplug.configuration-cache-for-platform-specific-build") version "3.44.0" }
 


### PR DESCRIPTION
In addition to the usual automated tests, I've also manually verified that `./gradlew compile{,Test}Java` succeeds and correctly uses the configuration cache on an M2 macOS machine using either Java 11 or 17. So these changes should not cause a regression of #1230 or #1278.