### PR TITLE
Refactor `EclipseSourceFileModule` to make it more extension-friendly

### DIFF
--- a/ide/src/main/java/com/ibm/wala/ide/classloader/EclipseSourceDirectoryTreeModule.java
+++ b/ide/src/main/java/com/ibm/wala/ide/classloader/EclipseSourceDirectoryTreeModule.java
@@ -69,7 +69,7 @@ public class EclipseSourceDirectoryTreeModule extends SourceDirectoryTreeModule 
     IWorkspaceRoot root = ws.getRoot();
     IFile ifile = root.getFile(p);
     assert ifile.exists();
-    return EclipseSourceFileModule.createEclipseSourceFileModule(ifile);
+    return new EclipseSourceFileModule(ifile);
   }
 
   @Override

--- a/ide/src/main/java/com/ibm/wala/ide/classloader/EclipseSourceFileModule.java
+++ b/ide/src/main/java/com/ibm/wala/ide/classloader/EclipseSourceFileModule.java
@@ -21,7 +21,8 @@ public class EclipseSourceFileModule extends SourceFileModule {
 
   public EclipseSourceFileModule(IFile f) {
     super(
-        // NOTE: Passing `null` here causes an exception to be thrown in the ctor of `com.ibm.wala.classLoader.FileModule`.
+        // NOTE: Passing `null` here causes an exception to be thrown in the ctor of
+        // `com.ibm.wala.classLoader.FileModule`.
         f == null ? null : new File(f.getFullPath().toOSString()),
         f == null ? null : f.getName(),
         null);

--- a/ide/src/main/java/com/ibm/wala/ide/classloader/EclipseSourceFileModule.java
+++ b/ide/src/main/java/com/ibm/wala/ide/classloader/EclipseSourceFileModule.java
@@ -20,7 +20,10 @@ public class EclipseSourceFileModule extends SourceFileModule {
   protected final IFile f;
 
   public EclipseSourceFileModule(IFile f) {
-    super(f == null ? null : new File(f.getFullPath().toOSString()), f == null ? null : f.getName(), null);
+    super(
+        f == null ? null : new File(f.getFullPath().toOSString()),
+        f == null ? null : f.getName(),
+        null);
     this.f = f;
   }
 

--- a/ide/src/main/java/com/ibm/wala/ide/classloader/EclipseSourceFileModule.java
+++ b/ide/src/main/java/com/ibm/wala/ide/classloader/EclipseSourceFileModule.java
@@ -21,6 +21,7 @@ public class EclipseSourceFileModule extends SourceFileModule {
 
   public EclipseSourceFileModule(IFile f) {
     super(
+        // NOTE: Passing `null` here causes an exception to be thrown in the ctor of `com.ibm.wala.classLoader.FileModule`.
         f == null ? null : new File(f.getFullPath().toOSString()),
         f == null ? null : f.getName(),
         null);

--- a/ide/src/main/java/com/ibm/wala/ide/classloader/EclipseSourceFileModule.java
+++ b/ide/src/main/java/com/ibm/wala/ide/classloader/EclipseSourceFileModule.java
@@ -17,17 +17,10 @@ import org.eclipse.core.resources.IFile;
 /** A module which is a wrapper around a .java file */
 public class EclipseSourceFileModule extends SourceFileModule {
 
-  private final IFile f;
+  protected final IFile f;
 
-  public static EclipseSourceFileModule createEclipseSourceFileModule(IFile f) {
-    if (f == null) {
-      throw new IllegalArgumentException("null f");
-    }
-    return new EclipseSourceFileModule(f);
-  }
-
-  private EclipseSourceFileModule(IFile f) {
-    super(new File(f.getFullPath().toOSString()), f.getName(), null);
+  public EclipseSourceFileModule(IFile f) {
+    super(f == null ? null : new File(f.getFullPath().toOSString()), f == null ? null : f.getName(), null);
     this.f = f;
   }
 


### PR DESCRIPTION
The removed null checks seem to happen further up the class hierarchy. Replace the static construction method with a public constructor. A lone private constructor basically makes it basically impossible to subclass.