### PR TITLE
Enable parallel configuration caching

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,7 @@ dependency.analysis.print.build.health=true
 
 org.gradle.caching=true
 org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
 org.gradle.parallel=true
 


### PR DESCRIPTION
According to [Gradle's
documentation](https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:usage:parallel), "Configuration cache storing and loading are done sequentially by default. Parallel storing and loading provide better performance, however not all builds are compatible with it."  Our build appears to be compatible, so let's turn this feature on.

That being said, I haven't actually noticed a significant change in build times.  This feature may affect WALA more in theory than in practice.