### PR TITLE
Update `dependency-analysis` plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,7 @@ slf4j-api = "org.slf4j:slf4j-api:2.0.13"
 w3c-css-sac = "org.eclipse.birt.runtime:org.w3c.css.sac:1.3.1.v200903091627"
 
 [plugins]
-dependency-analysis = "com.autonomousapps.dependency-analysis:1.32.0"
+dependency-analysis = "com.autonomousapps.dependency-analysis:2.18.0"
 file-lister = "all.shared.gradle.file-lister:1.0.2"
 google-java-format = "com.github.sherter.google-java-format:0.9"
 markdown = "com.appmattus.markdown:0.6.0"

--- a/ide/build.gradle.kts
+++ b/ide/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+  alias(libs.plugins.dependency.analysis)
   id("com.ibm.wala.gradle.eclipse-maven-central")
   id("com.ibm.wala.gradle.java")
 }
@@ -16,7 +17,6 @@ walaEclipseMavenCentral {
   )
   implementation(
       "org.eclipse.jdt.core",
-      "org.eclipse.swt",
       "org.eclipse.ui.workbench",
   )
 }
@@ -37,6 +37,12 @@ configurations.all {
 }
 
 dependencyAnalysis.issues {
+  onDuplicateClassWarnings {
+    exclude(
+        "org.osgi.framework.Bundle",
+        "org.osgi.framework.BundleContext",
+    )
+  }
   onIncorrectConfiguration { exclude("org.eclipse.pde:org.eclipse.pde.core") }
   onUsedTransitiveDependencies {
     exclude(


### PR DESCRIPTION
The previous version did not yet support Gradle 9.  This newer version does, and also detects a few dependency problems that the previous version missed.

Fixes #1521.