### PR TITLE
Modernize a `for` loop

### DIFF
--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/AnalysisScope.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/AnalysisScope.java
@@ -55,6 +55,8 @@ import java.util.Set;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Base class that represents a set of files to analyze.
@@ -365,19 +367,15 @@ public class AnalysisScope {
       loaders.put(loader.getName().toString(), arr);
     }
     res.put("Loaders", loaders);
-    ArrayList<String> arr2 = new ArrayList<>();
-    if (getExclusions() == null) {
-      res.put("Exclusions", arr2);
-    } else {
-      String[] exclusions = getExclusions().toString().split("\\|");
-      for (int i = 0; i < exclusions.length; i++) {
-        String word = exclusions[i];
-        word = word.replace("(", "");
-        word = word.replace(")", "");
-        arr2.add(word);
-      }
-      res.put("Exclusions", arr2);
-    }
+    final var exclusions = getExclusions();
+    res.put(
+        "Exclusions",
+        exclusions == null
+            ? List.of()
+            : Pattern.compile("\\|")
+                .splitAsStream(exclusions.toString())
+                .map(exclusion -> exclusion.replace("(", "").replace(")", ""))
+                .collect(Collectors.toList()));
     Gson gson = new Gson();
     return gson.toJson(res);
   }


### PR DESCRIPTION
Replace a general `for (;;)` loop with something in a more functional style.  The restructured code also makes it more obvious that exactly one `List` instance is *always* put into the `Exclusions` key of the `res` `Map`.