### PR TITLE
Simplify JUnit entrypoints fix

### DIFF
--- a/core/src/main/java/com/ibm/wala/core/util/scope/JUnitEntryPoints.java
+++ b/core/src/main/java/com/ibm/wala/core/util/scope/JUnitEntryPoints.java
@@ -132,7 +132,7 @@ public class JUnitEntryPoints {
   private static boolean isTestEntryPoint(TypeName typeName) {
     // WALA uses $ to refers to inner classes. We have to replace "$" by "."
     // to make it a valid class name in Java source code.
-    String javaName = StringStuff.jvmToReadableType(typeName.toString().replace('$', '.'));
+    String javaName = typeName.toString().replace('$', '.');
 
     return TEST_ENTRY_POINT_ANNOTATION_NAMES.contains(javaName);
   }

--- a/core/src/main/java/com/ibm/wala/core/util/scope/JUnitEntryPoints.java
+++ b/core/src/main/java/com/ibm/wala/core/util/scope/JUnitEntryPoints.java
@@ -15,7 +15,6 @@ import com.ibm.wala.classLoader.IClassLoader;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.classLoader.ShrikeCTMethod;
 import com.ibm.wala.core.util.strings.Atom;
-import com.ibm.wala.core.util.strings.StringStuff;
 import com.ibm.wala.ipa.callgraph.Entrypoint;
 import com.ibm.wala.ipa.callgraph.impl.DefaultEntrypoint;
 import com.ibm.wala.ipa.cha.IClassHierarchy;


### PR DESCRIPTION
I don't think we need the `jvmToReadableType()` method if we are going to replace the characters directly.

Related to: https://github.com/wala/WALA/pull/1398//