### PR TITLE
Avoid cascaded project property lookups

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -28,5 +28,5 @@ spotless {
 
   kotlinGradle { ktfmt(ktfmtVersion) }
 
-  findProperty("spotless.ratchet.from")?.let { ratchetFrom(it as String) }
+  providers.gradleProperty("spotless.ratchet.from").orNull?.let(::ratchetFrom)
 }

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -98,7 +98,7 @@ tasks.named<Test>("test") {
   include("**/Test*.class")
   exclude("**/*AndroidLibs*.class")
 
-  val trial = project.findProperty("trial")
+  val trial = providers.gradleProperty("trial").orNull
   if (trial != null) {
     outputs.upToDateWhen { false }
     afterTest(
@@ -116,7 +116,7 @@ tasks.named<Test>("test") {
   }
 }
 
-if (hasProperty("excludeSlowTests")) {
+if (providers.gradleProperty("excludeSlowTests").isPresent) {
   tasks.named<Test>("test") { useJUnitPlatform { excludeTags("slow") } }
 }
 
@@ -136,7 +136,7 @@ tasks.withType<JavaCompile> {
 tasks.withType<JavaCompileUsingEcj> {
 
   // Allow skipping all ECJ compilation tasks by setting a project property.
-  val skipJavaUsingEcjTasks = project.hasProperty("skipJavaUsingEcjTasks")
+  val skipJavaUsingEcjTasks = providers.gradleProperty("skipJavaUsingEcjTasks").isPresent
   onlyIf { !skipJavaUsingEcjTasks }
 
   // ECJ warning / error levels are set via a configuration file, not this argument

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/project.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/project.gradle.kts
@@ -41,7 +41,7 @@ tasks.register<DependencyReportTask>("allDeps") {}
 //
 
 spotless {
-  findProperty("spotless.ratchet.from")?.let { ratchetFrom(it as String) }
+  providers.gradleProperty("spotless.ratchet.from").orNull?.let(::ratchetFrom)
 
   kotlinGradle { ktfmt(versionCatalogs.named("libs").findVersion("ktfmt").get().toString()) }
 }

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
@@ -94,7 +94,7 @@ mavenPublishing {
 publishing {
   repositories.maven {
     name = "fakeRemote"
-    setUrl(rootProject.layout.buildDirectory.dir("maven-fake-remote-repository"))
+    setUrl(rootDir.resolve("build/maven-fake-remote-repository"))
   }
 
   publications.named<MavenPublication>("maven") {

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/subproject.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/subproject.gradle.kts
@@ -7,8 +7,6 @@ plugins {
   id("com.ibm.wala.gradle.project")
 }
 
-version = rootProject.version
-
 ////////////////////////////////////////////////////////////////////////
 //
 //  IntelliJ IDEA IDE integration

--- a/cast/js/rhino/build.gradle.kts
+++ b/cast/js/rhino/build.gradle.kts
@@ -37,7 +37,7 @@ tasks.named<Test>("test") {
     events("passed", "skipped", "failed")
   }
 
-  if (project.hasProperty("excludeRequiresInternetTests") ||
+  if (providers.gradleProperty("excludeRequiresInternetTests").isPresent ||
       gradle.startParameter.isOffline ||
       environment["CI"] == "true") {
     useJUnitPlatform { excludeTags("requires-Internet") }

--- a/ide/tests/build.gradle.kts
+++ b/ide/tests/build.gradle.kts
@@ -97,5 +97,5 @@ tasks.register<JavaExec>("runIFDSExplorerExample") {
   if (System.getProperty("os.name").startsWith("Mac OS X")) {
     jvmArgs = listOf("-XstartOnFirstThread")
   }
-  project.findProperty("args")?.let { args((it as String).split("\\s+".toRegex())) }
+  providers.gradleProperty("args").orNull?.let { args(it.split("\\s+".toRegex())) }
 }


### PR DESCRIPTION
Gradle subprojects inherit properties from their parent projects.  Thus, looking for a property on a project may involve a cascaded sequence of lookups, eventually reaching the root project.  Unfortunately, these cascades are incompatible with Gradle project isolation.  So we now use a different strategy for property lookups.  This strategy should give us the same results in the case of properties on the root Gradle project, which is all we really care about.  However, this strategy is (apparently) compatible with project isolation.

Before this change, trying to enable Gradle project isolation failed with 632 problems, in 10 distinct locations, having 82 distinct messages.  After this change, trying to enable Gradle project isolation fails with 451 problems, in 7 distinct locations, having 58 distinct messages.  The problems that remain appear to all be due to third-party Gradle plugins that are not yet compatible with project isolation.  See <https://github.com/orgs/wala/projects/4> for links to existing bug reports for some (but not all) of those incompatibilities.