### PR TITLE
Remove a redundant `asSequence()` call

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/cast/helpers.kt
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/cast/helpers.kt
@@ -93,4 +93,4 @@ val AbstractLinkTask.nativeLibraryOutput: File
   get() =
       // On all supported platforms, the link task's first two outputs are a directory and a library
       // in that directory. On Windows, the link task also has a third output file: a DLL.
-      outputs.files.asSequence().elementAt(1)
+      outputs.files.elementAt(1)


### PR DESCRIPTION
The `FileCollection` provided by `outputs.files` already offers an `elementAt(Int)` method.  There's no need to convert this `FileCollection` to a `Sequence<File>` just for indexed access.