### PR TITLE
Fix a couple of bugs in parsing array type arguments in type signatures

### DIFF
--- a/core/src/main/java/com/ibm/wala/types/generics/TypeSignature.java
+++ b/core/src/main/java/com/ibm/wala/types/generics/TypeSignature.java
@@ -141,8 +141,14 @@ public abstract class TypeSignature extends Signature {
             switch (typeSigs.charAt(i)) {
               case TypeReference.BooleanTypeCode:
               case TypeReference.ByteTypeCode:
+              case TypeReference.ShortTypeCode:
               case TypeReference.IntTypeCode:
+              case TypeReference.LongTypeCode:
+              case TypeReference.FloatTypeCode:
+              case TypeReference.DoubleTypeCode:
+              case TypeReference.CharTypeCode:
                 sigs.add(typeSigs.substring(i - 1, i + 1));
+                i++;
                 break;
               case 'T':
               case TypeReference.ClassTypeCode:

--- a/core/src/test/java/com/ibm/wala/types/generics/MethodTypeSignatureTest.java
+++ b/core/src/test/java/com/ibm/wala/types/generics/MethodTypeSignatureTest.java
@@ -33,5 +33,9 @@ class MethodTypeSignatureTest {
             is(TypeSignature.make("[J")),
             is(TypeSignature.make("[D")),
             is(TypeSignature.make("B"))));
+    assertThat(
+        MethodTypeSignature.make("([Ljava/lang/String;B)V").getArguments(),
+        arrayContaining(
+            is(TypeSignature.make("[Ljava/lang/String;")), is(TypeSignature.make("B"))));
   }
 }

--- a/core/src/test/java/com/ibm/wala/types/generics/MethodTypeSignatureTest.java
+++ b/core/src/test/java/com/ibm/wala/types/generics/MethodTypeSignatureTest.java
@@ -21,4 +21,17 @@ class MethodTypeSignatureTest {
   void getVoidReturn() {
     assertThat(MethodTypeSignature.make("(I)V").getReturnType(), is(TypeSignature.make("V")));
   }
+
+  @Test
+  void arrayArgumentType() {
+    assertThat(
+        MethodTypeSignature.make("([I)V").getArguments(),
+        arrayContaining(is(TypeSignature.make("[I"))));
+    assertThat(
+        MethodTypeSignature.make("([J[DB)V").getArguments(),
+        arrayContaining(
+            is(TypeSignature.make("[J")),
+            is(TypeSignature.make("[D")),
+            is(TypeSignature.make("B"))));
+  }
 }


### PR DESCRIPTION
We forgot to increment a variable, and we didn't handle all the primitive types.