### PR TITLE
Use Gradle native-code APIs to check for Windows

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/cast/helpers.kt
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/cast/helpers.kt
@@ -9,7 +9,6 @@ import org.gradle.api.tasks.TaskInstantiationException
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.internal.jvm.Jvm
 import org.gradle.kotlin.dsl.closureOf
-import org.gradle.kotlin.dsl.extra
 import org.gradle.language.cpp.CppBinary
 import org.gradle.nativeplatform.OperatingSystemFamily
 import org.gradle.nativeplatform.tasks.AbstractLinkTask
@@ -83,7 +82,7 @@ fun AbstractLinkTask.addJvmLibrary(binary: CppBinary) {
 }
 
 fun AbstractLinkTask.addRpath(library: Provider<File>) {
-  if (!(project.rootProject.extra["isWindows"] as Boolean)) {
+  if (!targetPlatform.get().operatingSystem.isWindows) {
     linkerArgs.add(project.provider { "-Wl,-rpath,${library.get().parent}" })
   }
 }

--- a/cast/smoke_main/build.gradle.kts
+++ b/cast/smoke_main/build.gradle.kts
@@ -108,7 +108,7 @@ application {
               }
             }
 
-        if (!(rootProject.extra["isWindows"] as Boolean)) {
+        if (!targetPlatform.get().operatingSystem.isWindows) {
           // Known to be broken on Windows, but not intentionally so.  Please fix if you
           // know how!  <https://github.com/wala/WALA/issues/608>
           tasks.named("check").configure { dependsOn(checkSmokeMain) }


### PR DESCRIPTION
Previously, we relied on the root project to provide an extra `isWindows` property to help decide whether to trigger certain Windows-specific linker behaviors.  Now we instead use APIs that are part of Gradle's tasks for linking native code.  This change reduces coupling between subprojects and the root project.