### PR TITLE
Correct and simplify access to Javadoc directory

### DIFF
--- a/cast/js/build.gradle.kts
+++ b/cast/js/build.gradle.kts
@@ -58,8 +58,7 @@ val processTestResources by tasks.existing(Copy::class) { from(unpackAjaxslt) { 
 val testResources: Configuration by configurations.creating { isCanBeResolved = false }
 
 artifacts {
-  val java: JavaPluginExtension by extensions
-  add(javadocDestinationDirectory.name, file("${java.docsDir}/javadoc"))
+  add(javadocDestinationDirectory.name, tasks.javadoc)
   add(packageListDirectory.name, createPackageList)
   add(testResources.name, processTestResources)
 }


### PR DESCRIPTION
The previous approach was needlessly complicated.  It was also flat-out wrong, since it turned a property (rather than a property's value) into a `String` for use in a `File` name.