### PR TITLE
Update to JSpecify 1.0 annotations

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ java_cup = "java_cup:java_cup:0.9e"
 javax-annotation-api = { module = "javax.annotation:javax.annotation-api", version = { strictly = "1.3.2" } }
 jericho-html = "net.htmlparser.jericho:jericho-html:3.2"
 json = "org.json:json:20240303"
-jspecify = "org.jspecify:jspecify:0.3.0"
+jspecify = "org.jspecify:jspecify:1.0.0"
 junit-bom = "org.junit:junit-bom:5.10.2"
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }

--- a/util/build.gradle.kts
+++ b/util/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 eclipse.project.natures("org.eclipse.pde.PluginNature")
 
 dependencies {
-  compileOnly(libs.jspecify)
+  api(libs.jspecify)
   javadocClasspath(projects.core)
   testImplementation(libs.hamcrest)
   testImplementation(libs.junit.jupiter.api)


### PR DESCRIPTION
Also switch to an `api` dependence as suggested in [the docs](https://jspecify.dev/docs/using/#gradle).
