### PR TITLE
Make parameterized test names deterministic

### DIFF
--- a/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJJava17IRTest.java
+++ b/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJJava17IRTest.java
@@ -175,7 +175,7 @@ public class ECJJava17IRTest extends IRTests {
         Arguments.of("UnderscoresInNumericLiterals", emptyList));
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "java17IRTestName={0}")
   @MethodSource("java17IRTestNames")
   public void runJava17IRTests(String java17IRTestName, List<IRAssertion> ca)
       throws IllegalArgumentException, CancelException, IOException {

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/JavaIRTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/JavaIRTests.java
@@ -446,7 +446,7 @@ public abstract class JavaIRTests extends IRTests {
         Arguments.of("p", "NonPrimaryTopLevel", emptyList, true, null));
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "java17IRTestName={0}, assertReachable={2}, exclusionsFile={3}")
   @MethodSource("javaIRTestsParameters")
   public void runJavaIRTests(
       String java17IRTestName, List<IRAssertion> ca, boolean assertReachable, String exclusionsFile)


### PR DESCRIPTION
Previously several parameterized tests used `List`s of items without custom `toString` methods.  Including these in test names led to generated test names like `java17IRTestName=CatchMultipleExceptionTypes, ca=[com.ibm.wala.cast.java.test.ECJJava17IRTest$3@6e576b5a]`, where the `6e576b5a` part varied randomly from one run to the next.  That nondeterminism, in turn, led to misleading claims of test churn in test reports.  For example, [this report](https://github.com/wala/WALA/pull/1495#issuecomment-2832598703) states that "this pull request removes 118 and adds 118 tests."  No tests were actually removed, though: 118 tests simply changed the hex digits in their names.

Now we customize the name template for some parameterized tests to omit items with nondeterministic `toString` results.  This change should give us test reports that more truthfully reflect the real amount of test churn, or lack thereof.