### PR TITLE
Decouple OS detection from Gradle root project

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/operating-system.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/operating-system.gradle.kts
@@ -1,0 +1,23 @@
+package com.ibm.wala.gradle
+
+/**
+ * Utility script for operating system detection in Gradle builds.
+ *
+ * This script provides variables to identify the current operating system, which can be used to
+ * configure platform-specific build settings.
+ */
+
+/**
+ * The name of the operating system as reported by the Java runtime.
+ *
+ * This value is obtained from
+ * [the `os.name` system property](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/System.html#getProperties()).
+ */
+val osName: String by extra(System.getProperty("os.name"))
+
+/**
+ * Indicates whether the current operating system is Windows.
+ *
+ * This is determined by checking if the operating system name starts with `"Windows "`.
+ */
+@Suppress("unused") val isWindows by extra(osName.startsWith("Windows "))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,9 +30,6 @@ repositories {
   mavenCentral()
 }
 
-val osName: String by extra(System.getProperty("os.name"))
-val isWindows by extra(osName.startsWith("Windows "))
-
 JavaVersion.current().let {
   if (!it.isCompatibleWith(VERSION_17)) {
     logger.error(

--- a/cast/build.gradle.kts
+++ b/cast/build.gradle.kts
@@ -4,6 +4,7 @@ import org.gradle.language.cpp.CppBinary.OPTIMIZED_ATTRIBUTE
 
 plugins {
   id("com.ibm.wala.gradle.java")
+  id("com.ibm.wala.gradle.operating-system")
   id("com.ibm.wala.gradle.publishing")
 }
 
@@ -77,7 +78,7 @@ tasks.named<Test>("test") {
   val xlatorTestSharedLibraryDir = xlatorTestSharedLibrary.map { it.singleFile.parent }
   doFirst { systemProperty("java.library.path", xlatorTestSharedLibraryDir.get()) }
 
-  if (rootProject.extra["isWindows"] as Boolean) {
+  if (project.extra["isWindows"] as Boolean) {
 
     // Windows has nothing akin to RPATH for embedding DLL search paths in other DLLs or
     // executables.  Instead, we need to ensure that any required DLLs are in the standard

--- a/dalvik/build.gradle.kts
+++ b/dalvik/build.gradle.kts
@@ -2,6 +2,7 @@ import com.ibm.wala.gradle.adHocDownload
 
 plugins {
   id("com.ibm.wala.gradle.java")
+  id("com.ibm.wala.gradle.operating-system")
   id("com.ibm.wala.gradle.publishing")
 }
 
@@ -11,7 +12,7 @@ val extraTestResources by configurations.registering { isCanBeConsumed = false }
 
 val sampleCupSources by configurations.registering { isCanBeConsumed = false }
 
-val isWindows: Boolean by rootProject.extra
+val isWindows: Boolean by extra
 
 val platformsVersion by extra("android-28")
 
@@ -123,7 +124,7 @@ val unpackDroidBench by
     }
 
 val downloadAndroidSdk = run {
-  val osName: String by rootProject.extra
+  val osName: String by extra
   val sdkOs =
       when {
         "Linux".toRegex().containsMatchIn(osName) -> "linux"


### PR DESCRIPTION
We are refining Gradle subprojects to be less intertwined.  In this specific case, a subproject no longer looks to the root project to identify the current operating system.  Instead, any subproject that requires this information should import a small project plugin that provides this information.