### PR TITLE
Use explicit JUnit 5 launcher

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
 
   testImplementation(platform(findLibrary("junit-bom")))
   testRuntimeOnly(findLibrary("junit-jupiter-engine"))
+  testRuntimeOnly(findLibrary("junit-platform-launcher"))
   testRuntimeOnly(findLibrary("junit-vintage-engine"))
 }
 


### PR DESCRIPTION
Gradle 9 will no longer add a `junit-platform-launcher` dependency automatically unless a (sub)project uses Gradle's test suites feature. We're not using that feature yet, so we need to add this dependency ourselves.

Fixes #1523.