### PR TITLE
Simplify setting macOS-specific linker flag

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/cast/helpers.kt
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/cast/helpers.kt
@@ -81,9 +81,3 @@ fun Provider<out AbstractLinkTask>.addRpaths() {
     }
   }
 }
-
-val AbstractLinkTask.nativeLibraryOutput: File
-  get() =
-      // On all supported platforms, the link task's first two outputs are a directory and a library
-      // in that directory. On Windows, the link task also has a third output file: a DLL.
-      outputs.files.elementAt(1)

--- a/cast/cast/build.gradle.kts
+++ b/cast/cast/build.gradle.kts
@@ -1,7 +1,6 @@
 import com.ibm.wala.gradle.cast.addJvmLibrary
 import com.ibm.wala.gradle.cast.addRpaths
 import com.ibm.wala.gradle.cast.configure
-import com.ibm.wala.gradle.cast.nativeLibraryOutput
 
 plugins {
   `cpp-library`
@@ -18,7 +17,7 @@ library {
     linkTask.addRpaths()
     linkTask.configure {
       if (targetMachine.operatingSystemFamily.isMacOs) {
-        linkerArgs.add("-Wl,-install_name,@rpath/${nativeLibraryOutput.name}")
+        linkerArgs.add(provider { "-Wl,-install_name,@rpath/${linkedFile.get().asFile.name}" })
       }
     }
   }


### PR DESCRIPTION
Also remove the `AbstractLinkTask.nativeLibraryOutput`, since we no longer have any use for it after this simplification.