### PR TITLE
Remove snapshot uploading CI job

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -98,29 +98,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.WALA_BOT_GH_TOKEN }}
         run: ./generate-latest-docs.sh
-  publish_snapshot:
-    name: 'Publish snapshot'
-    needs: build_gradle
-    if: github.event_name == 'push' && github.repository == 'wala/WALA' && github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
-    steps:
-      - name: 'Check out repository'
-        uses: actions/checkout@v3
-      - name: Cache Goomph
-        uses: actions/cache@v3
-        with:
-          path: ~/.goomph
-          key: ${{ runner.os }}-goomph-${{ hashFiles('build.gradle') }}
-          restore-keys: ${{ runner.os }}-goomph-
-      - name: 'Set up JDK 11'
-        uses: actions/setup-java@v3
-        with:
-          java-version: 11
-          distribution: 'temurin'
-      - name: 'Publish'
-        env:
-          ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: publishAllPublicationsToMavenRepository


### PR DESCRIPTION
This broke recently since I had to rotate my Sonatype credentials.  I think we should just disable it.  Building a snapshot locally is pretty easy, and it's generally not a great practice to add a dependence on a remote snapshot build that may change unexpectedly.  If anyone needs us to cut a release to get some change, they can just ask and we will do it.