### PR TITLE
Update IntelliJ IDEA scopes

### DIFF
--- a/.idea/scopes/Java_Sources_as_Test_Subjects.xml
+++ b/.idea/scopes/Java_Sources_as_Test_Subjects.xml
@@ -1,3 +1,3 @@
 <component name="DependencyValidationManager">
-  <scope name="Java Sources as Test Subjects" pattern="file[com.ibm.wala.com.ibm.wala.cast.java.test.data.test]:*/||file[com.ibm.wala.com.ibm.wala.core.testSubjects]:java//*" />
+  <scope name="Java Sources as Test Subjects" pattern="file[wala.cast.java.test.data.test]:*/||file[wala.core.testSubjects]:java//*" />
 </component>

--- a/.idea/scopes/Sketchy_HTML.xml
+++ b/.idea/scopes/Sketchy_HTML.xml
@@ -1,3 +1,3 @@
 <component name="DependencyValidationManager">
-  <scope name="Sketchy HTML" pattern="file[com.ibm.wala.com.ibm.wala.cast.js.test]:resources//*.html" />
+  <scope name="Sketchy HTML" pattern="file[wala.cast.js.test]:resources//*.html" />
 </component>


### PR DESCRIPTION
These IntelliJ IDEA scopes broke way back in 941036214fe19f737b22fe57f190f7d1cebb4f16, but we didn't notice. Unfortunately I don't have a clever way to test for this regression without building some sort of custom IntelliJ IDEA plugin.