### PR TITLE
Add development container configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "Java",
+  "image": "mcr.microsoft.com/devcontainers/java:1-21-bullseye",
+  "features": {
+    "ghcr.io/devcontainers/features/java:1": {}
+  },
+  "customizations": {
+    "jetbrains": {
+      "backend": "IntelliJ",
+      "plugins": ["google-java-format"]
+    }
+  }
+}


### PR DESCRIPTION
This configuration file is fairly simple: WALA bundles what it needs (e.g., Gradle) or downloads components at build time.  But there's no harm providing this metadata, and perhaps it will be helpful if someone wants to spin up a container that is ready to use for WALA development.  See [Development
Containers](https://containers.dev/) for more information.

Right now there is no automated validation of this file.  Potentially we could validate by running the Development Container CLI as `devcontainer read-configuration`.  But doing that requires the `devcontainer` command, which in turn is installed using `npm`.  This seems like a lot of extra material to bring in just to validate one file.  I'm going to hold off on that for now.