### PR TITLE
Factor out operating on all Java subprojects

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java-projects.kt
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java-projects.kt
@@ -1,0 +1,51 @@
+package com.ibm.wala.gradle
+
+/**
+ * Utility functions and properties for working with Java projects in the WALA build system.
+ *
+ * This file provides functionality to [identify Java projects][Project.isJavaProject], [collect all
+ * Java projects from the root project's subprojects][Project.allJavaProjects], and
+ * [perform operations on those Java projects][Project.forEachJavaProject]. These utilities help
+ * streamline build configuration by making it easier to apply common settings across multiple Java
+ * projects.
+ *
+ * See also
+ * [a related Gradle Forums discussion of alternate strategies](https://discuss.gradle.org/t/configuration-on-demand-versus-plugins-withid/51264).
+ */
+import org.gradle.api.Project
+
+/**
+ * Determines whether this project is a Java project.
+ *
+ * @return `false` for the root project and specific cast-related projects, `true` for all other
+ *   projects
+ */
+val Project.isJavaProject
+  get() =
+      when (path) {
+        ":",
+        ":cast:cast",
+        ":cast:java:test",
+        ":cast:js:html",
+        ":cast:smoke_main",
+        ":cast:xlator_test", -> false
+        else -> true
+      }
+
+/**
+ * Gets all Java projects from [rootProject][the root project]'s subprojects.
+ *
+ * @return A filtered list of subprojects that are Java projects (as determined by the
+ *   [isJavaProject] property)
+ */
+val Project.allJavaProjects
+  get() = rootProject.subprojects.filter { it.isJavaProject }
+
+/**
+ * Performs the given [action] for each of [rootProject][the root project]'s Java subprojects.
+ *
+ * @param action The action to perform on each Java project
+ */
+fun Project.forEachJavaProject(action: (Project) -> Unit) {
+  allJavaProjects.forEach(action)
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@
 
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import com.github.gradle.node.npm.task.NpxTask
+import com.ibm.wala.gradle.forEachJavaProject
 import org.gradle.api.JavaVersion.VERSION_17
 
 buildscript { dependencies.classpath(libs.commons.io) }
@@ -56,13 +57,11 @@ val aggregatedJavadocClasspath by configurations.registering { isCanBeConsumed =
 val aggregatedJavadocSource by configurations.registering { isCanBeConsumed = false }
 
 dependencies {
-  subprojects {
-    pluginManager.withPlugin("java-base") {
-      aggregatedJavadocClasspath(
-          project(mapOf("path" to path, "configuration" to "javadocClasspath")))
+  forEachJavaProject {
+    aggregatedJavadocClasspath(
+        project(mapOf("path" to it.path, "configuration" to "javadocClasspath")))
 
-      aggregatedJavadocSource(project(mapOf("path" to path, "configuration" to "javadocSource")))
-    }
+    aggregatedJavadocSource(project(mapOf("path" to it.path, "configuration" to "javadocSource")))
   }
 }
 

--- a/code-coverage-report/build.gradle.kts
+++ b/code-coverage-report/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.ibm.wala.gradle.forEachJavaProject
+
 plugins {
   id("com.ibm.wala.gradle.eclipse-maven-central")
   id("com.ibm.wala.gradle.java")
@@ -5,7 +7,4 @@ plugins {
   id("jacoco-report-aggregation")
 }
 
-(rootProject.subprojects - project).forEach {
-  evaluationDependsOn(it.path)
-  it.pluginManager.withPlugin("jacoco") { dependencies.jacocoAggregation(it) }
-}
+forEachJavaProject(dependencies::jacocoAggregation)


### PR DESCRIPTION
Previously we were installing hooks to detect when certain plugins (e.g., `java-base` or `jacoco`) were loaded.  However, that entails one project fiddling with a different project's mutable internal state, which is now considered taboo.

Now, instead, we identify all Java subprojects by explicitly listing the few subprojects that are _not_ Java.  This feels less automated and therefore less elegant.  However, it better matches the modern Gradle trend of isolating (sub)projects from each other, especially regarding mutable project state.

See also [a related Gradle Forums discussion of alternate strategies](https://discuss.gradle.org/t/configuration-on-demand-versus-plugins-withid/51264).