### PR TITLE
Upgrade to v4 of `upload-artifact` GitHub action

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -62,16 +62,16 @@ jobs:
         if: runner.os != 'Windows'
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: Test results for JDK ${{ matrix.java }} on ${{ runner.os }}
+          name: Test results for JDK ${{ matrix.java }} on ${{ matrix.os }}
           path: '**/build/test-results/test/TEST-*.xml'
   upload_event_file:
     name: Upload event file
     runs-on: ubuntu-latest
     steps:
       - name: Upload event file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Event file
           path: ${{ github.event_path }}


### PR DESCRIPTION
v3 of this action is [deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) and will stop working in November 2024.