### PR TITLE
Bump deps and version used for compiling Java

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
 
 tasks.withType<JavaCompile>().configureEach {
   // Always compile with a recent JDK version, to get the latest bug fixes in the compiler toolchain
-  javaCompiler = javaToolchains.compilerFor { languageVersion = JavaLanguageVersion.of(23) }
+  javaCompiler = javaToolchains.compilerFor { languageVersion = JavaLanguageVersion.of(24) }
   // Generate JDK 11 bytecodes; that is the minimum version supported by WALA
   options.release = 11
   options.errorprone {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,14 +16,14 @@ eclipse-ecj = "org.eclipse.jdt:ecj:3.37.0"
 eclipse-osgi = "org.eclipse.platform:org.eclipse.osgi:3.19.0"
 eclipse-wst-jsdt-core = { module = "org.eclipse.wst.jsdt:core", version.ref = "eclipse-wst-jsdt" }
 eclipse-wst-jsdt-ui = { module = "org.eclipse.wst.jsdt:ui", version.ref = "eclipse-wst-jsdt" }
-errorprone-core = "com.google.errorprone:error_prone_core:2.36.0"
+errorprone-core = "com.google.errorprone:error_prone_core:2.37.0"
 gradle-download-task = "de.undercouch:gradle-download-task:5.6.0"
 gradle-errorprone-plugin = "net.ltgt.gradle:gradle-errorprone-plugin:4.1.0"
 gradle-goomph-plugin = "com.diffplug.gradle:goomph:3.44.0"
 gradle-maven-publish-plugin = "com.vanniktech:gradle-maven-publish-plugin:0.29.0"
 gradle-spotless-plugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 gson = "com.google.code.gson:gson:2.11.0"
-guava = "com.google.guava:guava:33.2.0-jre"
+guava = "com.google.guava:guava:33.4.5-jre"
 hamcrest = "org.hamcrest:hamcrest:2.2"
 htmlparser = "nu.validator.htmlparser:htmlparser:1.4"
 java_cup = "java_cup:java_cup:0.9e"


### PR DESCRIPTION
Guava and Error Prone to latest, and use JDK 24 to compile code.  (We can't test WALA on JDK 24 under Gradle supports running on JDK 24.)