### PR TITLE
Further enhancements to `parseForTypeSignatures`

### DIFF
--- a/core/src/main/java/com/ibm/wala/types/generics/TypeSignature.java
+++ b/core/src/main/java/com/ibm/wala/types/generics/TypeSignature.java
@@ -85,10 +85,6 @@ public abstract class TypeSignature extends Signature {
    * signatures. The string should start with either {@code (} or {@code <} and have a respective
    * matching {@code )} or {@code >}.
    *
-   * <p>TODO handle wildcards
-   *
-   * <p>TODO test on all methods in JDK
-   *
    * @param typeSigs a string of consecutive type signatures
    * @return an array of top-level type signatures
    */
@@ -189,6 +185,16 @@ public abstract class TypeSignature extends Signature {
             result[j] = it.next();
           }
           return result;
+        case (byte) '*': // unbounded wildcard
+          sigs.add("*");
+          break;
+        case (byte) '-': // bounded wildcard
+        case (byte) '+': // bounded wildcard
+          int boundedStart = i - 1;
+          i++; // to skip 'L'
+          i = getEndIndexOfClassType(typeSigs, i);
+          sigs.add(typeSigs.substring(boundedStart, i));
+          break;
         default:
           throw new IllegalArgumentException("bad type signature list " + typeSigs);
       }

--- a/core/src/main/java/com/ibm/wala/types/generics/TypeSignature.java
+++ b/core/src/main/java/com/ibm/wala/types/generics/TypeSignature.java
@@ -13,7 +13,6 @@ package com.ibm.wala.types.generics;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.debug.Assertions;
 import java.util.ArrayList;
-import java.util.Iterator;
 
 /**
  * UNDER CONSTRUCTION.
@@ -173,18 +172,6 @@ public abstract class TypeSignature extends Signature {
             sigs.add(typeSigs.substring(off, i));
             continue;
           }
-        case (byte) ')': // end of parameter list
-        case (byte) '>': // end of type argument list
-          int size = sigs.size();
-          if (size == 0) {
-            return new String[0];
-          }
-          Iterator<String> it = sigs.iterator();
-          String[] result = new String[size];
-          for (int j = 0; j < size; j++) {
-            result[j] = it.next();
-          }
-          return result;
         case (byte) '*': // unbounded wildcard
           sigs.add("*");
           break;
@@ -195,6 +182,9 @@ public abstract class TypeSignature extends Signature {
           i = getEndIndexOfClassType(typeSigs, i);
           sigs.add(typeSigs.substring(boundedStart, i));
           break;
+        case (byte) ')': // end of parameter list
+        case (byte) '>': // end of type argument list
+          return sigs.toArray(new String[sigs.size()]);
         default:
           throw new IllegalArgumentException("bad type signature list " + typeSigs);
       }

--- a/core/src/main/java/com/ibm/wala/types/generics/TypeSignature.java
+++ b/core/src/main/java/com/ibm/wala/types/generics/TypeSignature.java
@@ -82,7 +82,12 @@ public abstract class TypeSignature extends Signature {
 
   /**
    * Split a string of consecutive type signatures (TypeSignature*) into its top-level type
-   * signatures. The string should start with either '(' or '<' and have a matching ')' or '>'.
+   * signatures. The string should start with either {@code (} or {@code <} and have a respective
+   * matching {@code )} or {@code >}.
+   *
+   * <p>TODO handle wildcards
+   *
+   * <p>TODO test on all methods in JDK
    *
    * @param typeSigs a string of consecutive type signatures
    * @return an array of top-level type signatures
@@ -137,7 +142,7 @@ public abstract class TypeSignature extends Signature {
           }
         case TypeReference.ArrayTypeCode:
           {
-            int arrayStart = i-1;
+            int arrayStart = i - 1;
             while (typeSigs.charAt(i) == TypeReference.ArrayTypeCode) {
               i++;
             }

--- a/core/src/test/java/com/ibm/wala/types/generics/TypeSignatureTest.java
+++ b/core/src/test/java/com/ibm/wala/types/generics/TypeSignatureTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 public class TypeSignatureTest {
@@ -22,5 +21,4 @@ public class TypeSignatureTest {
         TypeSignature.parseForTypeSignatures("<[[Ljava/lang/String;[[[J>"),
         arrayContaining(is("[[Ljava/lang/String;"), is("[[[J")));
   }
-
 }

--- a/core/src/test/java/com/ibm/wala/types/generics/TypeSignatureTest.java
+++ b/core/src/test/java/com/ibm/wala/types/generics/TypeSignatureTest.java
@@ -4,6 +4,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.is;
 
+import com.ibm.wala.classLoader.IClass;
+import com.ibm.wala.classLoader.IMethod;
+import com.ibm.wala.classLoader.ShrikeCTMethod;
+import com.ibm.wala.core.tests.callGraph.CallGraphTestUtil;
+import com.ibm.wala.core.tests.util.TestConstants;
+import com.ibm.wala.ipa.callgraph.AnalysisScope;
+import com.ibm.wala.ipa.cha.ClassHierarchy;
+import com.ibm.wala.ipa.cha.ClassHierarchyException;
+import com.ibm.wala.ipa.cha.ClassHierarchyFactory;
+import com.ibm.wala.shrike.shrikeCT.InvalidClassFileException;
+import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 public class TypeSignatureTest {
@@ -20,5 +31,44 @@ public class TypeSignatureTest {
     assertThat(
         TypeSignature.parseForTypeSignatures("<[[Ljava/lang/String;[[[J>"),
         arrayContaining(is("[[Ljava/lang/String;"), is("[[[J")));
+  }
+
+  @Test
+  void wildcards() {
+    assertThat(
+        TypeSignature.parseForTypeSignatures("<B*J>"), arrayContaining(is("B"), is("*"), is("J")));
+    assertThat(
+        TypeSignature.parseForTypeSignatures("<+Ljava/lang/Object;>"),
+        arrayContaining(is("+Ljava/lang/Object;")));
+    assertThat(
+        TypeSignature.parseForTypeSignatures("<-Ljava/lang/Double;BB>"),
+        arrayContaining(is("-Ljava/lang/Double;"), is("B"), is("B")));
+  }
+
+  @Test
+  void testAllGenericMethodSigs()
+      throws IOException, ClassHierarchyException, InvalidClassFileException {
+    AnalysisScope scope =
+        CallGraphTestUtil.makeJ2SEAnalysisScope(
+            TestConstants.WALA_TESTDATA, "J2SEClassHierarchyExclusions.txt");
+    ClassHierarchy cha = ClassHierarchyFactory.make(scope);
+    for (IClass klass : cha) {
+      for (IMethod m : klass.getDeclaredMethods()) {
+        if (m instanceof ShrikeCTMethod) {
+          ShrikeCTMethod method = (ShrikeCTMethod) m;
+          MethodTypeSignature methodTypeSignature = method.getMethodTypeSignature();
+          if (methodTypeSignature != null) {
+            String typeSigStr = methodTypeSignature.toString();
+            for (int i = 0; i < typeSigStr.length(); i++) {
+              if ((typeSigStr.charAt(i) == '<' && i != 0) || typeSigStr.charAt(i) == '(') {
+                // parsing will automatically end at the matching '>' or ')'
+                // this is just testing for crashes
+                TypeSignature.parseForTypeSignatures(typeSigStr.substring(i));
+              }
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/core/src/test/java/com/ibm/wala/types/generics/TypeSignatureTest.java
+++ b/core/src/test/java/com/ibm/wala/types/generics/TypeSignatureTest.java
@@ -1,0 +1,26 @@
+package com.ibm.wala.types.generics;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+public class TypeSignatureTest {
+
+  @Test
+  void basicTypeArguments() {
+    assertThat(
+        TypeSignature.parseForTypeSignatures("<Ljava/lang/String;ILjava/lang/Object;>"),
+        arrayContaining(is("Ljava/lang/String;"), is("I"), is("Ljava/lang/Object;")));
+  }
+
+  @Test
+  void multiDimArray() {
+    assertThat(
+        TypeSignature.parseForTypeSignatures("<[[Ljava/lang/String;[[[J>"),
+        arrayContaining(is("[[Ljava/lang/String;"), is("[[[J")));
+  }
+
+}


### PR DESCRIPTION
We generalize the method so it is useful for parsing either method argument types or generic type arguments.  (The latter required handling wildcards.)  Also factor out some common logic, and make the method public so it can be used from other projects.
