### PR TITLE
Postpone some work until after task configuration

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/cast/helpers.kt
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/cast/helpers.kt
@@ -79,11 +79,13 @@ fun AbstractLinkTask.addJvmLibrary(binary: CppBinary) {
       })
 }
 
-fun AbstractLinkTask.addRpath(library: File) {
+fun AbstractLinkTask.addRpath(library: Provider<File>) {
   if (!(project.rootProject.extra["isWindows"] as Boolean)) {
-    linkerArgs.add("-Wl,-rpath,${library.parent}")
+    linkerArgs.add(project.provider { "-Wl,-rpath,${library.get().parent}" })
   }
 }
+
+fun AbstractLinkTask.addRpath(library: File) = addRpath(project.provider { library })
 
 val AbstractLinkTask.nativeLibraryOutput: File
   get() =

--- a/cast/build.gradle.kts
+++ b/cast/build.gradle.kts
@@ -61,17 +61,21 @@ artifacts.add(
 tasks.named<Javadoc>("javadoc") {
   inputs.files(castJsPackageListDirectory)
 
-  val extdocURL = castJsJavadocDestinationDirectory.get().singleFile
-  val packagelistLoc = castJsPackageListDirectory.get().singleFile
+  val extdocURL = castJsJavadocDestinationDirectory.map { it.singleFile }
+  val packagelistLoc = castJsPackageListDirectory.map { it.singleFile }
   inputs.property("extdocURL", extdocURL)
   inputs.property("packagelistLoc", packagelistLoc)
-  (options as StandardJavadocDocletOptions).linksOffline(
-      extdocURL.toString(), packagelistLoc.toString())
+
+  doFirst {
+    (options as StandardJavadocDocletOptions).linksOffline(
+        extdocURL.get().toString(), packagelistLoc.get().toString())
+  }
 }
 
 tasks.named<Test>("test") {
   inputs.files(xlatorTestSharedLibrary)
-  systemProperty("java.library.path", xlatorTestSharedLibrary.get().singleFile.parent)
+  val xlatorTestSharedLibraryDir = xlatorTestSharedLibrary.map { it.singleFile.parent }
+  doFirst { systemProperty("java.library.path", xlatorTestSharedLibraryDir.get()) }
 
   if (rootProject.extra["isWindows"] as Boolean) {
 
@@ -85,7 +89,7 @@ tasks.named<Test>("test") {
 
     inputs.files(castCastSharedLibrary)
     val pathEntry = environment.entries.find { it.key.equals("path", true) }!!
-    environment(
-        pathEntry.key, "${pathEntry.value};${castCastSharedLibrary.get().singleFile.parent}")
+    val castCastSharedLibraryDir = castCastSharedLibrary.map { it.singleFile.parent }
+    doFirst { environment(pathEntry.key, "${pathEntry.value};${castCastSharedLibraryDir.get()}") }
   }
 }

--- a/cast/java/ecj/build.gradle.kts
+++ b/cast/java/ecj/build.gradle.kts
@@ -33,13 +33,11 @@ application.mainClass = "com.ibm.wala.cast.java.ecj.util.SourceDirCallGraph"
 
 val run by
     tasks.existing(JavaExec::class) {
+      val runSourceDirectoryPath = runSourceDirectory.map { it.files.single().toString() }
       // this is for testing purposes
-      args =
-          listOf(
-              "-sourceDir",
-              runSourceDirectory.get().files.single().toString(),
-              "-mainClass",
-              "LArray1")
+      argumentProviders.add {
+        listOf("-sourceDir", runSourceDirectoryPath.get(), "-mainClass", "LArray1")
+      }
 
       // log output to file, although we don"t validate it
       val outFile = project.layout.buildDirectory.file("SourceDirCallGraph.log")

--- a/cast/smoke_main/build.gradle.kts
+++ b/cast/smoke_main/build.gradle.kts
@@ -64,8 +64,7 @@ application {
       val libxlatorTest =
           (if (isOptimized) xlatorTestReleaseSharedLibraryConfig
               else xlatorTestDebugSharedLibraryConfig)
-              .get()
-              .singleFile
+              .map { it.singleFile }
       addRpath(libxlatorTest)
       addCastLibrary(this@whenElementFinalized)
 
@@ -84,10 +83,11 @@ application {
 
               // xlator Java bytecode + implementation of native methods
               val pathElements = project.objects.listProperty<File>()
-              pathElements.addAll(files("../build/classes/java/test", libxlatorTest.parent))
+              pathElements.addAll(
+                  files("../build/classes/java/test", libxlatorTest.map { it.parent }))
 
               // "primordial.txt" resource loaded during test
-              pathElements.add(coreResources.get().singleFile)
+              pathElements.add(coreResources.map { it.singleFile })
               inputs.files(coreResources)
 
               // additional supporting Java class files


### PR DESCRIPTION
The more work we do during task _configuration_, the more likely we are to trigger something (e.g., a large dependency download) that won't actually be needed.  We should prefer to postpone work until task _execution_ time, since at that point we know that there is truly something to do.