### PR TITLE
Support JDK 23

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -27,7 +27,7 @@ jobs:
           - os: ubuntu-latest
             java: 21
           - os: ubuntu-latest
-            java: 22
+            java: 23-ea
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -27,7 +27,7 @@ jobs:
           - os: ubuntu-latest
             java: 21
           - os: ubuntu-latest
-            java: 23-ea
+            java: 23
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/core/src/main/java/com/ibm/wala/analysis/reflection/GetMethodContext.java
+++ b/core/src/main/java/com/ibm/wala/analysis/reflection/GetMethodContext.java
@@ -37,10 +37,12 @@ import com.ibm.wala.ipa.callgraph.propagation.FilteredPointerKey;
  * GetMethodContextSelector} should be placed in be placed in front of {@link
  * JavaLangClassContextInterpreter} and {@link JavaLangClassContextSelector} .
  *
+ * <p>TODO Do the same for {@link Class#getField(String)} and {@link
+ * Class#getDeclaredField(String)}.
+ *
  * @author Michael Heilmann
  * @see com.ibm.wala.analysis.reflection.GetMethodContextInterpreter
- * @see com.ibm.wala.analysis.reflection.GetMethodContextSelector TODO Do the same for {@link
- *     Class#getField(String)} and {@link Class#getDeclaredField(String)}.
+ * @see com.ibm.wala.analysis.reflection.GetMethodContextSelector
  */
 public class GetMethodContext implements Context {
   /** The type abstraction. */

--- a/core/src/main/java/com/ibm/wala/dataflow/IFDS/TabulationSolver.java
+++ b/core/src/main/java/com/ibm/wala/dataflow/IFDS/TabulationSolver.java
@@ -53,8 +53,6 @@ import java.util.TreeSet;
  *   <li>it stores summary edges at each callee instead of at each call site.
  * </ul>
  *
- * <p>
- *
  * @param <T> type of node in the supergraph
  * @param <P> type of a procedure (like a box in an RSM)
  * @param <F> type of factoids propagated when solving this problem

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/ExplicitCallGraph.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/ExplicitCallGraph.java
@@ -226,10 +226,6 @@ public class ExplicitCallGraph extends BasicCallGraph<SSAContextInterpreter>
       }
     }
 
-    /**
-     * @see
-     *     com.ibm.wala.ipa.callgraph.impl.BasicCallGraph.NodeImpl#removeNodeAndEdges(com.ibm.wala.ipa.callgraph.CGNode)
-     */
     public void removeTarget(CGNode target) {
       allTargets.remove(getCallGraph().getNumber(target));
       for (IntIterator it = targets.safeIterateIndices(); it.hasNext(); ) {

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/ClassReader.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/ClassReader.java
@@ -67,8 +67,8 @@ public final class ClassReader implements ClassConstants {
     if (magic != MAGIC) {
       throw new InvalidClassFileException(offset, "bad magic number: " + magic);
     }
-    // Support class files up through JDK 22 (version 66)
-    if (majorVersion < 45 || majorVersion > 66) {
+    // Support class files up through JDK 23 (version 67)
+    if (majorVersion < 45 || majorVersion > 67) {
       throw new InvalidClassFileException(
           offset, "unknown class file version: " + majorVersion + '.' + minorVersion);
     }


### PR DESCRIPTION
As usual, we verify existing tests don't crash on JDK 23 bytecodes, but we haven't added or tested support for any new features.