### PR TITLE
Initialize Gradle dependency configurations lazily

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/javadoc.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/javadoc.gradle.kts
@@ -2,17 +2,17 @@ package com.ibm.wala.gradle
 
 // Build configuration for projects that include `Javadoc` tasks.
 
-val javadocClasspath: Configuration by
-    configurations.creating { description = "Classpath used during Javadoc creation." }
+val javadocClasspath by
+    configurations.registering { description = "Classpath used during Javadoc creation." }
 
-val javadocSource: Configuration by
-    configurations.creating {
+val javadocSource by
+    configurations.registering {
       description = "Java source files from which Javadoc should be extracted."
     }
 
 tasks.named<Javadoc>("javadoc") {
-  classpath = configurations.named("javadocClasspath").get()
-  source(configurations.named("javadocSource"))
+  classpath = javadocClasspath.get()
+  source(javadocSource)
 }
 
 tasks.withType<Javadoc>().configureEach {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,9 +63,9 @@ val eclipseVersion: EclipseRelease by extra {
 //  Javadoc documentation
 //
 
-val aggregatedJavadocClasspath: Configuration by configurations.creating { isCanBeConsumed = false }
+val aggregatedJavadocClasspath by configurations.registering { isCanBeConsumed = false }
 
-val aggregatedJavadocSource: Configuration by configurations.creating { isCanBeConsumed = false }
+val aggregatedJavadocSource by configurations.registering { isCanBeConsumed = false }
 
 dependencies {
   subprojects {
@@ -84,7 +84,7 @@ tasks.register<Javadoc>("aggregatedJavadocs") {
   setDestinationDir(layout.buildDirectory.dir("docs/javadoc").get().asFile)
   title = "${project.name} $version API"
   (options as StandardJavadocDocletOptions).author(true)
-  classpath = aggregatedJavadocClasspath
+  classpath = aggregatedJavadocClasspath.get()
   source(aggregatedJavadocSource)
 }
 

--- a/cast/build.gradle.kts
+++ b/cast/build.gradle.kts
@@ -9,8 +9,8 @@ plugins {
 
 eclipse.project.natures("org.eclipse.pde.PluginNature")
 
-val castCastSharedLibrary: Configuration by
-    configurations.creating {
+val castCastSharedLibrary by
+    configurations.registering {
       isCanBeConsumed = false
       attributes {
         attribute(OPTIMIZED_ATTRIBUTE, false)
@@ -18,13 +18,12 @@ val castCastSharedLibrary: Configuration by
       }
     }
 
-val castJsJavadocDestinationDirectory: Configuration by
-    configurations.creating { isCanBeConsumed = false }
+val castJsJavadocDestinationDirectory by configurations.registering { isCanBeConsumed = false }
 
-val castJsPackageListDirectory: Configuration by configurations.creating { isCanBeConsumed = false }
+val castJsPackageListDirectory by configurations.registering { isCanBeConsumed = false }
 
-val xlatorTestSharedLibrary: Configuration by
-    configurations.creating {
+val xlatorTestSharedLibrary by
+    configurations.registering {
       isCanBeConsumed = false
       isTransitive = false
       attributes {
@@ -52,7 +51,7 @@ dependencies {
   xlatorTestSharedLibrary(projects.cast.xlatorTest)
 }
 
-val castHeaderDirectory: Configuration by configurations.creating { isCanBeResolved = false }
+val castHeaderDirectory by configurations.registering { isCanBeResolved = false }
 
 artifacts.add(
     castHeaderDirectory.name,
@@ -61,8 +60,8 @@ artifacts.add(
 tasks.named<Javadoc>("javadoc") {
   inputs.files(castJsPackageListDirectory)
 
-  val extdocURL = castJsJavadocDestinationDirectory.singleFile
-  val packagelistLoc = castJsPackageListDirectory.singleFile
+  val extdocURL = castJsJavadocDestinationDirectory.get().singleFile
+  val packagelistLoc = castJsPackageListDirectory.get().singleFile
   inputs.property("extdocURL", extdocURL)
   inputs.property("packagelistLoc", packagelistLoc)
   (options as StandardJavadocDocletOptions).linksOffline(
@@ -71,7 +70,7 @@ tasks.named<Javadoc>("javadoc") {
 
 tasks.named<Test>("test") {
   inputs.files(xlatorTestSharedLibrary)
-  systemProperty("java.library.path", xlatorTestSharedLibrary.singleFile.parent)
+  systemProperty("java.library.path", xlatorTestSharedLibrary.get().singleFile.parent)
 
   if (rootProject.extra["isWindows"] as Boolean) {
 
@@ -85,6 +84,7 @@ tasks.named<Test>("test") {
 
     inputs.files(castCastSharedLibrary)
     val pathEntry = environment.entries.find { it.key.equals("path", true) }!!
-    environment(pathEntry.key, "${pathEntry.value};${castCastSharedLibrary.singleFile.parent}")
+    environment(
+        pathEntry.key, "${pathEntry.value};${castCastSharedLibrary.get().singleFile.parent}")
   }
 }

--- a/cast/java/ecj/build.gradle.kts
+++ b/cast/java/ecj/build.gradle.kts
@@ -12,7 +12,7 @@ walaEclipseMavenCentral {
   )
 }
 
-val runSourceDirectory: Configuration by configurations.creating { isCanBeConsumed = false }
+val runSourceDirectory by configurations.registering { isCanBeConsumed = false }
 
 dependencies {
   implementation(libs.eclipse.ecj)
@@ -36,7 +36,10 @@ val run by
       // this is for testing purposes
       args =
           listOf(
-              "-sourceDir", runSourceDirectory.files.single().toString(), "-mainClass", "LArray1")
+              "-sourceDir",
+              runSourceDirectory.get().files.single().toString(),
+              "-mainClass",
+              "LArray1")
 
       // log output to file, although we don"t validate it
       val outFile = project.layout.buildDirectory.file("SourceDirCallGraph.log")

--- a/cast/java/test/data/build.gradle.kts
+++ b/cast/java/test/data/build.gradle.kts
@@ -22,9 +22,9 @@ val testJar by
       from(compileTestJava)
     }
 
-val testJarConfig: Configuration by configurations.creating { isCanBeResolved = false }
+val testJarConfig by configurations.registering { isCanBeResolved = false }
 
-val testJavaSourceDirectory: Configuration by configurations.creating { isCanBeResolved = false }
+val testJavaSourceDirectory by configurations.registering { isCanBeResolved = false }
 
 artifacts {
   add(testJarConfig.name, testJar)

--- a/cast/js/build.gradle.kts
+++ b/cast/js/build.gradle.kts
@@ -28,10 +28,9 @@ dependencies {
 val createPackageList by
     tasks.registering(CreatePackageList::class) { sourceSet(sourceSets.main.get()) }
 
-val packageListDirectory: Configuration by configurations.creating { isCanBeResolved = false }
+val packageListDirectory by configurations.registering { isCanBeResolved = false }
 
-val javadocDestinationDirectory: Configuration by
-    configurations.creating { isCanBeResolved = false }
+val javadocDestinationDirectory by configurations.registering { isCanBeResolved = false }
 
 tasks.named<Test>("test") { maxHeapSize = "800M" }
 
@@ -59,7 +58,7 @@ val unpackAjaxslt by
 
 val processTestResources by tasks.existing(Copy::class) { from(unpackAjaxslt) { into("ajaxslt") } }
 
-val testResources: Configuration by configurations.creating { isCanBeResolved = false }
+val testResources by configurations.registering { isCanBeResolved = false }
 
 artifacts {
   add(javadocDestinationDirectory.name, tasks.javadoc)

--- a/cast/js/html/nu_validator/build.gradle.kts
+++ b/cast/js/html/nu_validator/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins { id("com.ibm.wala.gradle.java") }
 
-val extraTestResources: Configuration by configurations.creating { isCanBeConsumed = false }
+val extraTestResources by configurations.registering { isCanBeConsumed = false }
 
 dependencies {
   api(projects.cast.js)

--- a/cast/js/rhino/build.gradle.kts
+++ b/cast/js/rhino/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
   id("com.ibm.wala.gradle.publishing")
 }
 
-val extraTestResources: Configuration by configurations.creating { isCanBeConsumed = false }
+val extraTestResources by configurations.registering { isCanBeConsumed = false }
 
 dependencies {
   extraTestResources(project(mapOf("path" to ":cast:js", "configuration" to "testResources")))

--- a/cast/smoke_main/build.gradle.kts
+++ b/cast/smoke_main/build.gradle.kts
@@ -13,8 +13,8 @@ plugins {
   id("com.ibm.wala.gradle.subproject")
 }
 
-val coreResources: Configuration by
-    configurations.creating {
+val coreResources by
+    configurations.registering {
       isCanBeConsumed = false
       isTransitive = false
       attributes {
@@ -22,8 +22,8 @@ val coreResources: Configuration by
       }
     }
 
-val smokeMainExtraPathElements: Configuration by
-    configurations.creating {
+val smokeMainExtraPathElements by
+    configurations.registering {
       isCanBeConsumed = false
       isTransitive = false
       attributes {
@@ -31,8 +31,8 @@ val smokeMainExtraPathElements: Configuration by
       }
     }
 
-fun createXlatorConfig(isOptimized: Boolean): Configuration =
-    configurations.create(
+fun createXlatorConfig(isOptimized: Boolean): NamedDomainObjectProvider<Configuration> =
+    configurations.register(
         "xlatorTest${if (isOptimized) "Release" else "Debug"}SharedLibraryConfig") {
           isCanBeConsumed = false
           isTransitive = false
@@ -64,6 +64,7 @@ application {
       val libxlatorTest =
           (if (isOptimized) xlatorTestReleaseSharedLibraryConfig
               else xlatorTestDebugSharedLibraryConfig)
+              .get()
               .singleFile
       addRpath(libxlatorTest)
       addCastLibrary(this@whenElementFinalized)
@@ -86,7 +87,7 @@ application {
               pathElements.addAll(files("../build/classes/java/test", libxlatorTest.parent))
 
               // "primordial.txt" resource loaded during test
-              pathElements.add(coreResources.singleFile)
+              pathElements.add(coreResources.get().singleFile)
               inputs.files(coreResources)
 
               // additional supporting Java class files

--- a/cast/xlator_test/build.gradle.kts
+++ b/cast/xlator_test/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
   id("com.ibm.wala.gradle.subproject")
 }
 
-val castHeaderDirectory: Configuration by configurations.creating { isCanBeConsumed = false }
+val castHeaderDirectory by configurations.registering { isCanBeConsumed = false }
 
 dependencies {
   castHeaderDirectory(project(mapOf("path" to ":cast", "configuration" to "castHeaderDirectory")))

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -229,7 +229,7 @@ val downloadJavaCup by
 //  collect "JLex.jar"
 //
 
-val collectJLexFrom: Configuration by configurations.creating { isCanBeConsumed = false }
+val collectJLexFrom by configurations.registering { isCanBeConsumed = false }
 
 dependencies {
   collectJLexFrom(
@@ -239,7 +239,7 @@ dependencies {
 val collectJLex by
     tasks.registering(Jar::class) {
       inputs.files(collectJLexFrom)
-      from(zipTree(collectJLexFrom.singleFile))
+      from({ zipTree(collectJLexFrom.get().singleFile) })
       include("JLex/")
       archiveFileName = "JLex.jar"
       destinationDirectory = layout.buildDirectory.dir(name)
@@ -312,7 +312,7 @@ val collectTestData by
       destinationDirectory = layout.buildDirectory.dir(name)
     }
 
-val collectTestDataJar: Configuration by configurations.creating { isCanBeResolved = false }
+val collectTestDataJar by configurations.registering { isCanBeResolved = false }
 
 artifacts.add(collectTestDataJar.name, collectTestData.map { it.destinationDirectory })
 
@@ -370,7 +370,7 @@ tasks.named<Test>("test") {
   outputs.file(layout.buildDirectory.file("report"))
 }
 
-val testResources: Configuration by configurations.creating { isCanBeResolved = false }
+val testResources by configurations.registering { isCanBeResolved = false }
 
 artifacts.add(testResources.name, sourceSets.test.map { it.resources.srcDirs.single() })
 
@@ -383,11 +383,11 @@ val testJar by
       from(tasks.named("compileTestJava"))
     }
 
-val testJarConfig: Configuration by configurations.creating { isCanBeResolved = false }
+val testJarConfig by configurations.registering { isCanBeResolved = false }
 
 artifacts.add(testJarConfig.name, testJar)
 
-val dalvikTestResources: Configuration by configurations.creating { isCanBeResolved = false }
+val dalvikTestResources by configurations.registering { isCanBeResolved = false }
 
 listOf(
         collectJLex,

--- a/dalvik/build.gradle.kts
+++ b/dalvik/build.gradle.kts
@@ -6,11 +6,11 @@ plugins {
   id("com.ibm.wala.gradle.publishing")
 }
 
-val coreTestJar: Configuration by configurations.creating { isCanBeConsumed = false }
+val coreTestJar by configurations.registering { isCanBeConsumed = false }
 
-val extraTestResources: Configuration by configurations.creating { isCanBeConsumed = false }
+val extraTestResources by configurations.registering { isCanBeConsumed = false }
 
-val sampleCupSources: Configuration by configurations.creating { isCanBeConsumed = false }
+val sampleCupSources by configurations.registering { isCanBeConsumed = false }
 
 val isWindows: Boolean by rootProject.extra
 
@@ -183,7 +183,7 @@ tasks.named<Copy>("processTestResources") {
   from(downloadSampleLex)
   from(extractSampleCup)
   from(extraTestResources)
-  from(zipTree(coreTestJar.singleFile))
+  from({ zipTree(coreTestJar.get().singleFile) })
 }
 
 if (isWindows) tasks.named<Test>("test") { exclude("**/droidbench/**") }

--- a/ide/tests/build.gradle.kts
+++ b/ide/tests/build.gradle.kts
@@ -21,24 +21,24 @@ walaEclipseMavenCentral {
   testImplementation("org.eclipse.jface")
 }
 
-val coreTestDataJar: Configuration by
-    configurations.creating {
+val coreTestDataJar by
+    configurations.registering {
       isCanBeConsumed = false
       isTransitive = false
     }
 
-val coreTestResources: Configuration by configurations.creating { isCanBeConsumed = false }
+val coreTestResources by configurations.registering { isCanBeConsumed = false }
 
-val coreMainSource: Configuration by
-    configurations.creating {
+val coreMainSource by
+    configurations.registering {
       isCanBeConsumed = false
       attributes {
         attribute(VERIFICATION_TYPE_ATTRIBUTE, objects.named(VerificationType::class, MAIN_SOURCES))
       }
     }
 
-val ifdsExplorerExampleClasspath: Configuration by
-    configurations.creating {
+val ifdsExplorerExampleClasspath by
+    configurations.registering {
       isCanBeConsumed = false
       isTransitive = false
     }
@@ -92,7 +92,7 @@ tasks.named<Copy>("processTestResources") {
 tasks.register<JavaExec>("runIFDSExplorerExample") {
   group = "Execution"
   description = "Run the IFDSExplorerExample driver"
-  classpath = ifdsExplorerExampleClasspath
+  classpath(ifdsExplorerExampleClasspath)
   mainClass = "com.ibm.wala.examples.drivers.IFDSExplorerExample"
   if (System.getProperty("os.name").startsWith("Mac OS X")) {
     jvmArgs = listOf("-XstartOnFirstThread")


### PR DESCRIPTION
[Gradle 8.14](https://docs.gradle.org/current/release-notes.html#configurations-are-initialized-lazily) allows dependency configurations to be "realized only when necessary."  "This change can lead to reduced configuration time and lower memory usage in some builds."