### PR TITLE
Use `pluginManager`, not `plugins`

### DIFF
--- a/code-coverage-report/build.gradle.kts
+++ b/code-coverage-report/build.gradle.kts
@@ -7,5 +7,5 @@ plugins {
 
 (rootProject.subprojects - project).forEach {
   evaluationDependsOn(it.path)
-  it.plugins.withId("jacoco") { dependencies.jacocoAggregation(it) }
+  it.pluginManager.withPlugin("jacoco") { dependencies.jacocoAggregation(it) }
 }


### PR DESCRIPTION
According to [Gradle's
documentation](https://docs.gradle.org/current/javadoc/org/gradle/api/plugins/PluginAware.html#getPlugins()), `getPlugins` is not deprecated, but it is preferred to use the plugin manager (via `getPluginManager`).