### PR TITLE
Add configuration for IntelliJ IDEA Develocity plugin

### DIFF
--- a/.idea/develocity.xml
+++ b/.idea/develocity.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DevelocitySettings">
+    <option name="enableAutoInjection" value="true" />
+    <option name="develocityGradlePluginVersion" value="4.1" />
+  </component>
+</project>


### PR DESCRIPTION
The Develocity plugin gives some of the features of a Gradle build scan (`--scan`) but can operate locally, with nice IntelliJ IDEA integration.  I've found the timeline view useful recently for finding opportunities to speed up our builds.

This additional fragment of project metadata will be used if the corresponding IntelliJ IDEA plugin is present.  If that plugin is absent, then this new configuration file will quietly do nothing.