### PR TITLE
Make check task depend on running ECJ command-line driver

### DIFF
--- a/cast/java/ecj/build.gradle.kts
+++ b/cast/java/ecj/build.gradle.kts
@@ -50,11 +50,11 @@ val run by
       }
     }
 
+// ensure the command-line driver for running ECJ works
+tasks.named("check") { dependsOn(run) }
+
 tasks.named<Test>("test") {
   maxHeapSize = "1200M"
 
   workingDir(project(":cast:java:test:data").projectDir)
-
-  // ensure the command-line driver for running ECJ works
-  dependsOn(run)
 }


### PR DESCRIPTION
Previously the `test` task had this dependence, but this prevented running the unit tests when the command-line driver was failing for some reason.