### PR TITLE
Prefer HTTPS over HTTP

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -220,7 +220,7 @@ val extractBcel by
 val downloadJavaCup by
     tasks.registering(VerifiedDownload::class) {
       val archive = "java-cup-11a.jar"
-      src = URI("http://www2.cs.tum.edu/projects/cup/$archive")
+      src = URI("https://www2.cs.tum.edu/projects/cup/$archive")
       dest = layout.buildDirectory.file("$name/$archive")
       checksum = "2bda8c40abd0cbc295d3038643d6e4ec"
     }


### PR DESCRIPTION
All the cool kinds encrypt these days.

Our only remaining `http:` URL is for OCaml-Java, which does not have an `https:` server.

https://github.com/wala/WALA/blob/1f29f627e1e4415279734bbe16331ee77aa62bb1/core/build.gradle.kts#L259