### PR TITLE
Simplify helper functions for native code

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/project.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/project.gradle.kts
@@ -19,11 +19,10 @@ repositories.mavenCentral()
 
 // workaround for <https://github.com/gradle/gradle/issues/4802>
 eclipse.classpath.file.whenMerged {
-  (this as Classpath).run {
-    entries.forEach {
-      if (it is AbstractClasspathEntry && it.entryAttributes["gradle_used_by_scope"] == "test")
-          it.entryAttributes["test"] = true
-    }
+  this as Classpath
+  entries.forEach {
+    if (it is AbstractClasspathEntry && it.entryAttributes["gradle_used_by_scope"] == "test")
+        it.entryAttributes["test"] = true
   }
 }
 

--- a/cast/cast/build.gradle.kts
+++ b/cast/cast/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.ibm.wala.gradle.cast.addJvmLibrary
+import com.ibm.wala.gradle.cast.configure
 import com.ibm.wala.gradle.cast.nativeLibraryOutput
 
 plugins {
@@ -9,17 +10,14 @@ plugins {
 
 library {
   binaries.whenElementFinalized {
-    compileTask.get().configure(closureOf<CppCompile> { macros["BUILD_CAST_DLL"] = "1" })
+    compileTask.configure { macros["BUILD_CAST_DLL"] = "1" }
 
     this as CppSharedLibrary
-    linkTask
-        .get()
-        .configure(
-            closureOf<LinkSharedLibrary> {
-              if (targetMachine.operatingSystemFamily.isMacOs) {
-                linkerArgs.add("-Wl,-install_name,@rpath/${nativeLibraryOutput.name}")
-              }
-              addJvmLibrary(this@whenElementFinalized, this, project)
-            })
+    linkTask.configure {
+      if (targetMachine.operatingSystemFamily.isMacOs) {
+        linkerArgs.add("-Wl,-install_name,@rpath/${nativeLibraryOutput.name}")
+      }
+      addJvmLibrary(this@whenElementFinalized)
+    }
   }
 }

--- a/cast/xlator_test/build.gradle.kts
+++ b/cast/xlator_test/build.gradle.kts
@@ -18,6 +18,7 @@ library {
   dependencies { implementation(projects.cast.cast) }
 
   binaries.whenElementFinalized {
-    addCastLibrary(this, (this as CppSharedLibrary).linkTask.get(), project)
+    this as CppSharedLibrary
+    linkTask.get().addCastLibrary(this)
   }
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -15,11 +15,10 @@ plugins {
 eclipse {
   project.natures("org.eclipse.pde.PluginNature")
   classpath.file.whenMerged {
-    (this as Classpath).run {
-      entries.forEach {
-        if (it is AbstractClasspathEntry && it.path == "src/testSubjects/java") {
-          it.entryAttributes["ignore_optional_problems"] = true
-        }
+    this as Classpath
+    entries.forEach {
+      if (it is AbstractClasspathEntry && it.path == "src/testSubjects/java") {
+        it.entryAttributes["ignore_optional_problems"] = true
       }
     }
   }


### PR DESCRIPTION
The `cast/helpers.kt` script defines various functions that help us configure tasks that work with native code, such as natively compiled libraries.  I ported these from Groovy to Kotlin when I was still fairly new to the latter.  I've gotten better with Kotlin since then, and I now see how some of these functions could be simplified.

For example, judicious use of extension methods makes some functions easier to call, and also makes it easier for those functions' implementations to access properties of the receiver object.  In other cases, some function parameters can be computed from other parameters, thereby making the function easier to call correctly and harder to call incorrectly.

None of this constitutes a radical change to the suite of helper functions or how they are used to configure tasks.  It's just a bunch of small cleanups and simplifications from 2024-me, who knows Kotlin better than 2022-me.

---

**Reviewer tip:** ignore whitespace for a more semantic diff view.