### PR TITLE
Simplify access to current project's members

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -28,7 +28,7 @@ repositories {
 java.toolchain.languageVersion =
     JavaLanguageVersion.of(property("com.ibm.wala.jdk-version") as String)
 
-base.archivesName = "com.ibm.wala${project.path.replace(':', '.')}"
+base.archivesName = "com.ibm.wala${path.replace(':', '.')}"
 
 configurations {
   resolvable("ecj")
@@ -135,7 +135,7 @@ tasks.named<Test>("test") {
   }
 }
 
-if (project.hasProperty("excludeSlowTests")) {
+if (hasProperty("excludeSlowTests")) {
   dependencies { testImplementation(testFixtures(project(":core"))) }
   tasks.named<Test>("test") { useJUnitPlatform { excludeTags("slow") } }
 }
@@ -143,7 +143,7 @@ if (project.hasProperty("excludeSlowTests")) {
 val ecjCompileTaskProviders =
     sourceSets.map { sourceSet -> JavaCompileUsingEcj.withSourceSet(project, sourceSet) }
 
-project.tasks.named("check") { dependsOn(ecjCompileTaskProviders) }
+tasks.named("check") { dependsOn(ecjCompileTaskProviders) }
 
 tasks.withType<JavaCompile>().configureEach {
   options.run {
@@ -172,7 +172,7 @@ tasks.withType<JavaCompileUsingEcj>().configureEach {
 // fixtures, we extend the main sourceSet to include all
 // test-fixture sources too.  This hack is only applied when
 // WALA itself is an included build.
-if (project.gradle.parent != null) {
+if (gradle.parent != null) {
   afterEvaluate {
     sourceSets["main"].java.srcDirs(sourceSets["testFixtures"].java.srcDirs)
 

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
@@ -56,7 +56,7 @@ val mavenPublication =
       }
 
       pom {
-        name = project.properties["POM_NAME"] as String
+        name = property("POM_NAME") as String
         description = "T. J. Watson Libraries for Analysis"
         inceptionYear = "2006"
         url = "https://github.com/wala/WALA"
@@ -128,17 +128,17 @@ val mavenRepository: MavenArtifactRepository =
       url =
           uri(
               (if (isSnapshot)
-                  project.properties.getOrDefault(
+                  properties.getOrDefault(
                       "SNAPSHOT_REPOSITORY_URL",
                       "https://oss.sonatype.org/content/repositories/snapshots/")
               else
-                  project.properties.getOrDefault(
+                  properties.getOrDefault(
                       "RELEASE_REPOSITORY_URL",
                       "https://oss.sonatype.org/service/local/staging/deploy/maven2/"))
                   as String)
       credentials {
-        username = project.properties["SONATYPE_NEXUS_USERNAME"] as String?
-        password = project.properties["SONATYPE_NEXUS_PASSWORD"] as String?
+        username = properties["SONATYPE_NEXUS_USERNAME"] as String?
+        password = properties["SONATYPE_NEXUS_PASSWORD"] as String?
       }
     }
 


### PR DESCRIPTION
There's no need to explicitly use `project.` to get the current project when that project is already a Kotlin implicit receiver.