### PR TITLE
Be cautious with single-use `Iterable`s

### DIFF
--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PointerAnalysisImpl.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PointerAnalysisImpl.java
@@ -571,7 +571,7 @@ public class PointerAnalysisImpl extends AbstractPointerAnalysis {
    */
   @Override
   public Iterable<PointerKey> getPointerKeys() {
-    return Iterator2Iterable.make(pointsToMap.iterateKeys());
+    return pointsToMap::iterateKeys;
   }
 
   @Override

--- a/core/src/test/java/com/ibm/wala/core/tests/basic/PrimitivesTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/basic/PrimitivesTest.java
@@ -770,7 +770,8 @@ public class PrimitivesTest extends WalaTestCase {
     Dominators<Object> D = Dominators.make(G, nodes[10]);
 
     // Assert.assertions
-    assertThat(Iterator2Iterable.make(D.dominators(nodes[4])))
+    assertThat(D.dominators(nodes[4]))
+        .toIterable()
         .containsExactly(nodes[4], nodes[7], nodes[8], nodes[5], nodes[10]);
 
     int j = 0;


### PR DESCRIPTION
The `Iterable` returned by `Iterator2Iterable.make` is single-use. If you try to iterate through it multiple times, you get an empty sequence of elements the second and subsequent times.

That's unhelpful when reporting assertion failures.  We may need to iterate through the elements once to check them, and a second time to describe the elements in a diagnostic message if the assertion fails.

A single-use `Iterable` is also dangerous when used to produce an `Iterable` value returned by a method.  Callers may be expecting an `Iterable` that can be iterated multiple times, as that is the standard `Iterable` contract.

There are two good ways around this problem.  The generic solution is to build an `Iterable` from an uncalled reference to a nullary function that returns the `Iterator`.  In the specific case of `AssertJ` assertions, we also have the option to use the `toIterable` method. Internally, the latter consumes the `Iterator` just once, stashing its elements in a `List` that can be replayed later as often as needed.