### PR TITLE
Update to NullAway 0.10.24 and enable experimental JSpecify mode

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/NullAway.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/NullAway.gradle.kts
@@ -17,8 +17,8 @@ tasks.withType<JavaCompile>().configureEach {
     if (!name.contains("test", true)) {
       error("NullAway")
       errorproneArgs.addAll(
-        "-XepOpt:NullAway:AnnotatedPackages=com.ibm.wala",
-        "-XepOpt:NullAway:JSpecifyMode=true",
+          "-XepOpt:NullAway:AnnotatedPackages=com.ibm.wala",
+          "-XepOpt:NullAway:JSpecifyMode=true",
       )
     }
   }

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/NullAway.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/NullAway.gradle.kts
@@ -17,7 +17,8 @@ tasks.withType<JavaCompile>().configureEach {
     if (!name.contains("test", true)) {
       error("NullAway")
       errorproneArgs.addAll(
-          "-XepOpt:NullAway:AnnotatedPackages=com.ibm.wala",
+        "-XepOpt:NullAway:AnnotatedPackages=com.ibm.wala",
+        "-XepOpt:NullAway:JSpecifyMode=true",
       )
     }
   }

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -21,7 +21,6 @@ repositories {
   mavenCentral()
   // to get r8
   maven { url = uri("https://storage.googleapis.com/r8-releases/raw") }
-  mavenLocal()
 }
 
 java.toolchain.languageVersion =

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ eclipse-ecj = "org.eclipse.jdt:ecj:3.21.0"
 eclipse-osgi = "org.eclipse.platform:org.eclipse.osgi:3.17.0"
 eclipse-wst-jsdt-core = { module = "org.eclipse.wst.jsdt:core", version.ref = "eclipse-wst-jsdt" }
 eclipse-wst-jsdt-ui = { module = "org.eclipse.wst.jsdt:ui", version.ref = "eclipse-wst-jsdt" }
-errorprone-core = "com.google.errorprone:error_prone_core:2.24.0"
+errorprone-core = "com.google.errorprone:error_prone_core:2.24.1"
 gradle-goomph-plugin = "com.diffplug.gradle:goomph:3.44.0"
 gradle-download-task = "de.undercouch:gradle-download-task:5.5.0"
 gradle-errorprone-plugin = "net.ltgt.gradle:gradle-errorprone-plugin:3.0.1"
@@ -36,7 +36,7 @@ junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine" }
-nullaway = "com.uber.nullaway:nullaway:0.10.19"
+nullaway = "com.uber.nullaway:nullaway:0.10.21"
 rhino = "org.mozilla:rhino:1.7.14"
 slf4j-api = "org.slf4j:slf4j-api:2.0.7"
 w3c-css-sac = "org.eclipse.birt.runtime:org.w3c.css.sac:1.3.1.v200903091627"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine" }
-nullaway = "com.uber.nullaway:nullaway:0.10.24-SNAPSHOT"
+nullaway = "com.uber.nullaway:nullaway:0.10.24"
 rhino = "org.mozilla:rhino:1.7.14"
 slf4j-api = "org.slf4j:slf4j-api:2.0.7"
 w3c-css-sac = "org.eclipse.birt.runtime:org.w3c.css.sac:1.3.1.v200903091627"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ htmlparser = "nu.validator.htmlparser:htmlparser:1.4"
 java_cup = "java_cup:java_cup:0.9e"
 javax-annotation-api = { module = "javax.annotation:javax.annotation-api", version = { strictly = "1.3.2" } }
 jericho-html = "net.htmlparser.jericho:jericho-html:3.2"
-json = "org.json:json:20230618"
+json = "org.json:json:20231013"
 jspecify = "org.jspecify:jspecify:0.3.0"
 junit-bom = "org.junit:junit-bom:5.10.0"
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine" }
-nullaway = "com.uber.nullaway:nullaway:0.10.22-SNAPSHOT"
+nullaway = "com.uber.nullaway:nullaway:0.10.24-SNAPSHOT"
 rhino = "org.mozilla:rhino:1.7.14"
 slf4j-api = "org.slf4j:slf4j-api:2.0.7"
 w3c-css-sac = "org.eclipse.birt.runtime:org.w3c.css.sac:1.3.1.v200903091627"

--- a/util/src/main/java/com/ibm/wala/util/graph/GraphSlicer.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/GraphSlicer.java
@@ -226,8 +226,7 @@ public class GraphSlicer {
 
           private final Map<E, Collection<E>> preds = new HashMap<>();
 
-          private Set<E> getConnected(
-              @Nullable E inst, Function<E, Iterator<? extends E>> fconnected) {
+          private Set<E> getConnected(E inst, Function<E, Iterator<? extends E>> fconnected) {
             Set<E> result = new LinkedHashSet<>();
             Set<E> seenInsts = new HashSet<>();
             Set<E> newInsts = Iterator2Collection.toSet(fconnected.apply(inst));
@@ -253,11 +252,11 @@ public class GraphSlicer {
             return result;
           }
 
-          private void setPredNodes(@Nullable E N) {
+          private void setPredNodes(E N) {
             preds.put(N, getConnected(N, G::getPredNodes));
           }
 
-          private void setSuccNodes(@Nullable E N) {
+          private void setSuccNodes(E N) {
             succs.put(N, getConnected(N, G::getSuccNodes));
           }
 

--- a/util/src/main/java/com/ibm/wala/util/io/RtJar.java
+++ b/util/src/main/java/com/ibm/wala/util/io/RtJar.java
@@ -45,8 +45,7 @@ public class RtJar {
                   try {
                     return new JarFile(object);
                   } catch (IOException e) {
-                    assert false : e.toString();
-                    return null;
+                    throw new RuntimeException(e);
                   }
                 }));
 


### PR DESCRIPTION
NullAway's JSpecify mode does greater checking around generic types.  It is still experimental, but I will ensure that future fixes in JSpecify mode won't break WALA's build.
