### PR TITLE
Improve modeling and caching of a Gradle task

### DIFF
--- a/cast/java/ecj/build.gradle.kts
+++ b/cast/java/ecj/build.gradle.kts
@@ -33,15 +33,17 @@ application.mainClass = "com.ibm.wala.cast.java.ecj.util.SourceDirCallGraph"
 
 val run by
     tasks.existing(JavaExec::class) {
-      val runSourceDirectoryPath = runSourceDirectory.map { it.files.single().toString() }
+      val runSourceDirectoryPath = runSourceDirectory.map { it.files.single() }
+      inputs.dir(runSourceDirectoryPath)
       // this is for testing purposes
       argumentProviders.add {
-        listOf("-sourceDir", runSourceDirectoryPath.get(), "-mainClass", "LArray1")
+        listOf("-sourceDir", runSourceDirectoryPath.get().toString(), "-mainClass", "LArray1")
       }
 
       // log output to file, although we don"t validate it
       val outFile = layout.buildDirectory.file("SourceDirCallGraph.log")
       outputs.file(outFile)
+      outputs.cacheIf { true }
       doFirst {
         outFile.get().asFile.outputStream().let {
           standardOutput = it


### PR DESCRIPTION
The `:cast:java:ecj:run` task passes a directory full of source files as a command-line parameter to a subprocess.  We should probably assume that everything in that directory is a potential input to the task.

This same task can be cached, now that we have its inputs and outputs modeled correctly.  It takes about three seconds to run, but its outputs are small.  So we'd rather grab cached outputs if possible instead of computing them from scratch.