### PR TITLE
Be more careful when printing some bytes in an input stream

### DIFF
--- a/util/src/main/java/com/ibm/wala/util/processes/Launcher.java
+++ b/util/src/main/java/com/ibm/wala/util/processes/Launcher.java
@@ -14,8 +14,9 @@ import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -260,12 +261,12 @@ public abstract class Launcher {
   }
 
   /** Drain some data from the input stream, and print said data to p. Do not block. */
-  private static void drainAndPrint(BufferedInputStream s, PrintStream p) {
+  private static void drainAndPrint(InputStream s, OutputStream p) {
     try {
       while (s.available() > 0) {
         byte[] data = new byte[s.available()];
-        s.read(data);
-        p.print(new String(data, StandardCharsets.UTF_8));
+        final var actuallyRead = s.read(data);
+        p.write(data, 0, actuallyRead);
       }
     } catch (IOException e) {
       // assume the stream has been closed (e.g. the process died)


### PR DESCRIPTION
The value returned by `InputStream.available()` is an _estimate_ of the number of bytes that can be read without blocking.  There is no guarantee that a subsequent `InputStream.read(byte[])` will receive exactly that same number of bytes.  Instead, we should use the `int` returned by the latter to tell us how many bytes were actually read.

Also, while we're here, make this method slightly more efficient by skipping UTF-8 encoding/decoding.  It's fine to just transfer raw bytes from one stream to another.