### PR TITLE
Enable AnnotationPosition check and auto-fix extant warnings

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -68,11 +68,11 @@ tasks.withType<JavaCompile>().configureEach {
     // that could introduce bugs
     disable("ReferenceEquality")
     // Example for running Error Prone's auto-patcher.  To run, uncomment and change the
-    // check name to the one you want to patch
-    //			errorproneArgs.appendAll(
-    //					"-XepPatchChecks:UnnecessaryParentheses",
-    //					"-XepPatchLocation:IN_PLACE"
-    //			)
+    // check name to the one you want to patch, and also disable -Werror below
+    //    		errorproneArgs.addAll(
+    //    				"-XepPatchChecks:UnnecessaryParentheses",
+    //    				"-XepPatchLocation:IN_PLACE"
+    //    		)
   }
 }
 

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -59,6 +59,7 @@ tasks.withType<JavaCompile>().configureEach {
     error("UnnecessaryParentheses")
     error("UnusedVariable")
     error("JdkObsolete")
+    error("AnnotationPosition")
     // checks we do not intend to try to fix in the near-term:
     // Just too many of these; proper Javadoc would be a great long-term goal
     disable("MissingSummary")

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/Java7CallGraphTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/Java7CallGraphTest.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 public class Java7CallGraphTest extends DynamicCallGraphTestBase {
 
-  private @TempDir Path temporaryDirectory;
+  @TempDir private Path temporaryDirectory;
 
   @Override
   protected Path getTemporaryDirectory() {

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/KawaCallGraphTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/KawaCallGraphTest.java
@@ -47,7 +47,7 @@ import org.junit.jupiter.api.io.TempDir;
 @Tag("slow")
 public class KawaCallGraphTest extends DynamicCallGraphTestBase {
 
-  private @TempDir Path temporaryDirectory;
+  @TempDir private Path temporaryDirectory;
 
   @Override
   protected Path getTemporaryDirectory() {

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/DalvikCallGraphTestBase.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/DalvikCallGraphTestBase.java
@@ -65,7 +65,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 public class DalvikCallGraphTestBase extends DynamicCallGraphTestBase {
 
-  private @TempDir Path temporaryDirectory;
+  @TempDir private Path temporaryDirectory;
 
   @Override
   protected Path getTemporaryDirectory() {

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/DynamicDalvikComparisonJavaLibsTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/DynamicDalvikComparisonJavaLibsTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 public class DynamicDalvikComparisonJavaLibsTest extends DynamicDalvikComparisonTest {
 
-  private @TempDir Path temporaryDirectory;
+  @TempDir private Path temporaryDirectory;
 
   @Override
   protected Path getTemporaryDirectory() {

--- a/util/src/main/java/com/ibm/wala/dataflow/graph/DataflowSolver.java
+++ b/util/src/main/java/com/ibm/wala/dataflow/graph/DataflowSolver.java
@@ -96,13 +96,11 @@ public abstract class DataflowSolver<T, V extends IVariable<V>> extends DefaultF
     return node2In.get(node);
   }
 
-  @Nullable
-  public V getEdge(Object key) {
+  public @Nullable V getEdge(Object key) {
     return edge2Var.get(key);
   }
 
-  @Nullable
-  public V getEdge(Object src, Object dst) {
+  public @Nullable V getEdge(Object src, Object dst) {
     assert src != null;
     assert dst != null;
     V v = getEdge(Pair.make(src, dst));

--- a/util/src/main/java/com/ibm/wala/fixpoint/BitVectorVariable.java
+++ b/util/src/main/java/com/ibm/wala/fixpoint/BitVectorVariable.java
@@ -19,7 +19,7 @@ import org.jspecify.annotations.Nullable;
 /** A bit vector variable for dataflow analysis. */
 public class BitVectorVariable extends AbstractVariable<BitVectorVariable> {
 
-  @Nullable private MutableSharedBitVectorIntSet V;
+  private @Nullable MutableSharedBitVectorIntSet V;
 
   public BitVectorVariable() {}
 
@@ -126,8 +126,7 @@ public class BitVectorVariable extends AbstractVariable<BitVectorVariable> {
   /**
    * @return the value of this variable as a bit vector ... null if the bit vector is empty.
    */
-  @Nullable
-  public IntSet getValue() {
+  public @Nullable IntSet getValue() {
     return V;
   }
 

--- a/util/src/main/java/com/ibm/wala/fixpoint/UnaryStatement.java
+++ b/util/src/main/java/com/ibm/wala/fixpoint/UnaryStatement.java
@@ -17,7 +17,7 @@ public abstract class UnaryStatement<T extends IVariable<T>>
     extends AbstractStatement<T, UnaryOperator<T>> {
 
   /** The operands */
-  @Nullable protected final T lhs;
+  protected final @Nullable T lhs;
 
   protected final T rhs;
 
@@ -37,9 +37,8 @@ public abstract class UnaryStatement<T extends IVariable<T>>
    *
    * @return the lattice cell this equation computes
    */
-  @Nullable
   @Override
-  public T getLHS() {
+  public @Nullable T getLHS() {
     return lhs;
   }
 

--- a/util/src/main/java/com/ibm/wala/util/collections/BimodalMap.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/BimodalMap.java
@@ -31,7 +31,7 @@ public class BimodalMap<K, V> implements Map<K, V> {
   private final int cutOff;
 
   /** The implementation we delegate to */
-  @Nullable private Map<K, V> backingStore;
+  private @Nullable Map<K, V> backingStore;
 
   /**
    * @param cutoff the map size at which to switch from the small map implementation to the large
@@ -61,15 +61,13 @@ public class BimodalMap<K, V> implements Map<K, V> {
     return (backingStore == null) ? false : backingStore.containsValue(value);
   }
 
-  @Nullable
   @Override
-  public V get(Object key) {
+  public @Nullable V get(Object key) {
     return (backingStore == null) ? null : backingStore.get(key);
   }
 
-  @Nullable
   @Override
-  public V put(K key, V value) {
+  public @Nullable V put(K key, V value) {
     if (backingStore == null) {
       backingStore = new SmallMap<>();
       backingStore.put(key, value);
@@ -99,9 +97,8 @@ public class BimodalMap<K, V> implements Map<K, V> {
   /**
    * @throws UnsupportedOperationException if the backingStore doesn't support remove
    */
-  @Nullable
   @Override
-  public V remove(Object key) {
+  public @Nullable V remove(Object key) {
     return (backingStore == null) ? null : backingStore.remove(key);
   }
 

--- a/util/src/main/java/com/ibm/wala/util/collections/ComposedIterator.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/ComposedIterator.java
@@ -18,7 +18,7 @@ import org.jspecify.annotations.Nullable;
 public abstract class ComposedIterator<O, I> implements Iterator<I> {
 
   private final Iterator<O> outer;
-  @Nullable private Iterator<? extends I> inner;
+  private @Nullable Iterator<? extends I> inner;
 
   public ComposedIterator(Iterator<O> outer) {
     this.outer = outer;

--- a/util/src/main/java/com/ibm/wala/util/collections/FilterIterator.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/FilterIterator.java
@@ -21,7 +21,7 @@ public class FilterIterator<T> implements java.util.Iterator<T> {
 
   final Predicate<? super T> f;
 
-  @Nullable private T next = null;
+  private @Nullable T next = null;
 
   private boolean done = false;
 
@@ -53,9 +53,8 @@ public class FilterIterator<T> implements java.util.Iterator<T> {
     done = true;
   }
 
-  @Nullable
   @Override
-  public T next() throws NoSuchElementException {
+  public @Nullable T next() throws NoSuchElementException {
     if (done) {
       throw new java.util.NoSuchElementException();
     }

--- a/util/src/main/java/com/ibm/wala/util/collections/Iterator2Iterable.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/Iterator2Iterable.java
@@ -16,7 +16,7 @@ import org.jspecify.annotations.Nullable;
 /** Converts an {@link Iterator} to an {@link Iterable}. */
 public class Iterator2Iterable<T> implements Iterable<T> {
 
-  @Nullable private final Iterator<T> iter;
+  private final @Nullable Iterator<T> iter;
 
   public static <T> Iterator2Iterable<T> make(@Nullable Iterator<T> iter) {
     return new Iterator2Iterable<>(iter);
@@ -26,9 +26,8 @@ public class Iterator2Iterable<T> implements Iterable<T> {
     this.iter = iter;
   }
 
-  @Nullable
   @Override
-  public Iterator<T> iterator() {
+  public @Nullable Iterator<T> iterator() {
     return iter;
   }
 }

--- a/util/src/main/java/com/ibm/wala/util/collections/IteratorPlusOne.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/IteratorPlusOne.java
@@ -26,7 +26,7 @@ public class IteratorPlusOne<T> implements Iterator<T> {
   private final Iterator<? extends T> it;
 
   // the following field will be nulled out after visiting xtra.
-  @Nullable private T xtra;
+  private @Nullable T xtra;
 
   private IteratorPlusOne(Iterator<? extends T> it, T xtra) {
     this.it = it;

--- a/util/src/main/java/com/ibm/wala/util/collections/IteratorPlusTwo.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/IteratorPlusTwo.java
@@ -18,8 +18,8 @@ public class IteratorPlusTwo<T> implements Iterator<T> {
   private final Iterator<T> it;
 
   // the following fields will be nulled out after visiting xtra.
-  @Nullable private T xtra1;
-  @Nullable private T xtra2;
+  private @Nullable T xtra1;
+  private @Nullable T xtra2;
 
   public IteratorPlusTwo(Iterator<T> it, T xtra1, T xtra2) {
     if (it == null) {
@@ -35,9 +35,8 @@ public class IteratorPlusTwo<T> implements Iterator<T> {
     return it.hasNext() || (xtra1 != null) || (xtra2 != null);
   }
 
-  @Nullable
   @Override
-  public T next() {
+  public @Nullable T next() {
     if (it.hasNext()) {
       return it.next();
     } else if (xtra1 != null) {

--- a/util/src/main/java/com/ibm/wala/util/collections/NonNullSingletonIterator.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/NonNullSingletonIterator.java
@@ -20,7 +20,7 @@ import org.jspecify.annotations.Nullable;
  */
 public class NonNullSingletonIterator<T> implements Iterator<T> {
 
-  @Nullable private T it;
+  private @Nullable T it;
 
   /**
    * @param o the single object in this collection, must be non-null

--- a/util/src/main/java/com/ibm/wala/util/collections/SmallMap.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/SmallMap.java
@@ -153,10 +153,9 @@ public class SmallMap<K, V> implements Map<K, V> {
     }
   }
 
-  @Nullable
   @Override
   @SuppressWarnings({"unchecked", "unused"})
-  public V put(Object key, Object value) {
+  public @Nullable V put(Object key, Object value) {
     if (key == null) {
       throw new IllegalArgumentException("null key");
     }

--- a/util/src/main/java/com/ibm/wala/util/collections/TwoLevelVector.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/TwoLevelVector.java
@@ -37,9 +37,8 @@ public class TwoLevelVector<T> implements IVector<T>, Serializable {
    * @see com.ibm.wala.util.intset.IntVector#get(int)
    */
   @NullUnmarked
-  @Nullable
   @Override
-  public T get(int x) {
+  public @Nullable T get(int x) {
     if (x < 0) {
       throw new IllegalArgumentException("invalid x: " + x);
     }

--- a/util/src/main/java/com/ibm/wala/util/collections/Util.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/Util.java
@@ -114,8 +114,8 @@ public class Util {
    * @return The first element satisfying the predicate; otherwise null.
    * @throws IllegalArgumentException if c == null
    */
-  @Nullable
-  public static <T> T find(Collection<T> c, Predicate<T> p) throws IllegalArgumentException {
+  public static <T> @Nullable T find(Collection<T> c, Predicate<T> p)
+      throws IllegalArgumentException {
     if (c == null) {
       throw new IllegalArgumentException("c == null");
     }
@@ -266,8 +266,7 @@ public class Util {
   }
 
   /** Remove the package name from a fully qualified class name */
-  @Nullable
-  public static String removePackageName(String fully_qualified_name_) {
+  public static @Nullable String removePackageName(String fully_qualified_name_) {
     if (fully_qualified_name_ == null) return null;
 
     int lastdot = fully_qualified_name_.lastIndexOf('.');

--- a/util/src/main/java/com/ibm/wala/util/config/FileOfClasses.java
+++ b/util/src/main/java/com/ibm/wala/util/config/FileOfClasses.java
@@ -27,9 +27,9 @@ public class FileOfClasses extends SetOfClasses {
 
   private static final boolean DEBUG = false;
 
-  @Nullable private Pattern pattern = null;
+  private @Nullable Pattern pattern = null;
 
-  @Nullable private String regex = null;
+  private @Nullable String regex = null;
 
   private boolean needsCompile = false;
 
@@ -97,9 +97,8 @@ public class FileOfClasses extends SetOfClasses {
     needsCompile = true;
   }
 
-  @Nullable
   @Override
-  public String toString() {
+  public @Nullable String toString() {
     return this.regex;
   }
 }

--- a/util/src/main/java/com/ibm/wala/util/graph/BasicTree.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/BasicTree.java
@@ -34,8 +34,7 @@ public class BasicTree<T> {
     return value;
   }
 
-  @Nullable
-  public T getChildValue(int i) {
+  public @Nullable T getChildValue(int i) {
     if (children.get(i) == null) {
       return null;
     } else {

--- a/util/src/main/java/com/ibm/wala/util/graph/GraphReachability.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/GraphReachability.java
@@ -44,7 +44,7 @@ public class GraphReachability<T, S> {
   private final Graph<T> g;
 
   /** Killdall-style dataflow solver */
-  @Nullable private DataflowSolver<T, BitVectorVariable> solver;
+  private @Nullable DataflowSolver<T, BitVectorVariable> solver;
 
   /** set of "interesting" CGNodes */
   final OrdinalSetMapping<S> domain;
@@ -112,9 +112,9 @@ public class GraphReachability<T, S> {
            * @see com.ibm.wala.dataflow.graph.ITransferFunctionProvider#getEdgeTransferFunction(java.lang.Object, java.lang.Object)
            */
           @NullUnmarked
-          @Nullable
           @Override
-          public UnaryOperator<BitVectorVariable> getEdgeTransferFunction(Object from, Object to) {
+          public @Nullable UnaryOperator<BitVectorVariable> getEdgeTransferFunction(
+              Object from, Object to) {
             Assertions.UNREACHABLE();
             return null;
           }

--- a/util/src/main/java/com/ibm/wala/util/graph/dominators/Dominators.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/dominators/Dominators.java
@@ -88,15 +88,14 @@ public abstract class Dominators<T> {
   }
 
   /** return the immediate dominator of node */
-  @Nullable
-  public T getIdom(@Nullable T node) {
+  public @Nullable T getIdom(@Nullable T node) {
     return getInfo(node).dominator;
   }
 
   /** return an Iterator over all nodes that dominate node */
   public Iterator<T> dominators(final T node) {
     return new Iterator<>() {
-      @Nullable private T current = node;
+      private @Nullable T current = node;
 
       @Override
       public void remove() {
@@ -329,8 +328,7 @@ public abstract class Dominators<T> {
    * @param node the node to evaluate
    * @return the node as described above
    */
-  @Nullable
-  private T EVAL(T node) {
+  private @Nullable T EVAL(T node) {
     if (DEBUG) {
       System.out.println("  Evaling " + node);
     }
@@ -418,12 +416,12 @@ public abstract class Dominators<T> {
     /*
      * The result of this computation: the immediate dominator of this node
      */
-    @Nullable private T dominator;
+    private @Nullable T dominator;
 
     /*
      * The parent node in the DFS tree used in dominator computation
      */
-    @Nullable private T parent;
+    private @Nullable T parent;
 
     /*
      * the ``semi-dominator,'' which starts as the DFS number in step 1
@@ -438,12 +436,12 @@ public abstract class Dominators<T> {
     /*
      * the labels used in the fast union-find structure
      */
-    @Nullable private T label;
+    private @Nullable T label;
 
     /*
      * ancestor for fast union-find data structure
      */
-    @Nullable private T ancestor;
+    private @Nullable T ancestor;
 
     /*
      * the size used by the fast union-find structure
@@ -453,7 +451,7 @@ public abstract class Dominators<T> {
     /*
      * the child used by the fast union-find structure
      */
-    @Nullable private T child;
+    private @Nullable T child;
 
     DominatorInfo(@Nullable T node) {
       semiDominator = 0;
@@ -480,8 +478,7 @@ public abstract class Dominators<T> {
     getInfo(node).bucket.add(addend);
   }
 
-  @Nullable
-  private T getDominator(@Nullable T node) {
+  private @Nullable T getDominator(@Nullable T node) {
     assert node != null;
     return getInfo(node).dominator;
   }
@@ -490,8 +487,7 @@ public abstract class Dominators<T> {
     getInfo(node).dominator = dominator;
   }
 
-  @Nullable
-  private T getParent(T node) {
+  private @Nullable T getParent(T node) {
     return getInfo(node).parent;
   }
 
@@ -499,8 +495,7 @@ public abstract class Dominators<T> {
     getInfo(node).parent = parent;
   }
 
-  @Nullable
-  private T getAncestor(@Nullable T node) {
+  private @Nullable T getAncestor(@Nullable T node) {
     return getInfo(node).ancestor;
   }
 
@@ -508,8 +503,7 @@ public abstract class Dominators<T> {
     getInfo(node).ancestor = ancestor;
   }
 
-  @Nullable
-  private T getLabel(@Nullable T node) {
+  private @Nullable T getLabel(@Nullable T node) {
     if (node == null) return null;
     else return getInfo(node).label;
   }
@@ -527,8 +521,7 @@ public abstract class Dominators<T> {
     getInfo(node).size = size;
   }
 
-  @Nullable
-  private T getChild(@Nullable T node) {
+  private @Nullable T getChild(@Nullable T node) {
     return getInfo(node).child;
   }
 

--- a/util/src/main/java/com/ibm/wala/util/graph/impl/DelegatingNumberedNodeManager.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/impl/DelegatingNumberedNodeManager.java
@@ -91,10 +91,9 @@ public class DelegatingNumberedNodeManager<T extends INodeWithNumber>
         return nextCounter != -1;
       }
 
-      @Nullable
       @Override
       @SuppressWarnings("unchecked")
-      public T next() {
+      public @Nullable T next() {
         if (hasNext()) {
           int r = nextCounter;
           advance();

--- a/util/src/main/java/com/ibm/wala/util/graph/impl/ExtensionGraph.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/impl/ExtensionGraph.java
@@ -36,7 +36,7 @@ public class ExtensionGraph<T> implements NumberedGraph<T> {
         private final Map<T, MutableIntSet> inEdges = HashMapFactory.make();
         private final Map<T, MutableIntSet> outEdges = HashMapFactory.make();
 
-        private Iterator<T> nodes(@Nullable final T node, final Map<T, ? extends IntSet> extra) {
+        private Iterator<T> nodes(final @Nullable T node, final Map<T, ? extends IntSet> extra) {
           if (extra.containsKey(node)) {
             return new Iterator<>() {
               private final IntIterator i = extra.get(node).intIterator();

--- a/util/src/main/java/com/ibm/wala/util/graph/impl/NodeWithNumberedEdges.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/impl/NodeWithNumberedEdges.java
@@ -20,19 +20,17 @@ import org.jspecify.annotations.Nullable;
 /** Simple implementation of {@link INodeWithNumberedEdges} */
 public class NodeWithNumberedEdges extends NodeWithNumber implements INodeWithNumberedEdges {
 
-  @Nullable private BimodalMutableIntSet predNumbers;
+  private @Nullable BimodalMutableIntSet predNumbers;
 
-  @Nullable private BimodalMutableIntSet succNumbers;
+  private @Nullable BimodalMutableIntSet succNumbers;
 
-  @Nullable
   @Override
-  public IntSet getSuccNumbers() {
+  public @Nullable IntSet getSuccNumbers() {
     return succNumbers;
   }
 
-  @Nullable
   @Override
-  public IntSet getPredNumbers() {
+  public @Nullable IntSet getPredNumbers() {
     return predNumbers;
   }
 

--- a/util/src/main/java/com/ibm/wala/util/graph/impl/SelfLoopAddedEdgeManager.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/impl/SelfLoopAddedEdgeManager.java
@@ -9,7 +9,7 @@ public class SelfLoopAddedEdgeManager<T> implements EdgeManager<T> {
   private class PrependItterator implements Iterator<T> {
     private boolean usedFirst = false;
     private final Iterator<T> original;
-    @Nullable private T first;
+    private @Nullable T first;
 
     public PrependItterator(Iterator<T> original, @Nullable T first) {
       super();
@@ -26,9 +26,8 @@ public class SelfLoopAddedEdgeManager<T> implements EdgeManager<T> {
       }
     }
 
-    @Nullable
     @Override
-    public T next() {
+    public @Nullable T next() {
       if (!usedFirst) {
         T tmp = first;
         first = null;

--- a/util/src/main/java/com/ibm/wala/util/graph/labeled/AbstractNumberedLabeledGraph.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/labeled/AbstractNumberedLabeledGraph.java
@@ -85,9 +85,8 @@ public abstract class AbstractNumberedLabeledGraph<T, U> extends AbstractNumbere
     return getEdgeManager().getEdgeLabels(src, dst);
   }
 
-  @Nullable
   @Override
-  public U getDefaultLabel() {
+  public @Nullable U getDefaultLabel() {
     return getEdgeManager().getDefaultLabel();
   }
 

--- a/util/src/main/java/com/ibm/wala/util/graph/labeled/SparseNumberedLabeledEdgeManager.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/labeled/SparseNumberedLabeledEdgeManager.java
@@ -71,7 +71,7 @@ public class SparseNumberedLabeledEdgeManager<T, U>
   private static final long serialVersionUID = 5298089288917726790L;
 
   /** the label to be attached to an edge when no label is specified */
-  @Nullable private final U defaultLabel;
+  private final @Nullable U defaultLabel;
 
   private final NumberedNodeManager<T> nodeManager;
 
@@ -283,9 +283,8 @@ public class SparseNumberedLabeledEdgeManager<T, U>
     }
   }
 
-  @Nullable
   @Override
-  public U getDefaultLabel() {
+  public @Nullable U getDefaultLabel() {
     return defaultLabel;
   }
 

--- a/util/src/main/java/com/ibm/wala/util/graph/traverse/BFSPathFinder.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/traverse/BFSPathFinder.java
@@ -138,16 +138,15 @@ public class BFSPathFinder<T> {
     }
   }
 
-  @Nullable private ArrayDeque<T> Q = null;
-  @Nullable private HashMap<Object, T> history = null;
+  private @Nullable ArrayDeque<T> Q = null;
+  private @Nullable HashMap<Object, T> history = null;
 
   /**
    * @return a List of nodes that specifies the first path found from a root to a node accepted by
    *     the filter. Returns null if no path found.
    */
   @NullUnmarked
-  @Nullable
-  public List<T> find() {
+  public @Nullable List<T> find() {
     if (Q == null) {
       Q = new ArrayDeque<>();
       history = HashMapFactory.make();

--- a/util/src/main/java/com/ibm/wala/util/graph/traverse/DFSAllPathsFinder.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/traverse/DFSAllPathsFinder.java
@@ -44,9 +44,8 @@ public class DFSAllPathsFinder<T> extends DFSPathFinder<T> {
     return new FilterIterator<>(G.getSuccNodes(n), o -> !cp.contains(o));
   }
 
-  @Nullable
   @Override
-  protected Iterator<? extends T> getPendingChildren(T n) {
+  protected @Nullable Iterator<? extends T> getPendingChildren(T n) {
     Pair<List<T>, T> key = Pair.make(currentPath(), n);
     return pendingChildren.get(key);
   }

--- a/util/src/main/java/com/ibm/wala/util/graph/traverse/DFSDiscoverTimeIterator.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/traverse/DFSDiscoverTimeIterator.java
@@ -32,7 +32,7 @@ public abstract class DFSDiscoverTimeIterator<T> extends ArrayList<T> implements
   private static final long serialVersionUID = 4238700455408861924L;
 
   /** an enumeration of all nodes to search from */
-  @Nullable private Iterator<? extends T> roots;
+  private @Nullable Iterator<? extends T> roots;
 
   /** subclass constructors must call this! */
   protected void init(Iterator<? extends T> nodes) {
@@ -60,8 +60,7 @@ public abstract class DFSDiscoverTimeIterator<T> extends ArrayList<T> implements
     return !empty();
   }
 
-  @Nullable
-  protected abstract Iterator<? extends T> getPendingChildren(T n);
+  protected abstract @Nullable Iterator<? extends T> getPendingChildren(T n);
 
   protected abstract void setPendingChildren(T v, Iterator<? extends T> iterator);
 

--- a/util/src/main/java/com/ibm/wala/util/graph/traverse/DFSFinishTimeIterator.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/traverse/DFSFinishTimeIterator.java
@@ -31,7 +31,7 @@ public abstract class DFSFinishTimeIterator<T> extends ArrayList<T> implements I
   private static final long serialVersionUID = 8440061593631309429L;
 
   /** the current next element in finishing time order */
-  @Nullable private T theNextElement;
+  private @Nullable T theNextElement;
 
   /** an enumeration of all nodes to search from */
   private Iterator<? extends T> roots;
@@ -61,8 +61,7 @@ public abstract class DFSFinishTimeIterator<T> extends ArrayList<T> implements I
     return (!empty() || (theNextElement != null && getPendingChildren(theNextElement) == null));
   }
 
-  @Nullable
-  abstract Iterator<T> getPendingChildren(@Nullable T n);
+  abstract @Nullable Iterator<T> getPendingChildren(@Nullable T n);
 
   abstract void setPendingChildren(@Nullable T v, Iterator<T> iterator);
 
@@ -85,10 +84,9 @@ public abstract class DFSFinishTimeIterator<T> extends ArrayList<T> implements I
    *
    * @return the next graph node in finishing time order.
    */
-  @Nullable
   @Override
   @SuppressWarnings("unchecked")
-  public T next() throws NoSuchElementException {
+  public @Nullable T next() throws NoSuchElementException {
     if (!hasNext()) {
       throw new NoSuchElementException();
     }

--- a/util/src/main/java/com/ibm/wala/util/graph/traverse/DFSPathFinder.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/traverse/DFSPathFinder.java
@@ -99,8 +99,7 @@ public class DFSPathFinder<T> extends ArrayList<T> {
    * @return a List of nodes that specifies the first path found from a root to a node accepted by
    *     the filter. Returns null if no path found.
    */
-  @Nullable
-  public List<T> find() {
+  public @Nullable List<T> find() {
     if (!initialized) {
       init();
     }
@@ -138,8 +137,7 @@ public class DFSPathFinder<T> extends ArrayList<T> {
    *
    * @return Object
    */
-  @Nullable
-  protected Iterator<? extends T> getPendingChildren(T n) {
+  protected @Nullable Iterator<? extends T> getPendingChildren(T n) {
     return pendingChildren.get(n);
   }
 

--- a/util/src/main/java/com/ibm/wala/util/graph/traverse/GraphDFSDiscoverTimeIterator.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/traverse/GraphDFSDiscoverTimeIterator.java
@@ -20,7 +20,7 @@ abstract class GraphDFSDiscoverTimeIterator<T> extends DFSDiscoverTimeIterator<T
   private static final long serialVersionUID = -5673397879499010863L;
 
   /** the graph being searched */
-  @Nullable private Graph<T> G;
+  private @Nullable Graph<T> G;
 
   protected void init(Graph<T> G, Iterator<? extends T> nodes) {
     if (G == null) {

--- a/util/src/main/java/com/ibm/wala/util/graph/traverse/NumberedDFSFinishTimeIterator.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/traverse/NumberedDFSFinishTimeIterator.java
@@ -62,9 +62,8 @@ public class NumberedDFSFinishTimeIterator<T> extends DFSFinishTimeIterator<T> {
     this(G, G.iterator());
   }
 
-  @Nullable
   @Override
-  Iterator<T> getPendingChildren(@Nullable T n) {
+  @Nullable Iterator<T> getPendingChildren(@Nullable T n) {
     int number = G.getNumber(n);
     if (number >= pendingChildren.length) {
       // the graph is probably growing as we travserse

--- a/util/src/main/java/com/ibm/wala/util/graph/traverse/SlowDFSDiscoverTimeIterator.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/traverse/SlowDFSDiscoverTimeIterator.java
@@ -66,9 +66,8 @@ public class SlowDFSDiscoverTimeIterator<T> extends GraphDFSDiscoverTimeIterator
     init(G, G.iterator());
   }
 
-  @Nullable
   @Override
-  protected Iterator<? extends T> getPendingChildren(Object n) {
+  protected @Nullable Iterator<? extends T> getPendingChildren(Object n) {
     return pendingChildren.get(n);
   }
 

--- a/util/src/main/java/com/ibm/wala/util/graph/traverse/SlowDFSFinishTimeIterator.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/traverse/SlowDFSFinishTimeIterator.java
@@ -68,9 +68,8 @@ public class SlowDFSFinishTimeIterator<T> extends DFSFinishTimeIterator<T> {
     this(G, G == null ? null : G.iterator());
   }
 
-  @Nullable
   @Override
-  Iterator<T> getPendingChildren(@Nullable T n) {
+  @Nullable Iterator<T> getPendingChildren(@Nullable T n) {
     return pendingChildren.get(n);
   }
 

--- a/util/src/main/java/com/ibm/wala/util/intset/BasicNaturalRelation.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/BasicNaturalRelation.java
@@ -192,7 +192,7 @@ public final class BasicNaturalRelation implements IBinaryNaturalRelation, Seria
      */
     private int nextIndex = -1;
 
-    @Nullable private IntIterator delegateIterator = null;
+    private @Nullable IntIterator delegateIterator = null;
 
     TotalIterator() {
       advanceX();

--- a/util/src/main/java/com/ibm/wala/util/intset/BimodalMutableIntSet.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/BimodalMutableIntSet.java
@@ -156,9 +156,8 @@ public class BimodalMutableIntSet implements MutableIntSet {
    * @see com.ibm.wala.util.intset.IntSet#intersection(com.ibm.wala.util.intset.IntSet)
    */
   @NullUnmarked
-  @Nullable
   @Override
-  public IntSet intersection(IntSet that) throws UnimplementedError {
+  public @Nullable IntSet intersection(IntSet that) throws UnimplementedError {
     if (that instanceof BimodalMutableIntSet) {
       BimodalMutableIntSet b = (BimodalMutableIntSet) that;
       return impl.intersection(b.impl);

--- a/util/src/main/java/com/ibm/wala/util/intset/DebuggingMutableIntSet.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/DebuggingMutableIntSet.java
@@ -160,9 +160,8 @@ class DebuggingMutableIntSet implements MutableIntSet {
    * @return a new IntSet which is the intersection of this and that
    */
   @NullUnmarked
-  @Nullable
   @Override
-  public IntSet intersection(IntSet that) {
+  public @Nullable IntSet intersection(IntSet that) {
     if (that instanceof DebuggingMutableIntSet) {
       DebuggingMutableIntSet db = (DebuggingMutableIntSet) that;
       IntSet ppr = primaryImpl.intersection(db.primaryImpl);

--- a/util/src/main/java/com/ibm/wala/util/intset/DebuggingMutableIntSetFactory.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/DebuggingMutableIntSetFactory.java
@@ -55,9 +55,8 @@ public class DebuggingMutableIntSetFactory implements MutableIntSetFactory<Debug
   }
 
   @NullUnmarked
-  @Nullable
   @Override
-  public DebuggingMutableIntSet makeCopy(IntSet x) throws UnimplementedError {
+  public @Nullable DebuggingMutableIntSet makeCopy(IntSet x) throws UnimplementedError {
     if (x == null) {
       throw new IllegalArgumentException("null x");
     }

--- a/util/src/main/java/com/ibm/wala/util/intset/LongSetUtil.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/LongSetUtil.java
@@ -21,7 +21,7 @@ public class LongSetUtil {
   public static final String INT_SET_FACTORY_CONFIG_PROPERTY_NAME =
       "com.ibm.wala.mutableLongSetFactory";
 
-  @Nullable private static MutableLongSetFactory defaultLongSetFactory;
+  private static @Nullable MutableLongSetFactory defaultLongSetFactory;
 
   static {
     MutableLongSetFactory defaultFactory = new MutableSparseLongSetFactory();
@@ -63,8 +63,7 @@ public class LongSetUtil {
    *     com.ibm.wala.util.intset.MutableSharedBitVectorLongSet ) )
    * @throws IllegalArgumentException if set == null
    */
-  @Nullable
-  public static MutableLongSet makeMutableCopy(LongSet set)
+  public static @Nullable MutableLongSet makeMutableCopy(LongSet set)
       throws IllegalArgumentException, UnimplementedError {
     if (set == null) {
       throw new IllegalArgumentException("set == null");
@@ -182,8 +181,7 @@ public class LongSetUtil {
     }
   }
 
-  @Nullable
-  public static MutableLongSetFactory getDefaultLongSetFactory() {
+  public static @Nullable MutableLongSetFactory getDefaultLongSetFactory() {
     return defaultLongSetFactory;
   }
 

--- a/util/src/main/java/com/ibm/wala/util/intset/MutableSharedBitVectorIntSet.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/MutableSharedBitVectorIntSet.java
@@ -31,9 +31,9 @@ public class MutableSharedBitVectorIntSet implements MutableIntSet {
 
   private static final int OVERFLOW = 20;
 
-  @Nullable private MutableSparseIntSet privatePart;
+  private @Nullable MutableSparseIntSet privatePart;
 
-  @Nullable private BitVectorIntSet sharedPart;
+  private @Nullable BitVectorIntSet sharedPart;
 
   /** */
   public MutableSharedBitVectorIntSet() {}

--- a/util/src/main/java/com/ibm/wala/util/intset/OrdinalSet.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/OrdinalSet.java
@@ -21,9 +21,9 @@ import org.jspecify.annotations.Nullable;
 /** A Set backed by a set of integers. */
 public class OrdinalSet<T> implements Iterable<T> {
 
-  @Nullable private final IntSet S;
+  private final @Nullable IntSet S;
 
-  @Nullable private final OrdinalSetMapping<T> mapping;
+  private final @Nullable OrdinalSetMapping<T> mapping;
 
   @SuppressWarnings("rawtypes")
   private static final OrdinalSet EMPTY = new OrdinalSet();
@@ -164,8 +164,7 @@ public class OrdinalSet<T> implements Iterable<T> {
   /**
    * Dangerous. Added for performance reasons. Use this only if you really know what you are doing.
    */
-  @Nullable
-  public IntSet getBackingSet() {
+  public @Nullable IntSet getBackingSet() {
     return S;
   }
 
@@ -214,8 +213,7 @@ public class OrdinalSet<T> implements Iterable<T> {
     return new OrdinalSet<>(s, m);
   }
 
-  @Nullable
-  public OrdinalSetMapping<T> getMapping() {
+  public @Nullable OrdinalSetMapping<T> getMapping() {
     return mapping;
   }
 }

--- a/util/src/main/java/com/ibm/wala/util/intset/SemiSparseMutableIntSet.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/SemiSparseMutableIntSet.java
@@ -27,7 +27,7 @@ public class SemiSparseMutableIntSet implements MutableIntSet {
   @SuppressWarnings("NullAway.Init")
   private MutableSparseIntSet sparsePart;
 
-  @Nullable private OffsetBitVector densePart = null;
+  private @Nullable OffsetBitVector densePart = null;
 
   public SemiSparseMutableIntSet() {
     this(MutableSparseIntSet.makeEmpty());

--- a/util/src/main/java/com/ibm/wala/util/intset/SparseLongSet.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/SparseLongSet.java
@@ -334,9 +334,9 @@ public class SparseLongSet implements LongSet {
   /**
    * @see com.ibm.wala.util.intset.IntSet#intersection(com.ibm.wala.util.intset.IntSet)
    */
-  @Nullable
   @Override
-  public LongSet intersection(LongSet that) throws IllegalArgumentException, UnimplementedError {
+  public @Nullable LongSet intersection(LongSet that)
+      throws IllegalArgumentException, UnimplementedError {
     if (that == null) {
       throw new IllegalArgumentException("that == null");
     }

--- a/util/src/main/java/com/ibm/wala/util/io/CommandLine.java
+++ b/util/src/main/java/com/ibm/wala/util/io/CommandLine.java
@@ -51,8 +51,7 @@ public class CommandLine {
   }
 
   /** if string is of the form "-foo" or "-foo=", return "foo". else return null. */
-  @Nullable
-  private static String parseForKey(String string) {
+  private static @Nullable String parseForKey(String string) {
     if (string.charAt(0) == '-') {
       if (string.contains("=")) {
         return string.substring(1, string.indexOf('='));

--- a/util/src/main/java/com/ibm/wala/util/io/TemporaryFile.java
+++ b/util/src/main/java/com/ibm/wala/util/io/TemporaryFile.java
@@ -22,7 +22,7 @@ import org.jspecify.annotations.Nullable;
 
 public class TemporaryFile {
 
-  @Nullable private static Path outputDir;
+  private static @Nullable Path outputDir;
 
   public static File urlToFile(String fileName, URL input) throws IOException {
     if (input == null) {

--- a/util/src/main/java/com/ibm/wala/util/processes/BasicLauncher.java
+++ b/util/src/main/java/com/ibm/wala/util/processes/BasicLauncher.java
@@ -18,14 +18,13 @@ import org.jspecify.annotations.Nullable;
 /** A generic process launcher */
 public class BasicLauncher extends Launcher {
 
-  @Nullable protected String cmd;
+  protected @Nullable String cmd;
 
   public BasicLauncher(boolean captureOutput, boolean captureErr, Logger logger) {
     super(captureOutput, captureErr, logger);
   }
 
-  @Nullable
-  public String getCmd() {
+  public @Nullable String getCmd() {
     return cmd;
   }
 

--- a/util/src/main/java/com/ibm/wala/util/processes/JavaLauncher.java
+++ b/util/src/main/java/com/ibm/wala/util/processes/JavaLauncher.java
@@ -79,10 +79,10 @@ public class JavaLauncher extends Launcher {
   private final List<String> xtraClasspath = new ArrayList<>();
 
   /** A {@link Thread} which spins and drains stdout of the running process. */
-  @Nullable private Thread stdOutDrain;
+  private @Nullable Thread stdOutDrain;
 
   /** A {@link Thread} which spins and drains stderr of the running process. */
-  @Nullable private Thread stdErrDrain;
+  private @Nullable Thread stdErrDrain;
 
   /** Absolute path of the 'java' executable to use. */
   private String javaExe;
@@ -91,7 +91,7 @@ public class JavaLauncher extends Launcher {
   private final List<String> vmArgs = new ArrayList<>();
 
   /** The last process returned by a call to start() on this object. */
-  @Nullable private Process lastProcess;
+  private @Nullable Process lastProcess;
 
   private JavaLauncher(
       String programArgs,
@@ -205,13 +205,11 @@ public class JavaLauncher extends Launcher {
     return p;
   }
 
-  @Nullable
-  public Process getLastProcess() {
+  public @Nullable Process getLastProcess() {
     return lastProcess;
   }
 
-  @Nullable
-  private static String makeLibPath() {
+  private static @Nullable String makeLibPath() {
     String libPath = System.getProperty("java.library.path");
     if (libPath == null) {
       return null;

--- a/util/src/main/java/com/ibm/wala/util/processes/Launcher.java
+++ b/util/src/main/java/com/ibm/wala/util/processes/Launcher.java
@@ -28,9 +28,9 @@ public abstract class Launcher {
   // use a fairly big buffer size to avoid performance problems with the default
   private static final int BUFFER_SIZE = 32 * 1024;
 
-  @Nullable protected File workingDir = null;
+  protected @Nullable File workingDir = null;
 
-  @Nullable protected Map<String, String> env = null;
+  protected @Nullable Map<String, String> env = null;
 
   protected byte @Nullable [] stdOut = null;
 
@@ -60,8 +60,7 @@ public abstract class Launcher {
     this.logger = logger;
   }
 
-  @Nullable
-  public File getWorkingDir() {
+  public @Nullable File getWorkingDir() {
     return workingDir;
   }
 
@@ -69,8 +68,7 @@ public abstract class Launcher {
     workingDir = newWorkingDir;
   }
 
-  @Nullable
-  public Map<String, String> getEnv() {
+  public @Nullable Map<String, String> getEnv() {
     return env;
   }
 
@@ -211,7 +209,7 @@ public abstract class Launcher {
 
     private final Process p;
 
-    @Nullable private ByteArrayOutputStream capture;
+    private @Nullable ByteArrayOutputStream capture;
 
     /** Drain data from the stream, but don't block. */
     abstract void drain() throws IOException;
@@ -333,14 +331,12 @@ public abstract class Launcher {
   }
 
   @NullUnmarked
-  @Nullable
-  public byte[] getStdOut() {
+  public @Nullable byte[] getStdOut() {
     return stdOut;
   }
 
   @NullUnmarked
-  @Nullable
-  public byte[] getStderr() {
+  public @Nullable byte[] getStderr() {
     return stdErr;
   }
 
@@ -353,8 +349,7 @@ public abstract class Launcher {
   }
 
   @NullUnmarked
-  @Nullable
-  public byte[] getInput() {
+  public @Nullable byte[] getInput() {
     return input;
   }
 

--- a/util/src/main/java/com/ibm/wala/util/viz/DotUtil.java
+++ b/util/src/main/java/com/ibm/wala/util/viz/DotUtil.java
@@ -254,8 +254,7 @@ public class DotUtil {
     return Iterator2Collection.toSet(g.iterator());
   }
 
-  @Nullable
-  private static String getRankDir() {
+  private static @Nullable String getRankDir() {
     return null;
   }
 

--- a/util/src/main/java/com/ibm/wala/util/viz/PDFViewLauncher.java
+++ b/util/src/main/java/com/ibm/wala/util/viz/PDFViewLauncher.java
@@ -22,20 +22,19 @@ import org.jspecify.annotations.Nullable;
  */
 public class PDFViewLauncher {
 
-  @Nullable private Process process;
+  private @Nullable Process process;
 
   /** Name of the postscript file to view */
-  @Nullable protected String pdffile = null;
+  protected @Nullable String pdffile = null;
 
   /** Path to ghostview executable */
-  @Nullable protected String gvExe = null;
+  protected @Nullable String gvExe = null;
 
   public PDFViewLauncher() {
     super();
   }
 
-  @Nullable
-  public String getPDFFile() {
+  public @Nullable String getPDFFile() {
     return pdffile;
   }
 
@@ -43,8 +42,7 @@ public class PDFViewLauncher {
     pdffile = newPsfile;
   }
 
-  @Nullable
-  public String getGvExe() {
+  public @Nullable String getGvExe() {
     return gvExe;
   }
 
@@ -57,7 +55,7 @@ public class PDFViewLauncher {
     return super.toString() + ", psfile: " + pdffile + ", gvExe: " + gvExe + ')';
   }
 
-  @Nullable private WalaException exception = null;
+  private @Nullable WalaException exception = null;
 
   /**
    * @see java.lang.Runnable#run()
@@ -73,13 +71,11 @@ public class PDFViewLauncher {
     }
   }
 
-  @Nullable
-  public WalaException getException() {
+  public @Nullable WalaException getException() {
     return exception;
   }
 
-  @Nullable
-  public Process getProcess() {
+  public @Nullable Process getProcess() {
     return process;
   }
 


### PR DESCRIPTION
The [AnnotationPosition Error Prone check](https://errorprone.info/bugpattern/AnnotationPosition) ensures type-use annotations appear next to the qualified type, and that declaration annotations appear before other qualifiers.  This PR enables the check and auto-fixes all existing warnings.