### PR TITLE
Correct several uses of deprecated APIs

### DIFF
--- a/.idea/inspectionProfiles/No_Back_Sliding.xml
+++ b/.idea/inspectionProfiles/No_Back_Sliding.xml
@@ -82,8 +82,6 @@
     <inspection_tool class="DanglingJavadoc" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Java Sources as Test Subjects" level="WARNING" enabled="false" />
     </inspection_tool>
-    <inspection_tool class="DeprecatedIsStillUsed" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="Deprecation" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="DuplicateExpressions" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="DuplicateThrows" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="DuplicatedCode" enabled="false" level="WEAK WARNING" enabled_by_default="true" />
@@ -139,7 +137,6 @@
       <option name="ignoreUntypedCollections" value="false" />
     </inspection_tool>
     <inspection_tool class="FunctionalExpressionCanBeFolded" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="GrDeprecatedAPIUsage" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="GrMethodMayBeStatic" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="GrUnresolvedAccess" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="GrazieInspection" enabled="false" level="TYPO" enabled_by_default="false" />
@@ -710,7 +707,7 @@
       <scope name="Eclipse Build Artifacts" level="INFORMATION" enabled="false" />
       <scope name="Sketchy HTML" level="ERROR" enabled="false" />
     </inspection_tool>
-    <inspection_tool class="unused" enabled="false" level="WARNING" enabled_by_default="false" checkParameterExcludingHierarchy="false">
+    <inspection_tool class="unused" enabled="false" level="WARNING" enabled_by_default="false" checkParameterExcludingHierarchy="false" isSelected="false">
       <option name="LOCAL_VARIABLE" value="true" />
       <option name="FIELD" value="true" />
       <option name="METHOD" value="true" />

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -60,30 +60,33 @@ tasks.withType<JavaCompile> {
   // Always compile with a recent JDK version, to get the latest bug fixes in the compiler toolchain
   javaCompiler = javaToolchains.compilerFor { languageVersion = JavaLanguageVersion.of(24) }
   // Generate JDK 11 bytecodes; that is the minimum version supported by WALA
-  options.release = 11
-  options.errorprone {
-    // don't run warning-level checks by default as they add too much noise to build output
-    disableAllWarnings = true
-    // warning-level checks upgraded to error, since we've fixed all the warnings
-    error("UnnecessaryParentheses")
-    error("UnusedVariable")
-    error("JdkObsolete")
-    error("AnnotationPosition")
-    error("AssertEqualsArgumentOrderChecker")
-    error("ArgumentSelectionDefectChecker")
-    // checks we do not intend to try to fix in the near-term:
-    // Just too many of these; proper Javadoc would be a great long-term goal
-    disable("MissingSummary")
-    // WALA has many optimizations involving using == to check reference equality.  They
-    // may be unnecessary on modern JITs, but fixing these issues requires subtle changes
-    // that could introduce bugs
-    disable("ReferenceEquality")
-    // Example for running Error Prone's auto-patcher.  To run, uncomment and change the
-    // check name to the one you want to patch, and also disable -Werror below
-    //    		errorproneArgs.addAll(
-    //    				"-XepPatchChecks:UnnecessaryParentheses",
-    //    				"-XepPatchLocation:IN_PLACE"
-    //    		)
+  options.run {
+    isDeprecation = true
+    release = 11
+    errorprone {
+      // don't run warning-level checks by default as they add too much noise to build output
+      disableAllWarnings = true
+      // warning-level checks upgraded to error, since we've fixed all the warnings
+      error("UnnecessaryParentheses")
+      error("UnusedVariable")
+      error("JdkObsolete")
+      error("AnnotationPosition")
+      error("AssertEqualsArgumentOrderChecker")
+      error("ArgumentSelectionDefectChecker")
+      // checks we do not intend to try to fix in the near-term:
+      // Just too many of these; proper Javadoc would be a great long-term goal
+      disable("MissingSummary")
+      // WALA has many optimizations involving using == to check reference equality.  They
+      // may be unnecessary on modern JITs, but fixing these issues requires subtle changes
+      // that could introduce bugs
+      disable("ReferenceEquality")
+      // Example for running Error Prone's auto-patcher.  To run, uncomment and change the
+      // check name to the one you want to patch, and also disable -Werror below
+      //    		errorproneArgs.addAll(
+      //    				"-XepPatchChecks:UnnecessaryParentheses",
+      //    				"-XepPatchLocation:IN_PLACE"
+      //    		)
+    }
   }
 }
 

--- a/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
+++ b/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
@@ -2958,6 +2958,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
 
   private CAstNode getSwitchCaseConstant(SwitchCase n, WalkContext context) {
     // TODO: enums
+    @SuppressWarnings("deprecation")
     Expression expr = n.getExpression();
     Object constant =
         (expr == null)

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/html/DomLessSourceExtractor.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/html/DomLessSourceExtractor.java
@@ -13,6 +13,7 @@ package com.ibm.wala.cast.js.html;
 import com.ibm.wala.cast.ir.translator.TranslatorToCAst.Error;
 import com.ibm.wala.cast.js.html.jericho.JerichoHtmlParser;
 import com.ibm.wala.cast.tree.CAstSourcePositionMap.Position;
+import com.ibm.wala.cast.util.BOMInputStreamFactory;
 import com.ibm.wala.util.collections.Pair;
 import java.io.BufferedReader;
 import java.io.File;
@@ -31,7 +32,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
-import org.apache.commons.io.ByteOrderMark;
 import org.apache.commons.io.input.BOMInputStream;
 
 /** extracts JavaScript source code from HTML, with no model of the actual DOM data structure */
@@ -246,15 +246,9 @@ public class DomLessSourceExtractor extends JSSourceExtractor {
       URL scriptSrc = new URL(entrypointUrl, urlAsString);
       BOMInputStream bs;
       try {
-        bs =
-            new BOMInputStream(
-                scriptSrc.openConnection().getInputStream(),
-                false,
-                ByteOrderMark.UTF_8,
-                ByteOrderMark.UTF_16LE,
-                ByteOrderMark.UTF_16BE,
-                ByteOrderMark.UTF_32LE,
-                ByteOrderMark.UTF_32BE);
+        @SuppressWarnings("resource")
+        final var origin = scriptSrc.openConnection().getInputStream();
+        bs = BOMInputStreamFactory.make(origin);
         if (bs.hasBOM()) {
           System.err.println("removing BOM " + bs.getBOM());
         }

--- a/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/CAstCallGraphUtil.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/CAstCallGraphUtil.java
@@ -11,6 +11,7 @@
 package com.ibm.wala.cast.ipa.callgraph;
 
 import com.ibm.wala.cast.loader.SingleClassLoaderFactory;
+import com.ibm.wala.cast.util.BOMInputStreamFactory;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.classLoader.Language;
 import com.ibm.wala.classLoader.Module;
@@ -34,8 +35,6 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
-import org.apache.commons.io.ByteOrderMark;
-import org.apache.commons.io.input.BOMInputStream;
 
 public class CAstCallGraphUtil {
 
@@ -61,16 +60,9 @@ public class CAstCallGraphUtil {
     return new SourceFileModule(scriptFile, scriptName, null) {
       @Override
       public InputStream getInputStream() {
-        BOMInputStream bs =
-            new BOMInputStream(
-                super.getInputStream(),
-                false,
-                ByteOrderMark.UTF_8,
-                ByteOrderMark.UTF_16LE,
-                ByteOrderMark.UTF_16BE,
-                ByteOrderMark.UTF_32LE,
-                ByteOrderMark.UTF_32BE);
         try {
+          @SuppressWarnings("resource")
+          final var bs = BOMInputStreamFactory.make(super.getInputStream());
           if (bs.hasBOM()) {
             System.err.println("removing BOM " + bs.getBOM());
           }

--- a/cast/src/main/java/com/ibm/wala/cast/util/BOMInputStreamFactory.java
+++ b/cast/src/main/java/com/ibm/wala/cast/util/BOMInputStreamFactory.java
@@ -1,0 +1,22 @@
+package com.ibm.wala.cast.util;
+
+import java.io.IOException;
+import org.apache.commons.io.ByteOrderMark;
+import org.apache.commons.io.input.BOMInputStream;
+
+public final class BOMInputStreamFactory {
+  private BOMInputStreamFactory() {}
+
+  public static BOMInputStream make(java.io.InputStream origin) throws IOException {
+    return BOMInputStream.builder()
+        .setInputStream(origin)
+        .setInclude(false)
+        .setByteOrderMarks(
+            ByteOrderMark.UTF_8,
+            ByteOrderMark.UTF_16LE,
+            ByteOrderMark.UTF_16BE,
+            ByteOrderMark.UTF_32LE,
+            ByteOrderMark.UTF_32BE)
+        .get();
+  }
+}

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -25,16 +25,20 @@ eclipse {
 
 val compileTestSubjectsJava by tasks.existing
 
-tasks.named<JavaCompileUsingEcj>("compileTestSubjectsJavaUsingEcj") {
-  options.compilerArgumentProviders.add {
-    listOf(
-        "-warn:none",
-        "-err:-serial",
-        "-err:-unchecked",
-        "-err:-unusedLocal",
-        "-err:-unusedParam",
-        "-err:-unusedThrown",
-    )
+tasks {
+  named<JavaCompile>("compileTestSubjectsJava") { options.isDeprecation = false }
+
+  named<JavaCompileUsingEcj>("compileTestSubjectsJavaUsingEcj") {
+    options.compilerArgumentProviders.add {
+      listOf(
+          "-warn:none",
+          "-err:-serial",
+          "-err:-unchecked",
+          "-err:-unusedLocal",
+          "-err:-unusedParam",
+          "-err:-unusedThrown",
+      )
+    }
   }
 }
 

--- a/ide/jdt/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTSourceModuleTranslator.java
+++ b/ide/jdt/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTSourceModuleTranslator.java
@@ -174,6 +174,7 @@ public class JDTSourceModuleTranslator implements SourceModuleTranslator {
       projectsFiles.get(proj).put(JavaCore.createCompilationUnitFrom(entry.getIFile()), entry);
     }
 
+    @SuppressWarnings("deprecation")
     final ASTParser parser = ASTParser.newParser(AST.JLS8);
 
     for (final Map.Entry<IProject, Map<ICompilationUnit, EclipseSourceFileModule>> proj :

--- a/ide/jdt/src/main/java/com/ibm/wala/ide/util/JdtUtil.java
+++ b/ide/jdt/src/main/java/com/ibm/wala/ide/util/JdtUtil.java
@@ -610,6 +610,7 @@ public class JdtUtil {
   }
 
   public static ASTNode getAST(IFile javaSourceFile) {
+    @SuppressWarnings("deprecation")
     ASTParser parser = ASTParser.newParser(AST.JLS3);
     parser.setSource(JavaCore.createCompilationUnitFrom(javaSourceFile));
     parser.setProject(JavaCore.create(javaSourceFile.getProject()));


### PR DESCRIPTION
Also, treat deprecated API uses as fatal errors in most Java compilations.  The only exception is for
`:core:compileTestSubjectsJava`, since those sources _intentionally_ use some deprecated APIs.