### PR TITLE
Bump Error Prone to 2.35.1 and enable javac `-parameters` flag

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -62,6 +62,8 @@ tasks.withType<JavaCompile>().configureEach {
     error("UnusedVariable")
     error("JdkObsolete")
     error("AnnotationPosition")
+    error("AssertEqualsArgumentOrderChecker")
+    error("ArgumentSelectionDefectChecker")
     // checks we do not intend to try to fix in the near-term:
     // Just too many of these; proper Javadoc would be a great long-term goal
     disable("MissingSummary")
@@ -120,6 +122,7 @@ tasks.withType<JavaCompile>().configureEach {
   options.run {
     encoding = "UTF-8"
     compilerArgs.add("-Werror")
+    compilerArgs.add("-parameters")
   }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ eclipse-ecj = "org.eclipse.jdt:ecj:3.37.0"
 eclipse-osgi = "org.eclipse.platform:org.eclipse.osgi:3.19.0"
 eclipse-wst-jsdt-core = { module = "org.eclipse.wst.jsdt:core", version.ref = "eclipse-wst-jsdt" }
 eclipse-wst-jsdt-ui = { module = "org.eclipse.wst.jsdt:ui", version.ref = "eclipse-wst-jsdt" }
-errorprone-core = "com.google.errorprone:error_prone_core:2.34.0"
+errorprone-core = "com.google.errorprone:error_prone_core:2.35.1"
 gradle-download-task = "de.undercouch:gradle-download-task:5.6.0"
 gradle-errorprone-plugin = "net.ltgt.gradle:gradle-errorprone-plugin:4.1.0"
 gradle-goomph-plugin = "com.diffplug.gradle:goomph:3.44.0"


### PR DESCRIPTION
The `-parameters` flag is required for certain checks like [ArgumentSelectionDefectChecker](https://errorprone.info/bugpattern/ArgumentSelectionDefectChecker).  We enable a couple of those checks; they don't turn up any issues at the moment.  In a follow up I'd like to enable [BooleanParameter](https://errorprone.info/bugpattern/BooleanParameter) and auto-fix extant issues.