### PR TITLE
Remove useless `final` for `static` methods

### DIFF
--- a/cast/src/main/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
@@ -3383,7 +3383,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
     return map;
   }
 
-  protected static final CAstType getTypeForNode(WalkContext context, CAstNode node) {
+  protected static CAstType getTypeForNode(WalkContext context, CAstNode node) {
     if (context.top().getNodeTypeMap() != null) {
       return context.top().getNodeTypeMap().getNodeType(node);
     } else {

--- a/core/src/main/java/com/ibm/wala/core/util/strings/StringStuff.java
+++ b/core/src/main/java/com/ibm/wala/core/util/strings/StringStuff.java
@@ -110,11 +110,11 @@ public class StringStuff {
     }
   }
 
-  public static final TypeName parseForReturnTypeName(String desc) throws IllegalArgumentException {
+  public static TypeName parseForReturnTypeName(String desc) throws IllegalArgumentException {
     return parseForReturnTypeName(Language.JAVA, ImmutableByteArray.make(desc));
   }
 
-  public static final TypeName parseForReturnTypeName(Language l, String desc)
+  public static TypeName parseForReturnTypeName(Language l, String desc)
       throws IllegalArgumentException {
     return parseForReturnTypeName(l, ImmutableByteArray.make(desc));
   }
@@ -127,7 +127,7 @@ public class StringStuff {
    * @return type description
    * @throws IllegalArgumentException if b is null
    */
-  public static final TypeName parseForReturnTypeName(Language l, ImmutableByteArray b)
+  public static TypeName parseForReturnTypeName(Language l, ImmutableByteArray b)
       throws IllegalArgumentException {
 
     if (b == null) {
@@ -183,12 +183,12 @@ public class StringStuff {
     }
   }
 
-  public static final TypeName[] parseForParameterNames(String descriptor)
+  public static TypeName[] parseForParameterNames(String descriptor)
       throws IllegalArgumentException {
     return parseForParameterNames(Language.JAVA, ImmutableByteArray.make(descriptor));
   }
 
-  public static final TypeName[] parseForParameterNames(Language l, String descriptor)
+  public static TypeName[] parseForParameterNames(Language l, String descriptor)
       throws IllegalArgumentException {
     return parseForParameterNames(l, ImmutableByteArray.make(descriptor));
   }
@@ -199,7 +199,7 @@ public class StringStuff {
    * @return parameter descriptions, or null if there are no parameters
    * @throws IllegalArgumentException if b is null
    */
-  public static final TypeName[] parseForParameterNames(Language l, ImmutableByteArray b)
+  public static TypeName[] parseForParameterNames(Language l, ImmutableByteArray b)
       throws IllegalArgumentException {
 
     if (b == null) {

--- a/core/src/main/java/com/ibm/wala/demandpa/util/ArrayContents.java
+++ b/core/src/main/java/com/ibm/wala/demandpa/util/ArrayContents.java
@@ -59,7 +59,7 @@ public class ArrayContents implements IField {
 
   private static final ArrayContents theContents = new ArrayContents();
 
-  public static final ArrayContents v() {
+  public static ArrayContents v() {
     return theContents;
   }
 

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/FakeRootClass.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/FakeRootClass.java
@@ -35,7 +35,7 @@ import java.util.Set;
 
 /** A synthetic class for the fake root method. */
 public class FakeRootClass extends SyntheticClass {
-  public static final TypeReference fakeRootClass(ClassLoaderReference clr) {
+  public static TypeReference fakeRootClass(ClassLoaderReference clr) {
     return TypeReference.findOrCreate(clr, TypeName.string2TypeName("Lcom/ibm/wala/FakeRootClass"));
   }
 

--- a/core/src/test/java/com/ibm/wala/core/tests/ptrs/MultiDimArrayTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/ptrs/MultiDimArrayTest.java
@@ -71,7 +71,7 @@ public class MultiDimArrayTest extends WalaTestCase {
     assertThat(ptsTo).hasSize(1);
   }
 
-  private static final CGNode findDoNothingNode(CallGraph cg) {
+  private static CGNode findDoNothingNode(CallGraph cg) {
     for (CGNode n : cg) {
       if (n.getMethod().getName().toString().equals("doNothing")) {
         return n;

--- a/core/src/test/java/com/ibm/wala/core/tests/ptrs/TypeBasedArrayAliasTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/ptrs/TypeBasedArrayAliasTest.java
@@ -72,7 +72,7 @@ public class TypeBasedArrayAliasTest extends WalaTestCase {
     assertThat(pa).has(mayAliased(pk1, pk2));
   }
 
-  private static final CGNode findNode(CallGraph cg, String methodName) {
+  private static CGNode findNode(CallGraph cg, String methodName) {
     for (CGNode n : cg) {
       if (n.getMethod().getName().toString().equals(methodName)) {
         return n;

--- a/ide/jdt/src/main/java/com/ibm/wala/ide/util/JdtUtil.java
+++ b/ide/jdt/src/main/java/com/ibm/wala/ide/util/JdtUtil.java
@@ -376,8 +376,7 @@ public class JdtUtil {
     }
   }
 
-  public static final String[] parseForParameterTypes(String selector)
-      throws IllegalArgumentException {
+  public static String[] parseForParameterTypes(String selector) throws IllegalArgumentException {
 
     try {
       if (selector == null) {

--- a/util/src/main/java/com/ibm/wala/util/collections/ImmutableStack.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/ImmutableStack.java
@@ -75,7 +75,7 @@ public class ImmutableStack<T> implements Iterable<T> {
   }
 
   @SuppressWarnings("unchecked")
-  public static final <T> ImmutableStack<T> emptyStack() {
+  public static <T> ImmutableStack<T> emptyStack() {
     return (ImmutableStack<T>) EMPTY;
   }
 

--- a/util/src/main/java/com/ibm/wala/util/collections/IteratorUtil.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/IteratorUtil.java
@@ -30,7 +30,7 @@ public class IteratorUtil {
     return false;
   }
 
-  public static final <T> int count(Iterator<T> it) throws IllegalArgumentException {
+  public static <T> int count(Iterator<T> it) throws IllegalArgumentException {
     if (it == null) {
       throw new IllegalArgumentException("it == null");
     }

--- a/util/src/main/java/com/ibm/wala/util/io/FileUtil.java
+++ b/util/src/main/java/com/ibm/wala/util/io/FileUtil.java
@@ -125,7 +125,7 @@ public class FileUtil {
    * Create a {@link FileOutputStream} corresponding to a particular file name. Delete the existing
    * file if one exists.
    */
-  public static final FileOutputStream createFile(String fileName) throws IOException {
+  public static FileOutputStream createFile(String fileName) throws IOException {
     if (fileName == null) {
       throw new IllegalArgumentException("null file");
     }


### PR DESCRIPTION
`static` methods don't use dynamic dispatch, so declaring such methods `final` doesn't do anything to boost performance.  Technically, `final` does prevent any subclass from declaring its own `static` method with the same name.  That restriction doesn't seem particularly useful, though.