### PR TITLE
Actually generate javadoc on latest JDK version

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -72,23 +72,20 @@ jobs:
     needs: build_gradle
     if: github.event_name == 'push' && github.repository == 'wala/WALA' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
+    env:
+      JDK_VERSION: 23
     steps:
       - name: 'Check out repository'
         uses: actions/checkout@v4
-      - name: Cache Goomph
-        uses: actions/cache@v4
-        with:
-          path: ~/.goomph
-          key: ${{ runner.os }}-goomph-${{ hashFiles('build.gradle') }}
-          restore-keys: ${{ runner.os }}-goomph-
-      - name: 'Set up JDK 21'
+      - name: 'Set up JDK'
         uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: ${{ env.JDK_VERSION }}
           distribution: 'temurin'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: 'Generate latest docs'
         env:
           GITHUB_TOKEN: ${{ secrets.WALA_BOT_GH_TOKEN }}
-        run: ./generate-latest-docs.sh
+        run: ./generate-latest-docs.sh ${{ env.JDK_VERSION }}
+

--- a/generate-latest-docs.sh
+++ b/generate-latest-docs.sh
@@ -18,6 +18,13 @@
 
 echo -e "Publishing docs...\n"
 
+if [ $# -eq 0 ]; then
+    echo "No JDK version provided. Usage: $0 <JDK_VERSION>"
+    exit 1
+fi
+
+JDK_VERSION=$1
+
 JAVADOC_DIR=$HOME/wala-javadoc
 
 git clone --quiet --filter=tree:0 https://x-access-token:"${GITHUB_TOKEN}"@github.com/wala/javadoc "$JAVADOC_DIR" > /dev/null
@@ -26,7 +33,7 @@ git clone --quiet --filter=tree:0 https://x-access-token:"${GITHUB_TOKEN}"@githu
   rm -rf ./*
 )
 
-./gradlew aggregatedJavadocs --no-configuration-cache
+./gradlew aggregatedJavadocs --no-configuration-cache "-Pcom.ibm.wala.jdk-version=$JDK_VERSION"
 rsync -a build/docs/javadoc/ "${JAVADOC_DIR}"
 
 cd "$JAVADOC_DIR"


### PR DESCRIPTION
We need to pass `-Pcom.ibm.wala.jdk-version` in the `generate-latest-docs.sh` script.

Attempted to test locally, but the real test will be when this lands.