### PR TITLE
Upgrade to newer ECJ release

### DIFF
--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/AnalysisScope.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/AnalysisScope.java
@@ -415,6 +415,7 @@ public class AnalysisScope {
   /**
    * @return the rt.jar (1.4), core.jar (1.5), java.core.jmod (13) file, or null if not found.
    */
+  @SuppressWarnings("resource")
   private JarFile getRtJar() {
     return RtJar.getRtJar(
         new MapIterator<>(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ assertj-core = "org.assertj:assertj-core:3.26.0"
 commons-cli = "commons-cli:commons-cli:1.8.0"
 commons-io = "commons-io:commons-io:2.16.1"
 dexlib2 = "org.smali:dexlib2:2.5.2"
-eclipse-ecj = "org.eclipse.jdt:ecj:3.21.0"
+eclipse-ecj = "org.eclipse.jdt:ecj:3.37.0"
 eclipse-osgi = "org.eclipse.platform:org.eclipse.osgi:3.19.0"
 eclipse-wst-jsdt-core = { module = "org.eclipse.wst.jsdt:core", version.ref = "eclipse-wst-jsdt" }
 eclipse-wst-jsdt-ui = { module = "org.eclipse.wst.jsdt:ui", version.ref = "eclipse-wst-jsdt" }


### PR DESCRIPTION
The `versionCatalogUpdate` task found this upgrade opportunity, but we also needed to suppress a resource-leak diagnostic that the newer ECJ produces for some of our `JarFile`-manipulating code.