### PR TITLE
Fix some weird indentation

### DIFF
--- a/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
+++ b/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
@@ -899,11 +899,13 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
     CAstNode mdast;
 
     if (n.isConstructor()) mdast = createConstructorBody(n, classBinding, context, inits);
-    else if ((n.getModifiers() & Modifier.ABSTRACT) != 0) // abstract
-    mdast = null;
-    else if (n.getBody() == null || n.getBody().statements().isEmpty()) // empty
-    mdast = makeNode(context, fFactory, n, CAstNode.RETURN);
-    else mdast = visitNode(n.getBody(), context);
+    else if ((n.getModifiers() & Modifier.ABSTRACT) != 0) {
+      // abstract
+      mdast = null;
+    } else if (n.getBody() == null || n.getBody().statements().isEmpty()) {
+      // empty
+      mdast = makeNode(context, fFactory, n, CAstNode.RETURN);
+    } else mdast = visitNode(n.getBody(), context);
     // Polyglot comment: Presumably the MethodContext's parent is a ClassContext,
     // and he has the list of initializers. Hopefully the following
     // will glue that stuff in the right place in any constructor body.
@@ -1482,9 +1484,10 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
 
     String t = type.getBinaryName();
     if (init == null) {
-      if (JDT2CAstUtils.isLongOrLess(type)) // doesn't include boolean
-      initNode = fFactory.makeConstant(0);
-      else if (t.equals("D") || t.equals("F")) initNode = fFactory.makeConstant(0.0);
+      if (JDT2CAstUtils.isLongOrLess(type)) {
+        // doesn't include boolean
+        initNode = fFactory.makeConstant(0);
+      } else if (t.equals("D") || t.equals("F")) initNode = fFactory.makeConstant(0.0);
       else initNode = fFactory.makeConstant(null);
     } else initNode = visitNode(init, context);
 

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/CorrelationFinder.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/CorrelationFinder.java
@@ -184,8 +184,10 @@ public class CorrelationFinder {
         indexName = null;
         break;
       }
-      if (!candidateName.contains(" ")) // ignore internal names
-      indexName = candidateName;
+      if (!candidateName.contains(" ")) {
+        // ignore internal names
+        indexName = candidateName;
+      }
     }
     return indexName;
   }

--- a/cast/src/main/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
@@ -3507,9 +3507,10 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
       WalkContext context,
       WalkContext codeContext,
       CAstVisitor<WalkContext> visitor) {
-    if (n.getAST() == null) // presumably abstract
-    declareFunction(n, context);
-    else {
+    if (n.getAST() == null) {
+      // presumably abstract
+      declareFunction(n, context);
+    } else {
       declareFunction(n, context);
       initFunctionEntity(n, codeContext);
     }
@@ -3522,8 +3523,10 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
       WalkContext context,
       WalkContext codeContext,
       CAstVisitor<WalkContext> visitor) {
-    if (n.getAST() != null) // non-abstract
-    closeFunctionEntity(n, context, codeContext);
+    if (n.getAST() != null) {
+      // non-abstract
+      closeFunctionEntity(n, context, codeContext);
+    }
   }
 
   @Override

--- a/scandroid/src/main/java/org/scandroid/flow/types/IKFlow.java
+++ b/scandroid/src/main/java/org/scandroid/flow/types/IKFlow.java
@@ -67,8 +67,10 @@ public class IKFlow<E extends ISSABasicBlock> extends FlowType<E> {
     IKFlow<E> other = (IKFlow<E>) obj;
     if (ik == null) {
       if (other.ik != null) return false;
-    } else if (!ik.equals(other.ik)) // TODO InstanceKey may not supply equals()
-    return false;
+    } else if (!ik.equals(other.ik)) {
+      // TODO InstanceKey may not supply equals()
+      return false;
+    }
     return true;
   }
 

--- a/shrike/src/main/java/com/ibm/wala/shrike/sourcepos/Position.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/sourcepos/Position.java
@@ -68,8 +68,10 @@ public final class Position {
    *     is 4194303. The maximum column number is 1023.
    */
   Position(int line, int column) throws InvalidPositionException {
-    if (line < 0 || line >= 4194304) // 4194304 = 2^32 >>> LINE_SHIFT
-    throw new InvalidPositionException(InvalidPositionException.Cause.LINE_NUMBER_OUT_OF_RANGE);
+    if (line < 0 || line >= 4194304) {
+      // 4194304 = 2^32 >>> LINE_SHIFT
+      throw new InvalidPositionException(InvalidPositionException.Cause.LINE_NUMBER_OUT_OF_RANGE);
+    }
     if (column < 0 || column > COLUMN_MASK)
       throw new InvalidPositionException(InvalidPositionException.Cause.COLUMN_NUMBER_OUT_OF_RANGE);
     if (line == 0 && column != 0)


### PR DESCRIPTION
When an `if` or `else` has a `//` comment on the same line, and the conditionally executed code is just a single statement, then Spotless uses rather strange indentation:

```java
if (condition) // comment
statement;
```

Let's wrap each such conditionally executed statement in a block so that the indentation is more reasonable:

```java
if (condition) {
  // comment
  statement;
}
```

I haven't applied this change to _all_ conditionally executed non-block statements.  I only changed those with a `//` comment that led to the weird indentation shown above.

Thank you for contributing to WALA!  Please see the contribution guidelines at https://github.com/wala/WALA/blob/master/CONTRIBUTING.md for information on code style and general guidelines for pull requests.