### PR TITLE
Add semantic annotations to some `String` parameters

### DIFF
--- a/cast/java/build.gradle.kts
+++ b/cast/java/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
   api(projects.cast)
   api(projects.core)
   api(projects.util)
+  compileOnly(libs.jetbrains.annotations)
   implementation(projects.shrike)
   testFixturesApi(libs.junit.jupiter.api)
   testFixturesApi(libs.junit.jupiter.params)

--- a/cast/java/src/main/java/com/ibm/wala/cast/java/translator/JavaCAst2IRTranslator.java
+++ b/cast/java/src/main/java/com/ibm/wala/cast/java/translator/JavaCAst2IRTranslator.java
@@ -43,6 +43,7 @@ import com.ibm.wala.util.debug.Assertions;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import org.intellij.lang.annotations.Language;
 
 public class JavaCAst2IRTranslator extends AstTranslator {
   private final CAstEntity fSourceEntity;
@@ -543,7 +544,7 @@ public class JavaCAst2IRTranslator extends AstTranslator {
     }
   }
 
-  private static CAstType getType(final String name) {
+  private static CAstType getType(@Language("jvm-class-name") final String name) {
     return new CAstType.Class() {
 
       @Override

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -48,6 +48,8 @@ dependencies {
   }
   api(projects.util) { because("public interface CallGraph extends interface NumberedGraph") }
   api(libs.jspecify)
+  compileOnly(libs.jetbrains.annotations)
+  testCompileOnly(libs.jetbrains.annotations)
   testFixturesApi(libs.assertj.core)
   testFixturesApi(libs.junit.jupiter.api)
   testFixturesApi(projects.shrike)

--- a/core/src/main/java/com/ibm/wala/core/util/strings/StringStuff.java
+++ b/core/src/main/java/com/ibm/wala/core/util/strings/StringStuff.java
@@ -62,7 +62,8 @@ public class StringStuff {
    *
    * @throws IllegalArgumentException if dString is null
    */
-  public static String deployment2CanonicalTypeString(String dString) {
+  public static String deployment2CanonicalTypeString(
+      @org.intellij.lang.annotations.Language("jvm-class-name") String dString) {
     if (dString == null) {
       throw new IllegalArgumentException("dString is null");
     }

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/AnalysisScope.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/AnalysisScope.java
@@ -302,7 +302,9 @@ public class AnalysisScope {
     return loaderImplByRef.get(ref);
   }
 
-  public void setLoaderImpl(ClassLoaderReference ref, String implClass) {
+  public void setLoaderImpl(
+      ClassLoaderReference ref,
+      @org.intellij.lang.annotations.Language("jvm-class-name") String implClass) {
     if (ref == null) {
       throw new IllegalArgumentException("null ref");
     }

--- a/core/src/test/java/com/ibm/wala/util/io/FileProviderTest.java
+++ b/core/src/test/java/com/ibm/wala/util/io/FileProviderTest.java
@@ -16,11 +16,15 @@ import com.ibm.wala.core.util.io.FileProvider;
 import com.ibm.wala.util.PlatformUtil;
 import java.net.MalformedURLException;
 import java.net.URL;
+import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 
 public class FileProviderTest {
 
-  private void checkFile(String actual, String expected, String expectedPatternOnWindows) {
+  private void checkFile(
+      String actual,
+      @Language("RegExp") String expected,
+      @Language("RegExp") String expectedPatternOnWindows) {
     if (PlatformUtil.onWindows()) {
       assertThat(actual).matches(expectedPatternOnWindows);
     } else {

--- a/util/src/main/java/com/ibm/wala/util/io/FileUtil.java
+++ b/util/src/main/java/com/ibm/wala/util/io/FileUtil.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
+import org.intellij.lang.annotations.Language;
 import org.jspecify.annotations.Nullable;
 
 /** Simple utilities for accessing files. */
@@ -38,7 +39,8 @@ public class FileUtil {
    * @param recurse recurse to subdirectories?
    * @throws IllegalArgumentException if dir is null
    */
-  public static Collection<File> listFiles(String dir, String regex, boolean recurse) {
+  public static Collection<File> listFiles(
+      String dir, @Language("RegExp") String regex, boolean recurse) {
     if (dir == null) {
       throw new IllegalArgumentException("dir is null");
     }


### PR DESCRIPTION
These parameter annotations activate some nice coding-assistance features in JetBrains IDEs.  Annotating parameters rather than uses magnifies the impact:  one annotated parameter actives improved coding assistance wherever that parameter is used.