### PR TITLE
Treat `addJvmLibrary` as a `CppBinary` method

### DIFF
--- a/cast/cast/build.gradle.kts
+++ b/cast/cast/build.gradle.kts
@@ -13,12 +13,13 @@ library {
     compileTask.configure { macros["BUILD_CAST_DLL"] = "1" }
 
     this as CppSharedLibrary
+    addJvmLibrary(project)
+
     linkTask.addRpaths()
     linkTask.configure {
       if (targetMachine.operatingSystemFamily.isMacOs) {
         linkerArgs.add("-Wl,-install_name,@rpath/${nativeLibraryOutput.name}")
       }
-      addJvmLibrary(this@whenElementFinalized)
     }
   }
 }

--- a/cast/smoke_main/build.gradle.kts
+++ b/cast/smoke_main/build.gradle.kts
@@ -59,13 +59,15 @@ application {
 
   binaries.whenElementFinalized {
     this as CppExecutable
+
+    addJvmLibrary(project)
+
     linkTask.addRpaths()
     linkTask.configure {
       val libxlatorTestConfig =
           if (isOptimized) xlatorTestReleaseSharedLibraryConfig
           else xlatorTestDebugSharedLibraryConfig
       val libxlatorTest = libxlatorTestConfig.map { it.singleFile }
-      addJvmLibrary(this@whenElementFinalized)
 
       if (isDebuggable && !isOptimized) {
         val checkSmokeMain by

--- a/cast/xlator_test/build.gradle.kts
+++ b/cast/xlator_test/build.gradle.kts
@@ -19,7 +19,7 @@ library {
 
   binaries.whenElementFinalized {
     this as CppSharedLibrary
+    addJvmLibrary(project)
     linkTask.addRpaths()
-    linkTask.get().addJvmLibrary(this)
   }
 }


### PR DESCRIPTION
Previously, this helper was an `AbstractLinkTask` extension method. However, we no longer do anything special with that link task.  Instead, we're operating on the enclosing `Project` instance and the target `CppBinary` instance.  So we can simplify a bit by turning `addJvmLibrary` into a `CppBinary` extension method instead of an `AbstractLinkTask` extension method.

A desirable side effect of this change is that we no longer force eager configuration of an `AbstractLinkTask` task in order to add the JVM library to its target binary.