### PR TITLE
Aggregate coverage from nested subprojects

### DIFF
--- a/code-coverage-report/build.gradle.kts
+++ b/code-coverage-report/build.gradle.kts
@@ -6,5 +6,5 @@ plugins {
 }
 
 dependencies {
-  rootProject.allprojects { plugins.withId("jacoco") { jacocoAggregation(this@subprojects) } }
+  rootProject.allprojects { plugins.withId("jacoco") { jacocoAggregation(this@allprojects) } }
 }

--- a/code-coverage-report/build.gradle.kts
+++ b/code-coverage-report/build.gradle.kts
@@ -6,5 +6,5 @@ plugins {
 }
 
 dependencies {
-  rootProject.subprojects { plugins.withId("jacoco") { jacocoAggregation(this@subprojects) } }
+  rootProject.allprojects { plugins.withId("jacoco") { jacocoAggregation(this@subprojects) } }
 }


### PR DESCRIPTION
Previously we might only have been aggregating coverage from the root project's immediate subprojects. Now it should be clear that we're considering all projects regardless of nesting depth.