### PR TITLE
Gradle 8.7 and Apple Silicon

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,6 +15,9 @@ jobs:
         include:
           - os: macos-latest
             java: 11
+          # Apple Silicon M1 CPU according to <https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories>
+          - os: macos-14
+            java: 11
           - os: ubuntu-latest
             java: 11
           - os: windows-latest

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/NullAway.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/NullAway.gradle.kts
@@ -16,7 +16,7 @@ tasks.withType<JavaCompile>().configureEach {
   options.errorprone {
     if (!name.contains("test", true)) {
       error("NullAway")
-      errorproneArgs.addAll(
+      errorproneArgs.appendAll(
           "-XepOpt:NullAway:AnnotatedPackages=com.ibm.wala",
           "-XepOpt:NullAway:JSpecifyMode=true",
       )

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/cast/helpers.kt
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/cast/helpers.kt
@@ -85,7 +85,7 @@ fun addJvmLibrary(binary: CppBinary, linkTask: AbstractLinkTask, project: Projec
 
 fun addRpath(linkTask: AbstractLinkTask, library: File) {
   if (!(linkTask.project.rootProject.extra["isWindows"] as Boolean)) {
-    linkTask.linkerArgs.add("-Wl,-rpath,${library.parent}")
+    linkTask.linkerArgs.append("-Wl,-rpath,${library.parent}")
   }
 }
 

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -70,7 +70,7 @@ tasks.withType<JavaCompile>().configureEach {
     disable("ReferenceEquality")
     // Example for running Error Prone's auto-patcher.  To run, uncomment and change the
     // check name to the one you want to patch
-    //			errorproneArgs.addAll(
+    //			errorproneArgs.appendAll(
     //					"-XepPatchChecks:UnnecessaryParentheses",
     //					"-XepPatchLocation:IN_PLACE"
     //			)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,6 @@ repositories {
 }
 
 val osName: String by extra(System.getProperty("os.name"))
-val archName: String by extra(System.getProperty("os.arch"))
 val isWindows by extra(osName.startsWith("Windows "))
 
 JavaVersion.current().let {

--- a/cast/cast/build.gradle.kts
+++ b/cast/cast/build.gradle.kts
@@ -17,7 +17,7 @@ library {
         .configure(
             closureOf<LinkSharedLibrary> {
               if (targetMachine.operatingSystemFamily.isMacOs) {
-                linkerArgs.add("-Wl,-install_name,@rpath/${nativeLibraryOutput.name}")
+                linkerArgs.append("-Wl,-install_name,@rpath/${nativeLibraryOutput.name}")
               }
               addJvmLibrary(this@whenElementFinalized, this, project)
             })

--- a/cast/cast/build.gradle.kts
+++ b/cast/cast/build.gradle.kts
@@ -8,13 +8,6 @@ plugins {
 }
 
 library {
-  // Temporary change to build on M1 Mac machines, until
-  // https://github.com/gradle/gradle/issues/18876
-  // is fixed
-  if (rootProject.extra["osName"] == "Mac OS X" && rootProject.extra["archName"] == "aarch64") {
-    targetMachines.add(machines.macOS.x86_64)
-  }
-
   binaries.whenElementFinalized {
     compileTask.get().configure(closureOf<CppCompile> { macros["BUILD_CAST_DLL"] = "1" })
 

--- a/cast/smoke_main/build.gradle.kts
+++ b/cast/smoke_main/build.gradle.kts
@@ -47,13 +47,6 @@ val xlatorTestDebugSharedLibraryConfig = createXlatorConfig(false)
 val xlatorTestReleaseSharedLibraryConfig = createXlatorConfig(true)
 
 application {
-  // Temporary change to build on M1 Mac machines, until
-  // https://github.com/gradle/gradle/issues/18876
-  // is fixed
-  if (rootProject.extra["osName"] == "Mac OS X" && rootProject.extra["archName"] == "aarch64") {
-    targetMachines.add(machines.macOS.x86_64)
-  }
-
   dependencies {
     coreResources(projects.core)
     smokeMainExtraPathElements(projects.cast)

--- a/cast/smoke_main/build.gradle.kts
+++ b/cast/smoke_main/build.gradle.kts
@@ -88,15 +88,16 @@ application {
 
                       // xlator Java bytecode + implementation of native methods
                       val pathElements = project.objects.listProperty<File>()
-                      pathElements.addAll(files("../build/classes/java/test", libxlatorTest.parent))
+                      pathElements.appendAll(
+                          files("../build/classes/java/test", libxlatorTest.parent))
 
                       // "primordial.txt" resource loaded during test
-                      pathElements.add(coreResources.singleFile)
+                      pathElements.append(coreResources.singleFile)
                       inputs.files(coreResources)
 
                       // additional supporting Java class files
                       inputs.files(smokeMainExtraPathElements)
-                      pathElements.addAll(smokeMainExtraPathElements)
+                      pathElements.appendAll(smokeMainExtraPathElements)
 
                       // all combined as a colon-delimited path list
                       argumentProviders.add { listOf(pathElements.get().joinToString(":")) }

--- a/cast/xlator_test/build.gradle.kts
+++ b/cast/xlator_test/build.gradle.kts
@@ -13,12 +13,6 @@ dependencies {
 }
 
 library {
-  // Temporary change to build on M1 Mac machines, until
-  // https://github.com/gradle/gradle/issues/18876
-  // is fixed
-  if (rootProject.extra["osName"] == "Mac OS X" && rootProject.extra["archName"] == "aarch64") {
-    targetMachines.add(machines.macOS.x86_64)
-  }
   privateHeaders.from(castHeaderDirectory)
 
   dependencies { implementation(projects.cast.cast) }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=c16d517b50dd28b3f5838f0e844b7520b8f1eb610f2f29de7e4e04a1b7c9c79b
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
+distributionSha256Sum=194717442575a6f96e1c1befa2c30e9a4fc90f701d7aee33eb879b79e7ff05c0
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -43,11 +43,11 @@ set JAVA_EXE=java.exe
 %JAVA_EXE% -version >NUL 2>&1
 if %ERRORLEVEL% equ 0 goto execute
 
-echo.
-echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
-echo.
-echo Please set the JAVA_HOME variable in your environment to match the
-echo location of your Java installation.
+echo. 1>&2
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH. 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
 
 goto fail
 
@@ -57,11 +57,11 @@ set JAVA_EXE=%JAVA_HOME%/bin/java.exe
 
 if exist "%JAVA_EXE%" goto execute
 
-echo.
-echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
-echo.
-echo Please set the JAVA_HOME variable in your environment to match the
-echo location of your Java installation.
+echo. 1>&2
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME% 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
 
 goto fail
 


### PR DESCRIPTION
Upgrade to Gradle 8.7, and fully support macOS on Apple Silicon, i.e., M1 CPUs. Specifically:

1. 327f3598a Remove customizations for macOS on Apple Silicon
1. b2a8f5d25 Add automated tests on Apple Silicon M1 CPU
1. 5a3f53410 Upgrade to Gradle 8.7
1. 5cdc1920b Use new API for updating collection properties
