### PR TITLE
Treat a library as a non-linked input file

### DIFF
--- a/cast/smoke_main/build.gradle.kts
+++ b/cast/smoke_main/build.gradle.kts
@@ -53,7 +53,6 @@ application {
     smokeMainExtraPathElements(projects.core)
     smokeMainExtraPathElements(projects.util)
     implementation(projects.cast.cast)
-    implementation(projects.cast.xlatorTest)
     xlatorTestDebugSharedLibraryConfig(projects.cast.xlatorTest)
     xlatorTestReleaseSharedLibraryConfig(projects.cast.xlatorTest)
   }
@@ -61,10 +60,10 @@ application {
   binaries.whenElementFinalized {
     this as CppExecutable
     linkTask.configure {
-      val libxlatorTest =
-          (if (isOptimized) xlatorTestReleaseSharedLibraryConfig
-              else xlatorTestDebugSharedLibraryConfig)
-              .map { it.singleFile }
+      val libxlatorTestConfig =
+          if (isOptimized) xlatorTestReleaseSharedLibraryConfig
+          else xlatorTestDebugSharedLibraryConfig
+      val libxlatorTest = libxlatorTestConfig.map { it.singleFile }
       addRpath(libxlatorTest)
       addCastLibrary(this@whenElementFinalized)
 
@@ -82,6 +81,7 @@ application {
                   })
 
               // xlator Java bytecode + implementation of native methods
+              inputs.files(libxlatorTestConfig)
               val pathElements = project.objects.listProperty<File>()
               pathElements.addAll(
                   files("../build/classes/java/test", libxlatorTest.map { it.parent }))


### PR DESCRIPTION
The `checkSmokeMain` task requires that `libxlator_test.so` be available when the test is run.  However, the `smoke_main` executable used for that test does not actually need to be linked with `libxlator_test.so`.