### PR TITLE
Add and use version catalog updater

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.shellcheck)
   alias(libs.plugins.task.tree)
+  alias(libs.plugins.version.catalog.update)
   alias(libs.plugins.versions)
   id("com.ibm.wala.gradle.javadoc")
   id("com.ibm.wala.gradle.eclipse-maven-central")

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,9 @@
 # in `build-logic/src/main/kotlin/com/ibm/wala/gradle/EclipseCompatibleJavaExtension.kt`.
 com.ibm.wala.jdk-version=11
 
+# <https://github.com/littlerobots/version-catalog-update-plugin/pull/125#issue-2024490739>
+nl.littlerobots.vcu.resolver=true
+
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,17 +3,17 @@ eclipse = "4.30.0"
 eclipse-wst-jsdt = "1.0.201.v2010012803"
 google-java-format = "1.17.0"
 ktfmt = "0.44"
-spotless = "6.23.3"
+spotless = "6.25.0"
 
 [libraries]
 android-tools = "com.android.tools:r8:8.2.46"
 ant = "org.apache.ant:ant:1.10.14"
-assertj-core = "org.assertj:assertj-core:3.24.2"
-commons-cli = "commons-cli:commons-cli:1.5.0"
-commons-io = "commons-io:commons-io:2.13.0"
+assertj-core = "org.assertj:assertj-core:3.26.0"
+commons-cli = "commons-cli:commons-cli:1.8.0"
+commons-io = "commons-io:commons-io:2.16.1"
 dexlib2 = "org.smali:dexlib2:2.5.2"
 eclipse-ecj = "org.eclipse.jdt:ecj:3.21.0"
-eclipse-osgi = "org.eclipse.platform:org.eclipse.osgi:3.17.0"
+eclipse-osgi = "org.eclipse.platform:org.eclipse.osgi:3.19.0"
 eclipse-wst-jsdt-core = { module = "org.eclipse.wst.jsdt:core", version.ref = "eclipse-wst-jsdt" }
 eclipse-wst-jsdt-ui = { module = "org.eclipse.wst.jsdt:ui", version.ref = "eclipse-wst-jsdt" }
 errorprone-core = "com.google.errorprone:error_prone_core:2.27.1"
@@ -21,33 +21,33 @@ gradle-download-task = "de.undercouch:gradle-download-task:5.6.0"
 gradle-errorprone-plugin = "net.ltgt.gradle:gradle-errorprone-plugin:3.1.0"
 gradle-goomph-plugin = "com.diffplug.gradle:goomph:3.44.0"
 gradle-spotless-plugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
-gson = "com.google.code.gson:gson:2.10.1"
-guava = "com.google.guava:guava:33.0.0-jre"
+gson = "com.google.code.gson:gson:2.11.0"
+guava = "com.google.guava:guava:33.2.0-jre"
 hamcrest = "org.hamcrest:hamcrest:2.2"
 htmlparser = "nu.validator.htmlparser:htmlparser:1.4"
 java_cup = "java_cup:java_cup:0.9e"
 javax-annotation-api = { module = "javax.annotation:javax.annotation-api", version = { strictly = "1.3.2" } }
 jericho-html = "net.htmlparser.jericho:jericho-html:3.2"
-json = "org.json:json:20231013"
+json = "org.json:json:20240303"
 jspecify = "org.jspecify:jspecify:0.3.0"
-junit-bom = "org.junit:junit-bom:5.10.0"
+junit-bom = "org.junit:junit-bom:5.10.2"
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine" }
 nullaway = "com.uber.nullaway:nullaway:0.10.24"
-rhino = "org.mozilla:rhino:1.7.14"
-slf4j-api = "org.slf4j:slf4j-api:2.0.7"
+rhino = "org.mozilla:rhino:1.7.15"
+slf4j-api = "org.slf4j:slf4j-api:2.0.13"
 w3c-css-sac = "org.eclipse.birt.runtime:org.w3c.css.sac:1.3.1.v200903091627"
 
 [plugins]
 file-lister = "all.shared.gradle.file-lister:1.0.2"
 google-java-format = "com.github.sherter.google-java-format:0.9"
-kotlin-jvm = "org.jetbrains.kotlin.jvm:1.9.20"
-ktfmt = "com.ncorti.ktfmt.gradle:0.11.0"
+kotlin-jvm = "org.jetbrains.kotlin.jvm:2.0.0"
+ktfmt = "com.ncorti.ktfmt.gradle:0.18.0"
 shellcheck = "com.felipefzdz.gradle.shellcheck:1.4.6"
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
-task-tree = "com.dorongold.task-tree:2.1.1"
+task-tree = "com.dorongold.task-tree:3.0.0"
 version-catalog-update = "nl.littlerobots.version-catalog-update:0.8.4"
-versions = "com.github.ben-manes.versions:0.50.0"
+versions = "com.github.ben-manes.versions:0.51.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,4 +49,5 @@ ktfmt = "com.ncorti.ktfmt.gradle:0.11.0"
 shellcheck = "com.felipefzdz.gradle.shellcheck:1.4.6"
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 task-tree = "com.dorongold.task-tree:2.1.1"
+version-catalog-update = "nl.littlerobots.version-catalog-update:0.8.4"
 versions = "com.github.ben-manes.versions:0.50.0"


### PR DESCRIPTION
## Add a dependency catalog updater plugin

[This plugin](https://github.com/littlerobots/version-catalog-update-plugin) will help us clean and update the shared version catalog in `gradle/libs.versions.toml`.  It does not run automatically.  Instead, it provides a few helpful housekeeping tasks in the `version catalog update` group that we can run manually whenever convenient.

## Update many dependencies

These updates were all discovered and applied using the `versionCatalogUpdate` task provided by the `nl.littlerobots.version-catalog-update` plugin.

For now, I'm considering only those upgrades that cause no test regressions and that require no changes to WALA's Java code.  There are a few additional update opportunities that currently cause regressions. We can consider those separately, along with any Java code changes needed to make them work correctly.