### PR TITLE
Migrate to Central Portal for publishing releases

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
@@ -1,7 +1,5 @@
 package com.ibm.wala.gradle
 
-import com.vanniktech.maven.publish.SonatypeHost
-
 plugins {
   `java-test-fixtures`
   signing
@@ -23,7 +21,7 @@ val testFixturesJavadocJar by
 
 mavenPublishing {
   configureBasedOnAppliedPlugins()
-  publishToMavenCentral(SonatypeHost.DEFAULT)
+  publishToMavenCentral()
   signAllPublications()
 
   pom {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ eclipse-wst-jsdt-ui = { module = "org.eclipse.wst.jsdt:ui", version.ref = "eclip
 errorprone-core = "com.google.errorprone:error_prone_core:2.38.0"
 gradle-errorprone-plugin = "net.ltgt.gradle:gradle-errorprone-plugin:4.2.0"
 gradle-goomph-plugin = "com.diffplug.gradle:goomph:4.3.0"
-gradle-maven-publish-plugin = "com.vanniktech:gradle-maven-publish-plugin:0.32.0"
+gradle-maven-publish-plugin = "com.vanniktech:gradle-maven-publish-plugin:0.34.0"
 gradle-spotless-plugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 gson = "com.google.code.gson:gson:2.13.1"
 guava = "com.google.guava:guava:33.4.8-jre"


### PR DESCRIPTION
Fixes #1517

I followed the instructions at https://github.com/vanniktech/gradle-maven-publish-plugin/releases/tag/0.33.0.  I successfully uploaded a `SNAPSHOT` release with these changes, but we should cut a normal release after this lands to make sure that works.