### PR TITLE
Fix a bug in IteratorPlusOne

### DIFF
--- a/util/src/main/java/com/ibm/wala/util/collections/IteratorPlusOne.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/IteratorPlusOne.java
@@ -11,6 +11,7 @@
 package com.ibm.wala.util.collections;
 
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 import org.jspecify.annotations.Nullable;
 
 /** A utility to efficiently compose an iterator and a singleton */
@@ -37,15 +38,18 @@ public class IteratorPlusOne<T> implements Iterator<T> {
     return it.hasNext() || (xtra != null);
   }
 
-  @Nullable
   @Override
   public T next() {
     if (it.hasNext()) {
       return it.next();
     } else {
       T result = xtra;
-      xtra = null;
-      return result;
+      if (result != null) {
+        xtra = null;
+        return result;
+      } else {
+        throw new NoSuchElementException();
+      }
     }
   }
 


### PR DESCRIPTION
`next()` should throw a `NoSuchElementException` when there are no more elements.  Before it returned `null`.
