### PR TITLE
Report coverage using just-tested Java version

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -64,7 +64,7 @@ jobs:
           path: '**/build/test-results/test/TEST-*.xml'
       - name: Aggregate coverage
         id: jacoco_report
-        run: ./gradlew testCodeCoverageReport
+        run: ./gradlew testCodeCoverageReport "-Pcom.ibm.wala.jdk-version=${{ matrix.java }}"
         if: matrix.coverage && github.repository == 'wala/WALA'
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
Previously we were running tests under Java 17, 21, and 24.  We were then reporting coverage from the Java 17 tests.  However, when aggregating that coverage report, we were actually asking for the coverage of tests run using Java 11 (the default value of `com.ibm.wala.jdk-version`).  That led to us needing to rerun nearly all tests for a second time.

Now we explicitly set the Java version when aggregating test coverage reports in the same way that we set it when running the tests the first time.  So when we aggregate coverage under Java 17, we're still requesting coverage data under Java 17, not Java 11.  That test data should already be available, and up-to-date, so we won't need to rerun the tests for a second time.

Fixes #1555.