### PR TITLE
refactor: remove getTestName from IRTests.java so tests do not rely on method name

### DIFF
--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -30,3 +30,4 @@ jobs:
           event_file: artifacts/Event file/event.json
           event_name: ${{ github.event.workflow_run.event }}
           files: "artifacts/**/*.xml"
+          test_changes_limit: 500

--- a/cast/java/build.gradle.kts
+++ b/cast/java/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
   api(projects.util)
   implementation(projects.shrike)
   testFixturesApi(libs.junit.jupiter.api)
+  testFixturesApi(libs.junit.jupiter.params)
   testFixturesApi(projects.core)
   testFixturesApi(projects.util)
   testFixturesImplementation(projects.cast)

--- a/cast/java/ecj/build.gradle.kts
+++ b/cast/java/ecj/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
       project(
           mapOf("path" to ":cast:java:test:data", "configuration" to "testJavaSourceDirectory")))
   testImplementation(libs.junit.jupiter.api)
+  testImplementation(libs.junit.jupiter.params)
   testImplementation(testFixtures(projects.cast.java))
 }
 

--- a/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJJava15IRTest.java
+++ b/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJJava15IRTest.java
@@ -14,7 +14,9 @@ import com.ibm.wala.util.CancelException;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
-import org.junit.jupiter.api.Test;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ECJJava15IRTest extends IRTests {
 
@@ -39,241 +41,39 @@ public class ECJJava15IRTest extends IRTests {
     return engine;
   }
 
-  @Test
-  public void testVarargsOverriding()
+  static Stream<String> java15IRTestNames() {
+    return Stream.of(
+        "AnonGeneNullarySimple",
+        "AnonymousGenerics",
+        "Annotations",
+        "BasicsGenerics",
+        "Cocovariant",
+        "CustomGenericsAndFields",
+        "EnumSwitch",
+        "ExplicitBoxingTest",
+        "GenericArrays",
+        "GenericMemberClasses",
+        "GenericSuperSink",
+        "MoreOverriddenGenerics",
+        "NotSoSimpleEnums",
+        "OverridesOnePointFour",
+        "SimpleEnums",
+        "SimpleEnums2",
+        "TypeInferencePrimAndStringOp",
+        "Varargs",
+        "VarargsCovariant",
+        "VarargsOverriding",
+        "Wildcards");
+  }
+
+  @ParameterizedTest
+  @MethodSource("java15IRTestNames")
+  public void runJava15IRTests(String java15IRTestName)
       throws IllegalArgumentException, CancelException, IOException {
     runTest(
-        singlePkgTestSrc("javaonepointfive"),
+        singlePkgTestSrc("javaonepointfive", java15IRTestName),
         rtJar,
-        simplePkgTestEntryPoint("javaonepointfive"),
-        emptyList,
-        true,
-        null);
-  }
-
-  @Test
-  public void testEnumSwitch() throws IllegalArgumentException, CancelException, IOException {
-    runTest(
-        singlePkgTestSrc("javaonepointfive"),
-        rtJar,
-        simplePkgTestEntryPoint("javaonepointfive"),
-        emptyList,
-        true,
-        null);
-  }
-
-  @Test
-  public void testOverridesOnePointFour()
-      throws IllegalArgumentException, CancelException, IOException {
-    runTest(
-        singlePkgTestSrc("javaonepointfive"),
-        rtJar,
-        simplePkgTestEntryPoint("javaonepointfive"),
-        emptyList,
-        true,
-        null);
-  }
-
-  @Test
-  public void testVarargsCovariant() throws IllegalArgumentException, CancelException, IOException {
-    runTest(
-        singlePkgTestSrc("javaonepointfive"),
-        rtJar,
-        simplePkgTestEntryPoint("javaonepointfive"),
-        emptyList,
-        true,
-        null);
-  }
-
-  @Test
-  public void testSimpleEnums() throws IllegalArgumentException, CancelException, IOException {
-    runTest(
-        singlePkgTestSrc("javaonepointfive"),
-        rtJar,
-        simplePkgTestEntryPoint("javaonepointfive"),
-        emptyList,
-        true,
-        null);
-  }
-
-  @Test
-  public void testGenericSuperSink() throws IllegalArgumentException, CancelException, IOException {
-    runTest(
-        singlePkgTestSrc("javaonepointfive"),
-        rtJar,
-        simplePkgTestEntryPoint("javaonepointfive"),
-        emptyList,
-        true,
-        null);
-  }
-
-  @Test
-  public void testAnonGeneNullarySimple()
-      throws IllegalArgumentException, CancelException, IOException {
-    runTest(
-        singlePkgTestSrc("javaonepointfive"),
-        rtJar,
-        simplePkgTestEntryPoint("javaonepointfive"),
-        emptyList,
-        true,
-        null);
-  }
-
-  @Test
-  public void testAnonymousGenerics()
-      throws IllegalArgumentException, CancelException, IOException {
-    runTest(
-        singlePkgTestSrc("javaonepointfive"),
-        rtJar,
-        simplePkgTestEntryPoint("javaonepointfive"),
-        emptyList,
-        true,
-        null);
-  }
-
-  @Test
-  public void testNotSoSimpleEnums() throws IllegalArgumentException, CancelException, IOException {
-    runTest(
-        singlePkgTestSrc("javaonepointfive"),
-        rtJar,
-        simplePkgTestEntryPoint("javaonepointfive"),
-        emptyList,
-        true,
-        null);
-  }
-
-  @Test
-  public void testVarargs() throws IllegalArgumentException, CancelException, IOException {
-    runTest(
-        singlePkgTestSrc("javaonepointfive"),
-        rtJar,
-        simplePkgTestEntryPoint("javaonepointfive"),
-        emptyList,
-        true,
-        null);
-  }
-
-  @Test
-  public void testGenericArrays() throws IllegalArgumentException, CancelException, IOException {
-    runTest(
-        singlePkgTestSrc("javaonepointfive"),
-        rtJar,
-        simplePkgTestEntryPoint("javaonepointfive"),
-        emptyList,
-        true,
-        null);
-  }
-
-  @Test
-  public void testAnnotations() throws IllegalArgumentException, CancelException, IOException {
-    runTest(
-        singlePkgTestSrc("javaonepointfive"),
-        rtJar,
-        simplePkgTestEntryPoint("javaonepointfive"),
-        emptyList,
-        true,
-        null);
-  }
-
-  @Test
-  public void testCocovariant() throws IllegalArgumentException, CancelException, IOException {
-    runTest(
-        singlePkgTestSrc("javaonepointfive"),
-        rtJar,
-        simplePkgTestEntryPoint("javaonepointfive"),
-        emptyList,
-        true,
-        null);
-  }
-
-  @Test
-  public void testExplicitBoxingTest()
-      throws IllegalArgumentException, CancelException, IOException {
-    runTest(
-        singlePkgTestSrc("javaonepointfive"),
-        rtJar,
-        simplePkgTestEntryPoint("javaonepointfive"),
-        emptyList,
-        true,
-        null);
-  }
-
-  @Test
-  public void testWildcards() throws IllegalArgumentException, CancelException, IOException {
-    runTest(
-        singlePkgTestSrc("javaonepointfive"),
-        rtJar,
-        simplePkgTestEntryPoint("javaonepointfive"),
-        emptyList,
-        true,
-        null);
-  }
-
-  @Test
-  public void testBasicsGenerics() throws IllegalArgumentException, CancelException, IOException {
-    runTest(
-        singlePkgTestSrc("javaonepointfive"),
-        rtJar,
-        simplePkgTestEntryPoint("javaonepointfive"),
-        emptyList,
-        true,
-        null);
-  }
-
-  @Test
-  public void testCustomGenericsAndFields()
-      throws IllegalArgumentException, CancelException, IOException {
-    runTest(
-        singlePkgTestSrc("javaonepointfive"),
-        rtJar,
-        simplePkgTestEntryPoint("javaonepointfive"),
-        emptyList,
-        true,
-        null);
-  }
-
-  @Test
-  public void testTypeInferencePrimAndStringOp()
-      throws IllegalArgumentException, CancelException, IOException {
-    runTest(
-        singlePkgTestSrc("javaonepointfive"),
-        rtJar,
-        simplePkgTestEntryPoint("javaonepointfive"),
-        emptyList,
-        true,
-        null);
-  }
-
-  @Test
-  public void testSimpleEnums2() throws IllegalArgumentException, CancelException, IOException {
-    runTest(
-        singlePkgTestSrc("javaonepointfive"),
-        rtJar,
-        simplePkgTestEntryPoint("javaonepointfive"),
-        emptyList,
-        true,
-        null);
-  }
-
-  @Test
-  public void testGenericMemberClasses()
-      throws IllegalArgumentException, CancelException, IOException {
-    runTest(
-        singlePkgTestSrc("javaonepointfive"),
-        rtJar,
-        simplePkgTestEntryPoint("javaonepointfive"),
-        emptyList,
-        true,
-        null);
-  }
-
-  @Test
-  public void testMoreOverriddenGenerics()
-      throws IllegalArgumentException, CancelException, IOException {
-    runTest(
-        singlePkgTestSrc("javaonepointfive"),
-        rtJar,
-        simplePkgTestEntryPoint("javaonepointfive"),
+        simplePkgTestEntryPoint("javaonepointfive", java15IRTestName),
         emptyList,
         true,
         null);

--- a/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJJava17IRTest.java
+++ b/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJJava17IRTest.java
@@ -34,7 +34,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import org.junit.jupiter.api.Test;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ECJJava17IRTest extends IRTests {
 
@@ -61,7 +64,7 @@ public class ECJJava17IRTest extends IRTests {
     return engine;
   }
 
-  private final IRAssertion checkBinaryLiterals =
+  private static final IRAssertion checkBinaryLiterals =
       new IRAssertion() {
         private final TypeReference testClass =
             TypeReference.findOrCreate(
@@ -107,18 +110,7 @@ public class ECJJava17IRTest extends IRTests {
         }
       };
 
-  @Test
-  public void testBinaryLiterals() throws IllegalArgumentException, CancelException, IOException {
-    runTest(
-        singlePkgTestSrc("javaonepointseven"),
-        rtJar,
-        simplePkgTestEntryPoint("javaonepointseven"),
-        Collections.singletonList(checkBinaryLiterals),
-        true,
-        null);
-  }
-
-  private final IRAssertion checkCatchMultipleExceptionTypes =
+  private static final IRAssertion checkCatchMultipleExceptionTypes =
       new IRAssertion() {
 
         private final TypeReference testClass =
@@ -161,18 +153,6 @@ public class ECJJava17IRTest extends IRTests {
         }
       };
 
-  @Test
-  public void testCatchMultipleExceptionTypes()
-      throws IllegalArgumentException, CancelException, IOException {
-    runTest(
-        singlePkgTestSrc("javaonepointseven"),
-        rtJar,
-        simplePkgTestEntryPoint("javaonepointseven"),
-        Collections.singletonList(checkCatchMultipleExceptionTypes),
-        true,
-        null);
-  }
-
   private static final List<IRAssertion> SiSAssertions =
       Collections.singletonList(
           new InstructionOperandAssertion(
@@ -183,49 +163,27 @@ public class ECJJava17IRTest extends IRTests {
               1,
               new int[] {9, 58, 9, 67}));
 
-  @Test
-  public void testStringsInSwitch() throws IllegalArgumentException, CancelException, IOException {
-    runTest(
-        singlePkgTestSrc("javaonepointseven"),
-        rtJar,
-        simplePkgTestEntryPoint("javaonepointseven"),
-        SiSAssertions,
-        true,
-        null);
+  static Stream<Arguments> java17IRTestNames() {
+    return Stream.of(
+        Arguments.of("BinaryLiterals", Collections.singletonList(checkBinaryLiterals)),
+        Arguments.of(
+            "CatchMultipleExceptionTypes",
+            Collections.singletonList(checkCatchMultipleExceptionTypes)),
+        Arguments.of("StringsInSwitch", SiSAssertions),
+        Arguments.of("TypeInferenceforGenericInstanceCreation", emptyList),
+        Arguments.of("TryWithResourcesStatement", emptyList),
+        Arguments.of("UnderscoresInNumericLiterals", emptyList));
   }
 
-  @Test
-  public void testTryWithResourcesStatement()
+  @ParameterizedTest
+  @MethodSource("java17IRTestNames")
+  public void runJava17IRTests(String java17IRTestName, List<IRAssertion> ca)
       throws IllegalArgumentException, CancelException, IOException {
     runTest(
-        singlePkgTestSrc("javaonepointseven"),
+        singlePkgTestSrc("javaonepointseven", java17IRTestName),
         rtJar,
-        simplePkgTestEntryPoint("javaonepointseven"),
-        emptyList,
-        true,
-        null);
-  }
-
-  @Test
-  public void testTypeInferenceforGenericInstanceCreation()
-      throws IllegalArgumentException, CancelException, IOException {
-    runTest(
-        singlePkgTestSrc("javaonepointseven"),
-        rtJar,
-        simplePkgTestEntryPoint("javaonepointseven"),
-        emptyList,
-        true,
-        null);
-  }
-
-  @Test
-  public void testUnderscoresInNumericLiterals()
-      throws IllegalArgumentException, CancelException, IOException {
-    runTest(
-        singlePkgTestSrc("javaonepointseven"),
-        rtJar,
-        simplePkgTestEntryPoint("javaonepointseven"),
-        emptyList,
+        simplePkgTestEntryPoint("javaonepointseven", java17IRTestName),
+        ca,
         true,
         null);
   }

--- a/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJTestComments.java
+++ b/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJTestComments.java
@@ -60,7 +60,13 @@ public class ECJTestComments extends IRTests {
   @Test
   public void testComments() throws IllegalArgumentException, CancelException, IOException {
     Pair<CallGraph, CallGraphBuilder<? super InstanceKey>> result =
-        runTest(singleTestSrc(), rtJar, simpleTestEntryPoint(), emptyList, true, null);
+        runTest(
+            singleTestSrc("Comments"),
+            rtJar,
+            simpleTestEntryPoint("Comments"),
+            emptyList,
+            true,
+            null);
     for (CGNode node : result.fst.getNodes(testMethod)) {
       if (node.getMethod() instanceof AstMethod) {
         AstMethod m = (AstMethod) node.getMethod();

--- a/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJTestComments.java
+++ b/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJTestComments.java
@@ -59,14 +59,7 @@ public class ECJTestComments extends IRTests {
 
   @Test
   public void testComments() throws IllegalArgumentException, CancelException, IOException {
-    Pair<CallGraph, CallGraphBuilder<? super InstanceKey>> result =
-        runTest(
-            singleTestSrc("Comments"),
-            rtJar,
-            simpleTestEntryPoint("Comments"),
-            emptyList,
-            true,
-            null);
+    Pair<CallGraph, CallGraphBuilder<? super InstanceKey>> result = runTest("Comments");
     for (CGNode node : result.fst.getNodes(testMethod)) {
       if (node.getMethod() instanceof AstMethod) {
         AstMethod m = (AstMethod) node.getMethod();

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
@@ -354,6 +354,11 @@ public abstract class IRTests {
         getTestSrcPath() + File.separator + singleJavaPkgInputForTest(pkgName));
   }
 
+  protected Collection<String> singlePkgTestSrc(String pkgName, String testName) {
+    return Collections.singletonList(
+        getTestSrcPath() + File.separator + pkgName + File.separator + testName + ".java");
+  }
+
   protected String getTestName() {
     StackTraceElement stack[] = new Throwable().getStackTrace();
     for (int i = 0; i <= stack.length; i++) {
@@ -371,6 +376,10 @@ public abstract class IRTests {
 
   protected String[] simplePkgTestEntryPoint(String pkgName) {
     return new String[] {"L" + pkgName + "/" + getTestName().substring(4)};
+  }
+
+  protected String[] simplePkgTestEntryPoint(String pkgName, String testName) {
+    return new String[] {"L" + pkgName + "/" + testName};
   }
 
   protected abstract AbstractAnalysisEngine<InstanceKey, CallGraphBuilder<InstanceKey>, ?>

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
@@ -361,6 +361,12 @@ public abstract class IRTests {
       getAnalysisEngine(
           String[] mainClassDescriptors, Collection<String> sources, List<String> libs);
 
+  public Pair<CallGraph, CallGraphBuilder<? super InstanceKey>> runTest(String testName)
+      throws CancelException, IOException {
+    return runTest(
+        singleTestSrc(testName), rtJar, simpleTestEntryPoint(testName), emptyList, true, null);
+  }
+
   public Pair<CallGraph, CallGraphBuilder<? super InstanceKey>> runTest(
       Collection<String> sources,
       List<String> libs,

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
@@ -340,18 +340,8 @@ public abstract class IRTests {
     }
   }
 
-  protected Collection<String> singleTestSrc() {
-    return Collections.singletonList(getTestSrcPath() + File.separator + singleJavaInputForTest());
-  }
-
-  protected Collection<String> singleTestSrc(final String folder) {
-    return Collections.singletonList(
-        getTestSrcPath() + File.separator + folder + File.separator + singleJavaInputForTest());
-  }
-
-  protected Collection<String> singlePkgTestSrc(String pkgName) {
-    return Collections.singletonList(
-        getTestSrcPath() + File.separator + singleJavaPkgInputForTest(pkgName));
+  protected Collection<String> singleTestSrc(String testName) {
+    return Collections.singletonList(getTestSrcPath() + File.separator + testName + ".java");
   }
 
   protected Collection<String> singlePkgTestSrc(String pkgName, String testName) {
@@ -359,23 +349,8 @@ public abstract class IRTests {
         getTestSrcPath() + File.separator + pkgName + File.separator + testName + ".java");
   }
 
-  protected String getTestName() {
-    StackTraceElement stack[] = new Throwable().getStackTrace();
-    for (int i = 0; i <= stack.length; i++) {
-      if (stack[i].getMethodName().startsWith("test")) {
-        return stack[i].getMethodName();
-      }
-    }
-
-    throw new Error("test method not found");
-  }
-
-  protected String[] simpleTestEntryPoint() {
-    return new String[] {'L' + getTestName().substring(4)};
-  }
-
-  protected String[] simplePkgTestEntryPoint(String pkgName) {
-    return new String[] {"L" + pkgName + "/" + getTestName().substring(4)};
+  protected String[] simpleTestEntryPoint(String testName) {
+    return new String[] {'L' + testName};
   }
 
   protected String[] simplePkgTestEntryPoint(String pkgName, String testName) {
@@ -533,15 +508,11 @@ public abstract class IRTests {
     return testSrcPath;
   }
 
-  protected String singleJavaInputForTest() {
-    return getTestName().substring(4) + ".java";
+  protected static String singleInputForTest(String testName) {
+    return testName;
   }
 
-  protected String singleInputForTest() {
-    return getTestName().substring(4);
-  }
-
-  protected String singleJavaPkgInputForTest(String pkgName) {
-    return pkgName + File.separator + getTestName().substring(4) + ".java";
+  protected String singleJavaPkgInputForTest(String pkgName, String testName) {
+    return pkgName + File.separator + testName + ".java";
   }
 }

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/Issue666Test.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/Issue666Test.java
@@ -22,7 +22,13 @@ public abstract class Issue666Test extends IRTests {
   @Test
   public void testPeekErrorCase() throws CancelException, IOException {
     Pair<CallGraph, ?> result =
-        runTest(singleTestSrc(), rtJar, simpleTestEntryPoint(), emptyList, true, null);
+        runTest(
+            singleTestSrc("PeekErrorCase"),
+            rtJar,
+            simpleTestEntryPoint("PeekErrorCase"),
+            emptyList,
+            true,
+            null);
 
     assert result != null;
 

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/Issue667Test.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/Issue667Test.java
@@ -24,7 +24,13 @@ public abstract class Issue667Test extends IRTests {
   @Test
   public void testDominanceFrontierCase() throws CancelException, IOException {
     Pair<CallGraph, ?> result =
-        runTest(singleTestSrc(), rtJar, simpleTestEntryPoint(), emptyList, true, null);
+        runTest(
+            singleTestSrc("DominanceFrontierCase"),
+            rtJar,
+            simpleTestEntryPoint("DominanceFrontierCase"),
+            emptyList,
+            true,
+            null);
 
     MethodReference cm =
         MethodReference.findOrCreate(

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/JLexTest.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/JLexTest.java
@@ -20,18 +20,12 @@ public abstract class JLexTest extends IRTests {
     super(null);
   }
 
-  @Override
   protected String singleJavaInputForTest() {
     return "JLex";
   }
 
   @Test
   public void testJLex() throws IllegalArgumentException, CancelException, IOException {
-    runTest(singleTestSrc(), rtJar, new String[] {"LJLex/Main"}, emptyList, false, null);
-  }
-
-  @Override
-  protected String singleJavaPkgInputForTest(String pkgName) {
-    return "";
+    runTest(singleTestSrc("JLex"), rtJar, new String[] {"LJLex/Main"}, emptyList, false, null);
   }
 }

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/JavaIRTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/JavaIRTests.java
@@ -61,7 +61,6 @@ import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.util.io.TemporaryFile;
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -481,14 +480,7 @@ public abstract class JavaIRTests extends IRTests {
 
   @Test
   public void testInnerClassA() throws IllegalArgumentException, CancelException, IOException {
-    Pair<CallGraph, CallGraphBuilder<? super InstanceKey>> x =
-        runTest(
-            singleTestSrc("InnerClassA"),
-            rtJar,
-            simpleTestEntryPoint("InnerClassA"),
-            new ArrayList<>(),
-            true,
-            null);
+    Pair<CallGraph, CallGraphBuilder<? super InstanceKey>> x = runTest("InnerClassA");
 
     // can't do an IRAssertion() -- we need the pointer analysis
 
@@ -555,14 +547,7 @@ public abstract class JavaIRTests extends IRTests {
 
   @Test
   public void testInnerClassSuper() throws IllegalArgumentException, CancelException, IOException {
-    Pair<CallGraph, CallGraphBuilder<? super InstanceKey>> x =
-        runTest(
-            singleTestSrc("InnerClassSuper"),
-            rtJar,
-            simpleTestEntryPoint("InnerClassSuper"),
-            new ArrayList<>(),
-            true,
-            null);
+    Pair<CallGraph, CallGraphBuilder<? super InstanceKey>> x = runTest("InnerClassSuper");
 
     // can't do an IRAssertion() -- we need the pointer analysis
 
@@ -605,14 +590,7 @@ public abstract class JavaIRTests extends IRTests {
 
   @Test
   public void testMiniaturSliceBug() throws IllegalArgumentException, CancelException, IOException {
-    Pair<CallGraph, CallGraphBuilder<? super InstanceKey>> x =
-        runTest(
-            singleTestSrc("MiniaturSliceBug"),
-            rtJar,
-            simpleTestEntryPoint("MiniaturSliceBug"),
-            emptyList,
-            true,
-            null);
+    Pair<CallGraph, CallGraphBuilder<? super InstanceKey>> x = runTest("MiniaturSliceBug");
 
     PointerAnalysis<? extends InstanceKey> pa =
         ((PropagationCallGraphBuilder) x.snd).getPointerAnalysis();

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/SyncDuplicatorTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/SyncDuplicatorTests.java
@@ -41,6 +41,7 @@ public abstract class SyncDuplicatorTests extends IRTests {
 
   @Test
   public void testMonitor2() throws IllegalArgumentException, CancelException, IOException {
-    runTest(singleTestSrc(), rtJar, simpleTestEntryPoint(), emptyList, true, null);
+    runTest(
+        singleTestSrc("Monitor2"), rtJar, simpleTestEntryPoint("Monitor2"), emptyList, true, null);
   }
 }


### PR DESCRIPTION
Cleaned up `ECJJava15IRTest.java` by refactoring the tests to be parameterized to not rely on method name for running the tests. Also removed the `getTestName` from `IRTests` so the tests do not rely on that method to get the name of the test it should run. With this we pass in the name and tests can now be parameterized as well instead of relying on naming tests differently