### PR TITLE
Set ECJ compiler's source and target Java versions

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/JavaCompileUsingEcj.kt
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/JavaCompileUsingEcj.kt
@@ -50,6 +50,10 @@ abstract class JavaCompileUsingEcj : JavaCompile() {
     options.compilerArgumentProviders.run {
       add {
         listOf(
+            "-source",
+            sourceCompatibility,
+            "-target",
+            targetCompatibility,
             "-properties",
             jdtPrefs.toString(),
             "-classpath",


### PR DESCRIPTION
Without these extra command-line flags, ECJ assumes that the source and target are the same as the JVM running ECJ itself.  So when we build everything using Java 24, ECJ warns that we are using `URL` constructors that were deprecated in Java 20.  While that's true, it's not something that we want to act on now, since we still use Java 11 as the source and target for most WALA code.

With these extra command-line flags, we tell ECJ that we are using Java 11, or Java 17 for the small subset of sources that require that.  In either case, ECJ now understands that the source and target versions are the same as the ones we use for standard (non-ECJ) Java compilation tasks.