### PR TITLE
Extract only the subset of DroidBench that we use

### DIFF
--- a/dalvik/build.gradle.kts
+++ b/dalvik/build.gradle.kts
@@ -114,6 +114,7 @@ val downloadDroidBench =
 val unpackDroidBench by
     tasks.registering(Sync::class) {
       from(zipTree { downloadDroidBench.singleFile }) {
+        include("*/apk/**")
         eachFile {
           relativePath = RelativePath(!isDirectory, *relativePath.segments.drop(1).toTypedArray())
         }


### PR DESCRIPTION
DroidBench unpacks into 119.4 MB of data.  That's quite a lot to unpack and write into one's filesystem.  However, it turns out that we only use the `apk` subdirectory in our tests: 24.5 MB.  The rest of this archive is stuff we never touch, including 94.9 MB in the `eclipse-project` subdirectory.

Instead of unpacking everything, let's just unpack the 24.5 MB we need from that `apk` subdirectory.  Storing and hashing the other 94.9 MB is a waste of compute time and disk space.

Before this change, `:dalvik:unpackDroidBench` took about 1.7 seconds to run when the archive had not already been extracted.  After this change, that time drops to 0.4 seconds.  When the task is already up-to-date, we don't see much change:  both before and after this change, Gradle takes about 0.1 seconds to recognize that the task is up-to-date.