### PR TITLE
Prefer `Path` for filesystem paths

### DIFF
--- a/dalvik/src/test/java/com/ibm/wala/dalvik/drivers/APKCallGraphDriver.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/drivers/APKCallGraphDriver.java
@@ -89,7 +89,7 @@ public class APKCallGraphDriver {
                 DalvikCallGraphTestBase.makeAPKCallGraph(
                     null,
                     Util.androidJavaLib(),
-                    apk1.getAbsolutePath(),
+                    apk1.toPath().toAbsolutePath(),
                     pm,
                     ReflectionOptions.NONE);
             System.err.println("Analyzed " + apk1 + " in " + (System.currentTimeMillis() - time));

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/DalvikCallGraphTestBase.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/DalvikCallGraphTestBase.java
@@ -130,7 +130,7 @@ public class DalvikCallGraphTestBase extends DynamicCallGraphTestBase {
   public static Pair<CallGraph, PointerAnalysis<InstanceKey>> makeAPKCallGraph(
       URI[] androidLibs,
       File androidAPIJar,
-      String apkFileName,
+      final Path apkFileName,
       IProgressMonitor monitor,
       ReflectionOptions policy)
       throws IOException, ClassHierarchyException, IllegalArgumentException, CancelException {
@@ -160,10 +160,10 @@ public class DalvikCallGraphTestBase extends DynamicCallGraphTestBase {
   }
 
   public static AnalysisScope makeDalvikScope(
-      URI[] androidLibs, File androidAPIJar, String dexFileName) throws IOException {
+      URI[] androidLibs, File androidAPIJar, final Path dexFileName) throws IOException {
     if (androidLibs != null) {
       return AndroidAnalysisScope.setUpAndroidAnalysisScope(
-          new File(dexFileName).toURI(),
+          dexFileName.toUri(),
           CallGraphTestUtil.REGRESSION_EXCLUSIONS,
           CallGraphTestUtil.class.getClassLoader(),
           androidLibs);
@@ -171,7 +171,7 @@ public class DalvikCallGraphTestBase extends DynamicCallGraphTestBase {
     } else {
       AnalysisScope scope =
           AndroidAnalysisScope.setUpAndroidAnalysisScope(
-              new File(dexFileName).toURI(),
+              dexFileName.toUri(),
               CallGraphTestUtil.REGRESSION_EXCLUSIONS,
               CallGraphTestUtil.class.getClassLoader());
 
@@ -185,7 +185,7 @@ public class DalvikCallGraphTestBase extends DynamicCallGraphTestBase {
   }
 
   public static Pair<CallGraph, PointerAnalysis<InstanceKey>> makeDalvikCallGraph(
-      URI[] androidLibs, File androidAPIJar, String mainClassName, String dexFileName)
+      URI[] androidLibs, File androidAPIJar, String mainClassName, final Path dexFileName)
       throws IOException, ClassHierarchyException, IllegalArgumentException, CancelException {
     AnalysisScope scope = makeDalvikScope(androidLibs, androidAPIJar, dexFileName);
 

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/DroidBenchCGTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/DroidBenchCGTest.java
@@ -30,6 +30,7 @@ import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.util.io.FileUtil;
 import java.io.File;
 import java.net.URI;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Map;
@@ -141,25 +142,19 @@ public abstract class DroidBenchCGTest extends DalvikCallGraphTestBase {
     return generateData(getDroidBenchRoot(), androidLibs, androidJavaJar, filter);
   }
 
-  public static String getDroidBenchRoot() {
-    String f = walaProperties.getProperty("droidbench.root");
-    if (f == null || !new File(f).exists()) {
-      f = "build/DroidBench";
-    }
-
-    System.err.println("Use " + f + " as droid bench root");
-    assert new File(f).exists() : "Use " + f + " as droid bench root";
-    assert new File(f + "/apk/").exists() : "Use " + f + " as droid bench root";
-    return f;
+  public static Path getDroidBenchRoot() {
+    final var path = Path.of(walaProperties.getProperty("droidbench.root", "build/DroidBench"));
+    assertThat(path.resolve("apk")).isDirectory();
+    return path;
   }
 
   protected static Stream<Named<TestParameters>> generateData(
-      String droidBenchRoot,
+      final Path droidBenchRoot,
       final URI[] androidLibs,
       final File androidJavaJar,
       final String filter) {
     final Stream.Builder<Named<TestParameters>> testParameters = Stream.builder();
-    final var apkRoot = new File(droidBenchRoot + "/apk/");
+    final var apkRoot = droidBenchRoot.resolve("apk");
     FileUtil.recurseFiles(
         f -> {
           Set<MethodReference> uncalled = uncalledFunctions.get(f.getName());
@@ -168,14 +163,15 @@ public abstract class DroidBenchCGTest extends DalvikCallGraphTestBase {
           }
           testParameters.add(
               Named.of(
-                  apkRoot.toPath().relativize(f.toPath()).toString(),
-                  new TestParameters(androidLibs, androidJavaJar, f.getAbsolutePath(), uncalled)));
+                  apkRoot.relativize(f.toPath()).toString(),
+                  new TestParameters(
+                      androidLibs, androidJavaJar, f.toPath().toAbsolutePath(), uncalled)));
         },
         t ->
             (filter == null || t.getAbsolutePath().contains(filter))
                 && t.getName().endsWith("apk")
                 && !skipTests.contains(t.getName()),
-        apkRoot);
+        apkRoot.toFile());
     return testParameters.build().sorted(Comparator.comparing(Named::getName));
   }
 
@@ -183,11 +179,11 @@ public abstract class DroidBenchCGTest extends DalvikCallGraphTestBase {
 
     private final URI[] androidLibs;
     private final File androidJavaJar;
-    private final String apkFile;
+    private final Path apkFile;
     private final Set<MethodReference> uncalled;
 
     public TestParameters(
-        URI[] androidLibs, File androidJavaJar, String apkFile, Set<MethodReference> uncalled) {
+        URI[] androidLibs, File androidJavaJar, final Path apkFile, Set<MethodReference> uncalled) {
       this.androidLibs = androidLibs;
       this.androidJavaJar = androidJavaJar;
       this.apkFile = apkFile;
@@ -202,7 +198,7 @@ public abstract class DroidBenchCGTest extends DalvikCallGraphTestBase {
       return androidJavaJar;
     }
 
-    public String getApkFile() {
+    public Path getApkFile() {
       return apkFile;
     }
 

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/DynamicDalvikComparisonTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/DynamicDalvikComparisonTest.java
@@ -47,7 +47,7 @@ public abstract class DynamicDalvikComparisonTest extends DalvikCallGraphTestBas
     String javaJarPath = getJavaJar(javaScope);
     File androidDex = convertJarToDex(javaJarPath);
     Pair<CallGraph, PointerAnalysis<InstanceKey>> android =
-        makeDalvikCallGraph(androidLibs, null, mainClass, androidDex.getAbsolutePath());
+        makeDalvikCallGraph(androidLibs, null, mainClass, androidDex.toPath().toAbsolutePath());
 
     dynamicCG(new File(javaJarPath), mainClass, args);
 

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/JVMLDalvikComparisonTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/callGraph/JVMLDalvikComparisonTest.java
@@ -110,7 +110,7 @@ public class JVMLDalvikComparisonTest extends DalvikCallGraphTestBase {
     String javaJarPath = getJavaJar(javaScope);
     File androidDex = convertJarToDex(javaJarPath);
     Pair<CallGraph, PointerAnalysis<InstanceKey>> android =
-        makeDalvikCallGraph(null, null, mainClass, androidDex.getAbsolutePath());
+        makeDalvikCallGraph(null, null, mainClass, androidDex.toPath().toAbsolutePath());
 
     Set<MethodReference> androidMethods = applicationMethods(android.fst);
     Set<MethodReference> javaMethods = applicationMethods(java.fst);

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/cha/MultiDexScopeTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/cha/MultiDexScopeTest.java
@@ -35,6 +35,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Set;
@@ -49,8 +50,8 @@ import org.junit.jupiter.api.Test;
 public class MultiDexScopeTest {
 
   private static void addAPKtoScope(
-      ClassLoaderReference loader, AnalysisScope scope, String fileName) {
-    File apkFile = new File(fileName);
+      ClassLoaderReference loader, AnalysisScope scope, final Path fileName) {
+    final var apkFile = fileName.toFile();
     MultiDexContainer<? extends DexBackedDexFile> multiDex = null;
     try {
       multiDex = DexFileFactory.loadDexContainer(apkFile, Opcodes.forApi(24));
@@ -68,15 +69,15 @@ public class MultiDexScopeTest {
     }
   }
 
-  private static AnalysisScope setUpTestScope(String apkName, String exclusions, ClassLoader loader)
-      throws IOException {
+  private static AnalysisScope setUpTestScope(
+      final Path apkPath, String exclusions, ClassLoader loader) throws IOException {
     AnalysisScope scope;
     scope =
         AnalysisScopeReader.instance.readJavaScope("primordial.txt", new File(exclusions), loader);
     scope.setLoaderImpl(
         ClassLoaderReference.Application, "com.ibm.wala.dalvik.classLoader.WDexClassLoaderImpl");
 
-    addAPKtoScope(ClassLoaderReference.Application, scope, apkName);
+    addAPKtoScope(ClassLoaderReference.Application, scope, apkPath);
     return scope;
   }
 
@@ -98,7 +99,7 @@ public class MultiDexScopeTest {
 
     AnalysisScope scope, scope2;
     ClassHierarchy cha, cha2;
-    String testAPK = DroidBenchCGTest.getDroidBenchRoot() + "/apk/Aliasing/Merge1.apk";
+    final var testAPK = DroidBenchCGTest.getDroidBenchRoot().resolve("apk/Aliasing/Merge1.apk");
 
     scope = setUpTestScope(testAPK, "", MultiDexScopeTest.class.getClassLoader());
     cha = ClassHierarchyFactory.make(scope);
@@ -140,7 +141,7 @@ public class MultiDexScopeTest {
   public void testMultiDex() throws ClassHierarchyException, IOException {
     AnalysisScope scope, scope2;
     ClassHierarchy cha, cha2;
-    String multidexApk = "src/test/resources/multidex-test.apk";
+    final var multidexApk = Path.of("src/test/resources/multidex-test.apk");
 
     scope = manuallyInitScope();
     cha = ClassHierarchyFactory.make(scope);

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/util/Util.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/util/Util.java
@@ -120,7 +120,7 @@ public class Util {
         F, new FileProvider().getResource("com.ibm.wala.core.testdata_1.0.0a.jar"));
     File androidDex = convertJarToDex(F.getAbsolutePath());
     AnalysisScope dalvikScope =
-        DalvikCallGraphTestBase.makeDalvikScope(null, null, androidDex.getAbsolutePath());
+        DalvikCallGraphTestBase.makeDalvikScope(null, null, androidDex.toPath().toAbsolutePath());
     return ClassHierarchyFactory.make(dalvikScope);
   }
 }


### PR DESCRIPTION
A `String` can represent just about anything.  For strings that represent paths in the filesystem, prefer to use `Path`.  It gives us a better API for file-related operations, makes argument-swapping errors less likely, and is simply a semantically richer description of what we are doing.

Ordinarily I would consider an API change like this as backward-incompatible and therefore requiring careful management of version numbers, deprecation, etc..  But the APIs affected by this change are all in test code.  So I think we can justify making this change without a lot of backward-compatibility ceremony.