### PR TITLE
Prefer Gradle Sync tasks over Copy tasks

### DIFF
--- a/cast/js/nodejs/build.gradle.kts
+++ b/cast/js/nodejs/build.gradle.kts
@@ -25,7 +25,7 @@ val downloadNodeJS by
     }
 
 val unpackNodeJSLib by
-    tasks.registering(Copy::class) {
+    tasks.registering(Sync::class) {
       from(downloadNodeJS.map { tarTree(it.dest) }) {
         include("*/lib/*.js")
         eachFile { path = name }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -268,7 +268,7 @@ val unpackOcamlJava by
     }
 
 val prepareGenerateHelloHashJar by
-    tasks.registering(Copy::class) {
+    tasks.registering(Sync::class) {
       from("ocaml/hello_hash.ml")
       val outputDir = project.layout.buildDirectory.dir(name)
       into(outputDir)


### PR DESCRIPTION
`Sync` tasks remove any files in the destination that were not actually copied from the source.  This feels safer than `Copy`, which is happy to retain leftover destination files.  Those leftover files might have been copied manually or by an earlier version of the build logic, either of which threatens reproducibility of a build.