### PR TITLE
Update and broaden use of Java toolchain resolver

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,3 +1,5 @@
+plugins { id("org.gradle.toolchains.foojay-resolver-convention") version ("0.8.0") }
+
 rootProject.name = "build-logic"
 
 // The WALA root project and its standard subprojects automatically use the version catalog in

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,7 +2,7 @@ buildscript { dependencies { classpath("com.diffplug.spotless:spotless-lib-extra
 
 plugins {
   id("com.diffplug.configuration-cache-for-platform-specific-build") version "3.44.0"
-  id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+  id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
 }
 
 enableFeaturePreview("STABLE_CONFIGURATION_CACHE")


### PR DESCRIPTION
Use the latest 0.8.0 release of this plugin.

Use this plugin in the build-logic subproject, in case that subproject needs a Java toolchain that is not already installed system-wide or by the user.  In particular, this subproject compiles Kotlin for Java 11, but there's no guarantee that a Java 11 toolchain is already present.