### PR TITLE
Correct assertEquals argument order

### DIFF
--- a/.idea/inspectionProfiles/No_Back_Sliding.xml
+++ b/.idea/inspectionProfiles/No_Back_Sliding.xml
@@ -393,6 +393,7 @@
       </option>
     </inspection_tool>
     <inspection_tool class="MismatchedStringBuilderQueryUpdate" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="MisorderedAssertEqualsArguments" enabled="true" level="ERROR" enabled_by_default="true" editorAttributes="ERRORS_ATTRIBUTES" />
     <inspection_tool class="MissingDeprecatedAnnotation" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="MissingJavadoc" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <option name="PACKAGE_SETTINGS">

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/JavaIRTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/JavaIRTests.java
@@ -107,7 +107,7 @@ public abstract class JavaIRTests extends IRTests {
 
             final Collection<? extends IClass> interfaces = iClass.getDirectInterfaces();
 
-            assertEquals(interfaces.size(), 1, "Expected one single interface.");
+            assertEquals(1, interfaces.size(), "Expected one single interface.");
 
             assertTrue(
                 interfaces.contains(
@@ -171,10 +171,10 @@ public abstract class JavaIRTests extends IRTests {
                 s instanceof SSAGetInstruction && ((SSAGetInstruction) s).isStatic(),
                 "Did not find a getstatic instruction.");
             final FieldReference field = ((SSAGetInstruction) s).getDeclaredField();
-            assertEquals(field.getName().toString(), "value", "Expected a getstatic for 'value'.");
+            assertEquals("value", field.getName().toString(), "Expected a getstatic for 'value'.");
             assertEquals(
-                field.getDeclaringClass().getName().toString(),
                 "LFooQ",
+                field.getDeclaringClass().getName().toString(),
                 "Expected a getstatic for 'value'.");
           });
 
@@ -218,8 +218,8 @@ public abstract class JavaIRTests extends IRTests {
                 SSAArrayStoreInstruction as = (SSAArrayStoreInstruction) instructions[i];
 
                 assertEquals(
-                    node.getIR().getLocalNames(i, as.getArrayRef())[0],
                     "y",
+                    node.getIR().getLocalNames(i, as.getArrayRef())[0],
                     "Expected an array store to 'y'.");
 
                 final Integer valueOfArrayIndex =
@@ -262,7 +262,7 @@ public abstract class JavaIRTests extends IRTests {
                 }
               }
 
-              assertEquals(count, 4, "Unexpected number of array instructions in 'foo'.");
+              assertEquals(4, count, "Unexpected number of array instructions in 'foo'.");
             }
 
             private boolean isArrayInstruction(SSAInstruction s) {

--- a/core/src/test/java/com/ibm/wala/core/tests/basic/PrimitivesTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/basic/PrimitivesTest.java
@@ -863,7 +863,7 @@ public class PrimitivesTest extends WalaTestCase {
     int SIZE = 10000;
     IntegerUnionFind uf = new IntegerUnionFind(SIZE);
     int count = countEquivalenceClasses(uf);
-    assertEquals(count, SIZE, "Got count " + count);
+    assertEquals(SIZE, count, "Got count " + count);
 
     uf.union(3, 7);
     assertEquals(uf.find(3), uf.find(7));

--- a/core/src/test/java/com/ibm/wala/core/tests/cha/DupFieldsTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/cha/DupFieldsTest.java
@@ -54,11 +54,11 @@ public class DupFieldsTest extends WalaTestCase {
     IField f =
         cha.resolveField(
             FieldReference.findOrCreate(ref, Atom.findOrCreateUnicodeAtom("a"), TypeReference.Int));
-    assertEquals(f.getFieldTypeReference(), TypeReference.Int);
+    assertEquals(TypeReference.Int, f.getFieldTypeReference());
     f =
         cha.resolveField(
             FieldReference.findOrCreate(
                 ref, Atom.findOrCreateUnicodeAtom("a"), TypeReference.Boolean));
-    assertEquals(f.getFieldTypeReference(), TypeReference.Boolean);
+    assertEquals(TypeReference.Boolean, f.getFieldTypeReference());
   }
 }


### PR DESCRIPTION
JUnit 5's `assertEquals` method should be called with the _expected_ value _first_ and the _actual_ value _second_.