### PR TITLE
Factor out common `if`/`else` code

### DIFF
--- a/core/src/main/java/com/ibm/wala/ipa/slicer/SDG.java
+++ b/core/src/main/java/com/ibm/wala/ipa/slicer/SDG.java
@@ -756,10 +756,8 @@ public class SDG<T extends InstanceKey> extends AbstractNumberedGraph<Statement>
                   }
                 }
               }
-              return Collections.emptySet();
-            } else {
-              return Collections.emptySet();
             }
+            return Collections.emptySet();
           }
         case HEAP_PARAM_CALLER:
           if (dOptions.equals(DataDependenceOptions.NONE)) {


### PR DESCRIPTION
Both branches of this conditional end by returning an empty set.