### PR TITLE
Enable Gradle configuration-on-demand

### DIFF
--- a/code-coverage-report/build.gradle.kts
+++ b/code-coverage-report/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
   id("jacoco-report-aggregation")
 }
 
-dependencies {
-  rootProject.allprojects { plugins.withId("jacoco") { jacocoAggregation(this@allprojects) } }
+(rootProject.subprojects - project).forEach {
+  evaluationDependsOn(it.path)
+  it.plugins.withId("jacoco") { dependencies.jacocoAggregation(it) }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,7 @@ dependency.analysis.print.build.health=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.parallel=true
+org.gradle.configureondemand=true
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
 org.gradle.parallel=true
 


### PR DESCRIPTION
[Configuration-on-demand](https://docs.gradle.org/current/userguide/multi_project_configuration_and_execution.html) lets Gradle skip configuring subprojects that have no tasks to run.  For example, if you tell Gradle to build the `:util` subproject, then there is no need to configure the `:dalvik` subproject or even to compile the `:dalvik` subproject's build script.