### PR TITLE
Update CI actions and generate Javadoc on JDK 21

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -50,13 +50,13 @@ jobs:
 #        uses: gradle/gradle-build-action@v3
 #        with:
 #          gradle-executable: xvfb-gradle.sh
-        run: ./gradlew aggregatedJavadocs build publishAllPublicationsToFakeRemoteRepository shellcheck --no-configuration-cache -Pcom.ibm.wala.jdk-version=${{ matrix.java }}
+        run: ./xvfb-gradle.sh aggregatedJavadocs build publishAllPublicationsToFakeRemoteRepository shellcheck --no-configuration-cache "-Pcom.ibm.wala.jdk-version=${{ matrix.java }}"
         # testing ECJ compilation on any one OS is sufficient; we choose Linux arbitrarily
         if: runner.os == 'Linux'
       - name: Build and test using Gradle but without ECJ
 #        uses: gradle/gradle-build-action@v3
 #        with:
-        run: ./gradlew aggregatedJavadocs javadoc build -PskipJavaUsingEcjTasks --no-configuration-cache -Pcom.ibm.wala.jdk-version=${{ matrix.java }}
+        run: ./gradlew aggregatedJavadocs javadoc build -PskipJavaUsingEcjTasks --no-configuration-cache "-Pcom.ibm.wala.jdk-version=${{ matrix.java }}"
         if: runner.os != 'Linux'
       - name: Check for Git cleanliness after build and test
         run: ./check-git-cleanliness.sh

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -44,19 +44,19 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Build and test using Gradle with ECJ
-        uses: gradle/gradle-build-action@v3
-        with:
-          gradle-executable: xvfb-gradle.sh
-          arguments: aggregatedJavadocs build publishAllPublicationsToFakeRemoteRepository shellcheck --no-configuration-cache -Pcom.ibm.wala.jdk-version=${{ matrix.java }}
+#        uses: gradle/gradle-build-action@v3
+#        with:
+#          gradle-executable: xvfb-gradle.sh
+        run: ./gradlew aggregatedJavadocs build publishAllPublicationsToFakeRemoteRepository shellcheck --no-configuration-cache -Pcom.ibm.wala.jdk-version=${{ matrix.java }}
         # testing ECJ compilation on any one OS is sufficient; we choose Linux arbitrarily
         if: runner.os == 'Linux'
       - name: Build and test using Gradle but without ECJ
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: aggregatedJavadocs javadoc build -PskipJavaUsingEcjTasks --no-configuration-cache -Pcom.ibm.wala.jdk-version=${{ matrix.java }}
+#        uses: gradle/gradle-build-action@v3
+#        with:
+        run: ./gradlew aggregatedJavadocs javadoc build -PskipJavaUsingEcjTasks --no-configuration-cache -Pcom.ibm.wala.jdk-version=${{ matrix.java }}
         if: runner.os != 'Linux'
       - name: Check for Git cleanliness after build and test
         run: ./check-git-cleanliness.sh
@@ -96,6 +96,8 @@ jobs:
         with:
           java-version: 21
           distribution: 'temurin'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: 'Generate latest docs'
         env:
           GITHUB_TOKEN: ${{ secrets.WALA_BOT_GH_TOKEN }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -33,12 +33,12 @@ jobs:
     steps:
       - name: Check out WALA sources
         uses: actions/checkout@v4
-      - name: Cache Goomph
-        uses: actions/cache@v4
-        with:
-          path: ~/.goomph
-          key: ${{ runner.os }}-goomph-${{ hashFiles('build.gradle') }}
-          restore-keys: ${{ runner.os }}-goomph-
+#      - name: Cache Goomph
+#        uses: actions/cache@v4
+#        with:
+#          path: ~/.goomph
+#          key: ${{ runner.os }}-goomph-${{ hashFiles('build.gradle') }}
+#          restore-keys: ${{ runner.os }}-goomph-
       - name: 'Set up JDK ${{ matrix.java }}'
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -91,10 +91,10 @@ jobs:
           path: ~/.goomph
           key: ${{ runner.os }}-goomph-${{ hashFiles('build.gradle') }}
           restore-keys: ${{ runner.os }}-goomph-
-      - name: 'Set up JDK 22'
+      - name: 'Set up JDK 21'
         uses: actions/setup-java@v4
         with:
-          java-version: 22
+          java-version: 21
           distribution: 'temurin'
       - name: 'Generate latest docs'
         env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -47,17 +47,14 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Build and test using Gradle with ECJ
-#        uses: gradle/gradle-build-action@v3
-#        with:
-#          gradle-executable: xvfb-gradle.sh
-        run: ./gradlew aggregatedJavadocs build publishAllPublicationsToFakeRemoteRepository shellcheck --no-configuration-cache -Pcom.ibm.wala.jdk-version=${{ matrix.java }}
+        run: ./xvfb-gradle.sh aggregatedJavadocs build publishAllPublicationsToFakeRemoteRepository shellcheck --no-configuration-cache -Pcom.ibm.wala.jdk-version=${{ matrix.java }}
         # testing ECJ compilation on any one OS is sufficient; we choose Linux arbitrarily
-        if: runner.os == 'Linux'
+        if: runner.os != 'Windows'
       - name: Build and test using Gradle but without ECJ
 #        uses: gradle/gradle-build-action@v3
 #        with:
-        run: ./gradlew aggregatedJavadocs javadoc build -PskipJavaUsingEcjTasks --no-configuration-cache -Pcom.ibm.wala.jdk-version=${{ matrix.java }}
-        if: runner.os != 'Linux'
+        run: gradlew.bat aggregatedJavadocs javadoc build -PskipJavaUsingEcjTasks --no-configuration-cache "-Pcom.ibm.wala.jdk-version=${{ matrix.java }}"
+        if: runner.os == 'Windows'
       - name: Check for Git cleanliness after build and test
         run: ./check-git-cleanliness.sh
         # not running in Borne or POSIX shell on Windows

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -47,14 +47,17 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Build and test using Gradle with ECJ
-        run: ./xvfb-gradle.sh aggregatedJavadocs build publishAllPublicationsToFakeRemoteRepository shellcheck --no-configuration-cache -Pcom.ibm.wala.jdk-version=${{ matrix.java }}
+#        uses: gradle/gradle-build-action@v3
+#        with:
+#          gradle-executable: xvfb-gradle.sh
+        run: ./gradlew aggregatedJavadocs build publishAllPublicationsToFakeRemoteRepository shellcheck --no-configuration-cache -Pcom.ibm.wala.jdk-version=${{ matrix.java }}
         # testing ECJ compilation on any one OS is sufficient; we choose Linux arbitrarily
-        if: runner.os != 'Windows'
+        if: runner.os == 'Linux'
       - name: Build and test using Gradle but without ECJ
 #        uses: gradle/gradle-build-action@v3
 #        with:
-        run: gradlew.bat aggregatedJavadocs javadoc build -PskipJavaUsingEcjTasks --no-configuration-cache "-Pcom.ibm.wala.jdk-version=${{ matrix.java }}"
-        if: runner.os == 'Windows'
+        run: ./gradlew aggregatedJavadocs javadoc build -PskipJavaUsingEcjTasks --no-configuration-cache -Pcom.ibm.wala.jdk-version=${{ matrix.java }}
+        if: runner.os != 'Linux'
       - name: Check for Git cleanliness after build and test
         run: ./check-git-cleanliness.sh
         # not running in Borne or POSIX shell on Windows

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,29 +32,29 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out WALA sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache Goomph
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.goomph
           key: ${{ runner.os }}-goomph-${{ hashFiles('build.gradle') }}
           restore-keys: ${{ runner.os }}-goomph-
       - name: 'Set up JDK ${{ matrix.java }}'
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@v3
       - name: Build and test using Gradle with ECJ
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         with:
           gradle-executable: xvfb-gradle.sh
           arguments: aggregatedJavadocs build publishAllPublicationsToFakeRemoteRepository shellcheck --no-configuration-cache -Pcom.ibm.wala.jdk-version=${{ matrix.java }}
         # testing ECJ compilation on any one OS is sufficient; we choose Linux arbitrarily
         if: runner.os == 'Linux'
       - name: Build and test using Gradle but without ECJ
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         with:
           arguments: aggregatedJavadocs javadoc build -PskipJavaUsingEcjTasks --no-configuration-cache -Pcom.ibm.wala.jdk-version=${{ matrix.java }}
         if: runner.os != 'Linux'
@@ -84,17 +84,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache Goomph
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.goomph
           key: ${{ runner.os }}-goomph-${{ hashFiles('build.gradle') }}
           restore-keys: ${{ runner.os }}-goomph-
-      - name: 'Set up JDK 11'
-        uses: actions/setup-java@v3
+      - name: 'Set up JDK 22'
+        uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 22
           distribution: 'temurin'
       - name: 'Generate latest docs'
         env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -33,12 +33,6 @@ jobs:
     steps:
       - name: Check out WALA sources
         uses: actions/checkout@v4
-#      - name: Cache Goomph
-#        uses: actions/cache@v4
-#        with:
-#          path: ~/.goomph
-#          key: ${{ runner.os }}-goomph-${{ hashFiles('build.gradle') }}
-#          restore-keys: ${{ runner.os }}-goomph-
       - name: 'Set up JDK ${{ matrix.java }}'
         uses: actions/setup-java@v4
         with:
@@ -47,15 +41,11 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Build and test using Gradle with ECJ
-#        uses: gradle/gradle-build-action@v3
-#        with:
-#          gradle-executable: xvfb-gradle.sh
+        # use xvfb-gradle.sh to avoid headless test failures on Linux
         run: ./xvfb-gradle.sh aggregatedJavadocs build publishAllPublicationsToFakeRemoteRepository shellcheck --no-configuration-cache "-Pcom.ibm.wala.jdk-version=${{ matrix.java }}"
         # testing ECJ compilation on any one OS is sufficient; we choose Linux arbitrarily
         if: runner.os == 'Linux'
       - name: Build and test using Gradle but without ECJ
-#        uses: gradle/gradle-build-action@v3
-#        with:
         run: ./gradlew aggregatedJavadocs javadoc build -PskipJavaUsingEcjTasks --no-configuration-cache "-Pcom.ibm.wala.jdk-version=${{ matrix.java }}"
         if: runner.os != 'Linux'
       - name: Check for Git cleanliness after build and test


### PR DESCRIPTION
This keeps us up to date and also moves us off of some deprecated Gradle-related actions.  

We also generate Javadoc on a more recent JDK version to get latest Javadoc improvements.