### PR TITLE
Refactor `EclipseSourceDirectoryTreeModule` for more extensibility

### DIFF
--- a/ide/src/main/java/com/ibm/wala/ide/classloader/EclipseSourceDirectoryTreeModule.java
+++ b/ide/src/main/java/com/ibm/wala/ide/classloader/EclipseSourceDirectoryTreeModule.java
@@ -69,6 +69,10 @@ public class EclipseSourceDirectoryTreeModule extends SourceDirectoryTreeModule 
     IWorkspaceRoot root = ws.getRoot();
     IFile ifile = root.getFile(p);
     assert ifile.exists();
+    return this.makeFile(ifile);
+  }
+
+  protected FileModule makeFile(IFile file) {
     return EclipseSourceFileModule.createEclipseSourceFileModule(ifile);
   }
 

--- a/ide/src/main/java/com/ibm/wala/ide/classloader/EclipseSourceDirectoryTreeModule.java
+++ b/ide/src/main/java/com/ibm/wala/ide/classloader/EclipseSourceDirectoryTreeModule.java
@@ -73,7 +73,7 @@ public class EclipseSourceDirectoryTreeModule extends SourceDirectoryTreeModule 
   }
 
   protected FileModule makeFile(IFile file) {
-    return EclipseSourceFileModule.createEclipseSourceFileModule(ifile);
+    return EclipseSourceFileModule.createEclipseSourceFileModule(file);
   }
 
   @Override


### PR DESCRIPTION
When I subclassed `EclipseSourceDirectoryTreeModule`, I found myself needing to make a copy of `rootIPath` because it is private in the super class so that I could override a method. Overloading the `makeFile()` method now allows a bit more flexibility with the type of `FileModule` being created.