### PR TITLE
Simplify access to single properties

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
@@ -135,8 +135,8 @@ val mavenRepository: MavenArtifactRepository =
                       "https://oss.sonatype.org/service/local/staging/deploy/maven2/"))
                   as String)
       credentials {
-        username = properties["SONATYPE_NEXUS_USERNAME"] as String?
-        password = properties["SONATYPE_NEXUS_PASSWORD"] as String?
+        username = findProperty("SONATYPE_NEXUS_USERNAME") as String?
+        password = findProperty("SONATYPE_NEXUS_PASSWORD") as String?
       }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,7 @@ JavaVersion.current().let {
 
 group = name
 
-version = properties["VERSION_NAME"] as String
+version = property("VERSION_NAME") as String
 
 // version of Eclipse JARs to use for Eclipse-integrated WALA components.
 val eclipseVersion: EclipseRelease by extra {


### PR DESCRIPTION
If we only need to fetch a single property, then we don't need to build an entire mutable `Map` that represents all properties.