### PR TITLE
Use more specialized JUnit assertions

### DIFF
--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/JavaIRTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/JavaIRTests.java
@@ -15,6 +15,7 @@ package com.ibm.wala.cast.java.test;
 
 import static com.ibm.wala.ipa.slicer.SlicerUtil.dumpSlice;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -258,7 +259,7 @@ public abstract class JavaIRTests extends IRTests {
 
               CGNode node = cg.getNodes(mref).iterator().next();
               SSAInstruction s = node.getIR().getInstructions()[2];
-              assertTrue(s instanceof SSANewInstruction, "Did not find new array instruction.");
+              assertInstanceOf(SSANewInstruction.class, s, "Did not find new array instruction.");
               assertTrue(((SSANewInstruction) s).getNewSite().getDeclaredType().isArrayType(), "");
             }),
         true,
@@ -304,8 +305,9 @@ public abstract class JavaIRTests extends IRTests {
               {
                 final SymbolTable symbolTable = node.getIR().getSymbolTable();
                 for (int i = 4; i <= 7; i++) {
-                  assertTrue(
-                      instructions[i] instanceof SSAArrayStoreInstruction,
+                  assertInstanceOf(
+                      SSAArrayStoreInstruction.class,
+                      instructions[i],
                       "Expected only array stores.");
 
                   SSAArrayStoreInstruction as = (SSAArrayStoreInstruction) instructions[i];

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/ReflectionTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/ReflectionTest.java
@@ -12,6 +12,7 @@ package com.ibm.wala.core.tests.callGraph;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -753,7 +754,7 @@ public class ReflectionTest extends WalaTestCase {
 
     for (InstanceKey mappedObject : pts) {
       // the type corresponding to the 0th parameter should be Helper
-      assertTrue(mappedObject instanceof ConstantKey);
+      assertInstanceOf(ConstantKey.class, mappedObject);
       assertEquals(((ConstantKey<?>) mappedObject).getValue(), helperClass);
     }
   }

--- a/core/src/test/java/com/ibm/wala/core/tests/ir/TypeAnnotationTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/ir/TypeAnnotationTest.java
@@ -13,8 +13,8 @@ package com.ibm.wala.core.tests.ir;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.ibm.wala.classLoader.FieldImpl;
 import com.ibm.wala.classLoader.IClass;
@@ -265,7 +265,7 @@ public class TypeAnnotationTest extends WalaTestCase {
       throws InvalidClassFileException {
     IClass classUnderTest = cha.lookupClass(typeUnderTest);
     assertNotNull(classUnderTest, typeUnderTest.toString() + " not found");
-    assertTrue(classUnderTest instanceof ShrikeClass, classUnderTest + " must be BytecodeClass");
+    assertInstanceOf(ShrikeClass.class, classUnderTest, classUnderTest + " must be BytecodeClass");
     ShrikeClass bcClassUnderTest = (ShrikeClass) classUnderTest;
 
     Collection<TypeAnnotation> runtimeInvisibleAnnotations =
@@ -286,8 +286,8 @@ public class TypeAnnotationTest extends WalaTestCase {
       throws InvalidClassFileException {
     IMethod methodUnderTest = cha.resolveMethod(methodRefUnderTest);
     assertNotNull(methodUnderTest, methodRefUnderTest.toString() + " not found");
-    assertTrue(
-        methodUnderTest instanceof ShrikeCTMethod, methodUnderTest + " must be ShrikeCTMethod");
+    assertInstanceOf(
+        ShrikeCTMethod.class, methodUnderTest, methodUnderTest + " must be ShrikeCTMethod");
     ShrikeCTMethod bcMethodUnderTest = (ShrikeCTMethod) methodUnderTest;
 
     Collection<TypeAnnotation> runtimeInvisibleAnnotations = HashSetFactory.make();
@@ -311,7 +311,7 @@ public class TypeAnnotationTest extends WalaTestCase {
       Collection<TypeAnnotation> expectedAnnotations) {
     IClass classUnderTest = cha.lookupClass(typeUnderTest);
     assertNotNull(classUnderTest, typeUnderTest.toString() + " not found");
-    assertTrue(classUnderTest instanceof ShrikeClass, classUnderTest + " must be BytecodeClass");
+    assertInstanceOf(ShrikeClass.class, classUnderTest, classUnderTest + " must be BytecodeClass");
     ShrikeClass bcClassUnderTest = (ShrikeClass) classUnderTest;
 
     final Atom fieldName = Atom.findOrCreateUnicodeAtom(fieldNameStr);

--- a/core/src/test/java/com/ibm/wala/core/tests/shrike/FloatingPointsTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/shrike/FloatingPointsTest.java
@@ -1,6 +1,7 @@
 package com.ibm.wala.core.tests.shrike;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -196,7 +197,7 @@ public class FloatingPointsTest extends WalaTestCase {
     IInstruction instruction = instructions[index];
 
     // Check that the instruction type has not been changed
-    assertTrue(instruction instanceof ConstantInstruction);
+    assertInstanceOf(ConstantInstruction.class, instruction);
 
     // The type type should be the same as well
     ConstantInstruction instruction2 = (ConstantInstruction) instruction;

--- a/core/src/testFixtures/java/com/ibm/wala/core/tests/ir/AnnotationTest.java
+++ b/core/src/testFixtures/java/com/ibm/wala/core/tests/ir/AnnotationTest.java
@@ -11,6 +11,7 @@
 package com.ibm.wala.core.tests.ir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -160,7 +161,8 @@ public abstract class AnnotationTest extends WalaTestCase {
       throws InvalidClassFileException {
     IClass classUnderTest = cha.lookupClass(typeUnderTest);
     assertNotNull(classUnderTest, typeUnderTest.toString() + " not found");
-    assertTrue(classUnderTest instanceof BytecodeClass, classUnderTest + " must be BytecodeClass");
+    assertInstanceOf(
+        BytecodeClass.class, classUnderTest, classUnderTest + " must be BytecodeClass");
     BytecodeClass<?> bcClassUnderTest = (BytecodeClass<?>) classUnderTest;
 
     Collection<Annotation> runtimeInvisibleAnnotations = bcClassUnderTest.getAnnotations(true);
@@ -191,8 +193,8 @@ public abstract class AnnotationTest extends WalaTestCase {
 
     IMethod methodUnderTest = cha.resolveMethod(methodRefUnderTest);
     assertNotNull(methodUnderTest, methodRefUnderTest + " not found");
-    assertTrue(
-        methodUnderTest instanceof IBytecodeMethod, methodUnderTest + " must be IBytecodeMethod");
+    assertInstanceOf(
+        IBytecodeMethod.class, methodUnderTest, methodUnderTest + " must be IBytecodeMethod");
     IBytecodeMethod<IInstruction> bcMethodUnderTest =
         (IBytecodeMethod<IInstruction>) methodUnderTest;
 
@@ -301,8 +303,8 @@ public abstract class AnnotationTest extends WalaTestCase {
 
     IMethod methodUnderTest = cha.resolveMethod(methodRefUnderTest);
     assertNotNull(methodUnderTest, methodRefUnderTest + " not found");
-    assertTrue(
-        methodUnderTest instanceof IBytecodeMethod, methodUnderTest + " must be bytecode method");
+    assertInstanceOf(
+        IBytecodeMethod.class, methodUnderTest, methodUnderTest + " must be bytecode method");
     IBytecodeMethod<?> IBytecodeMethodUnderTest = (IBytecodeMethod<?>) methodUnderTest;
 
     Collection<Annotation>[] parameterAnnotations =


### PR DESCRIPTION
In particular, use `assertInstanceOf` instead of `assertTrue` on the result of an `instanceof` check.  If the assertion fails, `assertInstanceOf` will produce a more informative error message.