### PR TITLE
Remove unnecessary uses of `project.`

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/EclipseCompatibleJavaExtension.kt
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/EclipseCompatibleJavaExtension.kt
@@ -30,11 +30,9 @@ private const val MINIMUM_ECLIPSE_COMPATIBLE_JAVA_VERSION = 17
 open class EclipseCompatibleJavaExtension @Inject constructor(private val project: Project) {
 
   val languageVersion: JavaLanguageVersion by lazy {
-    project.run {
-      val projectVersion = the<JavaPluginExtension>().toolchain.languageVersion.get()
-      val minimumVersion = JavaLanguageVersion.of(MINIMUM_ECLIPSE_COMPATIBLE_JAVA_VERSION)
-      if (projectVersion.canCompileOrRun(minimumVersion)) projectVersion else minimumVersion
-    }
+    val projectVersion = project.the<JavaPluginExtension>().toolchain.languageVersion.get()
+    val minimumVersion = JavaLanguageVersion.of(MINIMUM_ECLIPSE_COMPATIBLE_JAVA_VERSION)
+    if (projectVersion.canCompileOrRun(minimumVersion)) projectVersion else minimumVersion
   }
 
   val launcher: Provider<JavaLauncher> by lazy {

--- a/cast/java/ecj/build.gradle.kts
+++ b/cast/java/ecj/build.gradle.kts
@@ -42,7 +42,7 @@ val run by
               "LArray1")
 
       // log output to file, although we don"t validate it
-      val outFile = project.layout.buildDirectory.file("SourceDirCallGraph.log")
+      val outFile = layout.buildDirectory.file("SourceDirCallGraph.log")
       outputs.file(outFile)
       doFirst {
         outFile.get().asFile.outputStream().let {

--- a/cast/js/build.gradle.kts
+++ b/cast/js/build.gradle.kts
@@ -52,7 +52,7 @@ val unpackAjaxslt by
           relativePath = RelativePath(!isDirectory, *newSegments)
         }
       }
-      into(project.layout.buildDirectory.dir(name))
+      into(layout.buildDirectory.dir(name))
     }
 
 val processTestResources by tasks.existing(Copy::class) { from(unpackAjaxslt) { into("ajaxslt") } }

--- a/cast/smoke_main/build.gradle.kts
+++ b/cast/smoke_main/build.gradle.kts
@@ -98,7 +98,7 @@ application {
               argumentProviders.add { listOf(pathElements.get().joinToString(":")) }
 
               // log output to file, although we don"t validate it
-              val outFile = project.layout.buildDirectory.file("${name}.log")
+              val outFile = layout.buildDirectory.file("${name}.log")
               outputs.file(outFile)
               doFirst {
                 outFile.get().asFile.outputStream().let {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -109,7 +109,7 @@ val kawaChess =
 val unpackKawaChess by
     tasks.registering {
       inputs.files(kawaChess)
-      outputs.dir(project.layout.buildDirectory.file("kawa-chess-$kawaChessCommitHash"))
+      outputs.dir(layout.buildDirectory.file("kawa-chess-$kawaChessCommitHash"))
 
       objects.newInstance<ExtractServices>().run {
         doLast {
@@ -130,7 +130,7 @@ val compileKawaSchemeChessMain by
 val buildChessJar by
     tasks.registering(Jar::class) {
       from(compileKawaSchemeChessMain)
-      destinationDirectory = project.layout.buildDirectory.dir(name)
+      destinationDirectory = layout.buildDirectory.dir(name)
       archiveFileName = "kawachess.jar"
       archiveVersion = null as String?
     }
@@ -148,7 +148,7 @@ val compileKawaSchemeTest by
 val buildKawaTestJar by
     tasks.registering(Jar::class) {
       from(compileKawaSchemeTest)
-      destinationDirectory = project.layout.buildDirectory.dir(name)
+      destinationDirectory = layout.buildDirectory.dir(name)
       archiveFileName = "kawatest.jar"
       archiveVersion = null as String?
     }
@@ -233,7 +233,7 @@ val unpackOcamlJava by
             downloadOcamlJava.singleFile.path,
             "ocamljava-$ocamlJavaVersion/lib/ocamljava.jar")
       }
-      val outputDir = project.layout.buildDirectory.dir(name)
+      val outputDir = layout.buildDirectory.dir(name)
       workingDir(outputDir)
       outputs.dir(outputDir)
     }
@@ -241,7 +241,7 @@ val unpackOcamlJava by
 val prepareGenerateHelloHashJar by
     tasks.registering(Sync::class) {
       from("ocaml/hello_hash.ml")
-      val outputDir = project.layout.buildDirectory.dir(name)
+      val outputDir = layout.buildDirectory.dir(name)
       into(outputDir)
       extra["copiedOcamlSource"] = file("${outputDir.get()}/${source.singleFile.name}")
     }


### PR DESCRIPTION
Code in a `*.gradle.kts` script has implicit access to members of the current `Project`.  Thus, it is rarely necessary to use `project.` as a prefix to access members of that instance.