### PR TITLE
Remove some unused fields in a test class

### DIFF
--- a/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJIssue666Test.java
+++ b/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJIssue666Test.java
@@ -22,10 +22,6 @@ import java.util.List;
 
 public class ECJIssue666Test extends Issue666Test {
 
-  public ECJIssue666Test() {
-    super(null);
-  }
-
   @Override
   protected AbstractAnalysisEngine<InstanceKey, CallGraphBuilder<InstanceKey>, ?> getAnalysisEngine(
       final String[] mainClassDescriptors, Collection<Path> sources, List<String> libs) {

--- a/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJIssue667Test.java
+++ b/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJIssue667Test.java
@@ -22,10 +22,6 @@ import java.util.List;
 
 public class ECJIssue667Test extends Issue667Test {
 
-  public ECJIssue667Test() {
-    super(null);
-  }
-
   @Override
   protected AbstractAnalysisEngine<InstanceKey, CallGraphBuilder<InstanceKey>, ?> getAnalysisEngine(
       final String[] mainClassDescriptors, Collection<Path> sources, List<String> libs) {

--- a/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJJava15IRTest.java
+++ b/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJJava15IRTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class ECJJava15IRTest extends IRTests {
 
   public ECJJava15IRTest() {
-    super(null);
     dump = true;
   }
 

--- a/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJJava17IRTest.java
+++ b/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJJava17IRTest.java
@@ -45,7 +45,6 @@ public class ECJJava17IRTest extends IRTests {
   private static final String packageName = "javaonepointseven";
 
   public ECJJava17IRTest() {
-    super(null);
     dump = true;
   }
 

--- a/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJJavaIRTest.java
+++ b/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJJavaIRTest.java
@@ -22,10 +22,6 @@ import java.util.List;
 
 public class ECJJavaIRTest extends JavaIRTests {
 
-  public ECJJavaIRTest() {
-    super(null);
-  }
-
   @Override
   protected AbstractAnalysisEngine<InstanceKey, CallGraphBuilder<InstanceKey>, ?> getAnalysisEngine(
       final String[] mainClassDescriptors, Collection<Path> sources, List<String> libs) {

--- a/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJTestComments.java
+++ b/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJTestComments.java
@@ -31,10 +31,6 @@ import org.junit.jupiter.api.Test;
 
 public class ECJTestComments extends IRTests {
 
-  public ECJTestComments() {
-    super(null);
-  }
-
   @Override
   protected AbstractAnalysisEngine<InstanceKey, CallGraphBuilder<InstanceKey>, ?> getAnalysisEngine(
       final String[] mainClassDescriptors, Collection<Path> sources, List<String> libs) {

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
@@ -68,14 +68,6 @@ public abstract class IRTests {
 
   protected boolean dump = true;
 
-  protected IRTests(String projectName) {
-    this.projectName = projectName;
-  }
-
-  protected final String projectName;
-
-  protected static String javaHomePath;
-
   public static final List<String> rtJar = Arrays.asList(WalaProperties.getJ2SEJarFiles());
 
   protected static List<IRAssertion> emptyList = Collections.emptyList();

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/Issue666Test.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/Issue666Test.java
@@ -15,10 +15,6 @@ import org.junit.jupiter.api.Test;
 
 public abstract class Issue666Test extends IRTests {
 
-  public Issue666Test(String projectName) {
-    super(projectName);
-  }
-
   @Test
   public void testPeekErrorCase() throws CancelException, IOException {
     Pair<CallGraph, ?> result =

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/Issue667Test.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/Issue667Test.java
@@ -17,10 +17,6 @@ import org.junit.jupiter.api.Test;
 
 public abstract class Issue667Test extends IRTests {
 
-  public Issue667Test(String projectName) {
-    super(projectName);
-  }
-
   @Test
   public void testDominanceFrontierCase() throws CancelException, IOException {
     Pair<CallGraph, ?> result =

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/JLexTest.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/JLexTest.java
@@ -16,10 +16,6 @@ import org.junit.jupiter.api.Test;
 
 public abstract class JLexTest extends IRTests {
 
-  public JLexTest() {
-    super(null);
-  }
-
   protected String singleJavaInputForTest() {
     return "JLex";
   }

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/JavaIRTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/JavaIRTests.java
@@ -75,14 +75,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 public abstract class JavaIRTests extends IRTests {
 
-  public JavaIRTests(String projectName) {
-    super(projectName);
-  }
-
-  public JavaIRTests() {
-    this(null);
-  }
-
   static List<? extends IRAssertion> callAssertionForInterfaceTest1 =
       Arrays.asList(
           cg -> {

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/SyncDuplicatorTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/SyncDuplicatorTests.java
@@ -25,10 +25,6 @@ import org.junit.jupiter.api.Test;
 
 public abstract class SyncDuplicatorTests extends IRTests {
 
-  public SyncDuplicatorTests() {
-    super(null);
-  }
-
   protected static final CallSiteReference testMethod =
       CallSiteReference.make(
           0,


### PR DESCRIPTION
`IRTests.projectName` was only ever set to `null` and was never subsequently used.  `IRTests.javaHomePath` was neither set nor used. Both can be removed.  Removing the pointless initialization of `IRTests.projectName`, in turn, makes many constructors trivial and therefore removable.