### PR TITLE
Prefer `Path` for filesystem paths

### DIFF
--- a/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJIssue666Test.java
+++ b/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJIssue666Test.java
@@ -16,6 +16,7 @@ import com.ibm.wala.ipa.callgraph.Entrypoint;
 import com.ibm.wala.ipa.callgraph.impl.Util;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 
@@ -27,7 +28,7 @@ public class ECJIssue666Test extends Issue666Test {
 
   @Override
   protected AbstractAnalysisEngine<InstanceKey, CallGraphBuilder<InstanceKey>, ?> getAnalysisEngine(
-      final String[] mainClassDescriptors, Collection<String> sources, List<String> libs) {
+      final String[] mainClassDescriptors, Collection<Path> sources, List<String> libs) {
     JavaSourceAnalysisEngine engine =
         new ECJJavaSourceAnalysisEngine() {
           @Override

--- a/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJIssue667Test.java
+++ b/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJIssue667Test.java
@@ -16,6 +16,7 @@ import com.ibm.wala.ipa.callgraph.Entrypoint;
 import com.ibm.wala.ipa.callgraph.impl.Util;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 
@@ -27,7 +28,7 @@ public class ECJIssue667Test extends Issue667Test {
 
   @Override
   protected AbstractAnalysisEngine<InstanceKey, CallGraphBuilder<InstanceKey>, ?> getAnalysisEngine(
-      final String[] mainClassDescriptors, Collection<String> sources, List<String> libs) {
+      final String[] mainClassDescriptors, Collection<Path> sources, List<String> libs) {
     JavaSourceAnalysisEngine engine =
         new ECJJavaSourceAnalysisEngine() {
           @Override

--- a/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJJava15IRTest.java
+++ b/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJJava15IRTest.java
@@ -12,6 +12,7 @@ import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.util.CancelException;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
@@ -27,7 +28,7 @@ public class ECJJava15IRTest extends IRTests {
 
   @Override
   protected AbstractAnalysisEngine<InstanceKey, CallGraphBuilder<InstanceKey>, ?> getAnalysisEngine(
-      final String[] mainClassDescriptors, Collection<String> sources, List<String> libs) {
+      final String[] mainClassDescriptors, Collection<Path> sources, List<String> libs) {
     JavaSourceAnalysisEngine engine =
         new ECJJavaSourceAnalysisEngine() {
           @Override

--- a/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJJava17IRTest.java
+++ b/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJJava17IRTest.java
@@ -30,6 +30,7 @@ import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.collections.Pair;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -50,7 +51,7 @@ public class ECJJava17IRTest extends IRTests {
 
   @Override
   protected AbstractAnalysisEngine<InstanceKey, CallGraphBuilder<InstanceKey>, ?> getAnalysisEngine(
-      final String[] mainClassDescriptors, Collection<String> sources, List<String> libs) {
+      final String[] mainClassDescriptors, Collection<Path> sources, List<String> libs) {
     JavaSourceAnalysisEngine engine =
         new ECJJavaSourceAnalysisEngine() {
           @Override

--- a/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJJavaIRTest.java
+++ b/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJJavaIRTest.java
@@ -16,6 +16,7 @@ import com.ibm.wala.ipa.callgraph.Entrypoint;
 import com.ibm.wala.ipa.callgraph.impl.Util;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 
@@ -27,7 +28,7 @@ public class ECJJavaIRTest extends JavaIRTests {
 
   @Override
   protected AbstractAnalysisEngine<InstanceKey, CallGraphBuilder<InstanceKey>, ?> getAnalysisEngine(
-      final String[] mainClassDescriptors, Collection<String> sources, List<String> libs) {
+      final String[] mainClassDescriptors, Collection<Path> sources, List<String> libs) {
     JavaSourceAnalysisEngine engine =
         new ECJJavaSourceAnalysisEngine() {
           @Override

--- a/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJSyncDuplicatorTest.java
+++ b/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJSyncDuplicatorTest.java
@@ -36,6 +36,7 @@ import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.config.SetOfClasses;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -53,7 +54,7 @@ public class ECJSyncDuplicatorTest extends SyncDuplicatorTests {
 
   @Override
   protected AbstractAnalysisEngine<InstanceKey, CallGraphBuilder<InstanceKey>, ?> getAnalysisEngine(
-      final String[] mainClassDescriptors, Collection<String> sources, List<String> libs) {
+      final String[] mainClassDescriptors, Collection<Path> sources, List<String> libs) {
     JavaSourceAnalysisEngine engine =
         new ECJJavaSourceAnalysisEngine() {
           @Override

--- a/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJTestComments.java
+++ b/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJTestComments.java
@@ -24,6 +24,7 @@ import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.collections.Pair;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -36,7 +37,7 @@ public class ECJTestComments extends IRTests {
 
   @Override
   protected AbstractAnalysisEngine<InstanceKey, CallGraphBuilder<InstanceKey>, ?> getAnalysisEngine(
-      final String[] mainClassDescriptors, Collection<String> sources, List<String> libs) {
+      final String[] mainClassDescriptors, Collection<Path> sources, List<String> libs) {
     JavaSourceAnalysisEngine engine =
         new ECJJavaSourceAnalysisEngine() {
           @Override

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/JavaIRTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/JavaIRTests.java
@@ -59,6 +59,7 @@ import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.util.io.TemporaryFile;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -617,7 +618,7 @@ public abstract class JavaIRTests extends IRTests {
   @Test
   public void testThinSlice() throws CancelException, IOException {
     String testName = "MiniaturSliceBug";
-    Collection<String> sources = singleTestSrc(testName);
+    Collection<Path> sources = singleTestSrc(testName);
     Pair<CallGraph, CallGraphBuilder<? super InstanceKey>> x =
         runTest(sources, rtJar, new String[] {'L' + testName}, emptyList, true, null);
 


### PR DESCRIPTION
A `String` can represent just about anything.  For strings that represent paths in the filesystem, prefer to use `Path`.  It gives us a better API for file-related operations, makes argument-swapping errors less likely, and is simply a semantically richer description of what we are doing.

Ordinarily I would consider an API change like this as backward-incompatible and therefore requiring careful management of version numbers, deprecation, etc..  But the APIs affected by this change are all in test code.  So I think we can justify making this change without a lot of backward-compatibility ceremony.