### PR TITLE
Trigger CI workflow for new items in merge queue

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,11 +1,12 @@
 name: Continuous integration
 on:
+  merge_group:
   pull_request:
   push:
     branches-ignore:
       - 'dependabot/**'
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 jobs:
   build_gradle:


### PR DESCRIPTION
After this change is approved and merged, we'll enable GitHub's "Require merge queue" branch protection rule for the `master` branch.

(cherry picked from commit 2647cfb0033ae0fe2c8836491fb3ea9d0b06fa60)

Partially addresses #1578.  The remaining work to complete that issue involves GitHub project configuration that is not tracked in Git.