### PR TITLE
Update Javadoc `@return`s that have deviated from code

### DIFF
--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/ConcreteTypeKey.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/ConcreteTypeKey.java
@@ -71,7 +71,7 @@ public final class ConcreteTypeKey implements InstanceKey {
   /**
    * @param pei a PEI instruction
    * @param cha governing class hierarchy
-   * @return a set of ConcreteTypeKeys that represent the exceptions the PEI may throw.
+   * @return an array of ConcreteTypeKeys that represent the exceptions the PEI may throw.
    * @throws IllegalArgumentException if pei is null
    */
   public static InstanceKey[] getInstanceKeysForPEI(SSAInstruction pei, IClassHierarchy cha) {

--- a/util/src/main/java/com/ibm/wala/fixedpoint/impl/GeneralStatement.java
+++ b/util/src/main/java/com/ibm/wala/fixedpoint/impl/GeneralStatement.java
@@ -12,6 +12,7 @@ package com.ibm.wala.fixedpoint.impl;
 
 import com.ibm.wala.fixpoint.AbstractOperator;
 import com.ibm.wala.fixpoint.AbstractStatement;
+import com.ibm.wala.fixpoint.FixedPointConstants;
 import com.ibm.wala.fixpoint.IVariable;
 import org.jspecify.annotations.NullUnmarked;
 
@@ -30,7 +31,8 @@ public abstract class GeneralStatement<T extends IVariable<T>>
   /**
    * Evaluate this equation, setting a new value for the left-hand side.
    *
-   * @return true if the lhs value changed. false otherwise
+   * @return a constant defined by {@link FixedPointConstants} that reflects whether the lhs value
+   *     changed
    */
   @Override
   public byte evaluate() {

--- a/util/src/main/java/com/ibm/wala/fixedpoint/impl/NullaryOperator.java
+++ b/util/src/main/java/com/ibm/wala/fixedpoint/impl/NullaryOperator.java
@@ -12,6 +12,7 @@
 package com.ibm.wala.fixedpoint.impl;
 
 import com.ibm.wala.fixpoint.AbstractOperator;
+import com.ibm.wala.fixpoint.FixedPointConstants;
 import com.ibm.wala.fixpoint.IVariable;
 
 /** An operator of the form lhs = op */
@@ -25,7 +26,8 @@ public abstract class NullaryOperator<T extends IVariable<T>> extends AbstractOp
   /**
    * Evaluate this equation, setting a new value for the left-hand side.
    *
-   * @return true if the lhs value changes. false otherwise.
+   * @return a constant defined by {@link FixedPointConstants} that reflects whether the lhs value
+   *     changed
    */
   public abstract byte evaluate(T lhs);
 }

--- a/util/src/main/java/com/ibm/wala/fixedpoint/impl/NullaryStatement.java
+++ b/util/src/main/java/com/ibm/wala/fixedpoint/impl/NullaryStatement.java
@@ -11,6 +11,7 @@
 package com.ibm.wala.fixedpoint.impl;
 
 import com.ibm.wala.fixpoint.AbstractStatement;
+import com.ibm.wala.fixpoint.FixedPointConstants;
 import com.ibm.wala.fixpoint.IVariable;
 
 /** Represents a single step, restricted to a nullary operator. */
@@ -23,7 +24,8 @@ public abstract class NullaryStatement<T extends IVariable<T>>
   /**
    * Evaluate this equation, setting a new value for the left-hand side.
    *
-   * @return true if the lhs value changed. false otherwise
+   * @return a constant defined by {@link FixedPointConstants} that reflects whether the lhs value
+   *     changed
    */
   @Override
   public byte evaluate() {

--- a/util/src/main/java/com/ibm/wala/fixpoint/UnaryOperator.java
+++ b/util/src/main/java/com/ibm/wala/fixpoint/UnaryOperator.java
@@ -20,7 +20,8 @@ public abstract class UnaryOperator<T extends IVariable<T>> extends AbstractOper
   /**
    * Evaluate this equation, setting a new value for the left-hand side.
    *
-   * @return true if the lhs value changes. false otherwise.
+   * @return a constant defined by {@link FixedPointConstants} that reflects whether the lhs value
+   *     changed
    */
   public abstract byte evaluate(@Nullable T lhs, T rhs);
 

--- a/util/src/main/java/com/ibm/wala/fixpoint/UnaryStatement.java
+++ b/util/src/main/java/com/ibm/wala/fixpoint/UnaryStatement.java
@@ -24,7 +24,8 @@ public abstract class UnaryStatement<T extends IVariable<T>>
   /**
    * Evaluate this equation, setting a new value for the left-hand side.
    *
-   * @return true if the lhs value changed. false otherwise
+   * @return a constant defined by {@link FixedPointConstants} that reflects whether the lhs value
+   *     changed
    */
   @Override
   public byte evaluate() {

--- a/util/src/main/java/com/ibm/wala/util/heapTrace/HeapTracer.java
+++ b/util/src/main/java/com/ibm/wala/util/heapTrace/HeapTracer.java
@@ -150,7 +150,7 @@ public class HeapTracer {
   }
 
   /**
-   * @return set of strings that are names of directories that contain "bin"
+   * @return duplicate-free array of strings that are names of directories that contain "bin"
    */
   private static Object[] extractBinDirectories(String classpath) {
     StringTokenizer t = new StringTokenizer(classpath, ";");


### PR DESCRIPTION
We shouldn't describe a method as returning a "set of" anything when it actually returns an array.

We shouldn't describe a method as returning `true` or `false` when it actually returns a `byte`.