### PR TITLE
Use an explicit setter to help IntelliJ IDEA

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,7 +75,7 @@ dependencies {
 tasks.register<Javadoc>("aggregatedJavadocs") {
   description = "Generate javadocs from all child projects as if they were a single project"
   group = "Documentation"
-  destinationDir = layout.buildDirectory.dir("docs/javadoc").get().asFile
+  setDestinationDir(layout.buildDirectory.dir("docs/javadoc").get().asFile)
   title = "${project.name} $version API"
   (options as StandardJavadocDocletOptions).author(true)
   classpath = aggregatedJavadocClasspath


### PR DESCRIPTION
For some reason, IntelliJ IDEA's Kotlin support does not recognize that `destinationDir = ...` is a correct invocation of the `setDestinationDir` setter.  That works just fine when run in Gradle, but IntelliJ IDEA flags it as an error.  To keep IntelliJ IDEA happy, we can write this property assignment as an explicit setter call instead.