### PR TITLE
Simplify rpath handling for Gradle native linking

### DIFF
--- a/cast/cast/build.gradle.kts
+++ b/cast/cast/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.ibm.wala.gradle.cast.addJvmLibrary
+import com.ibm.wala.gradle.cast.addRpaths
 import com.ibm.wala.gradle.cast.configure
 import com.ibm.wala.gradle.cast.nativeLibraryOutput
 
@@ -12,6 +13,7 @@ library {
     compileTask.configure { macros["BUILD_CAST_DLL"] = "1" }
 
     this as CppSharedLibrary
+    linkTask.addRpaths()
     linkTask.configure {
       if (targetMachine.operatingSystemFamily.isMacOs) {
         linkerArgs.add("-Wl,-install_name,@rpath/${nativeLibraryOutput.name}")

--- a/cast/smoke_main/build.gradle.kts
+++ b/cast/smoke_main/build.gradle.kts
@@ -1,5 +1,5 @@
-import com.ibm.wala.gradle.cast.addCastLibrary
-import com.ibm.wala.gradle.cast.addRpath
+import com.ibm.wala.gradle.cast.addJvmLibrary
+import com.ibm.wala.gradle.cast.addRpaths
 import com.ibm.wala.gradle.cast.configure
 import org.gradle.api.attributes.LibraryElements.CLASSES
 import org.gradle.api.attributes.LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE
@@ -59,13 +59,13 @@ application {
 
   binaries.whenElementFinalized {
     this as CppExecutable
+    linkTask.addRpaths()
     linkTask.configure {
       val libxlatorTestConfig =
           if (isOptimized) xlatorTestReleaseSharedLibraryConfig
           else xlatorTestDebugSharedLibraryConfig
       val libxlatorTest = libxlatorTestConfig.map { it.singleFile }
-      addRpath(libxlatorTest)
-      addCastLibrary(this@whenElementFinalized)
+      addJvmLibrary(this@whenElementFinalized)
 
       if (isDebuggable && !isOptimized) {
         val checkSmokeMain by

--- a/cast/xlator_test/build.gradle.kts
+++ b/cast/xlator_test/build.gradle.kts
@@ -1,4 +1,5 @@
-import com.ibm.wala.gradle.cast.addCastLibrary
+import com.ibm.wala.gradle.cast.addJvmLibrary
+import com.ibm.wala.gradle.cast.addRpaths
 
 plugins {
   `cpp-library`
@@ -18,6 +19,7 @@ library {
 
   binaries.whenElementFinalized {
     this as CppSharedLibrary
-    linkTask.get().addCastLibrary(this)
+    linkTask.addRpaths()
+    linkTask.get().addJvmLibrary(this)
   }
 }


### PR DESCRIPTION
Previously, we used various helper functions to add an rpath for each shared library.  However, it turns out to be simpler to manage rpaths all in one place.  Now, we wait until linker arguments are actually needed, and then compute _all_ required rpath arguments based on the _complete_ set of linked libraries.

A nice side effect of this change is that preparing to add these rpaths can work solely on a linker task _provider_, without requiring that the linker task be eagerly instantiated.