### PR TITLE
Update R8 and enable Dalvik tests on JDK 21

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -312,10 +312,10 @@ artifacts.add(collectTestDataJar.name, collectTestData.map { it.destinationDirec
 
 ////////////////////////////////////////////////////////////////////////
 //
-//  collect "com.ibm.wala.core.testdata_1.0.0a.jar"
+//  collect "com.ibm.wala.core.testdata_1.0.0a.jar" for Dalvik tests
 //
 
-val collectTestDataA by
+val collectTestDataAForDalvik by
     tasks.registering(Jar::class) {
       archiveFileName = "com.ibm.wala.core.testdata_1.0.0a.jar"
       from(compileTestSubjectsJava)
@@ -323,10 +323,8 @@ val collectTestDataA by
       includeEmptyDirs = false
       destinationDirectory = layout.buildDirectory.dir(name)
       exclude(
-          // This is an invalid class so don't include it, e.g., it causes D8 to crash
+          // This is an invalid class so don't include it; it causes D8 to crash
           "**/CodeDeleted.class",
-          //          "**/SortingExample.class",
-          //          "**/A.class",
       )
     }
 
@@ -387,7 +385,7 @@ val dalvikTestResources: Configuration by configurations.creating { isCanBeResol
 
 listOf(
         collectJLex,
-        collectTestDataA,
+        collectTestDataAForDalvik,
         downloadJavaCup,
         extractBcel,
     )

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -323,9 +323,10 @@ val collectTestDataA by
       includeEmptyDirs = false
       destinationDirectory = layout.buildDirectory.dir(name)
       exclude(
+          // This is an invalid class so don't include it, e.g., it causes D8 to crash
           "**/CodeDeleted.class",
-          "**/SortingExample.class",
-          "**/A.class",
+          //          "**/SortingExample.class",
+          //          "**/A.class",
       )
     }
 

--- a/dalvik/build.gradle.kts
+++ b/dalvik/build.gradle.kts
@@ -196,7 +196,7 @@ tasks.named<Test>("test") {
     // Disable the task for JDK 21 for now.  We have test failures due to a required r8 upgrade
     // that introduces some new behaviors we don't expect
     // See https://github.com/wala/WALA/issues/1349
-    enabled = false
+    // enabled = false
   }
   maxHeapSize = "800M"
 

--- a/dalvik/build.gradle.kts
+++ b/dalvik/build.gradle.kts
@@ -192,12 +192,6 @@ if (isWindows) tasks.named<Test>("test") { exclude("**/droidbench/**") }
 else sourceSets.test.configure { resources.srcDir(unpackDroidBench) }
 
 tasks.named<Test>("test") {
-  if (JavaVersion.current() == JavaVersion.VERSION_21) {
-    // Disable the task for JDK 21 for now.  We have test failures due to a required r8 upgrade
-    // that introduces some new behaviors we don't expect
-    // See https://github.com/wala/WALA/issues/1349
-    // enabled = false
-  }
   maxHeapSize = "800M"
 
   outputs.files(

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/JVMLDalvikComparisonTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/JVMLDalvikComparisonTest.java
@@ -100,6 +100,17 @@ public class JVMLDalvikComparisonTest extends DalvikCallGraphTestBase {
     test(mainClass, javaScopeFile, false);
   }
 
+  /**
+   * Run tests to compare the call graphs computing with the JVM bytecode frontend vs the Dalvik
+   * frontend
+   *
+   * @param mainClass main class for the test
+   * @param javaScopeFile scope file for the test
+   * @param allowExtraJavaCGEdges if true, allow extra edges in the JVM bytecode frontend call
+   *     graph. This flag is temporarily required due to issues with JLex caused by
+   *     https://issuetracker.google.com/issues/316744331. TODO: remove this flag once the D8 issue
+   *     is fixed.
+   */
   private static void test(String mainClass, String javaScopeFile, boolean allowExtraJavaCGEdges)
       throws IllegalArgumentException, IOException, CancelException, ClassHierarchyException {
     Pair<CallGraph, PointerAnalysis<InstanceKey>> java = makeJavaBuilder(javaScopeFile, mainClass);

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/JVMLDalvikComparisonTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/JVMLDalvikComparisonTest.java
@@ -107,7 +107,6 @@ public class JVMLDalvikComparisonTest extends DalvikCallGraphTestBase {
     AnalysisScope javaScope = java.fst.getClassHierarchy().getScope();
     String javaJarPath = getJavaJar(javaScope);
     File androidDex = convertJarToDex(javaJarPath);
-    System.err.println(androidDex.getAbsolutePath());
     Pair<CallGraph, PointerAnalysis<InstanceKey>> android =
         makeDalvikCallGraph(null, null, mainClass, androidDex.getAbsolutePath());
 
@@ -178,7 +177,6 @@ public class JVMLDalvikComparisonTest extends DalvikCallGraphTestBase {
         : "inconsistent debug info: " + ajlines + " " + aalines;
   }
 
-  @SuppressWarnings("UnusedVariable")
   private static boolean checkEdgeDiff(
       Pair<CallGraph, PointerAnalysis<InstanceKey>> firstResult,
       Set<MethodReference> methodsInFirst,
@@ -205,25 +203,6 @@ public class JVMLDalvikComparisonTest extends DalvikCallGraphTestBase {
           System.err.println("### " + n.getIR());
         }
       }
-
-      //      for (CGNode n : firstResult.fst) {
-      //        System.err.println("### " + n);
-      //        if (n.getIR() != null) {
-      //          System.err.println(n.getIR());
-
-      //          System.err.println("return: " + android.snd.getPointsToSet(new
-      // ReturnValueKey(n)));
-      //          System.err.println(
-      //              "exceptions: " + android.snd.getPointsToSet(new ExceptionReturnValueKey(n)));
-      //          for (int i = 1; i < n.getIR().getSymbolTable().getMaxValueNumber(); i++) {
-      //            LocalPointerKey x = new LocalPointerKey(n, i);
-      //            OrdinalSet<InstanceKey> s = android.snd.getPointsToSet(x);
-      //            if (s != null && !s.isEmpty()) {
-      //              System.err.println(i + ": " + s);
-      //            }
-      //          }
-      //        }
-      //      }
     }
     return fail;
   }

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/JVMLDalvikComparisonTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/JVMLDalvikComparisonTest.java
@@ -97,6 +97,11 @@ public class JVMLDalvikComparisonTest extends DalvikCallGraphTestBase {
 
   private static void test(String mainClass, String javaScopeFile)
       throws IllegalArgumentException, IOException, CancelException, ClassHierarchyException {
+    test(mainClass, javaScopeFile, false);
+  }
+
+  private static void test(String mainClass, String javaScopeFile, boolean allowExtraJavaCGEdges)
+      throws IllegalArgumentException, IOException, CancelException, ClassHierarchyException {
     Pair<CallGraph, PointerAnalysis<InstanceKey>> java = makeJavaBuilder(javaScopeFile, mainClass);
 
     AnalysisScope javaScope = java.fst.getClassHierarchy().getScope();
@@ -109,13 +114,15 @@ public class JVMLDalvikComparisonTest extends DalvikCallGraphTestBase {
     Set<MethodReference> androidMethods = applicationMethods(android.fst);
     Set<MethodReference> javaMethods = applicationMethods(java.fst);
 
-    Set<Pair<CGNode, CGNode>> javaExtraEdges =
-        edgeDiff(java.fst, android.fst, false);
-    assert !checkEdgeDiff(android, androidMethods, javaMethods, javaExtraEdges) : "found extra edges in Java call graph";
+    if (!allowExtraJavaCGEdges) {
+      Set<Pair<CGNode, CGNode>> javaExtraEdges = edgeDiff(java.fst, android.fst, false);
+      assert !checkEdgeDiff(android, androidMethods, javaMethods, javaExtraEdges)
+          : "found extra edges in Java call graph";
+    }
 
-    Set<Pair<CGNode, CGNode>> androidExtraEdges =
-        edgeDiff(android.fst, java.fst, true);
-    assert !checkEdgeDiff(java, javaMethods, androidMethods, androidExtraEdges) : "found extra edges in Android call graph";
+    Set<Pair<CGNode, CGNode>> androidExtraEdges = edgeDiff(android.fst, java.fst, true);
+    assert !checkEdgeDiff(java, javaMethods, androidMethods, androidExtraEdges)
+        : "found extra edges in Android call graph";
 
     checkSourceLines(java.fst, android.fst);
   }
@@ -199,23 +206,24 @@ public class JVMLDalvikComparisonTest extends DalvikCallGraphTestBase {
         }
       }
 
-//      for (CGNode n : firstResult.fst) {
-//        System.err.println("### " + n);
-//        if (n.getIR() != null) {
-//          System.err.println(n.getIR());
+      //      for (CGNode n : firstResult.fst) {
+      //        System.err.println("### " + n);
+      //        if (n.getIR() != null) {
+      //          System.err.println(n.getIR());
 
-//          System.err.println("return: " + android.snd.getPointsToSet(new ReturnValueKey(n)));
-//          System.err.println(
-//              "exceptions: " + android.snd.getPointsToSet(new ExceptionReturnValueKey(n)));
-//          for (int i = 1; i < n.getIR().getSymbolTable().getMaxValueNumber(); i++) {
-//            LocalPointerKey x = new LocalPointerKey(n, i);
-//            OrdinalSet<InstanceKey> s = android.snd.getPointsToSet(x);
-//            if (s != null && !s.isEmpty()) {
-//              System.err.println(i + ": " + s);
-//            }
-//          }
-//        }
-//      }
+      //          System.err.println("return: " + android.snd.getPointsToSet(new
+      // ReturnValueKey(n)));
+      //          System.err.println(
+      //              "exceptions: " + android.snd.getPointsToSet(new ExceptionReturnValueKey(n)));
+      //          for (int i = 1; i < n.getIR().getSymbolTable().getMaxValueNumber(); i++) {
+      //            LocalPointerKey x = new LocalPointerKey(n, i);
+      //            OrdinalSet<InstanceKey> s = android.snd.getPointsToSet(x);
+      //            if (s != null && !s.isEmpty()) {
+      //              System.err.println(i + ": " + s);
+      //            }
+      //          }
+      //        }
+      //      }
     }
     return fail;
   }
@@ -223,7 +231,7 @@ public class JVMLDalvikComparisonTest extends DalvikCallGraphTestBase {
   @Test
   public void testJLex()
       throws ClassHierarchyException, IllegalArgumentException, IOException, CancelException {
-    test(TestConstants.JLEX_MAIN, TestConstants.JLEX);
+    test(TestConstants.JLEX_MAIN, TestConstants.JLEX, true);
   }
 
   @Test

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/JVMLDalvikComparisonTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/JVMLDalvikComparisonTest.java
@@ -102,6 +102,7 @@ public class JVMLDalvikComparisonTest extends DalvikCallGraphTestBase {
     AnalysisScope javaScope = java.fst.getClassHierarchy().getScope();
     String javaJarPath = getJavaJar(javaScope);
     File androidDex = convertJarToDex(javaJarPath);
+    System.err.println(androidDex.getAbsolutePath());
     Pair<CallGraph, PointerAnalysis<InstanceKey>> android =
         makeDalvikCallGraph(null, null, mainClass, androidDex.getAbsolutePath());
 

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/JVMLDalvikComparisonTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/JVMLDalvikComparisonTest.java
@@ -26,11 +26,8 @@ import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.ibm.wala.ipa.callgraph.Entrypoint;
 import com.ibm.wala.ipa.callgraph.impl.Util;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
-import com.ibm.wala.ipa.callgraph.propagation.LocalPointerKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis;
-import com.ibm.wala.ipa.callgraph.propagation.ReturnValueKey;
 import com.ibm.wala.ipa.callgraph.propagation.SSAPropagationCallGraphBuilder;
-import com.ibm.wala.ipa.callgraph.propagation.cfa.ExceptionReturnValueKey;
 import com.ibm.wala.ipa.cha.ClassHierarchy;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.ipa.cha.ClassHierarchyFactory;
@@ -40,15 +37,12 @@ import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.collections.HashSetFactory;
-import com.ibm.wala.util.collections.Iterator2Collection;
 import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.util.intset.IntSet;
 import com.ibm.wala.util.intset.IntSetUtil;
 import com.ibm.wala.util.intset.MutableIntSet;
-import com.ibm.wala.util.intset.OrdinalSet;
 import java.io.File;
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
@@ -114,13 +108,13 @@ public class JVMLDalvikComparisonTest extends DalvikCallGraphTestBase {
     Set<MethodReference> androidMethods = applicationMethods(android.fst);
     Set<MethodReference> javaMethods = applicationMethods(java.fst);
 
-    Iterator<Pair<CGNode, CGNode>> javaExtraEdges =
-        edgeDiff(java.fst, android.fst, false).iterator();
-    assert !checkEdgeDiff(android, androidMethods, javaMethods, javaExtraEdges);
+    Set<Pair<CGNode, CGNode>> javaExtraEdges =
+        edgeDiff(java.fst, android.fst, false);
+    assert !checkEdgeDiff(android, androidMethods, javaMethods, javaExtraEdges) : "found extra edges in Java call graph";
 
-    Iterator<Pair<CGNode, CGNode>> androidExtraEdges =
-        edgeDiff(android.fst, java.fst, true).iterator();
-    assert !checkEdgeDiff(java, javaMethods, androidMethods, androidExtraEdges);
+    Set<Pair<CGNode, CGNode>> androidExtraEdges =
+        edgeDiff(android.fst, java.fst, true);
+    assert !checkEdgeDiff(java, javaMethods, androidMethods, androidExtraEdges) : "found extra edges in Android call graph";
 
     checkSourceLines(java.fst, android.fst);
   }
@@ -176,39 +170,51 @@ public class JVMLDalvikComparisonTest extends DalvikCallGraphTestBase {
         : "inconsistent debug info: " + ajlines + " " + aalines;
   }
 
+  @SuppressWarnings("UnusedVariable")
   private static boolean checkEdgeDiff(
-      Pair<CallGraph, PointerAnalysis<InstanceKey>> android,
-      Set<MethodReference> androidMethods,
-      Set<MethodReference> javaMethods,
-      Iterator<Pair<CGNode, CGNode>> javaExtraEdges) {
+      Pair<CallGraph, PointerAnalysis<InstanceKey>> firstResult,
+      Set<MethodReference> methodsInFirst,
+      Set<MethodReference> methodsInSecond,
+      Set<Pair<CGNode, CGNode>> extraEdgesInSecond) {
     boolean fail = false;
-    if (javaExtraEdges.hasNext()) {
+    if (!extraEdgesInSecond.isEmpty()) {
       fail = true;
-      Set<MethodReference> javaExtraNodes = HashSetFactory.make(javaMethods);
-      javaExtraNodes.removeAll(androidMethods);
+      Set<MethodReference> extraMethodsInSecond = HashSetFactory.make(methodsInSecond);
+      extraMethodsInSecond.removeAll(methodsInFirst);
 
-      System.err.println(Iterator2Collection.toSet(javaExtraEdges));
-      System.err.println(javaExtraNodes);
+      System.err.println(extraEdgesInSecond);
+      System.err.println(extraMethodsInSecond);
 
-      System.err.println(android.fst);
-
-      for (CGNode n : android.fst) {
-        System.err.println("### " + n);
-        if (n.getIR() != null) {
-          System.err.println(n.getIR());
-
-          System.err.println("return: " + android.snd.getPointsToSet(new ReturnValueKey(n)));
-          System.err.println(
-              "exceptions: " + android.snd.getPointsToSet(new ExceptionReturnValueKey(n)));
-          for (int i = 1; i < n.getIR().getSymbolTable().getMaxValueNumber(); i++) {
-            LocalPointerKey x = new LocalPointerKey(n, i);
-            OrdinalSet<InstanceKey> s = android.snd.getPointsToSet(x);
-            if (s != null && !s.isEmpty()) {
-              System.err.println(i + ": " + s);
-            }
-          }
+      CallGraph firstCG = firstResult.fst;
+      for (Pair<CGNode, CGNode> p : extraEdgesInSecond) {
+        System.err.println("### " + p.fst);
+        System.err.println("### " + p.snd);
+        System.err.println("### " + p.fst.getIR());
+        System.err.println("====");
+        Set<CGNode> nodes = firstCG.getNodes(p.fst.getMethod().getReference());
+        for (CGNode n : nodes) {
+          System.err.println("### " + n);
+          System.err.println("### " + n.getIR());
         }
       }
+
+//      for (CGNode n : firstResult.fst) {
+//        System.err.println("### " + n);
+//        if (n.getIR() != null) {
+//          System.err.println(n.getIR());
+
+//          System.err.println("return: " + android.snd.getPointsToSet(new ReturnValueKey(n)));
+//          System.err.println(
+//              "exceptions: " + android.snd.getPointsToSet(new ExceptionReturnValueKey(n)));
+//          for (int i = 1; i < n.getIR().getSymbolTable().getMaxValueNumber(); i++) {
+//            LocalPointerKey x = new LocalPointerKey(n, i);
+//            OrdinalSet<InstanceKey> s = android.snd.getPointsToSet(x);
+//            if (s != null && !s.isEmpty()) {
+//              System.err.println(i + ": " + s);
+//            }
+//          }
+//        }
+//      }
     }
     return fail;
   }

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/util/Util.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/util/Util.java
@@ -58,7 +58,7 @@ public class Util {
 
   public static File convertJarToDex(String jarFile) throws IOException {
     Path tmpDir = Files.createTempDirectory("dex");
-    //tmpDir.toFile().deleteOnExit();
+    tmpDir.toFile().deleteOnExit();
     try {
       D8.run(
           D8Command.builder()

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/util/Util.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/util/Util.java
@@ -58,7 +58,7 @@ public class Util {
 
   public static File convertJarToDex(String jarFile) throws IOException {
     Path tmpDir = Files.createTempDirectory("dex");
-    tmpDir.toFile().deleteOnExit();
+    //tmpDir.toFile().deleteOnExit();
     try {
       D8.run(
           D8Command.builder()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ ktfmt = "0.44"
 spotless = "6.23.3"
 
 [libraries]
-android-tools = "com.android.tools:r8:2.2.42"
+android-tools = "com.android.tools:r8:8.2.38"
 ant = "org.apache.ant:ant:1.10.14"
 assertj-core = "org.assertj:assertj-core:3.24.2"
 commons-cli = "commons-cli:commons-cli:1.5.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ ktfmt = "0.44"
 spotless = "6.23.3"
 
 [libraries]
-android-tools = "com.android.tools:r8:8.2.38"
+android-tools = "com.android.tools:r8:8.2.39"
 ant = "org.apache.ant:ant:1.10.14"
 assertj-core = "org.assertj:assertj-core:3.24.2"
 commons-cli = "commons-cli:commons-cli:1.5.0"


### PR DESCRIPTION
Updating to the latest R8 version lets us run the Dalvik tests on JDK 21.  We disable one check due to https://issuetracker.google.com/issues/316744331; we'll have to update R8 again once that is fixed.  We also needed to tweak how we construct the test jar for use with Dalvik.  My best guess is some classes caused issues with D8 before, but they no longer do so.  Finally, we performed some cleanup in `JVMLDalvikComparisonTest` to make failures easier to understand.

Fixes #1349 