### PR TITLE
Fix concurrency conflict on merge queue branches

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches-ignore:
       - 'dependabot/**'
+      - 'gh-readonly-queue/**'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true


### PR DESCRIPTION
When a PR enters GitHub's merge queue, the `merge_group` event triggers a CI run.  However, GitHub uses short-lived Git branches to manage the merge queue.  Adding a PR's commits to a merge queue branch creates a `push` event, which _also_ triggers a CI run.  These two runs have the same concurrency group, and our `cancel-in-progress` setting means that one will cancel the other.  If the `merge_group` run is canceled, then the job is evicted from the merge queue without having satisfied the checks that are required for merging.

The fix is to exclude the merge queue's short-lived Git branches from the `push` trigger.  Fortunately, that's easy to do based on these branches' names.

Big thanks to Arthur from GitHub Support for reviewing [our problem report](https://support.github.com/ticket/personal/0/3618633) and recommending this fix.