### PR TITLE
Do not ignore `File.delete()` result

### DIFF
--- a/cast/js/src/main/java/com/ibm/wala/cast/js/html/DomLessSourceExtractor.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/html/DomLessSourceExtractor.java
@@ -24,6 +24,7 @@ import java.io.PrintWriter;
 import java.io.Reader;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
@@ -354,9 +355,7 @@ public class DomLessSourceExtractor extends JSSourceExtractor {
     } else {
       outputFile = new File(fileName);
     }
-    if (outputFile.exists()) {
-      outputFile.delete();
-    }
+    Files.deleteIfExists(outputFile.toPath());
     if (delete) {
       outputFile.deleteOnExit();
     }

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/cha/MultiDexScopeTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/cha/MultiDexScopeTest.java
@@ -35,6 +35,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -126,11 +127,11 @@ public class MultiDexScopeTest {
 
       File dex1 = new File(dexTmpDir + File.separator + "classes.dex");
       scope.addToScope(ClassLoaderReference.Application, DexFileModule.make(dex1));
-      dex1.delete();
+      Files.delete(dex1.toPath());
 
       File dex2 = new File(dexTmpDir + File.separator + "classes2.dex");
       scope.addToScope(ClassLoaderReference.Application, DexFileModule.make(dex2));
-      dex2.delete();
+      Files.delete(dex2.toPath());
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/util/src/main/java/com/ibm/wala/util/io/FileUtil.java
+++ b/util/src/main/java/com/ibm/wala/util/io/FileUtil.java
@@ -138,9 +138,7 @@ public class FileUtil {
         throw new IOException("failed to create " + f.getParentFile());
       }
     }
-    if (f.exists()) {
-      f.delete();
-    }
+    Files.deleteIfExists(f.toPath());
     boolean result = f.createNewFile();
     if (!result) {
       throw new IOException("failed to create " + f);


### PR DESCRIPTION
In most of these cases, we'd want to throw an exception if the file could not be deleted.  `Files.delete(Path)` does that for us.  When we don't know that the file already exists, `Files.deleteIfExists(Path)` does the trick.