### PR TITLE
Write `AbstractScriptEntity.toString()`  in terms of `getName()`

### DIFF
--- a/cast/src/main/java/com/ibm/wala/cast/ir/translator/AbstractScriptEntity.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/translator/AbstractScriptEntity.java
@@ -49,7 +49,7 @@ public abstract class AbstractScriptEntity extends AbstractCodeEntity {
 
   @Override
   public String toString() {
-    return "script " + file.getName();
+    return this.getName();
   }
 
   @Override


### PR DESCRIPTION
Fixes https://github.com/wala/WALA/issues/1378.