### PR TITLE
Use implicit `super()` to simplify constructors

### DIFF
--- a/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
+++ b/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
@@ -1336,7 +1336,6 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
         T position,
         Set<CAstAnnotation> annotations,
         T namePos) {
-      super();
       this.type = type;
       this.quals = quals;
       this.name = name;

--- a/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTTypeDictionary.java
+++ b/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTTypeDictionary.java
@@ -114,7 +114,6 @@ public class JDTTypeDictionary extends CAstTypeDictionaryImpl<ITypeBinding> {
     private final CAstType fEltCAstType;
 
     private JdtJavaArrayType(ITypeBinding arrayType) {
-      super();
       fEltJdtType = arrayType.getComponentType();
       fEltCAstType = getCAstTypeFor(fEltJdtType);
     }
@@ -165,7 +164,6 @@ public class JDTTypeDictionary extends CAstTypeDictionaryImpl<ITypeBinding> {
     }
 
     public JdtJavaType(ITypeBinding type) {
-      super();
       fType = type;
     }
 

--- a/cast/java/src/main/java/com/ibm/wala/cast/java/client/JavaSourceAnalysisEngine.java
+++ b/cast/java/src/main/java/com/ibm/wala/cast/java/client/JavaSourceAnalysisEngine.java
@@ -54,10 +54,6 @@ public abstract class JavaSourceAnalysisEngine
   /** Modules which are system or library code TODO: what about extension loader? */
   private final Set<Module> systemEntries = HashSetFactory.make();
 
-  public JavaSourceAnalysisEngine() {
-    super();
-  }
-
   /**
    * Adds the given source module to the source loader's module list. Clients should/may call this
    * method if they don't supply an IJavaProject to the constructor.

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
@@ -272,7 +272,6 @@ public abstract class IRTests {
       private final String annotationTypeName;
 
       public ClassAnnotation(String className, String annotationTypeName) {
-        super();
         this.className = className;
         this.annotationTypeName = annotationTypeName;
       }
@@ -283,7 +282,6 @@ public abstract class IRTests {
       private final String annotationTypeName;
 
       public MethodAnnotation(String methodSig, String annotationTypeName) {
-        super();
         this.methodSig = methodSig;
         this.annotationTypeName = annotationTypeName;
       }

--- a/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/AbstractFieldBasedTest.java
+++ b/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/AbstractFieldBasedTest.java
@@ -28,10 +28,6 @@ public abstract class AbstractFieldBasedTest extends TestJSCallGraphShape {
 
   protected FieldBasedCGUtil util;
 
-  public AbstractFieldBasedTest() {
-    super();
-  }
-
   @BeforeEach
   public void setUp() throws Exception {
     util = new FieldBasedCGUtil(new CAstRhinoTranslatorFactory());

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/CreationSiteVertex.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/CreationSiteVertex.java
@@ -17,7 +17,6 @@ public class CreationSiteVertex extends Vertex implements ObjectVertex {
   private final TypeReference createdType;
 
   public CreationSiteVertex(IMethod node, int instructionIndex, TypeReference createdType) {
-    super();
     this.node = node;
     this.instructionIndex = instructionIndex;
     this.createdType = createdType;

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/html/RangeFileMapping.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/html/RangeFileMapping.java
@@ -34,7 +34,6 @@ public class RangeFileMapping implements FileMapping {
     }
 
     public Range(int rangeStart, int rangeEnd, int rangeStartingLine, int rangeEndingLine) {
-      super();
       this.rangeStart = rangeStart;
       this.rangeEnd = rangeEnd;
       this.rangeStartingLine = rangeStartingLine;

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptConstructorInstanceKeys.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptConstructorInstanceKeys.java
@@ -23,7 +23,6 @@ public class JavaScriptConstructorInstanceKeys implements InstanceKeyFactory {
   private final InstanceKeyFactory base;
 
   public JavaScriptConstructorInstanceKeys(InstanceKeyFactory base) {
-    super();
     this.base = base;
   }
 

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/LoadFileTargetSelector.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/LoadFileTargetSelector.java
@@ -100,7 +100,6 @@ public class LoadFileTargetSelector implements MethodTargetSelector {
 
   public LoadFileTargetSelector(
       MethodTargetSelector base, JSSSAPropagationCallGraphBuilder builder) {
-    super();
     this.base = base;
     this.builder = builder;
   }

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/ExtractionRegion.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/ExtractionRegion.java
@@ -28,7 +28,6 @@ public class ExtractionRegion {
   private final List<String> locals;
 
   public ExtractionRegion(int start, int end, List<String> parameters, List<String> locals) {
-    super();
     this.start = start;
     this.end = end;
     this.parameters = parameters;

--- a/cast/src/main/java/com/ibm/wala/cast/tree/CAstQualifier.java
+++ b/cast/src/main/java/com/ibm/wala/cast/tree/CAstQualifier.java
@@ -62,7 +62,6 @@ public class CAstQualifier {
   private final long fBit;
 
   public CAstQualifier(String name) {
-    super();
     fBit = 1L << sNextBitNum++;
     fName = name;
     sQualifiers.add(this);

--- a/cast/src/main/java/com/ibm/wala/cast/tree/impl/RangePosition.java
+++ b/cast/src/main/java/com/ibm/wala/cast/tree/impl/RangePosition.java
@@ -25,7 +25,6 @@ public class RangePosition extends AbstractSourcePosition {
   private final int endOffset;
 
   public RangePosition(URL url, int startLine, int endLine, int startOffset, int endOffset) {
-    super();
     this.url = url;
     this.startLine = startLine;
     this.endLine = endLine;

--- a/core/src/main/java/com/ibm/wala/analysis/arraybounds/BinaryOpWithConstant.java
+++ b/core/src/main/java/com/ibm/wala/analysis/arraybounds/BinaryOpWithConstant.java
@@ -53,7 +53,6 @@ public class BinaryOpWithConstant {
   private final Integer assigned;
 
   private BinaryOpWithConstant(IOperator op, Integer other, Integer value, Integer assigned) {
-    super();
     this.op = op;
     this.other = other;
     this.value = value;

--- a/core/src/main/java/com/ibm/wala/analysis/arraybounds/hypergraph/weight/Weight.java
+++ b/core/src/main/java/com/ibm/wala/analysis/arraybounds/hypergraph/weight/Weight.java
@@ -27,7 +27,6 @@ public class Weight {
   }
 
   public Weight(Type type, int number) {
-    super();
     this.type = type;
     this.number = number;
   }

--- a/core/src/main/java/com/ibm/wala/classLoader/SyntheticClass.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/SyntheticClass.java
@@ -31,7 +31,6 @@ public abstract class SyntheticClass implements IClass {
    * @param T type reference describing this class
    */
   public SyntheticClass(TypeReference T, IClassHierarchy cha) {
-    super();
     this.T = T;
     this.cha = cha;
   }

--- a/core/src/main/java/com/ibm/wala/classLoader/SyntheticMethod.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/SyntheticMethod.java
@@ -49,7 +49,6 @@ public class SyntheticMethod implements IMethod {
 
   public SyntheticMethod(
       MethodReference method, IClass declaringClass, boolean isStatic, boolean isFactory) {
-    super();
     if (method == null) {
       throw new IllegalArgumentException("null method");
     }
@@ -62,7 +61,6 @@ public class SyntheticMethod implements IMethod {
 
   public SyntheticMethod(
       IMethod method, IClass declaringClass, boolean isStatic, boolean isFactory) {
-    super();
     if (method == null) {
       throw new IllegalArgumentException("null method");
     }

--- a/core/src/main/java/com/ibm/wala/demandpa/flowgraph/DemandPointerFlowGraph.java
+++ b/core/src/main/java/com/ibm/wala/demandpa/flowgraph/DemandPointerFlowGraph.java
@@ -162,7 +162,6 @@ public class DemandPointerFlowGraph extends AbstractDemandFlowGraph implements I
 
     public StatementVisitor(
         HeapModel heapModel, IFlowGraph g, IClassHierarchy cha, CallGraph cg, CGNode node) {
-      super();
       this.heapModel = heapModel;
       this.g = g;
       this.cha = cha;

--- a/core/src/main/java/com/ibm/wala/demandpa/flowgraph/SimpleDemandPointerFlowGraph.java
+++ b/core/src/main/java/com/ibm/wala/demandpa/flowgraph/SimpleDemandPointerFlowGraph.java
@@ -135,7 +135,6 @@ public class SimpleDemandPointerFlowGraph extends SlowSparseNumberedGraph<Object
 
   public SimpleDemandPointerFlowGraph(
       CallGraph cg, HeapModel heapModel, MemoryAccessMap fam, IClassHierarchy cha) {
-    super();
     if (cg == null) {
       throw new IllegalArgumentException("null cg");
     }

--- a/core/src/main/java/com/ibm/wala/demandpa/util/MemoryAccess.java
+++ b/core/src/main/java/com/ibm/wala/demandpa/util/MemoryAccess.java
@@ -26,7 +26,6 @@ public class MemoryAccess {
   private final int instructionIndex;
 
   public MemoryAccess(int index, CGNode node) {
-    super();
     instructionIndex = index;
     this.node = node;
   }

--- a/core/src/main/java/com/ibm/wala/demandpa/util/SimpleMemoryAccessMap.java
+++ b/core/src/main/java/com/ibm/wala/demandpa/util/SimpleMemoryAccessMap.java
@@ -226,7 +226,6 @@ public class SimpleMemoryAccessMap implements MemoryAccessMap {
     final CGNode node;
 
     public MemoryAccessVisitor(ClassLoaderReference loader, CGNode node) {
-      super();
       this.loader = loader;
       this.node = node;
     }

--- a/core/src/main/java/com/ibm/wala/escape/FILiveObjectAnalysis.java
+++ b/core/src/main/java/com/ibm/wala/escape/FILiveObjectAnalysis.java
@@ -55,7 +55,6 @@ public class FILiveObjectAnalysis implements ILiveObjectAnalysis {
   /** */
   public FILiveObjectAnalysis(
       CallGraph callGraph, HeapGraph<?> heapGraph, boolean expensiveIntraproceduralAnalysis) {
-    super();
     this.callGraph = callGraph;
     this.heapGraph = heapGraph;
     this.expensiveIntraproceduralAnalysis = expensiveIntraproceduralAnalysis;

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/AnalysisCache.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/AnalysisCache.java
@@ -32,7 +32,6 @@ public class AnalysisCache implements IAnalysisCacheView {
   private final SSAOptions ssaOptions;
 
   public AnalysisCache(IRFactory<IMethod> irFactory, SSAOptions ssaOptions, SSACache cache) {
-    super();
     this.ssaOptions = ssaOptions;
     this.irFactory = irFactory;
     this.ssaCache = cache;

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/AnalysisScope.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/AnalysisScope.java
@@ -132,7 +132,6 @@ public class AnalysisScope {
   private final Map<Atom, Language> languages;
 
   protected AnalysisScope(Collection<? extends Language> languages) {
-    super();
     this.languages = new HashMap<>();
     for (Language l : languages) {
       this.languages.put(l.getName(), l);

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/CallGraphStats.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/CallGraphStats.java
@@ -33,7 +33,6 @@ public class CallGraphStats {
     private final int bytecodeBytes;
 
     private CGStats(int nodes, int edges, int methods, int bytecodeBytes) {
-      super();
       nNodes = nodes;
       nEdges = edges;
       nMethods = methods;

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/BasicCallGraph.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/BasicCallGraph.java
@@ -77,10 +77,6 @@ public abstract class BasicCallGraph<T> extends AbstractNumberedGraph<CGNode> im
    */
   protected final Map<MethodReference, Set<CGNode>> mr2Nodes = HashMapFactory.make();
 
-  public BasicCallGraph() {
-    super();
-  }
-
   public void init() throws CancelException {
     fakeRoot = makeFakeRootNode();
     Key k = new Key(fakeRoot.getMethod(), fakeRoot.getContext());

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/ExplicitCallGraph.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/ExplicitCallGraph.java
@@ -62,7 +62,6 @@ public class ExplicitCallGraph extends BasicCallGraph<SSAContextInterpreter>
 
   public ExplicitCallGraph(
       IMethod fakeRootMethod, AnalysisOptions options, IAnalysisCacheView cache) {
-    super();
     if (options == null) {
       throw new IllegalArgumentException("null options");
     }

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/LocalPointerKey.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/LocalPointerKey.java
@@ -19,7 +19,6 @@ public class LocalPointerKey extends AbstractLocalPointerKey {
   private final int valueNumber;
 
   public LocalPointerKey(CGNode node, int valueNumber) {
-    super();
     this.node = node;
     this.valueNumber = valueNumber;
     if (valueNumber <= 0) {

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PointsToSetVariable.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PointsToSetVariable.java
@@ -47,7 +47,6 @@ public class PointsToSetVariable extends IntSetVariable<PointsToSetVariable> {
   private PointerKey pointerKey;
 
   public PointsToSetVariable(PointerKey key) {
-    super();
     if (key == null) {
       throw new IllegalArgumentException("null key");
     }

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationCallGraphBuilder.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationCallGraphBuilder.java
@@ -1353,9 +1353,6 @@ public abstract class PropagationCallGraphBuilder implements CallGraphBuilder<In
   }
 
   protected class InverseFilterOperator extends FilterOperator {
-    public InverseFilterOperator() {
-      super();
-    }
 
     @Override
     public String toString() {

--- a/core/src/main/java/com/ibm/wala/ipa/cfg/exceptionpruning/FilteredException.java
+++ b/core/src/main/java/com/ibm/wala/ipa/cfg/exceptionpruning/FilteredException.java
@@ -18,7 +18,6 @@ public class FilteredException {
   }
 
   public FilteredException(TypeReference exception, boolean isSubclassFiltered) {
-    super();
     this.exception = exception;
     this.isSubclassFiltered = isSubclassFiltered;
   }

--- a/core/src/main/java/com/ibm/wala/ipa/slicer/PDG.java
+++ b/core/src/main/java/com/ibm/wala/ipa/slicer/PDG.java
@@ -158,7 +158,6 @@ public class PDG<T extends InstanceKey> implements NumberedLabeledGraph<Statemen
       ModRef<T> modRef,
       boolean ignoreAllocHeapDefs) {
 
-    super();
     if (node == null) {
       throw new IllegalArgumentException("node is null");
     }

--- a/core/src/main/java/com/ibm/wala/ipa/slicer/SDG.java
+++ b/core/src/main/java/com/ibm/wala/ipa/slicer/SDG.java
@@ -129,7 +129,6 @@ public class SDG<T extends InstanceKey> extends AbstractNumberedGraph<Statement>
       ControlDependenceOptions cOptions,
       HeapExclusions heapExclude)
       throws IllegalArgumentException {
-    super();
     if (dOptions == null) {
       throw new IllegalArgumentException("dOptions must not be null");
     }

--- a/core/src/main/java/com/ibm/wala/ipa/slicer/Statement.java
+++ b/core/src/main/java/com/ibm/wala/ipa/slicer/Statement.java
@@ -36,7 +36,6 @@ public abstract class Statement {
   private final CGNode node;
 
   public Statement(final CGNode node) {
-    super();
     if (node == null) {
       throw new IllegalArgumentException("null node");
     }

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/XMLMethodSummaryReader.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/XMLMethodSummaryReader.java
@@ -179,7 +179,6 @@ public class XMLMethodSummaryReader implements BytecodeConstants {
   private static final String V_TRUE = "true";
 
   public XMLMethodSummaryReader(InputStream xmlFile, AnalysisScope scope) {
-    super();
     if (xmlFile == null) {
       throw new IllegalArgumentException("null xmlFile");
     }

--- a/core/src/main/java/com/ibm/wala/types/generics/Signature.java
+++ b/core/src/main/java/com/ibm/wala/types/generics/Signature.java
@@ -21,7 +21,6 @@ public abstract class Signature {
   private final String s;
 
   public Signature(final String s) {
-    super();
     if (s == null) {
       throw new IllegalArgumentException("s cannot be null");
     }

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
@@ -726,7 +726,6 @@ public class AndroidManifestXMLReader {
     private int unimportantDepth = 0;
 
     public SAXHandler() {
-      super();
       parserStack.push(Tag.ROOT);
     }
 

--- a/ide/jdt/src/main/java/com/ibm/wala/ide/AbstractJavaAnalysisAction.java
+++ b/ide/jdt/src/main/java/com/ibm/wala/ide/AbstractJavaAnalysisAction.java
@@ -49,10 +49,6 @@ public abstract class AbstractJavaAnalysisAction
   /** The current {@link ISelection} highlighted in the Eclipse workspace */
   private ISelection currentSelection;
 
-  public AbstractJavaAnalysisAction() {
-    super();
-  }
-
   @Override
   public void setActivePart(IAction action, IWorkbenchPart targetPart) {}
 

--- a/ide/src/main/java/com/ibm/wala/ide/ui/AbstractJFaceRunner.java
+++ b/ide/src/main/java/com/ibm/wala/ide/ui/AbstractJFaceRunner.java
@@ -23,10 +23,6 @@ public abstract class AbstractJFaceRunner {
 
   protected boolean blockInput = false;
 
-  protected AbstractJFaceRunner() {
-    super();
-  }
-
   public ApplicationWindow getApplicationWindow() {
     return applicationWindow;
   }

--- a/ide/src/main/java/com/ibm/wala/ide/ui/SWTTreeViewer.java
+++ b/ide/src/main/java/com/ibm/wala/ide/ui/SWTTreeViewer.java
@@ -44,10 +44,6 @@ public class SWTTreeViewer<T> extends AbstractJFaceRunner {
 
   protected final List<IAction> popUpActions = new ArrayList<>();
 
-  public SWTTreeViewer() {
-    super();
-  }
-
   public Graph<T> getGraphInput() {
     return graphInput;
   }

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/AnnotationsReader.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/AnnotationsReader.java
@@ -117,7 +117,6 @@ public class AnnotationsReader extends AttributeReader {
     public final String enumVal;
 
     public EnumElementValue(String enumType, String enumVal) {
-      super();
       this.enumType = enumType;
       this.enumVal = enumVal;
     }
@@ -135,7 +134,6 @@ public class AnnotationsReader extends AttributeReader {
     public final ElementValue[] vals;
 
     public ArrayElementValue(ElementValue[] vals) {
-      super();
       this.vals = vals;
     }
 
@@ -262,7 +260,6 @@ public class AnnotationsReader extends AttributeReader {
     public final Map<String, ElementValue> elementValues;
 
     public AnnotationAttribute(String type, Map<String, ElementValue> elementValues) {
-      super();
       this.type = type;
       this.elementValues = elementValues;
     }

--- a/util/src/main/java/com/ibm/wala/fixedpoint/impl/DefaultFixedPointSolver.java
+++ b/util/src/main/java/com/ibm/wala/fixedpoint/impl/DefaultFixedPointSolver.java
@@ -24,12 +24,10 @@ public abstract class DefaultFixedPointSolver<T extends IVariable<T>>
    *     tune graph representation
    */
   public DefaultFixedPointSolver(int expectedOut) {
-    super();
     graph = new DefaultFixedPointSystem<>(expectedOut);
   }
 
   public DefaultFixedPointSolver() {
-    super();
     graph = new DefaultFixedPointSystem<>();
   }
 

--- a/util/src/main/java/com/ibm/wala/fixedpoint/impl/DefaultFixedPointSystem.java
+++ b/util/src/main/java/com/ibm/wala/fixedpoint/impl/DefaultFixedPointSystem.java
@@ -53,7 +53,6 @@ public class DefaultFixedPointSystem<T extends IVariable<T>> implements IFixedPo
    *     tune graph representation
    */
   public DefaultFixedPointSystem(int expectedOut) {
-    super();
     graph = new SparseNumberedGraph<>(expectedOut);
   }
 

--- a/util/src/main/java/com/ibm/wala/fixedpoint/impl/GeneralStatement.java
+++ b/util/src/main/java/com/ibm/wala/fixedpoint/impl/GeneralStatement.java
@@ -77,7 +77,6 @@ public abstract class GeneralStatement<T extends IVariable<T>>
    */
   @NullUnmarked
   public GeneralStatement(T lhs, AbstractOperator<T> operator) {
-    super();
     if (operator == null) {
       throw new IllegalArgumentException("null operator");
     }
@@ -96,7 +95,6 @@ public abstract class GeneralStatement<T extends IVariable<T>>
    * @param op2 the second operand on the rhs
    */
   public GeneralStatement(T lhs, AbstractOperator<T> operator, T op1, T op2) {
-    super();
     if (operator == null) {
       throw new IllegalArgumentException("null operator");
     }
@@ -118,7 +116,6 @@ public abstract class GeneralStatement<T extends IVariable<T>>
    * @param op3 the third operand on the rhs
    */
   public GeneralStatement(T lhs, AbstractOperator<T> operator, T op1, T op2, T op3) {
-    super();
     if (operator == null) {
       throw new IllegalArgumentException("null operator");
     }
@@ -140,7 +137,6 @@ public abstract class GeneralStatement<T extends IVariable<T>>
    * @throws IllegalArgumentException if rhs is null
    */
   public GeneralStatement(T lhs, AbstractOperator<T> operator, T[] rhs) {
-    super();
     if (operator == null) {
       throw new IllegalArgumentException("null operator");
     }

--- a/util/src/main/java/com/ibm/wala/fixedpoint/impl/NullaryStatement.java
+++ b/util/src/main/java/com/ibm/wala/fixedpoint/impl/NullaryStatement.java
@@ -60,7 +60,6 @@ public abstract class NullaryStatement<T extends IVariable<T>>
    * @param lhs the lattice cell set by this equation
    */
   protected NullaryStatement(T lhs) {
-    super();
     this.lhs = lhs;
   }
 

--- a/util/src/main/java/com/ibm/wala/fixpoint/UnaryStatement.java
+++ b/util/src/main/java/com/ibm/wala/fixpoint/UnaryStatement.java
@@ -96,7 +96,6 @@ public abstract class UnaryStatement<T extends IVariable<T>>
    * @param rhs the first operand on the rhs
    */
   protected UnaryStatement(T lhs, T rhs) {
-    super();
     this.lhs = lhs;
     this.rhs = rhs;
   }

--- a/util/src/main/java/com/ibm/wala/util/collections/ParanoidHashSet.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/ParanoidHashSet.java
@@ -42,7 +42,6 @@ public class ParanoidHashSet<T> extends LinkedHashSet<T> {
 
   /** */
   public ParanoidHashSet() {
-    super();
     hcFreq = HashMapFactory.make();
   }
 

--- a/util/src/main/java/com/ibm/wala/util/debug/UnimplementedError.java
+++ b/util/src/main/java/com/ibm/wala/util/debug/UnimplementedError.java
@@ -15,9 +15,7 @@ package com.ibm.wala.util.debug;
 public class UnimplementedError extends Error {
   public static final long serialVersionUID = 20981098918191L;
 
-  public UnimplementedError() {
-    super();
-  }
+  public UnimplementedError() {}
 
   public UnimplementedError(String s) {
     super(s);

--- a/util/src/main/java/com/ibm/wala/util/graph/EdgeFilteredNumberedGraph.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/EdgeFilteredNumberedGraph.java
@@ -33,7 +33,6 @@ public class EdgeFilteredNumberedGraph<T> extends AbstractNumberedGraph<T> {
    * @param ignoreEdges relation specifying which edges should be filtered out
    */
   public EdgeFilteredNumberedGraph(NumberedGraph<T> delegate, IBinaryNaturalRelation ignoreEdges) {
-    super();
     this.delegate = delegate;
     this.ignoreEdges = ignoreEdges;
     this.edges = new Edges();

--- a/util/src/main/java/com/ibm/wala/util/graph/GraphIntegrity.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/GraphIntegrity.java
@@ -179,9 +179,7 @@ public class GraphIntegrity {
 
     private static final long serialVersionUID = 1503478788521696930L;
 
-    public UnsoundGraphException() {
-      super();
-    }
+    public UnsoundGraphException() {}
 
     public UnsoundGraphException(String s) {
       super(s);

--- a/util/src/main/java/com/ibm/wala/util/graph/impl/SelfLoopAddedEdgeManager.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/impl/SelfLoopAddedEdgeManager.java
@@ -12,7 +12,6 @@ public class SelfLoopAddedEdgeManager<T> implements EdgeManager<T> {
     private @Nullable T first;
 
     public PrependItterator(Iterator<T> original, @Nullable T first) {
-      super();
       this.original = original;
       this.first = first;
     }

--- a/util/src/main/java/com/ibm/wala/util/graph/labeled/SparseNumberedLabeledEdgeManager.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/labeled/SparseNumberedLabeledEdgeManager.java
@@ -182,7 +182,6 @@ public class SparseNumberedLabeledEdgeManager<T, U>
 
   public SparseNumberedLabeledEdgeManager(
       final NumberedNodeManager<T> nodeManager, U defaultLabel) {
-    super();
     this.defaultLabel = defaultLabel;
     this.nodeManager = nodeManager;
     if (nodeManager == null) {
@@ -191,7 +190,6 @@ public class SparseNumberedLabeledEdgeManager<T, U>
   }
 
   public SparseNumberedLabeledEdgeManager(final NumberedNodeManager<T> nodeManager) {
-    super();
     this.defaultLabel = null;
     this.nodeManager = nodeManager;
     if (nodeManager == null) {

--- a/util/src/main/java/com/ibm/wala/util/intset/MutableSparseIntSet.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/MutableSparseIntSet.java
@@ -38,7 +38,6 @@ public class MutableSparseIntSet extends SparseIntSet implements MutableIntSet {
   private static final int TRAP_SIZE = 1000;
 
   protected MutableSparseIntSet(@Nullable IntSet set) {
-    super();
     copySet(set);
   }
 
@@ -55,9 +54,7 @@ public class MutableSparseIntSet extends SparseIntSet implements MutableIntSet {
     }
   }
 
-  protected MutableSparseIntSet() {
-    super();
-  }
+  protected MutableSparseIntSet() {}
 
   @Override
   public void clear() {

--- a/util/src/main/java/com/ibm/wala/util/intset/MutableSparseLongSet.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/MutableSparseLongSet.java
@@ -45,7 +45,6 @@ public final class MutableSparseLongSet extends SparseLongSet implements Mutable
   }
 
   private MutableSparseLongSet(LongSet set) {
-    super();
     copySet(set);
   }
 
@@ -59,9 +58,7 @@ public final class MutableSparseLongSet extends SparseLongSet implements Mutable
     size = 0;
   }
 
-  public MutableSparseLongSet() {
-    super();
-  }
+  public MutableSparseLongSet() {}
 
   /** */
   @NullUnmarked

--- a/util/src/main/java/com/ibm/wala/util/intset/TunedMutableSparseIntSet.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/TunedMutableSparseIntSet.java
@@ -26,7 +26,6 @@ public class TunedMutableSparseIntSet extends MutableSparseIntSet {
 
   public TunedMutableSparseIntSet(int initialSize, float expansion)
       throws IllegalArgumentException {
-    super();
     if (initialSize <= 0) {
       throw new IllegalArgumentException("invalid initial size " + initialSize);
     }

--- a/util/src/main/java/com/ibm/wala/util/perf/StopwatchGC.java
+++ b/util/src/main/java/com/ibm/wala/util/perf/StopwatchGC.java
@@ -20,7 +20,6 @@ public class StopwatchGC extends com.ibm.wala.util.perf.Stopwatch {
   private long endMemory;
 
   public StopwatchGC(String name) {
-    super();
     this.name = name;
   }
 

--- a/util/src/main/java/com/ibm/wala/util/processes/Launcher.java
+++ b/util/src/main/java/com/ibm/wala/util/processes/Launcher.java
@@ -47,14 +47,12 @@ public abstract class Launcher {
   private final Logger logger;
 
   protected Launcher(Logger logger) {
-    super();
     this.captureOutput = false;
     this.captureErr = false;
     this.logger = logger;
   }
 
   protected Launcher(boolean captureOutput, boolean captureErr, Logger logger) {
-    super();
     this.captureOutput = captureOutput;
     this.captureErr = captureErr;
     this.logger = logger;

--- a/util/src/main/java/com/ibm/wala/util/tables/StringTable.java
+++ b/util/src/main/java/com/ibm/wala/util/tables/StringTable.java
@@ -27,9 +27,7 @@ import org.jspecify.annotations.Nullable;
 public class StringTable extends Table<String> implements Cloneable {
 
   /** create an empty table */
-  public StringTable() {
-    super();
-  }
+  public StringTable() {}
 
   /** create an empty table with the same column headings as t */
   public StringTable(StringTable t) {

--- a/util/src/main/java/com/ibm/wala/util/viz/PDFViewLauncher.java
+++ b/util/src/main/java/com/ibm/wala/util/viz/PDFViewLauncher.java
@@ -30,10 +30,6 @@ public class PDFViewLauncher {
   /** Path to ghostview executable */
   protected @Nullable String gvExe = null;
 
-  public PDFViewLauncher() {
-    super();
-  }
-
   public @Nullable String getPDFFile() {
     return pdffile;
   }


### PR DESCRIPTION
If the first thing that a constructor does is call `super()` with no arguments, then we can let the Java compiler add that call for us.

If the _only_ thing that the _only_ constructor does is call `super()` with no arguments, and if we don't mind that constructor being `public`, then we can let the Java compiler generate the entire constructor for us.