### PR TITLE
Stop trying to download a non-existent dependency

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/xml-apis-ext.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/xml-apis-ext.gradle.kts
@@ -1,0 +1,15 @@
+package com.ibm.wala.gradle
+
+configurations.all {
+  // `org.eclipse.platform:org.eclipse.e4.ui.css.core:0.14.200`,
+  // `org.eclipse.platform:org.eclipse.e4.ui.css.swt.theme:0.14.200`, and
+  // `org.eclipse.platform:org.eclipse.e4.ui.css.swt:0.15.200` depend on
+  // `xml-apis:xml-apis-ext:1.0.0.v20230923-0644`, which is not available in any configured
+  // repository.
+  //
+  // `org.eclipse.platform:org.eclipse.e4.ui.css.core:0.14.200` also depends on
+  // `org.apache.xmlgraphics:batik-css:1.17`, which depends on `xml-apis:xml-apis-ext:1.3.04`, which
+  // is available from Maven Central.  So force that version of `xml-apis-ext` to be used instead of
+  // the missing one.
+  resolutionStrategy.force(versionCatalogs.named("libs").findLibrary("xml-apis-ext").get())
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,7 @@ osgi-framework = "org.osgi:org.osgi.framework:1.10.0"
 rhino = "org.mozilla:rhino:1.8.0"
 slf4j-api = "org.slf4j:slf4j-api:2.0.17"
 w3c-css-sac = "org.eclipse.birt.runtime:org.w3c.css.sac:1.3.1.v200903091627"
+xml-apis-ext = "xml-apis:xml-apis-ext:1.3.04"
 
 [plugins]
 dependency-analysis = "com.autonomousapps.dependency-analysis:2.19.0"

--- a/ide/build.gradle.kts
+++ b/ide/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
   alias(libs.plugins.dependency.analysis)
   id("com.ibm.wala.gradle.eclipse-maven-central")
   id("com.ibm.wala.gradle.java")
+  id("com.ibm.wala.gradle.xml-apis-ext")
 }
 
 eclipse.project.natures("org.eclipse.pde.PluginNature")
@@ -25,15 +26,6 @@ dependencies {
   api(libs.osgi.framework)
   api(projects.core)
   api(projects.util)
-}
-
-configurations.all {
-  resolutionStrategy.dependencySubstitution {
-    substitute(module("xml-apis:xml-apis-ext"))
-        .using(module(libs.w3c.css.sac.get().toString()))
-        .because(
-            "both provide several of the same classes, but org.w3c.css.sac includes everything we need from both")
-  }
 }
 
 dependencyAnalysis.issues {

--- a/ide/tests/build.gradle.kts
+++ b/ide/tests/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
   `java-test-fixtures`
   id("com.ibm.wala.gradle.eclipse-maven-central")
   id("com.ibm.wala.gradle.java")
+  id("com.ibm.wala.gradle.xml-apis-ext")
 }
 
 eclipse.project.natures("org.eclipse.pde.PluginNature")
@@ -65,10 +66,6 @@ configurations.all {
         .using(module(libs.eclipse.osgi.get().toString()))
         .because(
             "both provide several of the same classes, but org.eclipse.osgi includes everything we need from both")
-    substitute(module("xml-apis:xml-apis-ext"))
-        .using(module(libs.w3c.css.sac.get().toString()))
-        .because(
-            "both provide several of the same classes, but org.w3c.css.sac includes everything we need from both")
   }
 }
 


### PR DESCRIPTION
`org.eclipse.platform:org.eclipse.e4.ui.css.core:0.14.200`, `org.eclipse.platform:org.eclipse.e4.ui.css.swt.theme:0.14.200`, and `org.eclipse.platform:org.eclipse.e4.ui.css.swt:0.15.200` depend on `xml-apis:xml-apis-ext:1.0.0.v20230923-0644`, which is not available in any configured repository.

`org.eclipse.platform:org.eclipse.e4.ui.css.core:0.14.200` also depends on `org.apache.xmlgraphics:batik-css:1.17`, which depends on `xml-apis:xml-apis-ext:1.3.04`, which is available from Maven Central. So force that version of `xml-apis-ext` to be used instead of the missing one.

This tweak eliminates three failed attempts to download a POM for `xml-apis:xml-apis-ext:1.0.0.v20230923-0644` during build configuration. Avoiding those saves us a bit of time and useless network traffic.