### PR TITLE
Simplify JaCoCo report aggregation

### DIFF
--- a/code-coverage-report/build.gradle.kts
+++ b/code-coverage-report/build.gradle.kts
@@ -6,21 +6,5 @@ plugins {
 }
 
 dependencies {
-  jacocoAggregation(projects.cast.java)
-  jacocoAggregation(projects.cast.java.ecj)
-  jacocoAggregation(projects.cast.js)
-  jacocoAggregation(projects.cast.js.html.nuValidator)
-  jacocoAggregation(projects.cast.js.nodejs)
-  jacocoAggregation(projects.cast.js.rhino)
-  jacocoAggregation(projects.core)
-  jacocoAggregation(projects.dalvik)
-  jacocoAggregation(projects.ide)
-  jacocoAggregation(projects.ide.jdt)
-  jacocoAggregation(projects.ide.jdt.test)
-  jacocoAggregation(projects.ide.jsdt)
-  jacocoAggregation(projects.ide.jsdt.tests)
-  jacocoAggregation(projects.ide.tests)
-  jacocoAggregation(projects.scandroid)
-  jacocoAggregation(projects.shrike)
-  jacocoAggregation(projects.util)
+  rootProject.subprojects { plugins.withId("jacoco") { jacocoAggregation(this@subprojects) } }
 }


### PR DESCRIPTION
When aggregating, automatically include every subproject that uses the `jacoco` plugin.  The logic for doing this works out quite nicely thanks to `PluginContainer::withId`.  That method executes an action immediately if a project has already loaded the plugin of interest, _or_ registers the action to run later if the project loads the plugin of interest later.  Thus, everything works as intended regardless of the order in which subprojects are configured.