### PR TITLE
Limit visibility of test-parameter generators

### DIFF
--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/DroidBenchCGTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/DroidBenchCGTest.java
@@ -140,7 +140,7 @@ public abstract class DroidBenchCGTest extends DalvikCallGraphTestBase {
     skipTests.add("Button2.apk");
   }
 
-  public static Stream<Named<TestParameters>> generateData(
+  protected static Stream<Named<TestParameters>> generateData(
       final URI[] androidLibs, final File androidJavaJar, final String filter) {
 
     return generateData(getDroidBenchRoot(), androidLibs, androidJavaJar, filter);
@@ -158,7 +158,7 @@ public abstract class DroidBenchCGTest extends DalvikCallGraphTestBase {
     return f;
   }
 
-  public static Stream<Named<TestParameters>> generateData(
+  protected static Stream<Named<TestParameters>> generateData(
       String droidBenchRoot,
       final URI[] androidLibs,
       final File androidJavaJar,


### PR DESCRIPTION
If the `TestParameters` class is going to be `protected`, then test-parameter generators that return streams of this type may as well be `protected` too:  nothing outside of this class hierarchy would be able to use those generators anyway.