### PR TITLE
Support building and running on JDK 22

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,6 +26,8 @@ jobs:
             java: 17
           - os: ubuntu-latest
             java: 21
+          - os: ubuntu-latest
+            java: 22
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -362,9 +362,10 @@ tasks.named<Test>("test") {
   testLogging {
     exceptionFormat = TestExceptionFormat.FULL
     events("passed", "skipped", "failed", "started")
-    afterTest(KotlinClosure2<TestDescriptor, TestResult, Unit>({ descriptor, result ->
-      println("Test ${descriptor.name} completed in ${result.endTime - result.startTime} ms")
-    }))
+    afterTest(
+        KotlinClosure2<TestDescriptor, TestResult, Unit>({ descriptor, result ->
+          println("Test ${descriptor.name} completed in ${result.endTime - result.startTime} ms")
+        }))
   }
   // temporarily turn off some tests on JDK 11+
   if (JavaVersion.current() >= JavaVersion.VERSION_11) {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -361,7 +361,10 @@ tasks.named<Test>("test") {
   classpath += files(sourceSets.test.get().output.classesDirs)
   testLogging {
     exceptionFormat = TestExceptionFormat.FULL
-    events("passed", "skipped", "failed")
+    events("passed", "skipped", "failed", "started")
+    afterTest(KotlinClosure2<TestDescriptor, TestResult, Unit>({ descriptor, result ->
+      println("Test ${descriptor.name} completed in ${result.endTime - result.startTime} ms")
+    }))
   }
   // temporarily turn off some tests on JDK 11+
   if (JavaVersion.current() >= JavaVersion.VERSION_11) {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -361,11 +361,7 @@ tasks.named<Test>("test") {
   classpath += files(sourceSets.test.get().output.classesDirs)
   testLogging {
     exceptionFormat = TestExceptionFormat.FULL
-    events("passed", "skipped", "failed", "started")
-    afterTest(
-        KotlinClosure2<TestDescriptor, TestResult, Unit>({ descriptor, result ->
-          println("Test ${descriptor.name} completed in ${result.endTime - result.startTime} ms")
-        }))
+    events("passed", "skipped", "failed")
   }
   // temporarily turn off some tests on JDK 11+
   if (JavaVersion.current() >= JavaVersion.VERSION_11) {

--- a/core/src/test/java/com/ibm/wala/core/tests/slicer/SlicerTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/slicer/SlicerTest.java
@@ -1030,7 +1030,7 @@ public class SlicerTest {
             .filter(s -> s instanceof NormalStatement && s.getNode().equals(main))
             .collect(Collectors.toList());
     normalsInMain.stream().forEach(System.err::println);
-    assertEquals(7, normalsInMain.size());
+    assertEquals(5, normalsInMain.size());
   }
 
   @Test

--- a/core/src/testSubjects/java/slice/TestList.java
+++ b/core/src/testSubjects/java/slice/TestList.java
@@ -8,10 +8,10 @@ public class TestList {
   static void doNothing(Object o) {}
 
   public static void main(String[] args) {
-    List<Integer> list = new ArrayList<>();
+    List<String> list = new ArrayList<>();
 
-    list.add(2);
-    list.add(3);
+    list.add("hi");
+    list.add("bye");
 
     doNothing(list.get(0));
   }

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/ClassReader.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/ClassReader.java
@@ -68,7 +68,7 @@ public final class ClassReader implements ClassConstants {
       throw new InvalidClassFileException(offset, "bad magic number: " + magic);
     }
     // Support class files up through JDK 21 (version 65)
-    if (majorVersion < 45 || majorVersion > 65) {
+    if (majorVersion < 45 || majorVersion > 66) {
       throw new InvalidClassFileException(
           offset, "unknown class file version: " + majorVersion + '.' + minorVersion);
     }

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/ClassReader.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/ClassReader.java
@@ -67,7 +67,7 @@ public final class ClassReader implements ClassConstants {
     if (magic != MAGIC) {
       throw new InvalidClassFileException(offset, "bad magic number: " + magic);
     }
-    // Support class files up through JDK 21 (version 65)
+    // Support class files up through JDK 22 (version 66)
     if (majorVersion < 45 || majorVersion > 66) {
       throw new InvalidClassFileException(
           offset, "unknown class file version: " + majorVersion + '.' + minorVersion);


### PR DESCRIPTION
We don't immediately crash on JDK 22 bytecodes, but new bytecode features have not been tested.

We modify the `TestList` test input to avoid a blowup when running `SlicerTest.testList`.  https://github.com/openjdk/jdk/commit/b62e774e6a531db934de04211724a2a8159d94db introduced calls to `String.format` from `Integer.parseInt`, which dramatically increased the number of reachable methods for the previous version of this test, which in turn led to very slow performance with the slicer.  Changing the test to use a `List<String>` and string constants removes this blowup.  (Whole-program analysis is fun!)

Fixes #1414 