### PR TITLE
Replace some StringBuilders with String concatenation

### DIFF
--- a/core/src/main/java/com/ibm/wala/core/util/strings/StringStuff.java
+++ b/core/src/main/java/com/ibm/wala/core/util/strings/StringStuff.java
@@ -72,9 +72,7 @@ public class StringStuff {
       String baseType = dString.substring(0, arrayIndex);
       int dim = (dString.length() - arrayIndex) / 2;
       baseType = deployment2CanonicalTypeString(baseType);
-      StringBuilder result = new StringBuilder("[".repeat(dim));
-      result.append(baseType);
-      return result.toString();
+      return "[".repeat(dim) + baseType;
     } else {
       if (primitiveClassNames.get(dString) != null) {
         return primitiveClassNames.get(dString);
@@ -102,9 +100,7 @@ public class StringStuff {
       String baseType = dString.substring(0, arrayIndex);
       int dim = (dString.length() - arrayIndex) / 2;
       baseType = deployment2CanonicalDescriptorTypeString(baseType);
-      StringBuilder result = new StringBuilder("[".repeat(dim));
-      result.append(baseType);
-      return result.toString();
+      return "[".repeat(dim) + baseType;
     } else {
       if (primitiveClassNames.get(dString) != null) {
         return primitiveClassNames.get(dString);


### PR DESCRIPTION
`StringBuilder` provides no benefit when building a `String` using just one concatenation.