### PR TITLE
Publish using gradle-maven-publish plugin (#521)

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
   implementation(libs.gradle.download.task)
   implementation(libs.gradle.errorprone.plugin)
   implementation(libs.gradle.goomph.plugin)
+  implementation(libs.gradle.maven.publish.plugin)
   implementation(libs.gradle.spotless.plugin)
 }
 

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
@@ -1,18 +1,17 @@
 package com.ibm.wala.gradle
 
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
-  `java-library`
   `java-test-fixtures`
-  `maven-publish`
   signing
-  id("com.ibm.wala.gradle.subproject")
+  id("com.vanniktech.maven.publish")
 }
 
 val isSnapshot = "SNAPSHOT" in version as String
 
-val javaComponent = components["java"] as AdhocComponentWithVariants
-
-val allTestFixturesSource: SourceDirectorySet = sourceSets.testFixtures.get().allSource
+val java: JavaPluginExtension by extensions
 
 val testFixturesJavadoc by
     tasks.existing(Javadoc::class) { setDestinationDir(java.docsDir.get().dir(name).asFile) }
@@ -23,140 +22,112 @@ val testFixturesJavadocJar by
       from(testFixturesJavadoc.map { it.destinationDir!! })
     }
 
-val testFixturesSourcesJar by
-    tasks.registering(Jar::class) {
-      archiveClassifier = "test-fixtures-sources"
-      from(allTestFixturesSource)
+configure<MavenPublishBaseExtension> {
+  configureBasedOnAppliedPlugins()
+  publishToMavenCentral(SonatypeHost.DEFAULT)
+  signAllPublications()
+
+  pom {
+    name = property("POM_NAME") as String
+    description = "T. J. Watson Libraries for Analysis"
+    inceptionYear = "2006"
+    url = "https://github.com/wala/WALA"
+    val pomUrl = url
+
+    ciManagement {
+      system = "GitHub Actions"
+      url = "https://github.com/wala/WALA/actions"
     }
 
-val publishing: PublishingExtension by extensions
-
-val mavenPublication =
-    publishing.publications.create<MavenPublication>("maven") {
-      from(javaComponent)
-
-      groupId = "com.ibm.wala"
-      artifactId = base.archivesName.get()
-
-      val testFixturesCodeElementsNames =
-          listOf("testFixturesApiElements", "testFixturesRuntimeElements")
-      testFixturesCodeElementsNames.forEach(this::suppressPomMetadataWarningsFor)
-
-      if (allTestFixturesSource.isEmpty) {
-        // Test-fixtures jar would be empty except for the manifest, so skip it.
-        testFixturesCodeElementsNames.forEach {
-          javaComponent.withVariantsFromConfiguration(configurations[it]) { skip() }
-        }
-      } else {
-        // Test-fixtures jar will have real contents, so add Javadoc and sources
-        artifact(testFixturesJavadocJar)
-        artifact(testFixturesSourcesJar)
-      }
-
-      pom {
-        name = property("POM_NAME") as String
-        description = "T. J. Watson Libraries for Analysis"
-        inceptionYear = "2006"
-        url = "https://github.com/wala/WALA"
-        val pomUrl = url
-
-        ciManagement {
-          system = "GitHub Actions"
-          url = "https://github.com/wala/WALA/actions"
-        }
-
-        developers {
-          // Current WALA maintainers, alphabetical by ID
-          mapOf(
-                  "juliandolby" to "Julian Dolby",
-                  "liblit" to "Ben Liblit",
-                  "msridhar" to "Manu Sridharan",
-                  "sjfink" to "Stephen Fink",
-              )
-              .forEach { entry ->
-                developer {
-                  id = entry.key
-                  name = entry.value
-                  url = "https://github.com/{$entry.key}"
-                }
-              }
-        }
-
-        issueManagement {
-          system = "GitHub"
-          url = pomUrl.map { "$it/issues" }
-        }
-
-        licenses {
-          license {
-            name = "Eclipse Public License v2.0"
-            url = pomUrl.map { "$it/blob/master/LICENSE" }
+    developers {
+      // Current WALA maintainers, alphabetical by ID
+      mapOf(
+              "juliandolby" to "Julian Dolby",
+              "liblit" to "Ben Liblit",
+              "msridhar" to "Manu Sridharan",
+              "sjfink" to "Stephen Fink",
+          )
+          .forEach { entry ->
+            developer {
+              id = entry.key
+              name = entry.value
+              url = "https://github.com/{$entry.key}"
+            }
           }
-        }
+    }
 
-        mailingLists {
-          listOf(
-                  "commits",
-                  "wala",
-              )
-              .forEach { topic ->
-                mailingList {
-                  name = "wala-$topic"
-                  archive = "https://sourceforge.net/p/wala/mailman/wala-$topic"
-                  subscribe = "https://sourceforge.net/projects/wala/lists/wala-$topic"
-                  unsubscribe =
-                      "https://sourceforge.net/projects/wala/lists/wala-$topic/unsubscribe"
-                  post = "wala-$topic@lists.sourceforge.net"
-                }
-              }
-        }
+    issueManagement {
+      system = "GitHub"
+      url = pomUrl.map { "$it/issues" }
+    }
 
-        scm {
-          url = pomUrl
-          connection = "scm:git:git://github.com/wala/WALA.git"
-          developerConnection = "scm:git:ssh://git@github.com/wala/WALA.git"
-        }
+    licenses {
+      license {
+        name = "Eclipse Public License v2.0"
+        url = pomUrl.map { "$it/blob/master/LICENSE" }
       }
     }
 
-val repositories: RepositoryHandler = publishing.repositories
-
-val mavenRepository: MavenArtifactRepository =
-    repositories.maven {
-      url =
-          uri(
-              (if (isSnapshot)
-                  properties.getOrDefault(
-                      "SNAPSHOT_REPOSITORY_URL",
-                      "https://oss.sonatype.org/content/repositories/snapshots/")
-              else
-                  properties.getOrDefault(
-                      "RELEASE_REPOSITORY_URL",
-                      "https://oss.sonatype.org/service/local/staging/deploy/maven2/"))
-                  as String)
-      credentials {
-        username = findProperty("SONATYPE_NEXUS_USERNAME") as String?
-        password = findProperty("SONATYPE_NEXUS_PASSWORD") as String?
-      }
+    mailingLists {
+      listOf(
+              "commits",
+              "wala",
+          )
+          .forEach { topic ->
+            mailingList {
+              name = "wala-$topic"
+              archive = "https://sourceforge.net/p/wala/mailman/wala-$topic"
+              subscribe = "https://sourceforge.net/projects/wala/lists/wala-$topic"
+              unsubscribe = "https://sourceforge.net/projects/wala/lists/wala-$topic/unsubscribe"
+              post = "wala-$topic@lists.sourceforge.net"
+            }
+          }
     }
 
-repositories.maven {
-  name = "fakeRemote"
-  setUrl(rootProject.layout.buildDirectory.dir("maven-fake-remote-repository"))
-}
-
-signing {
-  sign(mavenPublication)
-  setRequired {
-    // Signatures are a hard requirement if publishing a non-snapshot to a real, remote repository.
-    !isSnapshot &&
-        gradle.taskGraph.allTasks.any {
-          it is PublishToMavenRepository && it.repository == mavenRepository
-        }
+    scm {
+      url = pomUrl
+      connection = "scm:git:git://github.com/wala/WALA.git"
+      developerConnection = "scm:git:ssh://git@github.com/wala/WALA.git"
+    }
   }
 }
 
-java {
-  withJavadocJar()
-  withSourcesJar()
+configure<PublishingExtension> {
+  repositories.maven {
+    name = "fakeRemote"
+    setUrl(rootProject.layout.buildDirectory.dir("maven-fake-remote-repository"))
+  }
+
+  publications.named<MavenPublication>("maven") {
+    groupId = "com.ibm.wala"
+    artifactId = the<BasePluginExtension>().archivesName.get()
+
+    val testFixturesCodeElementsNames =
+        listOf("testFixturesApiElements", "testFixturesRuntimeElements")
+    testFixturesCodeElementsNames.forEach(this::suppressPomMetadataWarningsFor)
+
+    if (java.sourceSets["testFixtures"].allSource.isEmpty) {
+      // Test-fixtures jars would be empty except for manifests, so skip them in the style of
+      // <https://docs.gradle.org/current/userguide/java_testing.html#ex-disable-publishing-of-test-fixtures-variants>.
+      val javaComponent = components["java"] as AdhocComponentWithVariants
+      listOf("Api", "Runtime", "Sources").forEach {
+        javaComponent.withVariantsFromConfiguration(configurations["testFixtures${it}Elements"]) {
+          skip()
+        }
+      }
+    } else {
+      // Test-fixtures jar will have real contents, so add Javadoc.
+      artifact(testFixturesJavadocJar)
+    }
+  }
+}
+
+configure<SigningExtension> {
+  setRequired {
+    // Signatures are a hard requirement if publishing a non-snapshot to Maven Central.
+    !isSnapshot &&
+        gradle.taskGraph.allTasks.any {
+          it is PublishToMavenRepository && it.name.endsWith("ToMavenCentralRepository")
+        }
+  }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ errorprone-core = "com.google.errorprone:error_prone_core:2.27.1"
 gradle-download-task = "de.undercouch:gradle-download-task:5.6.0"
 gradle-errorprone-plugin = "net.ltgt.gradle:gradle-errorprone-plugin:3.1.0"
 gradle-goomph-plugin = "com.diffplug.gradle:goomph:3.44.0"
+gradle-maven-publish-plugin = "com.vanniktech:gradle-maven-publish-plugin:0.29.0"
 gradle-spotless-plugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 gson = "com.google.code.gson:gson:2.11.0"
 guava = "com.google.guava:guava:33.2.0-jre"


### PR DESCRIPTION
Thoroughly testing these changes is delicate, since publishing to Maven Central involves an outside service, authentication, etc.  Instead, I've checked these changes in a limited manner:  I have verified that the `publishAllPublicationsToFakeRemoteRepository` task creates a local Maven repository containing exactly the same named files (in the same locations) as that task did before these changes.