### PR TITLE
Find Java test inputs as classpath resources

### DIFF
--- a/cast/java/ecj/build.gradle.kts
+++ b/cast/java/ecj/build.gradle.kts
@@ -14,6 +14,10 @@ walaEclipseMavenCentral {
 
 val runSourceDirectory by configurations.registering { isCanBeConsumed = false }
 
+sourceSets["test"]
+    .resources
+    .srcDir(project(":cast:java:test:data").projectDir.resolve("src/testSubjects/java"))
+
 dependencies {
   implementation(libs.eclipse.ecj)
   implementation(projects.cast)
@@ -53,8 +57,4 @@ val run by
 // ensure the command-line driver for running ECJ works
 tasks.named("check") { dependsOn(run) }
 
-tasks.named<Test>("test") {
-  maxHeapSize = "1200M"
-
-  workingDir(project(":cast:java:test:data").projectDir)
-}
+tasks.named<Test>("test") { maxHeapSize = "1200M" }

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/JavaIRTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/JavaIRTests.java
@@ -617,8 +617,7 @@ public abstract class JavaIRTests extends IRTests {
   @Test
   public void testThinSlice() throws CancelException, IOException {
     String testName = "MiniaturSliceBug";
-    List<String> sources =
-        Collections.singletonList(getTestSrcPath() + File.separator + testName + ".java");
+    Collection<String> sources = singleTestSrc(testName);
     Pair<CallGraph, CallGraphBuilder<? super InstanceKey>> x =
         runTest(sources, rtJar, new String[] {'L' + testName}, emptyList, true, null);
 


### PR DESCRIPTION
Previously the tests in `cast/java/ect` could only run correctly from the `cast/cata/test/data` directory.  That made things brittle.  For example IntelliJ IDEA was not setting this directory correctly when running individual test methods.  Furthermore, Gradle did not know that these tests implicitly took all of
`cast/cata/test/data/src/testSubjects/java/**/*.java` as potential test inputs.

Now we formally declare those test-subject source files as inputs to the `cast/java/ect` subproject's tests.  Furthermore, we find these files using the JVM classpath, which means that we no longer depend on the current working directory being set to anything in particular.  If some test resource cannot be found, we now show a more informative diagnostic message.