### PR TITLE
Switch to ConcurrentHashMap in SeqClassHierarchyFactory

### DIFF
--- a/core/src/main/java/com/ibm/wala/ipa/cha/SeqClassHierarchyFactory.java
+++ b/core/src/main/java/com/ibm/wala/ipa/cha/SeqClassHierarchyFactory.java
@@ -15,8 +15,8 @@ import com.ibm.wala.classLoader.ClassLoaderFactoryImpl;
 import com.ibm.wala.classLoader.Language;
 import com.ibm.wala.ipa.callgraph.AnalysisScope;
 import com.ibm.wala.util.MonitorUtil.IProgressMonitor;
-import com.ibm.wala.util.collections.HashMapFactory;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class SeqClassHierarchyFactory {
 
@@ -51,7 +51,11 @@ public class SeqClassHierarchyFactory {
       throw new IllegalArgumentException("null factory");
     }
     return new ClassHierarchy(
-        scope, factory, null, HashMapFactory.make(), ClassHierarchy.MissingSuperClassHandling.NONE);
+        scope,
+        factory,
+        null,
+        new ConcurrentHashMap<>(),
+        ClassHierarchy.MissingSuperClassHandling.NONE);
   }
 
   /**
@@ -65,7 +69,7 @@ public class SeqClassHierarchyFactory {
         scope,
         factory,
         monitor,
-        HashMapFactory.make(),
+        new ConcurrentHashMap<>(),
         ClassHierarchy.MissingSuperClassHandling.NONE);
   }
 
@@ -77,7 +81,7 @@ public class SeqClassHierarchyFactory {
         factory,
         languages,
         null,
-        HashMapFactory.make(),
+        new ConcurrentHashMap<>(),
         ClassHierarchy.MissingSuperClassHandling.NONE);
   }
 
@@ -89,7 +93,7 @@ public class SeqClassHierarchyFactory {
         factory,
         language,
         null,
-        HashMapFactory.make(),
+        new ConcurrentHashMap<>(),
         ClassHierarchy.MissingSuperClassHandling.NONE);
   }
 
@@ -108,7 +112,7 @@ public class SeqClassHierarchyFactory {
         factory,
         language,
         monitor,
-        HashMapFactory.make(),
+        new ConcurrentHashMap<>(),
         ClassHierarchy.MissingSuperClassHandling.NONE);
   }
 }


### PR DESCRIPTION
I believe this should address #1377.  See https://github.com/wala/WALA/commit/74b6c744926146ecaeaae5da5a74e18c95891fff.  For some reason at that point we decided not to use the type system to enforce use of a `ConcurrentHashMap` always.  In this spirit of trying not to break things I didn't do that here, but instead changed `SeqClassHierarchyFactory` to use `ConcurrentHashMap`.

Fixes #1377 (though we can reopen if the crash still happens)