### PR TITLE
Set the group property on the Maven publication

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
@@ -99,6 +99,7 @@ publishing {
 
   publications.named<MavenPublication>("maven") {
     groupId = "com.ibm.wala"
+    group = "com.ibm.wala"
     artifactId = base.archivesName.get()
 
     val testFixturesCodeElementsNames =


### PR DESCRIPTION
In attempting to cut release 1.6.7 I found that the artifact upload to Maven Central fails unless this is set.  I got the error thrown [here](https://github.com/vanniktech/gradle-maven-publish-plugin/blob/ebe12f08dca6a29eaa08e7050d772e426f55d8cc/nexus/src/main/kotlin/com/vanniktech/maven/publish/nexus/Nexus.kt#L66-L70).  So, this property should be set to the name of the staging profile.