### PR TITLE
Remove an unnecessary test dependency

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -108,7 +108,6 @@ tasks.named<Test>("test") {
 }
 
 if (hasProperty("excludeSlowTests")) {
-  dependencies { testImplementation(testFixtures(project(":core"))) }
   tasks.named<Test>("test") { useJUnitPlatform { excludeTags("slow") } }
 }
 


### PR DESCRIPTION
This dependency probably has not been needed since revision 63f33036c05b7a88da151f48ad2f82901760e97f removed `com.ibm.wala.tests.util.SlowTests` as part of porting tests from JUnit 4 to JUnit 5.