### PR TITLE
Upgrade to Gradle 8.11

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/cast/native.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/cast/native.gradle.kts
@@ -1,5 +1,0 @@
-package com.ibm.wala.gradle.cast
-
-tasks.withType<CppCompile> {
-  notCompatibleWithConfigurationCache("https://github.com/gradle/gradle/issues/13485")
-}

--- a/cast/cast/build.gradle.kts
+++ b/cast/cast/build.gradle.kts
@@ -4,7 +4,6 @@ import com.ibm.wala.gradle.cast.nativeLibraryOutput
 
 plugins {
   `cpp-library`
-  id("com.ibm.wala.gradle.cast.native")
   id("com.ibm.wala.gradle.subproject")
 }
 

--- a/cast/smoke_main/build.gradle.kts
+++ b/cast/smoke_main/build.gradle.kts
@@ -10,7 +10,6 @@ import org.gradle.language.cpp.CppBinary.OPTIMIZED_ATTRIBUTE
 
 plugins {
   `cpp-application`
-  id("com.ibm.wala.gradle.cast.native")
   id("com.ibm.wala.gradle.subproject")
 }
 
@@ -72,7 +71,6 @@ application {
       if (isDebuggable && !isOptimized) {
         val checkSmokeMain by
             tasks.registering(Exec::class) {
-              notCompatibleWithConfigurationCache("https://github.com/gradle/gradle/issues/13485")
 
               // main executable to run for test
               inputs.file(linkedFile)

--- a/cast/xlator_test/build.gradle.kts
+++ b/cast/xlator_test/build.gradle.kts
@@ -2,7 +2,6 @@ import com.ibm.wala.gradle.cast.addCastLibrary
 
 plugins {
   `cpp-library`
-  id("com.ibm.wala.gradle.cast.native")
   id("com.ibm.wala.gradle.subproject")
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,7 +49,7 @@ dependency-analysis = "com.autonomousapps.dependency-analysis:1.32.0"
 file-lister = "all.shared.gradle.file-lister:1.0.2"
 google-java-format = "com.github.sherter.google-java-format:0.9"
 markdown = "com.appmattus.markdown:0.6.0"
-shellcheck = "com.felipefzdz.gradle.shellcheck:1.4.6"
+shellcheck = "com.felipefzdz.gradle.shellcheck:1.5.0"
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 task-tree = "com.dorongold.task-tree:3.0.0"
 version-catalog-update = "nl.littlerobots.version-catalog-update:0.8.4"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=fdfca5dbc2834f0ece5020465737538e5ba679deeff5ab6c09621d67f8bb1a15
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-all.zip
+distributionSha256Sum=73d2d553933194d8eefed0a291acbe45392ca3572ba13834cbbf373da375276d
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Note that Gradle 8.11 finally includes configuration cache support for C++ applications and libraries. Yay!