### PR TITLE
Remove two useless calls to getter methods

### DIFF
--- a/core/src/main/java/com/ibm/wala/core/util/ssa/ParameterAccessor.java
+++ b/core/src/main/java/com/ibm/wala/core/util/ssa/ParameterAccessor.java
@@ -242,7 +242,6 @@ public class ParameterAccessor {
 
       this.disp = disp;
       this.descriptorOffset = descriptorOffset;
-      super.isAssigned();
     }
 
     /** The position of the parameter in the methods Desciptor starting with 1. */

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/analysis/Verifier.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/analysis/Verifier.java
@@ -256,8 +256,6 @@ public final class Verifier extends Analyzer {
       for (int i = 0; i < instruction.getArrayBoundsCount(); i++) {
         checkStackSubtype(i, Constants.TYPE_int);
       }
-      // make sure constant is dereferenced
-      instruction.getType();
     }
 
     @Override


### PR DESCRIPTION
The call to `NewInstruction.getType()` does not do anything useful. `NewInstruction` is a `final` class, so we know exactly which implementation of `getType()` will be called.  That implementation has no side effects.  So if we don't need the returned value, then there's no reason to call it.

The call to `super.isAssigned()` _appears_ to be useless as well.  We know exactly which implementation of `isAssigned()` will be called. That implementation has no side effects.  So if we don't need the returned value, then there's no reason to call it.  **However,** I do wonder whether this was supposed to be a call to `super.setAssigned()` instead.  Manu, any thoughts on that?