### PR TITLE
Clone by augmenting superclass clone

### DIFF
--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/Intent.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/Intent.java
@@ -70,7 +70,7 @@ import com.ibm.wala.types.TypeName;
  * @author Tobias Blaschke &lt;code@tobiasblaschke.de&gt;
  * @since 2013-10-12
  */
-public class Intent implements ContextItem, Comparable<Intent> {
+public class Intent implements Cloneable, ContextItem, Comparable<Intent> {
   /** Key into the Context that represents the Intent. */
   public static final ContextKey INTENT_KEY = new ContextKey() {};
 
@@ -159,12 +159,13 @@ public class Intent implements ContextItem, Comparable<Intent> {
 
   @Override
   public Intent clone() {
-    final Intent clone = new Intent();
-    clone.action = this.action; // OK here?
-    clone.uri = this.uri;
-    clone.type = this.type;
-    clone.explicit = this.explicit;
-    clone.targetCompontent = this.targetCompontent;
+    final Intent clone;
+    try {
+      clone = (Intent) super.clone();
+    } catch (CloneNotSupportedException e) {
+      throw new RuntimeException(e);
+    }
+    clone.immutable = false;
     return clone;
   }
 

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/Instruction.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/Instruction.java
@@ -126,6 +126,7 @@ public abstract class Instruction implements Constants, Cloneable, IInstruction 
 
   /** We're immutable so there's no need to clone any Instruction object. */
   @Override
+  @SuppressWarnings("MethodDoesntCallSuperMethod")
   public final Object clone() {
     return this;
   }

--- a/util/src/main/java/com/ibm/wala/util/tables/StringTable.java
+++ b/util/src/main/java/com/ibm/wala/util/tables/StringTable.java
@@ -183,7 +183,7 @@ public class StringTable extends Table<String> implements Cloneable {
 
   @Override
   public Object clone() throws CloneNotSupportedException {
-    StringTable result = new StringTable(this);
+    StringTable result = (StringTable) super.clone();
     for (int i = 0; i < getNumberOfRows(); i++) {
       result.addRow(row2Map(i));
     }


### PR DESCRIPTION
In general, one should implement `clone()` by calling the superclass `clone()` to make a shallow copy, then doing any extra work needed for the current class.