### PR TITLE
Remove redundant method overrides

### DIFF
--- a/.idea/inspectionProfiles/No_Back_Sliding.xml
+++ b/.idea/inspectionProfiles/No_Back_Sliding.xml
@@ -474,6 +474,9 @@
     <inspection_tool class="RedundantArrayCreation" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="RedundantBackticksAroundRawStringLiteral" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="RedundantCast" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="RedundantMethodOverride" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="Java Sources as Test Subjects" level="WARNING" enabled="false" />
+    </inspection_tool>
     <inspection_tool class="RedundantOperationOnEmptyContainer" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Java Sources as Test Subjects" level="WARNING" enabled="false" />
     </inspection_tool>

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/loader/JavaScriptLoader.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/loader/JavaScriptLoader.java
@@ -606,10 +606,6 @@ public class JavaScriptLoader extends CAstAbstractModuleLoader {
             @Override
             public SSANewInstruction NewInstruction(int iindex, int result, NewSiteReference site) {
               return new SSANewInstruction(iindex, result, site) {
-                @Override
-                public boolean isPEI() {
-                  return true;
-                }
 
                 @Override
                 public Collection<TypeReference> getExceptionTypes() {
@@ -676,10 +672,6 @@ public class JavaScriptLoader extends CAstAbstractModuleLoader {
             @Override
             public SSAThrowInstruction ThrowInstruction(int iindex, int exception) {
               return new SSAThrowInstruction(iindex, exception) {
-                @Override
-                public boolean isPEI() {
-                  return true;
-                }
 
                 @Override
                 public Collection<TypeReference> getExceptionTypes() {

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ssa/JSAbstractInstructionVisitor.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ssa/JSAbstractInstructionVisitor.java
@@ -11,20 +11,12 @@
 package com.ibm.wala.cast.js.ssa;
 
 import com.ibm.wala.cast.ir.ssa.AstAbstractInstructionVisitor;
-import com.ibm.wala.cast.ir.ssa.AstPropertyRead;
-import com.ibm.wala.cast.ir.ssa.AstPropertyWrite;
 
 public class JSAbstractInstructionVisitor extends AstAbstractInstructionVisitor
     implements JSInstructionVisitor {
 
   @Override
   public void visitJavaScriptInvoke(JavaScriptInvoke instruction) {}
-
-  @Override
-  public void visitPropertyRead(AstPropertyRead instruction) {}
-
-  @Override
-  public void visitPropertyWrite(AstPropertyWrite instruction) {}
 
   @Override
   public void visitTypeOf(JavaScriptTypeOfInstruction instruction) {}

--- a/cast/src/main/java/com/ibm/wala/cast/analysis/typeInference/AstTypeInference.java
+++ b/cast/src/main/java/com/ibm/wala/cast/analysis/typeInference/AstTypeInference.java
@@ -13,18 +13,12 @@ package com.ibm.wala.cast.analysis.typeInference;
 import com.ibm.wala.analysis.typeInference.ConeType;
 import com.ibm.wala.analysis.typeInference.TypeAbstraction;
 import com.ibm.wala.analysis.typeInference.TypeInference;
-import com.ibm.wala.cast.ir.ssa.AstAssertInstruction;
-import com.ibm.wala.cast.ir.ssa.AstEchoInstruction;
 import com.ibm.wala.cast.ir.ssa.AstGlobalRead;
-import com.ibm.wala.cast.ir.ssa.AstGlobalWrite;
 import com.ibm.wala.cast.ir.ssa.AstInstructionVisitor;
 import com.ibm.wala.cast.ir.ssa.AstIsDefinedInstruction;
 import com.ibm.wala.cast.ir.ssa.AstLexicalRead;
-import com.ibm.wala.cast.ir.ssa.AstLexicalWrite;
 import com.ibm.wala.cast.ir.ssa.AstPropertyRead;
-import com.ibm.wala.cast.ir.ssa.AstPropertyWrite;
 import com.ibm.wala.cast.ir.ssa.EachElementGetInstruction;
-import com.ibm.wala.cast.ir.ssa.EachElementHasNextInstruction;
 import com.ibm.wala.ssa.IR;
 
 public abstract class AstTypeInference extends TypeInference {
@@ -39,15 +33,9 @@ public abstract class AstTypeInference extends TypeInference {
     }
 
     @Override
-    public void visitPropertyWrite(AstPropertyWrite inst) {}
-
-    @Override
     public void visitAstLexicalRead(AstLexicalRead inst) {
       result = new DeclaredTypeOperator(new ConeType(cha.getRootClass()));
     }
-
-    @Override
-    public void visitAstLexicalWrite(AstLexicalWrite inst) {}
 
     @Override
     public void visitAstGlobalRead(AstGlobalRead instruction) {
@@ -55,18 +43,9 @@ public abstract class AstTypeInference extends TypeInference {
     }
 
     @Override
-    public void visitAstGlobalWrite(AstGlobalWrite instruction) {}
-
-    @Override
-    public void visitAssert(AstAssertInstruction instruction) {}
-
-    @Override
     public void visitEachElementGet(EachElementGetInstruction inst) {
       result = new DeclaredTypeOperator(new ConeType(cha.getRootClass()));
     }
-
-    @Override
-    public void visitEachElementHasNext(EachElementHasNextInstruction inst) {}
 
     @Override
     public void visitIsDefined(AstIsDefinedInstruction inst) {
@@ -74,9 +53,6 @@ public abstract class AstTypeInference extends TypeInference {
         result = new DeclaredTypeOperator(booleanType);
       }
     }
-
-    @Override
-    public void visitEcho(AstEchoInstruction inst) {}
   }
 
   public AstTypeInference(IR ir, TypeAbstraction booleanType, boolean doPrimitives) {

--- a/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/AstSSAPropagationCallGraphBuilder.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/AstSSAPropagationCallGraphBuilder.java
@@ -14,19 +14,16 @@ import com.ibm.wala.analysis.reflection.ReflectionContextInterpreter;
 import com.ibm.wala.cast.ipa.callgraph.AstCallGraph.AstCGNode;
 import com.ibm.wala.cast.ipa.callgraph.ScopeMappingInstanceKeys.ScopeMappingInstanceKey;
 import com.ibm.wala.cast.ir.ssa.AstAssertInstruction;
-import com.ibm.wala.cast.ir.ssa.AstEchoInstruction;
 import com.ibm.wala.cast.ir.ssa.AstGlobalRead;
 import com.ibm.wala.cast.ir.ssa.AstGlobalWrite;
 import com.ibm.wala.cast.ir.ssa.AstIRFactory;
 import com.ibm.wala.cast.ir.ssa.AstInstructionVisitor;
-import com.ibm.wala.cast.ir.ssa.AstIsDefinedInstruction;
 import com.ibm.wala.cast.ir.ssa.AstLexicalAccess.Access;
 import com.ibm.wala.cast.ir.ssa.AstLexicalRead;
 import com.ibm.wala.cast.ir.ssa.AstLexicalWrite;
 import com.ibm.wala.cast.ir.ssa.AstPropertyRead;
 import com.ibm.wala.cast.ir.ssa.AstPropertyWrite;
 import com.ibm.wala.cast.ir.ssa.EachElementGetInstruction;
-import com.ibm.wala.cast.ir.ssa.EachElementHasNextInstruction;
 import com.ibm.wala.cast.ir.translator.AstTranslator;
 import com.ibm.wala.cast.loader.AstMethod;
 import com.ibm.wala.cast.loader.AstMethod.LexicalInformation;
@@ -212,41 +209,11 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
       }
 
       @Override
-      public void visitPropertyRead(AstPropertyRead instruction) {}
-
-      @Override
-      public void visitPropertyWrite(AstPropertyWrite instruction) {}
-
-      @Override
-      public void visitAstLexicalRead(AstLexicalRead instruction) {}
-
-      @Override
-      public void visitAstLexicalWrite(AstLexicalWrite instruction) {}
-
-      @Override
       public void visitAstGlobalRead(AstGlobalRead instruction) {
         pointsToSet =
             analysis.computeImplicitPointsToSetAtGet(
                 node, instruction.getDeclaredField(), -1, true);
       }
-
-      @Override
-      public void visitAstGlobalWrite(AstGlobalWrite instruction) {}
-
-      @Override
-      public void visitAssert(AstAssertInstruction instruction) {}
-
-      @Override
-      public void visitEachElementGet(EachElementGetInstruction inst) {}
-
-      @Override
-      public void visitEachElementHasNext(EachElementHasNextInstruction inst) {}
-
-      @Override
-      public void visitIsDefined(AstIsDefinedInstruction inst) {}
-
-      @Override
-      public void visitEcho(AstEchoInstruction inst) {}
     }
   }
 
@@ -307,15 +274,6 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
     public void visitEachElementGet(EachElementGetInstruction inst) {
       bingo = true;
     }
-
-    @Override
-    public void visitEachElementHasNext(EachElementHasNextInstruction inst) {}
-
-    @Override
-    public void visitIsDefined(AstIsDefinedInstruction inst) {}
-
-    @Override
-    public void visitEcho(AstEchoInstruction inst) {}
   }
 
   @Override
@@ -558,12 +516,6 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
     }
 
     @Override
-    public void visitAssert(AstAssertInstruction instruction) {}
-
-    @Override
-    public void visitEachElementHasNext(EachElementHasNextInstruction inst) {}
-
-    @Override
     public void visitEachElementGet(EachElementGetInstruction inst) {
       int lval = inst.getDef(0);
       final PointerKey lk = getPointerKeyForLocal(lval);
@@ -616,12 +568,6 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
             rk);
       }
     }
-
-    @Override
-    public void visitIsDefined(AstIsDefinedInstruction inst) {}
-
-    @Override
-    public void visitEcho(AstEchoInstruction inst) {}
 
     // /////////////////////////////////////////////////////////////////////////
     //

--- a/cast/src/main/java/com/ibm/wala/cast/ipa/modref/AstModRef.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ipa/modref/AstModRef.java
@@ -11,18 +11,9 @@
 package com.ibm.wala.cast.ipa.modref;
 
 import com.ibm.wala.cast.ipa.callgraph.AstHeapModel;
-import com.ibm.wala.cast.ir.ssa.AstAssertInstruction;
-import com.ibm.wala.cast.ir.ssa.AstEchoInstruction;
-import com.ibm.wala.cast.ir.ssa.AstGlobalRead;
-import com.ibm.wala.cast.ir.ssa.AstGlobalWrite;
 import com.ibm.wala.cast.ir.ssa.AstInstructionVisitor;
-import com.ibm.wala.cast.ir.ssa.AstIsDefinedInstruction;
-import com.ibm.wala.cast.ir.ssa.AstLexicalRead;
-import com.ibm.wala.cast.ir.ssa.AstLexicalWrite;
 import com.ibm.wala.cast.ir.ssa.AstPropertyRead;
 import com.ibm.wala.cast.ir.ssa.AstPropertyWrite;
-import com.ibm.wala.cast.ir.ssa.EachElementGetInstruction;
-import com.ibm.wala.cast.ir.ssa.EachElementHasNextInstruction;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis;
@@ -65,33 +56,6 @@ public class AstModRef<T extends InstanceKey> extends ModRef<T> {
     public void visitPropertyWrite(AstPropertyWrite instruction) {
       // do nothing
     }
-
-    @Override
-    public void visitAstLexicalRead(AstLexicalRead instruction) {}
-
-    @Override
-    public void visitAstLexicalWrite(AstLexicalWrite instruction) {}
-
-    @Override
-    public void visitAstGlobalRead(AstGlobalRead instruction) {}
-
-    @Override
-    public void visitAstGlobalWrite(AstGlobalWrite instruction) {}
-
-    @Override
-    public void visitAssert(AstAssertInstruction instruction) {}
-
-    @Override
-    public void visitEachElementGet(EachElementGetInstruction inst) {}
-
-    @Override
-    public void visitEachElementHasNext(EachElementHasNextInstruction inst) {}
-
-    @Override
-    public void visitIsDefined(AstIsDefinedInstruction inst) {}
-
-    @Override
-    public void visitEcho(AstEchoInstruction inst) {}
   }
 
   @Override
@@ -107,33 +71,6 @@ public class AstModRef<T extends InstanceKey> extends ModRef<T> {
         CGNode n, Collection<PointerKey> result, AstHeapModel h, PointerAnalysis<T> pa) {
       super(n, result, h, pa, true);
     }
-
-    @Override
-    public void visitAstLexicalRead(AstLexicalRead instruction) {}
-
-    @Override
-    public void visitAstLexicalWrite(AstLexicalWrite instruction) {}
-
-    @Override
-    public void visitAstGlobalRead(AstGlobalRead instruction) {}
-
-    @Override
-    public void visitAstGlobalWrite(AstGlobalWrite instruction) {}
-
-    @Override
-    public void visitAssert(AstAssertInstruction instruction) {}
-
-    @Override
-    public void visitEachElementGet(EachElementGetInstruction inst) {}
-
-    @Override
-    public void visitEachElementHasNext(EachElementHasNextInstruction inst) {}
-
-    @Override
-    public void visitIsDefined(AstIsDefinedInstruction inst) {}
-
-    @Override
-    public void visitEcho(AstEchoInstruction inst) {}
 
     @Override
     public void visitPropertyRead(AstPropertyRead instruction) {

--- a/cast/src/main/java/com/ibm/wala/cast/ir/cfg/AstInducedCFG.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/cfg/AstInducedCFG.java
@@ -10,18 +10,7 @@
  */
 package com.ibm.wala.cast.ir.cfg;
 
-import com.ibm.wala.cast.ir.ssa.AstAssertInstruction;
-import com.ibm.wala.cast.ir.ssa.AstEchoInstruction;
-import com.ibm.wala.cast.ir.ssa.AstGlobalRead;
-import com.ibm.wala.cast.ir.ssa.AstGlobalWrite;
 import com.ibm.wala.cast.ir.ssa.AstInstructionVisitor;
-import com.ibm.wala.cast.ir.ssa.AstIsDefinedInstruction;
-import com.ibm.wala.cast.ir.ssa.AstLexicalRead;
-import com.ibm.wala.cast.ir.ssa.AstLexicalWrite;
-import com.ibm.wala.cast.ir.ssa.AstPropertyRead;
-import com.ibm.wala.cast.ir.ssa.AstPropertyWrite;
-import com.ibm.wala.cast.ir.ssa.EachElementGetInstruction;
-import com.ibm.wala.cast.ir.ssa.EachElementHasNextInstruction;
 import com.ibm.wala.cfg.InducedCFG;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.ipa.callgraph.Context;
@@ -38,39 +27,6 @@ public class AstInducedCFG extends InducedCFG {
     protected AstPEIVisitor(boolean[] r) {
       super(r);
     }
-
-    @Override
-    public void visitPropertyRead(AstPropertyRead inst) {}
-
-    @Override
-    public void visitPropertyWrite(AstPropertyWrite inst) {}
-
-    @Override
-    public void visitAstLexicalRead(AstLexicalRead inst) {}
-
-    @Override
-    public void visitAstLexicalWrite(AstLexicalWrite inst) {}
-
-    @Override
-    public void visitAstGlobalRead(AstGlobalRead instruction) {}
-
-    @Override
-    public void visitAstGlobalWrite(AstGlobalWrite instruction) {}
-
-    @Override
-    public void visitAssert(AstAssertInstruction instruction) {}
-
-    @Override
-    public void visitEachElementHasNext(EachElementHasNextInstruction inst) {}
-
-    @Override
-    public void visitEachElementGet(EachElementGetInstruction inst) {}
-
-    @Override
-    public void visitIsDefined(AstIsDefinedInstruction inst) {}
-
-    @Override
-    public void visitEcho(AstEchoInstruction inst) {}
   }
 
   protected class AstBranchVisitor extends BranchVisitor implements AstInstructionVisitor {
@@ -78,39 +34,6 @@ public class AstInducedCFG extends InducedCFG {
     protected AstBranchVisitor(boolean[] r) {
       super(r);
     }
-
-    @Override
-    public void visitPropertyRead(AstPropertyRead inst) {}
-
-    @Override
-    public void visitPropertyWrite(AstPropertyWrite inst) {}
-
-    @Override
-    public void visitAstLexicalRead(AstLexicalRead inst) {}
-
-    @Override
-    public void visitAstLexicalWrite(AstLexicalWrite inst) {}
-
-    @Override
-    public void visitAstGlobalRead(AstGlobalRead instruction) {}
-
-    @Override
-    public void visitAstGlobalWrite(AstGlobalWrite instruction) {}
-
-    @Override
-    public void visitAssert(AstAssertInstruction instruction) {}
-
-    @Override
-    public void visitEachElementHasNext(EachElementHasNextInstruction inst) {}
-
-    @Override
-    public void visitEachElementGet(EachElementGetInstruction inst) {}
-
-    @Override
-    public void visitIsDefined(AstIsDefinedInstruction inst) {}
-
-    @Override
-    public void visitEcho(AstEchoInstruction inst) {}
   }
 
   @Override

--- a/cast/src/main/java/com/ibm/wala/cast/ir/ssa/AstAbstractInstructionVisitor.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/ssa/AstAbstractInstructionVisitor.java
@@ -13,38 +13,4 @@ package com.ibm.wala.cast.ir.ssa;
 import com.ibm.wala.ssa.SSAInstruction;
 
 public abstract class AstAbstractInstructionVisitor extends SSAInstruction.Visitor
-    implements AstInstructionVisitor {
-
-  @Override
-  public void visitPropertyRead(AstPropertyRead instruction) {}
-
-  @Override
-  public void visitPropertyWrite(AstPropertyWrite instruction) {}
-
-  @Override
-  public void visitAstLexicalRead(AstLexicalRead instruction) {}
-
-  @Override
-  public void visitAstLexicalWrite(AstLexicalWrite instruction) {}
-
-  @Override
-  public void visitAstGlobalRead(AstGlobalRead instruction) {}
-
-  @Override
-  public void visitAstGlobalWrite(AstGlobalWrite instruction) {}
-
-  @Override
-  public void visitAssert(AstAssertInstruction instruction) {}
-
-  @Override
-  public void visitEachElementGet(EachElementGetInstruction inst) {}
-
-  @Override
-  public void visitEachElementHasNext(EachElementHasNextInstruction inst) {}
-
-  @Override
-  public void visitIsDefined(AstIsDefinedInstruction inst) {}
-
-  @Override
-  public void visitEcho(AstEchoInstruction inst) {}
-}
+    implements AstInstructionVisitor {}

--- a/cast/src/main/java/com/ibm/wala/cast/ir/ssa/AstConsumeInstruction.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/ssa/AstConsumeInstruction.java
@@ -25,11 +25,6 @@ public abstract class AstConsumeInstruction extends SSAInstruction {
   }
 
   @Override
-  public int getNumberOfDefs() {
-    return 0;
-  }
-
-  @Override
   public int getDef(int i) {
     Assertions.UNREACHABLE();
     return -1;

--- a/cast/src/main/java/com/ibm/wala/cast/ir/ssa/AstGlobalRead.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/ssa/AstGlobalRead.java
@@ -46,11 +46,6 @@ public class AstGlobalRead extends SSAGetInstruction {
   }
 
   @Override
-  public boolean isFallThrough() {
-    return true;
-  }
-
-  @Override
   public Collection<TypeReference> getExceptionTypes() {
     return null;
   }

--- a/cast/src/main/java/com/ibm/wala/cast/ir/ssa/AstGlobalWrite.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/ssa/AstGlobalWrite.java
@@ -46,11 +46,6 @@ public class AstGlobalWrite extends SSAPutInstruction {
   }
 
   @Override
-  public boolean isFallThrough() {
-    return true;
-  }
-
-  @Override
   public Collection<TypeReference> getExceptionTypes() {
     return null;
   }

--- a/cast/src/main/java/com/ibm/wala/cast/ir/ssa/AstLexicalRead.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/ssa/AstLexicalRead.java
@@ -66,11 +66,6 @@ public class AstLexicalRead extends AstLexicalAccess {
   }
 
   @Override
-  public int getNumberOfUses() {
-    return 0;
-  }
-
-  @Override
   public int getUse(int i) {
     throw new UnsupportedOperationException();
   }

--- a/cast/src/main/java/com/ibm/wala/cast/ir/ssa/AstLexicalWrite.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/ssa/AstLexicalWrite.java
@@ -66,11 +66,6 @@ public class AstLexicalWrite extends AstLexicalAccess {
   }
 
   @Override
-  public int getNumberOfDefs() {
-    return 0;
-  }
-
-  @Override
   public int getDef(int i) {
     throw new UnsupportedOperationException();
   }

--- a/cast/src/main/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
@@ -4528,31 +4528,12 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected boolean visitArrayRefAssign(
-      CAstNode n, CAstNode v, CAstNode a, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    /* empty */
-    return false;
-  }
-
-  @Override
   protected void leaveArrayRefAssign(
       CAstNode n, CAstNode v, CAstNode a, WalkContext c, CAstVisitor<WalkContext> visitor) {
     WalkContext context = c;
     int rval = c.getValue(v);
     c.setValue(n, rval);
     arrayOpHandler.doArrayWrite(context, c.getValue(n.getChild(0)), n, gatherArrayDims(c, n), rval);
-  }
-
-  @Override
-  protected boolean visitArrayRefAssignOp(
-      CAstNode n,
-      CAstNode v,
-      CAstNode a,
-      boolean pre,
-      WalkContext c,
-      CAstVisitor<WalkContext> visitor) {
-    /* empty */
-    return false;
   }
 
   @Override
@@ -4573,31 +4554,12 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected boolean visitObjectRefAssign(
-      CAstNode n, CAstNode v, CAstNode a, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    /* empty */
-    return false;
-  }
-
-  @Override
   protected void leaveObjectRefAssign(
       CAstNode n, CAstNode v, CAstNode a, WalkContext c, CAstVisitor<WalkContext> visitor) {
     WalkContext context = c;
     int rval = c.getValue(v);
     c.setValue(n, rval);
     doFieldWrite(context, c.getValue(n.getChild(0)), n.getChild(1), n, rval);
-  }
-
-  @Override
-  protected boolean visitObjectRefAssignOp(
-      CAstNode n,
-      CAstNode v,
-      CAstNode a,
-      boolean pre,
-      WalkContext c,
-      CAstVisitor<WalkContext> visitor) {
-    /* empty */
-    return false;
   }
 
   @Override
@@ -4617,28 +4579,9 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected boolean visitBlockExprAssign(
-      CAstNode n, CAstNode v, CAstNode a, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    /* empty */
-    return false;
-  }
-
-  @Override
   protected void leaveBlockExprAssign(
       CAstNode n, CAstNode v, CAstNode a, WalkContext c, CAstVisitor<WalkContext> visitor) {
     c.setValue(n, c.getValue(n.getChild(n.getChildCount() - 1)));
-  }
-
-  @Override
-  protected boolean visitBlockExprAssignOp(
-      CAstNode n,
-      CAstNode v,
-      CAstNode a,
-      boolean pre,
-      WalkContext c,
-      CAstVisitor<WalkContext> visitor) {
-    /* empty */
-    return false;
   }
 
   @Override
@@ -4651,13 +4594,6 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
       CAstVisitor<WalkContext> visitor) {
     /* empty */
     c.setValue(n, c.getValue(n.getChild(n.getChildCount() - 1)));
-  }
-
-  @Override
-  protected boolean visitVarAssign(
-      CAstNode n, CAstNode v, CAstNode a, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    /* empty */
-    return false;
   }
 
   /** assign rval to nm as appropriate, depending on the scope of ls */
@@ -4680,18 +4616,6 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
     Symbol ls = context.currentScope().lookup(nm);
     c.setValue(n, rval);
     assignValue(n, context, ls, nm, rval);
-  }
-
-  @Override
-  protected boolean visitVarAssignOp(
-      CAstNode n,
-      CAstNode v,
-      CAstNode a,
-      boolean pre,
-      WalkContext c,
-      CAstVisitor<WalkContext> visitor) {
-    /* empty */
-    return false;
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/core/util/ssa/SSAValue.java
+++ b/core/src/main/java/com/ibm/wala/core/util/ssa/SSAValue.java
@@ -139,11 +139,6 @@ public class SSAValue {
     }
 
     @Override
-    public int hashCode() {
-      return this.type.hashCode() * ((this.name == null) ? 1 : this.name.hashCode());
-    }
-
-    @Override
     public String toString() {
       return "<WaklyNamedKey type=\"" + this.type + "\" name=\"" + this.name + "\" />";
     }

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/FakeRootClass.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/FakeRootClass.java
@@ -27,7 +27,6 @@ import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.debug.Assertions;
 import com.ibm.wala.util.debug.UnimplementedError;
-import java.io.Reader;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -279,10 +278,5 @@ public class FakeRootClass extends SyntheticClass {
   @Override
   public boolean isPrivate() {
     return false;
-  }
-
-  @Override
-  public Reader getSource() {
-    return null;
   }
 }

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/DelegatingExplicitCallGraph.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/DelegatingExplicitCallGraph.java
@@ -17,7 +17,6 @@ import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.Context;
 import com.ibm.wala.ipa.callgraph.IAnalysisCacheView;
 import com.ibm.wala.ipa.callgraph.impl.ExplicitCallGraph;
-import com.ibm.wala.util.debug.Assertions;
 import com.ibm.wala.util.intset.BasicNaturalRelation;
 import com.ibm.wala.util.intset.BitVectorIntSet;
 import com.ibm.wala.util.intset.IBinaryNaturalRelation;
@@ -158,21 +157,6 @@ public class DelegatingExplicitCallGraph extends ExplicitCallGraph {
       // edges when NOT delegating.
       // see getPredNodeNumbers() below which recovers.
       super.addEdge(src, dst);
-    }
-
-    @Override
-    public void removeAllIncidentEdges(CGNode node) {
-      Assertions.UNREACHABLE();
-    }
-
-    @Override
-    public void removeIncomingEdges(CGNode node) {
-      Assertions.UNREACHABLE();
-    }
-
-    @Override
-    public void removeOutgoingEdges(CGNode node) {
-      Assertions.UNREACHABLE();
     }
 
     @Override

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/BypassSyntheticClass.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/BypassSyntheticClass.java
@@ -20,13 +20,10 @@ import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.types.Selector;
 import com.ibm.wala.types.TypeName;
 import com.ibm.wala.types.TypeReference;
-import com.ibm.wala.types.annotations.Annotation;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.debug.Assertions;
 import com.ibm.wala.util.debug.UnimplementedError;
-import java.io.Reader;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 
 /** A synthetic implementation of a class */
@@ -254,15 +251,5 @@ public class BypassSyntheticClass extends SyntheticClass {
   @Override
   public boolean isPrivate() {
     return realType.isPrivate();
-  }
-
-  @Override
-  public Reader getSource() {
-    return null;
-  }
-
-  @Override
-  public Collection<Annotation> getAnnotations() {
-    return Collections.emptySet();
   }
 }

--- a/core/src/main/java/com/ibm/wala/ssa/SSAArrayStoreInstruction.java
+++ b/core/src/main/java/com/ibm/wala/ssa/SSAArrayStoreInstruction.java
@@ -66,11 +66,6 @@ public abstract class SSAArrayStoreInstruction extends SSAArrayReferenceInstruct
     return 3;
   }
 
-  @Override
-  public int getNumberOfDefs() {
-    return 0;
-  }
-
   public int getValue() {
     return value;
   }

--- a/core/src/main/java/com/ibm/wala/ssa/SSAInstruction.java
+++ b/core/src/main/java/com/ibm/wala/ssa/SSAInstruction.java
@@ -115,76 +115,7 @@ public abstract class SSAInstruction {
   }
 
   /** A base visitor implementation that does nothing. */
-  public abstract static class Visitor implements IVisitor {
-    @Override
-    public void visitGoto(SSAGotoInstruction instruction) {}
-
-    @Override
-    public void visitArrayLoad(SSAArrayLoadInstruction instruction) {}
-
-    @Override
-    public void visitArrayStore(SSAArrayStoreInstruction instruction) {}
-
-    @Override
-    public void visitBinaryOp(SSABinaryOpInstruction instruction) {}
-
-    @Override
-    public void visitUnaryOp(SSAUnaryOpInstruction instruction) {}
-
-    @Override
-    public void visitConversion(SSAConversionInstruction instruction) {}
-
-    @Override
-    public void visitComparison(SSAComparisonInstruction instruction) {}
-
-    @Override
-    public void visitConditionalBranch(SSAConditionalBranchInstruction instruction) {}
-
-    @Override
-    public void visitSwitch(SSASwitchInstruction instruction) {}
-
-    @Override
-    public void visitReturn(SSAReturnInstruction instruction) {}
-
-    @Override
-    public void visitGet(SSAGetInstruction instruction) {}
-
-    @Override
-    public void visitPut(SSAPutInstruction instruction) {}
-
-    @Override
-    public void visitInvoke(SSAInvokeInstruction instruction) {}
-
-    @Override
-    public void visitNew(SSANewInstruction instruction) {}
-
-    @Override
-    public void visitArrayLength(SSAArrayLengthInstruction instruction) {}
-
-    @Override
-    public void visitThrow(SSAThrowInstruction instruction) {}
-
-    @Override
-    public void visitMonitor(SSAMonitorInstruction instruction) {}
-
-    @Override
-    public void visitCheckCast(SSACheckCastInstruction instruction) {}
-
-    @Override
-    public void visitInstanceof(SSAInstanceofInstruction instruction) {}
-
-    @Override
-    public void visitPhi(SSAPhiInstruction instruction) {}
-
-    @Override
-    public void visitPi(SSAPiInstruction instruction) {}
-
-    @Override
-    public void visitGetCaughtException(SSAGetCaughtExceptionInstruction instruction) {}
-
-    @Override
-    public void visitLoadMetadata(SSALoadMetadataInstruction instruction) {}
-  }
+  public abstract static class Visitor implements IVisitor {}
 
   /**
    * Does this instruction define a normal value, as distinct from a set of exceptions possibly

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexIClass.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexIClass.java
@@ -249,11 +249,6 @@ public class DexIClass extends BytecodeClass<IClassLoader> {
     }
   }
 
-  @Override
-  public int hashCode() {
-    return hashCode;
-  }
-
   Collection<Annotation> getAnnotations(Set<String> types) {
     Set<Annotation> result = HashSetFactory.make();
     for (org.jf.dexlib2.iface.Annotation a : classDef.getAnnotations()) {

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModelClass.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModelClass.java
@@ -309,21 +309,6 @@ public final /* singleton */ class AndroidModelClass extends SyntheticClass {
     return false;
   }
 
-  @Override
-  public boolean isInterface() {
-    return false;
-  }
-
-  @Override
-  public boolean isAbstract() {
-    return false;
-  }
-
-  @Override
-  public boolean isArrayClass() {
-    return false;
-  }
-
   /** This is a subclass of the root class. */
   @Override
   public IClass getSuperclass() throws UnsupportedOperationException {

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/analysis/Verifier.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/analysis/Verifier.java
@@ -13,9 +13,7 @@ package com.ibm.wala.shrike.shrikeBT.analysis;
 import com.ibm.wala.shrike.shrikeBT.ArrayLengthInstruction;
 import com.ibm.wala.shrike.shrikeBT.ConstantInstruction;
 import com.ibm.wala.shrike.shrikeBT.Constants;
-import com.ibm.wala.shrike.shrikeBT.DupInstruction;
 import com.ibm.wala.shrike.shrikeBT.ExceptionHandler;
-import com.ibm.wala.shrike.shrikeBT.GotoInstruction;
 import com.ibm.wala.shrike.shrikeBT.IArrayLoadInstruction;
 import com.ibm.wala.shrike.shrikeBT.IArrayStoreInstruction;
 import com.ibm.wala.shrike.shrikeBT.IBinaryOpInstruction;
@@ -36,7 +34,6 @@ import com.ibm.wala.shrike.shrikeBT.InvokeDynamicInstruction;
 import com.ibm.wala.shrike.shrikeBT.MethodData;
 import com.ibm.wala.shrike.shrikeBT.MonitorInstruction;
 import com.ibm.wala.shrike.shrikeBT.NewInstruction;
-import com.ibm.wala.shrike.shrikeBT.PopInstruction;
 import com.ibm.wala.shrike.shrikeBT.ReturnInstruction;
 import com.ibm.wala.shrike.shrikeBT.SwitchInstruction;
 import com.ibm.wala.shrike.shrikeBT.ThrowInstruction;
@@ -125,9 +122,6 @@ public final class Verifier extends Analyzer {
     }
 
     @Override
-    public void visitGoto(GotoInstruction instruction) {}
-
-    @Override
     public void visitLocalLoad(ILoadInstruction instruction) {
       String t = curLocals[instruction.getVarIndex()];
       if (t == null) {
@@ -168,12 +162,6 @@ public final class Verifier extends Analyzer {
       checkStackSubtype(1, Constants.TYPE_int);
       checkArrayStackSubtype(2, instruction.getType());
     }
-
-    @Override
-    public void visitPop(PopInstruction instruction) {}
-
-    @Override
-    public void visitDup(DupInstruction instruction) {}
 
     @Override
     public void visitBinaryOp(IBinaryOpInstruction instruction) {

--- a/util/src/main/java/com/ibm/wala/fixpoint/BitVectorVariable.java
+++ b/util/src/main/java/com/ibm/wala/fixpoint/BitVectorVariable.java
@@ -136,11 +136,6 @@ public class BitVectorVariable extends AbstractVariable<BitVectorVariable> {
     }
   }
 
-  @Override
-  public boolean equals(Object obj) {
-    return this == obj;
-  }
-
   public int populationCount() {
     if (V == null) {
       return 0;

--- a/util/src/main/java/com/ibm/wala/fixpoint/BooleanVariable.java
+++ b/util/src/main/java/com/ibm/wala/fixpoint/BooleanVariable.java
@@ -64,9 +64,4 @@ public class BooleanVariable extends AbstractVariable<BooleanVariable> {
   public void set(boolean b) {
     B = b;
   }
-
-  @Override
-  public boolean equals(Object obj) {
-    return this == obj;
-  }
 }


### PR DESCRIPTION
Each of these methods is equivalent to the corresponding superclass method.