### PR TITLE
Simplify Java toolchain configuration

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -24,11 +24,12 @@ repositories {
   maven { url = uri("https://storage.googleapis.com/r8-releases/raw") }
 }
 
-java.toolchain.languageVersion =
-    JavaLanguageVersion.of(property("com.ibm.wala.jdk-version") as String)
-// We prefer a toolchain that includes jmod files for the Java standard library, like Azul Zulu.
-// Temurin does not include jmod files as of their JDK 24 builds.
-java.toolchain.vendor = JvmVendorSpec.AZUL
+java.toolchain {
+  languageVersion = JavaLanguageVersion.of(property("com.ibm.wala.jdk-version") as String)
+  // We prefer a toolchain that includes jmod files for the Java standard library, like Azul Zulu.
+  // Temurin does not include jmod files as of their JDK 24 builds.
+  vendor = JvmVendorSpec.AZUL
+}
 
 base.archivesName = "com.ibm.wala${path.replace(':', '.')}"
 


### PR DESCRIPTION
If we have two settings to tweak for `java.toolchain`, then it's slightly more concise to use one configuration block for both rather than repeating `java.toolchain` twice.