### PR TITLE
Fix crash with void return type in TypeSignature code

### DIFF
--- a/core/src/main/java/com/ibm/wala/types/generics/TypeSignature.java
+++ b/core/src/main/java/com/ibm/wala/types/generics/TypeSignature.java
@@ -44,8 +44,7 @@ public abstract class TypeSignature extends Signature {
     assert !s.isEmpty();
     switch (s.charAt(0)) {
       case TypeReference.VoidTypeCode:
-        Assertions.UNREACHABLE();
-        return null;
+        return BaseType.VOID;
       case TypeReference.BooleanTypeCode:
         return BaseType.BOOLEAN;
       case TypeReference.ByteTypeCode:

--- a/core/src/test/java/com/ibm/wala/types/generics/MethodTypeSignatureTest.java
+++ b/core/src/test/java/com/ibm/wala/types/generics/MethodTypeSignatureTest.java
@@ -16,4 +16,11 @@ class MethodTypeSignatureTest {
         MethodTypeSignature.make("(I)V").getArguments(),
         arrayContaining(is(TypeSignature.make("I"))));
   }
+
+  @Test
+  void getVoidReturn() {
+    assertThat(
+        MethodTypeSignature.make("(I)V").getReturnType(),
+        is(TypeSignature.make("V")));
+  }
 }

--- a/core/src/test/java/com/ibm/wala/types/generics/MethodTypeSignatureTest.java
+++ b/core/src/test/java/com/ibm/wala/types/generics/MethodTypeSignatureTest.java
@@ -19,8 +19,6 @@ class MethodTypeSignatureTest {
 
   @Test
   void getVoidReturn() {
-    assertThat(
-        MethodTypeSignature.make("(I)V").getReturnType(),
-        is(TypeSignature.make("V")));
+    assertThat(MethodTypeSignature.make("(I)V").getReturnType(), is(TypeSignature.make("V")));
   }
 }


### PR DESCRIPTION
I'm not sure why there was an assert fail before, but it's straightforward enough to do the right thing.