### PR TITLE
Delay some downloads until actually needed

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/JavaCompileUsingEcj.kt
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/JavaCompileUsingEcj.kt
@@ -1,8 +1,8 @@
 package com.ibm.wala.gradle
 
-import java.io.File
 import javax.inject.Inject
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.CacheableTask
@@ -26,10 +26,8 @@ import org.gradle.work.InputChanges
 @CacheableTask
 abstract class JavaCompileUsingEcj : JavaCompile() {
 
-  /** ECJ compiler, resolved to a JAR archive. */
-  @CompileClasspath
-  @InputFile
-  val ecjJar: File = project.configurations.named("ecj").get().singleFile
+  /** ECJ compiler, typically consisting of a single JAR file. */
+  @CompileClasspath val ecjJar: Provider<Configuration> = project.configurations.named("ecj")
 
   @InputFile
   @PathSensitive(PathSensitivity.NONE)
@@ -66,7 +64,7 @@ abstract class JavaCompileUsingEcj : JavaCompile() {
   @TaskAction
   protected override fun compile(inputs: InputChanges) {
     execOperations.javaexec {
-      classpath(ecjJar.absolutePath)
+      classpath(ecjJar)
       executable(javaLauncherPath.get())
       args(options.allCompilerArgs)
     }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -179,6 +179,12 @@ val extractBcel by
 val downloadJavaCup =
     adHocDownload(uri("https://www2.cs.tum.edu/projects/cup"), "java-cup", "jar", "11a")
 
+val copyJavaCup by
+    tasks.registering(Sync::class) {
+      from(downloadJavaCup)
+      into(layout.buildDirectory.dir(name))
+    }
+
 ////////////////////////////////////////////////////////////////////////
 //
 //  collect "JLex.jar"
@@ -220,11 +226,13 @@ val downloadOcamlJava =
 // causes Gradle's native tar support to fail.
 val unpackOcamlJava by
     tasks.registering(Exec::class) {
-      commandLine(
-          "tar",
-          "xzf",
-          downloadOcamlJava.singleFile,
-          "ocamljava-$ocamlJavaVersion/lib/ocamljava.jar")
+      executable = "tar"
+      argumentProviders.add {
+        listOf(
+            "xzf",
+            downloadOcamlJava.singleFile.path,
+            "ocamljava-$ocamlJavaVersion/lib/ocamljava.jar")
+      }
       val outputDir = project.layout.buildDirectory.dir(name)
       workingDir(outputDir)
       outputs.dir(outputDir)
@@ -303,7 +311,7 @@ tasks.named<Copy>("processTestResources") {
       buildKawaTestJar,
       collectJLex,
       collectTestData,
-      downloadJavaCup,
+      copyJavaCup,
       extractBcel,
       extractKawa,
   )
@@ -353,7 +361,7 @@ val dalvikTestResources by configurations.registering { isCanBeResolved = false 
 listOf(
         collectJLex,
         collectTestDataAForDalvik,
-        downloadJavaCup.singleFile,
+        copyJavaCup,
         extractBcel,
     )
     .forEach { artifacts.add(dalvikTestResources.name, it) }


### PR DESCRIPTION
Before this change, several project activities could trigger downloads of `ecj`, `java-cup`, and `ocamljava`.  For example, this would happen when running `./gradlew tasks` or when importing the WALA project into IntelliJ IDEA.  Those three downloads pulled in 101 MB of cacheable data, 95 MB of which was for `ocamljava` alone.  As [discussed elsewhere](https://github.com/wala/WALA/pull/1536#issuecomment-3014794567), it's undesirable to download anything more than what we actually need.

With this change applied, we no longer download `ecj` or any of the ad-hoc downloads (including `java-cup` and `ocamljava`) during `./gradle tasks` or during IntelliJ IDEA project import.  Thus, those actions now download 101 MB less than they did before.  Of course, these downloads will still happen _eventually_ if we actually execute tasks that require them.