### PR TITLE
IntelliJ IDEA should use Zulu JDK 17

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">
@@ -6,7 +7,7 @@
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="ES6" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="zulu-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
   <component name="TaskProjectConfiguration">


### PR DESCRIPTION
Previously we were using JDK 11, but this project now requires JDK 17 or newer.  I opted for the Zulu distribution of Java 17, since [that's what we use in our GitHub CI actions](https://github.com/wala/WALA/blob/803325995285fcf18f9c802211c1df444dc2e623/.github/workflows/continuous-integration.yml#L44).