### PR TITLE
Correct numerous small dependency nits

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -41,10 +41,8 @@ dependencies {
   "javadocSource"(sourceSets.main.get().allJava)
 
   testFixturesImplementation(platform(findLibrary("junit-bom")))
-  testFixturesImplementation(findLibrary("junit-jupiter-api"))
 
   testImplementation(platform(findLibrary("junit-bom")))
-  testImplementation(findLibrary("junit-jupiter-api"))
   testRuntimeOnly(findLibrary("junit-jupiter-engine"))
   testRuntimeOnly(findLibrary("junit-vintage-engine"))
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ buildscript { dependencies.classpath(libs.commons.io) }
 plugins {
   idea
   java
+  alias(libs.plugins.dependency.analysis)
   alias(libs.plugins.file.lister)
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.shellcheck)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,6 @@ plugins {
   java
   alias(libs.plugins.dependency.analysis)
   alias(libs.plugins.file.lister)
-  alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.shellcheck)
   alias(libs.plugins.task.tree)
   alias(libs.plugins.version.catalog.update)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,6 +99,8 @@ shellcheck {
       }
 }
 
+tasks.named("check") { dependsOn("buildHealth") }
+
 tasks.named("shellcheck") { group = "verification" }
 
 // install Java reformatter as git pre-commit hook

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,6 +87,9 @@ tasks.register<Javadoc>("aggregatedJavadocs") {
 //  linters for various specific languages or file formats
 //
 
+// Gradle dependencies
+dependencyAnalysis.issues { all { onAny { severity("fail") } } }
+
 // shell scripts, provided they have ".sh" extension
 shellcheck {
   isUseDocker = false

--- a/cast/build.gradle.kts
+++ b/cast/build.gradle.kts
@@ -37,16 +37,19 @@ dependencies {
   api(projects.core) {
     because("public method AstCGNode.addTarget receives an argument of type CGNode")
   }
+  api(projects.shrike)
+  api(projects.util)
   implementation(libs.commons.io)
-  implementation(projects.shrike)
-  implementation(projects.util)
   castJsJavadocDestinationDirectory(
       project(mapOf("path" to ":cast:js", "configuration" to "javadocDestinationDirectory")))
   castCastSharedLibrary(projects.cast.cast)
   castJsPackageListDirectory(
       project(mapOf("path" to ":cast:js", "configuration" to "packageListDirectory")))
   javadocClasspath(projects.cast.js)
-  xlatorTestSharedLibrary(project("xlator_test"))
+  testFixturesApi(projects.core)
+  testFixturesImplementation(projects.util)
+  testImplementation(libs.junit.jupiter.api)
+  xlatorTestSharedLibrary(projects.cast.xlatorTest)
 }
 
 val castHeaderDirectory: Configuration by configurations.creating { isCanBeResolved = false }

--- a/cast/java/build.gradle.kts
+++ b/cast/java/build.gradle.kts
@@ -6,10 +6,13 @@ plugins {
 eclipse.project.natures("org.eclipse.pde.PluginNature")
 
 dependencies {
-  implementation(projects.cast)
-  implementation(projects.core)
+  api(projects.cast)
+  api(projects.core)
+  api(projects.util)
   implementation(projects.shrike)
-  implementation(projects.util)
+  testFixturesApi(libs.junit.jupiter.api)
+  testFixturesApi(projects.core)
+  testFixturesApi(projects.util)
   testFixturesImplementation(projects.cast)
-  testFixturesImplementation(projects.core)
+  testFixturesImplementation(projects.shrike)
 }

--- a/cast/java/ecj/build.gradle.kts
+++ b/cast/java/ecj/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 walaEclipseMavenCentral {
   implementation(
-      "org.eclipse.core.runtime",
+      "org.eclipse.equinox.common",
       "org.eclipse.jdt.core",
   )
 }
@@ -15,9 +15,8 @@ walaEclipseMavenCentral {
 val runSourceDirectory: Configuration by configurations.creating { isCanBeConsumed = false }
 
 dependencies {
-  implementation(
-      projects.cast,
-  )
+  implementation(libs.eclipse.ecj)
+  implementation(projects.cast)
   implementation(projects.cast.java)
   implementation(projects.core)
   implementation(projects.shrike)
@@ -25,6 +24,7 @@ dependencies {
   runSourceDirectory(
       project(
           mapOf("path" to ":cast:java:test:data", "configuration" to "testJavaSourceDirectory")))
+  testImplementation(libs.junit.jupiter.api)
   testImplementation(testFixtures(projects.cast.java))
 }
 

--- a/cast/js/build.gradle.kts
+++ b/cast/js/build.gradle.kts
@@ -8,16 +8,20 @@ plugins {
 }
 
 dependencies {
+  api(libs.jericho.html)
   api(projects.cast) { because("public class JSCallGraphUtil extends class CAstCallGraphUtil") }
+  api(projects.core)
+  api(projects.util)
   implementation(libs.commons.io)
   implementation(libs.gson)
-  implementation(libs.jericho.html)
-  implementation(projects.core)
   implementation(projects.shrike)
-  implementation(projects.util)
   javadocClasspath(projects.cast.js.rhino)
-  testFixturesImplementation(testFixtures(projects.cast))
-  testImplementation(testFixtures(projects.cast))
+  testFixturesApi(libs.junit.jupiter.api)
+  testFixturesApi(projects.cast)
+  testFixturesApi(projects.core)
+  testFixturesApi(projects.util)
+  testFixturesApi(testFixtures(projects.cast))
+  testImplementation(libs.junit.jupiter.api)
   testImplementation(testFixtures(projects.core))
 }
 

--- a/cast/js/html/nu_validator/build.gradle.kts
+++ b/cast/js/html/nu_validator/build.gradle.kts
@@ -3,13 +3,11 @@ plugins { id("com.ibm.wala.gradle.java") }
 val extraTestResources: Configuration by configurations.creating { isCanBeConsumed = false }
 
 dependencies {
+  api(projects.cast.js)
   extraTestResources(project(mapOf("path" to ":cast:js", "configuration" to "testResources")))
   implementation(libs.htmlparser)
   implementation(projects.cast)
-  implementation(projects.cast.js)
   implementation(projects.util)
-  testImplementation(testFixtures(projects.cast))
-  testImplementation(testFixtures(projects.cast.js))
   testImplementation(testFixtures(projects.cast.js.rhino))
 }
 

--- a/cast/js/nodejs/build.gradle.kts
+++ b/cast/js/nodejs/build.gradle.kts
@@ -7,12 +7,13 @@ dependencies {
   api(projects.cast.js) {
     because("public class NodejsCallGraphBuilderUtil extends class JSCallGraphUtil")
   }
+  api(projects.core)
+  api(projects.util)
   implementation(libs.commons.io)
   implementation(libs.json)
   implementation(projects.cast)
   implementation(projects.cast.js.rhino)
-  implementation(projects.core)
-  implementation(projects.util)
+  testImplementation(libs.junit.jupiter.api)
 }
 
 val downloadNodeJS by

--- a/cast/js/rhino/build.gradle.kts
+++ b/cast/js/rhino/build.gradle.kts
@@ -9,17 +9,21 @@ val extraTestResources: Configuration by configurations.creating { isCanBeConsum
 
 dependencies {
   extraTestResources(project(mapOf("path" to ":cast:js", "configuration" to "testResources")))
-  implementation(libs.rhino)
-  implementation(projects.cast)
-  implementation(projects.cast.js)
-  implementation(projects.core)
-  implementation(projects.util)
+  api(libs.rhino)
+  api(projects.cast)
+  api(projects.cast.js)
+  api(projects.core)
+  api(projects.util)
+  testFixturesApi(libs.junit.jupiter.api)
+  testFixturesApi(projects.cast.js)
+  testFixturesApi(projects.util)
+  testFixturesApi(testFixtures(projects.cast.js))
+  testFixturesImplementation(projects.cast)
+  testFixturesImplementation(projects.core)
   testImplementation(libs.gson)
   testImplementation(libs.hamcrest)
-  testImplementation(testFixtures(projects.cast))
+  testImplementation(libs.junit.jupiter.api)
   testImplementation(testFixtures(projects.cast.js))
-  testFixturesImplementation(testFixtures(projects.cast))
-  testFixturesImplementation(testFixtures(projects.cast.js))
 }
 
 tasks.named<Copy>("processTestResources") { from(extraTestResources) }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -57,11 +57,16 @@ dependencies {
     because("public class Entrypoint implements interface BytecodeConstraints")
   }
   api(projects.util) { because("public interface CallGraph extends interface NumberedGraph") }
+  testFixturesApi(libs.junit.jupiter.api)
+  testFixturesApi(projects.shrike)
   testFixturesImplementation(libs.ant)
+  testFixturesImplementation(libs.junit.platform.engine)
   testFixturesImplementation(libs.junit.platform.launcher)
+  testFixturesImplementation(projects.util)
   implementation(libs.gson)
   testImplementation(libs.assertj.core)
   testImplementation(libs.hamcrest)
+  testImplementation(libs.junit.jupiter.api)
   testRuntimeOnly(sourceSets["testSubjects"].output.classesDirs)
   // add the testSubjects source files to enable SourceMapTest to pass
   testRuntimeOnly(files(sourceSets["testSubjects"].java.srcDirs))

--- a/dalvik/build.gradle.kts
+++ b/dalvik/build.gradle.kts
@@ -79,25 +79,23 @@ val installAndroidSdk by
 eclipse { synchronizationTasks(installAndroidSdk) }
 
 dependencies {
+  api(libs.dexlib2)
+  api(projects.core)
+  api(projects.shrike)
+  api(projects.util)
+
   coreTestJar(project("path" to ":core", "configuration" to "testJarConfig"))
   extraTestResources(project("path" to ":core", "configuration" to "dalvikTestResources"))
 
   implementation(libs.slf4j.api)
-  implementation(libs.dexlib2)
   implementation(libs.guava)
-  implementation(projects.core)
-  implementation(projects.shrike)
-  implementation(projects.util)
 
   sampleCupSources(libs.java.cup.map { "$it:sources" })
 
   testImplementation(libs.android.tools)
-  testImplementation(libs.dexlib2)
+  testImplementation(libs.junit.jupiter.api)
   testImplementation(libs.junit.jupiter.params)
-  testImplementation(projects.core)
   testImplementation(projects.dalvik)
-  testImplementation(projects.shrike)
-  testImplementation(projects.util)
   testImplementation(testFixtures(projects.core))
 
   // directory containing "android.jar", which various tests want to find as a resource

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,9 @@ com.ibm.wala.jdk-version=11
 # <https://github.com/littlerobots/version-catalog-update-plugin/pull/125#issue-2024490739>
 nl.littlerobots.vcu.resolver=true
 
+# <https://github.com/autonomousapps/dependency-analysis-gradle-plugin?tab=readme-ov-file#add-to-your-project-and-use>
+dependency.analysis.print.build.health=true
+
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,6 +42,7 @@ slf4j-api = "org.slf4j:slf4j-api:2.0.13"
 w3c-css-sac = "org.eclipse.birt.runtime:org.w3c.css.sac:1.3.1.v200903091627"
 
 [plugins]
+dependency-analysis = "com.autonomousapps.dependency-analysis:1.32.0"
 file-lister = "all.shared.gradle.file-lister:1.0.2"
 google-java-format = "com.github.sherter.google-java-format:0.9"
 kotlin-jvm = "org.jetbrains.kotlin.jvm:2.0.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,9 +34,11 @@ junit-bom = "org.junit:junit-bom:5.10.2"
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params" }
+junit-platform-engine = { module = "org.junit.platform:junit-platform-engine" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine" }
 nullaway = "com.uber.nullaway:nullaway:0.10.24"
+osgi-framework = "org.osgi:org.osgi.framework:1.8.0"
 rhino = "org.mozilla:rhino:1.7.15"
 slf4j-api = "org.slf4j:slf4j-api:2.0.13"
 w3c-css-sac = "org.eclipse.birt.runtime:org.w3c.css.sac:1.3.1.v200903091627"
@@ -45,7 +47,6 @@ w3c-css-sac = "org.eclipse.birt.runtime:org.w3c.css.sac:1.3.1.v200903091627"
 dependency-analysis = "com.autonomousapps.dependency-analysis:1.32.0"
 file-lister = "all.shared.gradle.file-lister:1.0.2"
 google-java-format = "com.github.sherter.google-java-format:0.9"
-kotlin-jvm = "org.jetbrains.kotlin.jvm:2.0.0"
 ktfmt = "com.ncorti.ktfmt.gradle:0.18.0"
 shellcheck = "com.felipefzdz.gradle.shellcheck:1.4.6"
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/ide/build.gradle.kts
+++ b/ide/build.gradle.kts
@@ -6,24 +6,25 @@ plugins {
 eclipse.project.natures("org.eclipse.pde.PluginNature")
 
 walaEclipseMavenCentral {
-  api("org.eclipse.pde.core")
-  implementation(
-      "org.eclipse.core.commands",
-      "org.eclipse.core.jobs",
+  api(
       "org.eclipse.core.resources",
       "org.eclipse.core.runtime",
       "org.eclipse.equinox.common",
-      "org.eclipse.jdt.core",
       "org.eclipse.jface",
       "org.eclipse.osgi",
+      "org.eclipse.pde.core",
+  )
+  implementation(
+      "org.eclipse.jdt.core",
       "org.eclipse.swt",
       "org.eclipse.ui.workbench",
   )
 }
 
 dependencies {
-  implementation(projects.core)
-  implementation(projects.util)
+  api(libs.osgi.framework)
+  api(projects.core)
+  api(projects.util)
 }
 
 configurations.all {
@@ -32,5 +33,16 @@ configurations.all {
         .using(module(libs.w3c.css.sac.get().toString()))
         .because(
             "both provide several of the same classes, but org.w3c.css.sac includes everything we need from both")
+  }
+}
+
+dependencyAnalysis.issues {
+  onIncorrectConfiguration { exclude("org.eclipse.pde:org.eclipse.pde.core") }
+  onUsedTransitiveDependencies {
+    exclude(
+        "org.eclipse.platform:org.eclipse.swt.cocoa.macosx.aarch64",
+        "org.eclipse.platform:org.eclipse.swt.gtk.linux.x86_64",
+        "org.eclipse.platform:org.eclipse.swt.win32.win32.x86_64",
+    )
   }
 }

--- a/ide/jdt/build.gradle.kts
+++ b/ide/jdt/build.gradle.kts
@@ -4,24 +4,27 @@ plugins {
 }
 
 walaEclipseMavenCentral {
-  api("org.eclipse.equinox.common")
-  implementation(
-      "org.eclipse.core.jobs",
+  api(
       "org.eclipse.core.resources",
-      "org.eclipse.core.runtime",
       "org.eclipse.equinox.app",
+      "org.eclipse.equinox.common",
       "org.eclipse.jdt.core",
       "org.eclipse.jface",
       "org.eclipse.osgi",
       "org.eclipse.ui.workbench",
   )
+  implementation(
+      "org.eclipse.core.jobs",
+  )
 }
 
 dependencies {
-  implementation(projects.cast)
-  implementation(projects.cast.java)
-  implementation(projects.cast.java.ecj)
-  implementation(projects.core)
-  implementation(projects.ide)
-  implementation(projects.util)
+  api(libs.osgi.framework)
+  api(projects.cast)
+  api(projects.cast.java)
+  api(projects.cast.java.ecj)
+  api(projects.core)
+  api(projects.ide)
+  api(projects.util)
+  implementation(libs.eclipse.ecj)
 }

--- a/ide/jdt/test/build.gradle.kts
+++ b/ide/jdt/test/build.gradle.kts
@@ -5,23 +5,17 @@ plugins {
 
 walaEclipseMavenCentral {
   testImplementation(
-      "org.eclipse.core.contenttype",
       "org.eclipse.core.runtime",
-      "org.eclipse.equinox.preferences",
-      "org.eclipse.jdt.core",
-      "org.eclipse.osgi",
   )
 }
 
 dependencies {
   testImplementation(libs.eclipse.osgi)
-  testImplementation(projects.cast)
+  testImplementation(libs.junit.jupiter.api)
+  testImplementation(libs.osgi.framework)
   testImplementation(projects.cast.java)
-  testImplementation(projects.cast.java.ecj)
   testImplementation(projects.core)
-  testImplementation(projects.ide)
   testImplementation(projects.ide.jdt)
-  testImplementation(projects.shrike)
   testImplementation(projects.util)
   testImplementation(testFixtures(projects.cast.java))
   testImplementation(testFixtures(projects.ide.tests))

--- a/ide/jsdt/build.gradle.kts
+++ b/ide/jsdt/build.gradle.kts
@@ -5,8 +5,7 @@ plugins {
 }
 
 walaEclipseMavenCentral {
-  implementation(
-      "org.eclipse.core.jobs",
+  api(
       "org.eclipse.core.resources",
       "org.eclipse.core.runtime",
       "org.eclipse.equinox.common",
@@ -16,14 +15,13 @@ walaEclipseMavenCentral {
 }
 
 dependencies {
+  api(libs.eclipse.wst.jsdt.core)
+  api(libs.osgi.framework)
+  api(projects.cast.js)
+  api(projects.core)
   api(projects.ide) { because("public class JavaScriptHeadlessUtil extends class HeadlessUtil") }
-  implementation(libs.eclipse.wst.jsdt.core)
+  api(projects.util)
   implementation(libs.eclipse.wst.jsdt.ui)
-  implementation(libs.javax.annotation.api)
   implementation(projects.cast)
-  implementation(projects.cast.js)
   implementation(projects.cast.js.rhino)
-  implementation(projects.core)
-  implementation(projects.util)
-  testFixturesImplementation(libs.javax.annotation.api)
 }

--- a/ide/jsdt/tests/build.gradle.kts
+++ b/ide/jsdt/tests/build.gradle.kts
@@ -8,14 +8,14 @@ walaEclipseMavenCentral {
   testImplementation(
       "org.eclipse.core.runtime",
       "org.eclipse.equinox.common",
-      "org.eclipse.osgi",
   )
 }
 
 dependencies {
   testImplementation(libs.eclipse.osgi)
   testImplementation(libs.eclipse.wst.jsdt.core)
-  testImplementation(libs.javax.annotation.api)
+  testImplementation(libs.junit.jupiter.api)
+  testImplementation(libs.osgi.framework)
   testImplementation(projects.cast)
   testImplementation(projects.cast.js)
   testImplementation(projects.cast.js.rhino)

--- a/ide/tests/build.gradle.kts
+++ b/ide/tests/build.gradle.kts
@@ -11,8 +11,13 @@ plugins {
 eclipse.project.natures("org.eclipse.pde.PluginNature")
 
 walaEclipseMavenCentral {
-  testFixturesApi("org.eclipse.core.resources", "org.eclipse.core.runtime")
-  testFixturesImplementation("org.eclipse.ui.ide")
+  testFixturesApi(
+      "org.eclipse.core.resources",
+      "org.eclipse.core.runtime",
+      "org.eclipse.equinox.common",
+      "org.eclipse.ui.ide",
+  )
+  testFixturesImplementation("org.eclipse.ui.workbench")
   testImplementation("org.eclipse.jface")
 }
 
@@ -45,6 +50,10 @@ dependencies {
   ifdsExplorerExampleClasspath(sourceSets.test.map { it.runtimeClasspath })
   ifdsExplorerExampleClasspath(
       project(mapOf("path" to ":core", "configuration" to "collectTestDataJar")))
+  testFixturesImplementation(libs.eclipse.osgi)
+  testImplementation(libs.eclipse.osgi)
+  testImplementation(libs.junit.jupiter.api)
+  testImplementation(libs.osgi.framework)
   testImplementation(projects.core)
   testImplementation(projects.ide)
   testImplementation(projects.util)

--- a/scandroid/build.gradle.kts
+++ b/scandroid/build.gradle.kts
@@ -4,10 +4,10 @@ plugins {
 }
 
 dependencies {
+  api(projects.core)
+  api(projects.util)
   implementation(libs.commons.cli)
   implementation(libs.guava)
-  implementation(projects.core)
   implementation(projects.dalvik)
   implementation(projects.shrike)
-  implementation(projects.util)
 }

--- a/shrike/build.gradle.kts
+++ b/shrike/build.gradle.kts
@@ -5,4 +5,4 @@ plugins {
 
 eclipse.project.natures("org.eclipse.pde.PluginNature")
 
-dependencies { implementation(projects.util) }
+dependencies { api(projects.util) }

--- a/util/build.gradle.kts
+++ b/util/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
   compileOnly(libs.jspecify)
   javadocClasspath(projects.core)
   testImplementation(libs.hamcrest)
+  testImplementation(libs.junit.jupiter.api)
 }
 
 tasks.named<Javadoc>("javadoc") {


### PR DESCRIPTION
1. Add a dependency analysis plugin: 69ea56f834f6708ae24eae470b88b0f9ffc3d035

1. Add dependency checking to standard build checks: d1bd3356837db687ba9ffd46cde3bc27fc5aa8ee

1. Print dependency problems directly to build output: d76b1451627fb47d425f7a1aed4ebef9ffc1347c

   Dependency problems are always reported in `build/reports/dependency-analysis/build-health-report.txt`.  With this property setting, they are also printed directly as build output.  The latter is more accessible when debugging dependency problems that are discovered during GitHub Actions builds.

1. Correct numerous dependency nits: d34b25621d4bcc5ee8a824893129c8a014dcb4b9

   These tweaks correct all warnings provided by the excellent [dependency-analysis-gradle-plugin](https://github.com/autonomousapps/dependency-analysis-gradle-plugin).

   <details>
   <summary>Dependency problems reported immediately before applying these fixes:</summary>
   
   ```text
   Advice for root project
   Unused dependencies which should be removed:
     api("org.jetbrains.kotlin:kotlin-stdlib:2.0.0")
     testFixturesApi("org.jetbrains.kotlin:kotlin-stdlib:2.0.0")
     testFixturesImplementation(libs.junit.jupiter.api)
     testImplementation(libs.junit.jupiter.api)
   
   Unused plugins that can be removed:
     org.jetbrains.kotlin.jvm: this project has both java-library and org.jetbrains.kotlin.jvm applied, which is redundant. You can remove org.jetbrains.kotlin.jvm
   
   Advice for :cast
   Unused dependencies which should be removed:
     testFixturesImplementation(libs.junit.jupiter.api)
   
   These transitive dependencies should be declared directly:
     testFixturesApi(project(":core"))
     testFixturesImplementation(project(":util"))
   
   Existing dependencies which should be modified to be as indicated:
     api(project(":shrike")) (was implementation)
     api(project(":util")) (was implementation)
   
   Advice for :cast:java
   Unused dependencies which should be removed:
     testImplementation(libs.junit.jupiter.api)
   
   These transitive dependencies should be declared directly:
     testFixturesApi(project(":util"))
     testFixturesImplementation(project(":shrike"))
   
   Existing dependencies which should be modified to be as indicated:
     api(project(":cast")) (was implementation)
     api(project(":core")) (was implementation)
     api(project(":util")) (was implementation)
     testFixturesApi(libs.junit.jupiter.api) (was testFixturesImplementation)
     testFixturesApi(project(":core")) (was testFixturesImplementation)
   
   Advice for :cast:java:ecj
   Unused dependencies which should be removed:
     implementation("org.eclipse.platform:org.eclipse.core.runtime:3.30.0")
     testFixturesImplementation(libs.junit.jupiter.api)
   
   These transitive dependencies should be declared directly:
     implementation("org.eclipse.platform:org.eclipse.equinox.common:3.18.200")
     implementation(libs.eclipse.ecj)
   
   Advice for :cast:java:test:data
   Unused dependencies which should be removed:
     testFixturesImplementation(libs.junit.jupiter.api)
     testImplementation(libs.junit.jupiter.api)
   
   Advice for :cast:js
   Unused dependencies which should be removed:
     testImplementation(testFixtures(project(":cast")))
   
   These transitive dependencies should be declared directly:
     testFixturesApi(project(":cast"))
     testFixturesApi(project(":core"))
     testFixturesApi(project(":util"))
   
   Existing dependencies which should be modified to be as indicated:
     api(libs.jericho.html) (was implementation)
     api(project(":core")) (was implementation)
     api(project(":util")) (was implementation)
     testFixturesApi(libs.junit.jupiter.api) (was testFixturesImplementation)
     testFixturesApi(testFixtures(project(":cast"))) (was testFixturesImplementation)
   
   Advice for :cast:js:html:nu_validator
   Unused dependencies which should be removed:
     testFixturesImplementation(libs.junit.jupiter.api)
     testImplementation(libs.junit.jupiter.api)
     testImplementation(testFixtures(project(":cast")))
     testImplementation(testFixtures(project(":cast:js")))
   
   Existing dependencies which should be modified to be as indicated:
     api(project(":cast:js")) (was implementation)
   
   Advice for :cast:js:nodejs
   Unused dependencies which should be removed:
     testFixturesImplementation(libs.junit.jupiter.api)
   
   Existing dependencies which should be modified to be as indicated:
     api(project(":core")) (was implementation)
     api(project(":util")) (was implementation)
   
   Advice for :cast:js:rhino
   Unused dependencies which should be removed:
     testFixturesImplementation(testFixtures(project(":cast")))
     testImplementation(testFixtures(project(":cast")))
   
   These transitive dependencies should be declared directly:
     testFixturesApi(project(":cast:js"))
     testFixturesApi(project(":util"))
     testFixturesImplementation(project(":cast"))
     testFixturesImplementation(project(":core"))
   
   Existing dependencies which should be modified to be as indicated:
     api(libs.rhino) (was implementation)
     api(project(":cast")) (was implementation)
     api(project(":cast:js")) (was implementation)
     api(project(":core")) (was implementation)
     api(project(":util")) (was implementation)
     testFixturesApi(libs.junit.jupiter.api) (was testFixturesImplementation)
     testFixturesApi(testFixtures(project(":cast:js"))) (was testFixturesImplementation)
   
   Advice for :core
   These transitive dependencies should be declared directly:
     testFixturesApi(project(":shrike"))
     testFixturesImplementation("org.junit.platform:junit-platform-engine:1.10.2")
     testFixturesImplementation(project(":util"))
   
   Existing dependencies which should be modified to be as indicated:
     testFixturesApi(libs.junit.jupiter.api) (was testFixturesImplementation)
   
   Advice for :dalvik
   Unused dependencies which should be removed:
     testFixturesImplementation(libs.junit.jupiter.api)
     testImplementation(libs.dexlib2)
     testImplementation(project(":core"))
     testImplementation(project(":shrike"))
     testImplementation(project(":util"))
   
   Existing dependencies which should be modified to be as indicated:
     api(libs.dexlib2) (was implementation)
     api(project(":core")) (was implementation)
     api(project(":shrike")) (was implementation)
     api(project(":util")) (was implementation)
   
   Advice for :ide
   Unused dependencies which should be removed:
     implementation("org.eclipse.platform:org.eclipse.core.commands:3.11.200")
     implementation("org.eclipse.platform:org.eclipse.core.jobs:3.15.100")
     testFixturesImplementation(libs.junit.jupiter.api)
     testImplementation(libs.junit.jupiter.api)
   
   These transitive dependencies should be declared directly:
     api("org.osgi:org.osgi.framework:1.8.0")
     implementation("org.eclipse.platform:org.eclipse.swt.gtk.linux.x86_64:3.124.200")
   
   Existing dependencies which should be modified to be as indicated:
     api("org.eclipse.platform:org.eclipse.core.resources:3.20.0") (was implementation)
     api("org.eclipse.platform:org.eclipse.core.runtime:3.30.0") (was implementation)
     api("org.eclipse.platform:org.eclipse.equinox.common:3.18.200") (was implementation)
     api("org.eclipse.platform:org.eclipse.jface:3.32.0") (was implementation)
     api(libs.eclipse.osgi) (was implementation)
     api(project(":core")) (was implementation)
     api(project(":util")) (was implementation)
     implementation("org.eclipse.pde:org.eclipse.pde.core:3.17.200") (was api)
   
   Advice for :ide:jdt
   Unused dependencies which should be removed:
     implementation("org.eclipse.platform:org.eclipse.core.runtime:3.30.0")
     testFixturesImplementation(libs.junit.jupiter.api)
     testImplementation(libs.junit.jupiter.api)
   
   These transitive dependencies should be declared directly:
     api("org.osgi:org.osgi.framework:1.8.0")
     implementation(libs.eclipse.ecj)
   
   Existing dependencies which should be modified to be as indicated:
     api("org.eclipse.jdt:org.eclipse.jdt.core:3.36.0") (was implementation)
     api("org.eclipse.platform:org.eclipse.core.resources:3.20.0") (was implementation)
     api("org.eclipse.platform:org.eclipse.equinox.app:1.6.400") (was implementation)
     api("org.eclipse.platform:org.eclipse.jface:3.32.0") (was implementation)
     api("org.eclipse.platform:org.eclipse.ui.workbench:3.131.0") (was implementation)
     api(libs.eclipse.osgi) (was implementation)
     api(project(":cast")) (was implementation)
     api(project(":cast:java")) (was implementation)
     api(project(":cast:java:ecj")) (was implementation)
     api(project(":core")) (was implementation)
     api(project(":ide")) (was implementation)
     api(project(":util")) (was implementation)
   
   Advice for :ide:jdt:test
   Unused dependencies which should be removed:
     testFixturesImplementation(libs.junit.jupiter.api)
     testImplementation("org.eclipse.jdt:org.eclipse.jdt.core:3.36.0")
     testImplementation("org.eclipse.platform:org.eclipse.core.contenttype:3.9.200")
     testImplementation("org.eclipse.platform:org.eclipse.equinox.preferences:3.10.400")
     testImplementation(libs.eclipse.osgi)
     testImplementation(project(":cast"))
     testImplementation(project(":cast:java:ecj"))
     testImplementation(project(":ide"))
     testImplementation(project(":shrike"))
   
   These transitive dependencies should be declared directly:
     testImplementation("org.osgi:org.osgi.framework:1.8.0")
   
   Advice for :ide:jsdt
   Unused dependencies which should be removed:
     implementation("org.eclipse.platform:org.eclipse.core.jobs:3.15.100")
     implementation(libs.javax.annotation.api)
     testFixturesImplementation(libs.javax.annotation.api)
     testFixturesImplementation(libs.junit.jupiter.api)
     testImplementation(libs.junit.jupiter.api)
   
   These transitive dependencies should be declared directly:
     api("org.osgi:org.osgi.framework:1.8.0")
   
   Existing dependencies which should be modified to be as indicated:
     api("org.eclipse.platform:org.eclipse.core.resources:3.20.0") (was implementation)
     api("org.eclipse.platform:org.eclipse.core.runtime:3.30.0") (was implementation)
     api("org.eclipse.platform:org.eclipse.equinox.common:3.18.200") (was implementation)
     api("org.eclipse.platform:org.eclipse.ui.workbench:3.131.0") (was implementation)
     api(libs.eclipse.osgi) (was implementation)
     api(libs.eclipse.wst.jsdt.core) (was implementation)
     api(project(":cast:js")) (was implementation)
     api(project(":core")) (was implementation)
     api(project(":util")) (was implementation)
   
   Advice for :ide:jsdt:tests
   Unused dependencies which should be removed:
     testFixturesImplementation(libs.junit.jupiter.api)
     testImplementation(libs.eclipse.osgi)
     testImplementation(libs.javax.annotation.api)
   
   These transitive dependencies should be declared directly:
     testImplementation("org.osgi:org.osgi.framework:1.8.0")
   
   Advice for :ide:tests
   Unused dependencies which should be removed:
     testFixturesImplementation(libs.junit.jupiter.api)
   
   These transitive dependencies should be declared directly:
     testFixturesApi("org.eclipse.platform:org.eclipse.equinox.common:3.18.200")
     testFixturesImplementation("org.eclipse.platform:org.eclipse.ui.workbench:3.131.0")
     testFixturesImplementation(libs.eclipse.osgi)
     testImplementation("org.osgi:org.osgi.framework:1.8.0")
     testImplementation(libs.eclipse.osgi)
   
   Existing dependencies which should be modified to be as indicated:
     testFixturesApi("org.eclipse.platform:org.eclipse.ui.ide:3.22.0") (was testFixturesImplementation)
   
   Advice for :scandroid
   Unused dependencies which should be removed:
     testFixturesImplementation(libs.junit.jupiter.api)
     testImplementation(libs.junit.jupiter.api)
   
   Existing dependencies which should be modified to be as indicated:
     api(project(":core")) (was implementation)
     api(project(":util")) (was implementation)
   
   Advice for :shrike
   Unused dependencies which should be removed:
     testFixturesImplementation(libs.junit.jupiter.api)
     testImplementation(libs.junit.jupiter.api)
   
   Existing dependencies which should be modified to be as indicated:
     api(project(":util")) (was implementation)
   
   Advice for :util
   Unused dependencies which should be removed:
     testFixturesImplementation(libs.junit.jupiter.api)
   ```
   </details>

1. Treat dependency problems as fatal errors: a8842f3b276e27683111ff0eaf1a3abe7c579b90
