### PR TITLE
Remove many redundant local variables

### DIFF
--- a/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/ecj/util/SourceDirCallGraph.java
+++ b/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/ecj/util/SourceDirCallGraph.java
@@ -120,8 +120,6 @@ public class SourceDirCallGraph {
   }
 
   protected Iterable<Entrypoint> getEntrypoints(String mainClass, IClassHierarchy cha) {
-    Iterable<Entrypoint> entrypoints =
-        Util.makeMainEntrypoints(JavaSourceAnalysisScope.SOURCE, cha, new String[] {mainClass});
-    return entrypoints;
+    return Util.makeMainEntrypoints(JavaSourceAnalysisScope.SOURCE, cha, new String[] {mainClass});
   }
 }

--- a/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
+++ b/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
@@ -1304,9 +1304,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
 
       Expression init = f.getInitializer();
       CAstNode rhsNode = visitNode(init, context);
-      CAstNode assNode = makeNode(context, fFactory, f, CAstNode.ASSIGN, lhsNode, rhsNode);
-
-      return assNode; // their naming, not mine
+      return makeNode(context, fFactory, f, CAstNode.ASSIGN, lhsNode, rhsNode);
 
     } else if (node instanceof EnumConstantDeclaration) {
       return createEnumConstantDeclarationInit((EnumConstantDeclaration) node, context);
@@ -2067,7 +2065,6 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
     ITypeBinding fromtype =
         JDT2CAstUtils.getTypesVariablesBase(
             field.resolveFieldBinding().getVariableDeclaration().getType(), ast);
-    CAstNode castedObref = obref2; // createCast(left, obref2, fromtype, realtype, context);
 
     // put it all together
     // CAST(LOCAL SCOPE(BLOCK EXPR(DECL STMT(temp,
@@ -2095,7 +2092,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
                         realtype,
                         left.getStartPosition(),
                         left.getLength(),
-                        castedObref,
+                        obref2,
                         right,
                         context))));
 
@@ -2473,9 +2470,8 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
       WalkContext context) {
     CAstNode rightNode = visitNode(right, context);
 
-    int start = leftStartPosition;
     int end = right.getStartPosition() + right.getLength();
-    T pos = makePosition(start, end);
+    T pos = makePosition(leftStartPosition, end);
     T leftPos = makePosition(leftStartPosition, leftStartPosition + leftLength);
     T rightPos =
         makePosition(right.getStartPosition(), right.getStartPosition() + right.getLength());
@@ -4240,11 +4236,8 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
       // Why do we seemingly catch a RuntimeException in every method? this won't catch the
       // RuntimeException above where
       // it is supposed to be caught?
-      Collection<Pair<ITypeBinding, Object>> result =
-          Collections.singleton(
-              Pair.<ITypeBinding, Object>make(
-                  fRuntimeExcType, CAstControlFlowMap.EXCEPTION_TO_EXIT));
-      return result;
+      return Collections.singleton(
+          Pair.<ITypeBinding, Object>make(fRuntimeExcType, CAstControlFlowMap.EXCEPTION_TO_EXIT));
     }
 
     @Override
@@ -4381,9 +4374,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
               node.getAnonymousClassDeclaration(),
               context);
 
-      CAstNode assNode = makeNode(context, fFactory, node, CAstNode.ASSIGN, lhsNode, rhsNode);
-
-      return assNode; // their naming, not mine
+      return makeNode(context, fFactory, node, CAstNode.ASSIGN, lhsNode, rhsNode);
     } else {
 
       // String[] x = (new Direction[] {

--- a/cast/java/src/main/java/com/ibm/wala/cast/java/analysis/typeInference/AstJavaTypeInference.java
+++ b/cast/java/src/main/java/com/ibm/wala/cast/java/analysis/typeInference/AstJavaTypeInference.java
@@ -155,16 +155,11 @@ public class AstJavaTypeInference extends AstTypeInference {
 
       if (meet == null) {
         return super.evaluate(lhs, rhs);
+      } else if (lhs.getType().equals(meet)) {
+        return NOT_CHANGED;
       } else {
-        TypeVariable L = lhs;
-        TypeAbstraction lhsType = L.getType();
-
-        if (lhsType.equals(meet)) {
-          return NOT_CHANGED;
-        } else {
-          L.setType(meet);
-          return CHANGED;
-        }
+        lhs.setType(meet);
+        return CHANGED;
       }
     }
 

--- a/cast/java/src/main/java/com/ibm/wala/cast/java/ipa/callgraph/AstJavaSSAPropagationCallGraphBuilder.java
+++ b/cast/java/src/main/java/com/ibm/wala/cast/java/ipa/callgraph/AstJavaSSAPropagationCallGraphBuilder.java
@@ -22,7 +22,6 @@ import com.ibm.wala.cast.java.ssa.EnclosingObjectReference;
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.core.util.strings.Atom;
-import com.ibm.wala.fixpoint.IntSetVariable;
 import com.ibm.wala.fixpoint.UnaryOperator;
 import com.ibm.wala.ipa.callgraph.AnalysisOptions;
 import com.ibm.wala.ipa.callgraph.CGNode;
@@ -183,9 +182,8 @@ public class AstJavaSSAPropagationCallGraphBuilder extends AstSSAPropagationCall
             new UnaryOperator<>() {
               @Override
               public byte evaluate(PointsToSetVariable lhs, PointsToSetVariable rhs) {
-                IntSetVariable<?> tv = rhs;
-                if (tv.getValue() != null) {
-                  tv.getValue()
+                if (rhs.getValue() != null) {
+                  rhs.getValue()
                       .foreach(
                           ptr -> {
                             InstanceKey iKey = system.getInstanceKey(ptr);

--- a/cast/java/src/main/java/com/ibm/wala/cast/java/ipa/callgraph/AstJavaZeroOneContainerCFABuilder.java
+++ b/cast/java/src/main/java/com/ibm/wala/cast/java/ipa/callgraph/AstJavaZeroOneContainerCFABuilder.java
@@ -60,17 +60,15 @@ public class AstJavaZeroOneContainerCFABuilder extends AstJavaCFABuilder {
 
   protected ZeroXInstanceKeys makeInstanceKeys(
       IClassHierarchy cha, AnalysisOptions options, SSAContextInterpreter contextInterpreter) {
-    ZeroXInstanceKeys zik =
-        new ZeroXInstanceKeys(
-            options,
-            cha,
-            contextInterpreter,
-            ZeroXInstanceKeys.ALLOCATIONS
-                | ZeroXInstanceKeys.SMUSH_PRIMITIVE_HOLDERS
-                | ZeroXInstanceKeys.SMUSH_STRINGS
-                | ZeroXInstanceKeys.SMUSH_MANY
-                | ZeroXInstanceKeys.SMUSH_THROWABLES);
-    return zik;
+    return new ZeroXInstanceKeys(
+        options,
+        cha,
+        contextInterpreter,
+        ZeroXInstanceKeys.ALLOCATIONS
+            | ZeroXInstanceKeys.SMUSH_PRIMITIVE_HOLDERS
+            | ZeroXInstanceKeys.SMUSH_STRINGS
+            | ZeroXInstanceKeys.SMUSH_MANY
+            | ZeroXInstanceKeys.SMUSH_THROWABLES);
   }
 
   /**

--- a/cast/java/src/main/java/com/ibm/wala/cast/java/translator/JavaCAst2IRTranslator.java
+++ b/cast/java/src/main/java/com/ibm/wala/cast/java/translator/JavaCAst2IRTranslator.java
@@ -250,7 +250,6 @@ public class JavaCAst2IRTranslator extends AstTranslator {
     assert name.getKind() == CAstNode.CONSTANT;
     CallSiteReference dummySiteRef = (CallSiteReference) name.getValue();
     int instNumber = context.cfg().getCurrentInstruction();
-    int pc = instNumber;
     boolean isStatic = (receiver == -1);
     int[] realArgs = isStatic ? arguments : new int[arguments.length + 1];
 
@@ -274,7 +273,7 @@ public class JavaCAst2IRTranslator extends AstTranslator {
     }
     CallSiteReference realSiteRef =
         CallSiteReference.make(
-            pc, dummySiteRef.getDeclaredTarget(), dummySiteRef.getInvocationCode());
+            instNumber, dummySiteRef.getDeclaredTarget(), dummySiteRef.getInvocationCode());
 
     if (realSiteRef.getDeclaredTarget().getReturnType().equals(TypeReference.Void))
       context

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
@@ -473,8 +473,7 @@ public abstract class IRTests {
       String loaderName, String typeStr, IClassHierarchy cha) {
     ClassLoaderReference clr = findLoader(loaderName, cha);
     TypeName typeName = TypeName.string2TypeName('L' + typeStr);
-    TypeReference typeRef = TypeReference.findOrCreate(clr, typeName);
-    return typeRef;
+    return TypeReference.findOrCreate(clr, typeName);
   }
 
   private static ClassLoaderReference findLoader(String loaderName, IClassHierarchy cha) {

--- a/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/rhino/test/HTMLCGBuilder.java
+++ b/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/rhino/test/HTMLCGBuilder.java
@@ -125,8 +125,7 @@ public class HTMLCGBuilder {
     // assume it's a URL
     try {
       File f = new FileProvider().getFileFromClassLoader(src, HTMLCGBuilder.class.getClassLoader());
-      URL url = f.toURI().toURL();
-      return url;
+      return f.toURI().toURL();
     } catch (FileNotFoundException fnfe) {
       return new URI(src).toURL();
     }

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/ArgumentSpecialization.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/ArgumentSpecialization.java
@@ -261,8 +261,7 @@ public class ArgumentSpecialization {
               if (result == null) {
                 final List<CAstNode> children =
                     copyChildrenArrayAndTargets(root, cfg, context, nodeMap);
-                CAstNode copy = Ast.makeNode(root.getKind(), children);
-                result = copy;
+                result = Ast.makeNode(root.getKind(), children);
               }
 
               nodeMap.put(Pair.make(root, context.key()), result);

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionApplyTargetSelector.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionApplyTargetSelector.java
@@ -55,8 +55,7 @@ public class JavaScriptFunctionApplyTargetSelector implements MethodTargetSelect
   private static MethodReference genSyntheticMethodRef(IClass receiver) {
     Atom atom = Atom.findOrCreateUnicodeAtom(SYNTHETIC_APPLY_METHOD_PREFIX);
     Descriptor desc = Descriptor.findOrCreateUTF8(JavaScriptLoader.JS, "()LRoot;");
-    MethodReference ref = MethodReference.findOrCreate(receiver.getReference(), atom, desc);
-    return ref;
+    return MethodReference.findOrCreate(receiver.getReference(), atom, desc);
   }
 
   @Override

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionDotCallTargetSelector.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionDotCallTargetSelector.java
@@ -171,8 +171,7 @@ public class JavaScriptFunctionDotCallTargetSelector implements MethodTargetSele
   private static MethodReference genSyntheticMethodRef(IClass receiver, String key) {
     Atom atom = Atom.findOrCreateUnicodeAtom(SYNTHETIC_CALL_METHOD_PREFIX + key);
     Descriptor desc = Descriptor.findOrCreateUTF8(JavaScriptLoader.JS, "()LRoot;");
-    MethodReference ref = MethodReference.findOrCreate(receiver.getReference(), atom, desc);
-    return ref;
+    return MethodReference.findOrCreate(receiver.getReference(), atom, desc);
   }
 
   private static String getKey(int nargs, CGNode caller, CallSiteReference site) {
@@ -191,7 +190,6 @@ public class JavaScriptFunctionDotCallTargetSelector implements MethodTargetSele
     IR callerIR = caller.getIR();
     SSAAbstractInvokeInstruction callStmts[] = callerIR.getCalls(site);
     assert callStmts.length == 1;
-    int nargs = callStmts[0].getNumberOfPositionalParameters();
-    return nargs;
+    return callStmts[0].getNumberOfPositionalParameters();
   }
 }

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/CorrelationFinder.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/CorrelationFinder.java
@@ -265,8 +265,7 @@ public class CorrelationFinder {
         assert false : e.warning;
       }
     }
-    Map<IMethod, CorrelationSummary> summaries = findCorrelatedAccesses(scripts);
-    return summaries;
+    return findCorrelatedAccesses(scripts);
   }
 
   public Map<IMethod, CorrelationSummary> findCorrelatedAccesses(
@@ -308,8 +307,7 @@ public class CorrelationFinder {
     // first try interpreting as local file name, if that doesn't work just assume it's a URL
     try {
       File f = new FileProvider().getFileFromClassLoader(src, this.getClass().getClassLoader());
-      URL url = f.toURI().toURL();
-      return url;
+      return f.toURI().toURL();
     } catch (FileNotFoundException fnfe) {
       return new URL(src);
     }

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/translator/JSAstTranslator.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/translator/JSAstTranslator.java
@@ -536,16 +536,16 @@ public class JSAstTranslator extends AstTranslator {
   }
 
   @Override
-  protected boolean visitInstanceOf(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
+  protected boolean visitInstanceOf(
+      CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
     int result = context.currentScope().allocateTempValue();
     context.setValue(n, result);
     return false;
   }
 
   @Override
-  protected void leaveInstanceOf(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
+  protected void leaveInstanceOf(
+      CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
     int result = context.getValue(n);
 
     visit(n.getChild(0), context, visitor);

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/util/JSCallGraphBuilderUtil.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/util/JSCallGraphBuilderUtil.java
@@ -143,14 +143,12 @@ public class JSCallGraphBuilderUtil extends com.ibm.wala.cast.js.ipa.callgraph.J
   public static Module[] makeSourceModules(String dir, String name, ClassLoader loader)
       throws IOException {
     URL script = getURLforFile(dir, name, loader);
-    Module[] modules =
-        new Module[] {
-          (script.openConnection() instanceof JarURLConnection)
-              ? new SourceURLModule(script)
-              : makeSourceModule(script, dir, name),
-          getPrologueFile("prologue.js")
-        };
-    return modules;
+    return new Module[] {
+      (script.openConnection() instanceof JarURLConnection)
+          ? new SourceURLModule(script)
+          : makeSourceModule(script, dir, name),
+      getPrologueFile("prologue.js")
+    };
   }
 
   public static JSCFABuilder makeScriptCGBuilder(String dir, String name, ClassLoader loader)
@@ -194,9 +192,8 @@ public class JSCallGraphBuilderUtil extends com.ibm.wala.cast.js.ipa.callgraph.J
       String dir, String name, CGBuilderType builderType, ClassLoader loader)
       throws IOException, IllegalArgumentException, CancelException, WalaException {
     PropagationCallGraphBuilder b = makeScriptCGBuilder(dir, name, builderType, loader);
-    CallGraph CG = b.makeCallGraph(b.getOptions());
     // dumpCG(b.getPointerAnalysis(), CG);
-    return CG;
+    return b.makeCallGraph(b.getOptions());
   }
 
   public static CallGraph makeScriptCG(
@@ -208,9 +205,8 @@ public class JSCallGraphBuilderUtil extends com.ibm.wala.cast.js.ipa.callgraph.J
             : null;
     PropagationCallGraphBuilder b =
         makeCGBuilder(makeLoaders(preprocessor), scripts, builderType, irFactory);
-    CallGraph CG = b.makeCallGraph(b.getOptions());
     // dumpCG(b.getPointerAnalysis(), CG);
-    return CG;
+    return b.makeCallGraph(b.getOptions());
   }
 
   public static JSCFABuilder makeHTMLCGBuilder(URL url, Supplier<JSSourceExtractor> fExtractor)
@@ -279,8 +275,7 @@ public class JSCallGraphBuilderUtil extends com.ibm.wala.cast.js.ipa.callgraph.J
       ((CAstAbstractLoader) loaders.getTheLoader()).addMessages(dummy, e.warning);
     }
 
-    SourceModule[] scriptsArray = scripts.toArray(new SourceModule[0]);
-    return scriptsArray;
+    return scripts.toArray(new SourceModule[0]);
   }
 
   public static CallGraph makeHTMLCG(URL url, Supplier<JSSourceExtractor> fExtractor)
@@ -295,8 +290,7 @@ public class JSCallGraphBuilderUtil extends com.ibm.wala.cast.js.ipa.callgraph.J
       URL url, CGBuilderType builderType, Supplier<JSSourceExtractor> fExtractor)
       throws IllegalArgumentException, CancelException, WalaException {
     PropagationCallGraphBuilder b = makeHTMLCGBuilder(url, builderType, fExtractor);
-    CallGraph CG = b.makeCallGraph(b.getOptions());
-    return CG;
+    return b.makeCallGraph(b.getOptions());
   }
 
   public static JSCFABuilder makeCGBuilder(

--- a/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestJavaScriptSlicer.java
+++ b/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestJavaScriptSlicer.java
@@ -85,8 +85,7 @@ public abstract class TestJavaScriptSlicer extends TestJSCallGraphShape {
         new SDG<>(CG, B.getPointerAnalysis(), new JavaScriptModRef<>(), data, ctrl);
 
     final Collection<Statement> ss = findTargetStatement(CG);
-    Collection<Statement> result = Slicer.computeBackwardSlice(sdg, ss);
-    return result;
+    return Slicer.computeBackwardSlice(sdg, ss);
   }
 
   private Collection<Statement> findTargetStatement(CallGraph CG) {

--- a/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/AstSSAPropagationCallGraphBuilder.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/AstSSAPropagationCallGraphBuilder.java
@@ -478,10 +478,8 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
             new UnaryOperator<>() {
               @Override
               public byte evaluate(PointsToSetVariable lhs, PointsToSetVariable rhs) {
-                final IntSetVariable<?> objects = rhs;
-                if (objects.getValue() != null) {
-                  objects
-                      .getValue()
+                if (rhs.getValue() != null) {
+                  rhs.getValue()
                       .foreach(
                           optr -> {
                             InstanceKey object = system.getInstanceKey(optr);
@@ -534,10 +532,8 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
             new UnaryOperator<>() {
               @Override
               public byte evaluate(PointsToSetVariable lhs, PointsToSetVariable rhs) {
-                final IntSetVariable<?> objects = rhs;
-                if (objects.getValue() != null) {
-                  objects
-                      .getValue()
+                if (rhs.getValue() != null) {
+                  rhs.getValue()
                       .foreach(
                           optr -> {
                             InstanceKey object = system.getInstanceKey(optr);
@@ -1013,10 +1009,8 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
           new UnaryOperator<>() {
             @Override
             public byte evaluate(PointsToSetVariable lhs, PointsToSetVariable rhs) {
-              final IntSetVariable<?> objects = rhs;
-              if (objects.getValue() != null) {
-                objects
-                    .getValue()
+              if (rhs.getValue() != null) {
+                rhs.getValue()
                     .foreach(
                         optr -> {
                           InstanceKey object = system.getInstanceKey(optr);
@@ -1084,10 +1078,8 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
           new UnaryOperator<>() {
             @Override
             public byte evaluate(PointsToSetVariable lhs, PointsToSetVariable rhs) {
-              final IntSetVariable<?> fields = rhs;
-              if (fields.getValue() != null) {
-                fields
-                    .getValue()
+              if (rhs.getValue() != null) {
+                rhs.getValue()
                     .foreach(
                         fptr -> {
                           InstanceKey field = system.getInstanceKey(fptr);

--- a/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/CAstCallGraphUtil.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/CAstCallGraphUtil.java
@@ -76,16 +76,12 @@ public class CAstCallGraphUtil {
 
   public static AnalysisScope makeScope(
       String[] files, SingleClassLoaderFactory loaders, Language language) {
-    CAstAnalysisScope result =
-        new CAstAnalysisScope(files, loaders, Collections.singleton(language));
-    return result;
+    return new CAstAnalysisScope(files, loaders, Collections.singleton(language));
   }
 
   public static AnalysisScope makeScope(
       Module[] files, SingleClassLoaderFactory loaders, Language language) {
-    CAstAnalysisScope result =
-        new CAstAnalysisScope(files, loaders, Collections.singleton(language));
-    return result;
+    return new CAstAnalysisScope(files, loaders, Collections.singleton(language));
   }
 
   public static IAnalysisCacheView makeCache(IRFactory<IMethod> factory) {

--- a/cast/src/main/java/com/ibm/wala/cast/ir/ssa/AstIRFactory.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/ssa/AstIRFactory.java
@@ -158,15 +158,12 @@ public class AstIRFactory<T extends IMethod> implements IRFactory<T> {
     SSAInstruction[] oldInstrs = (SSAInstruction[]) oldCfg.getInstructions();
     SSAInstruction[] instrs = oldInstrs.clone();
 
-    IR newIR =
-        new AstIR(
-            (AstMethod) method,
-            instrs,
-            ((AstMethod) method).symbolTable().copy(),
-            new SSACFG(method, oldCfg, instrs),
-            options);
-
-    return newIR;
+    return new AstIR(
+        (AstMethod) method,
+        instrs,
+        ((AstMethod) method).symbolTable().copy(),
+        new SSACFG(method, oldCfg, instrs),
+        options);
   }
 
   public static IRFactory<IMethod> makeDefaultFactory() {

--- a/cast/src/main/java/com/ibm/wala/cast/ir/ssa/SSAConversion.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/ssa/SSAConversion.java
@@ -619,8 +619,7 @@ public class SSAConversion extends AbstractSSAConversion {
   protected int getNextNewValueNumber() {
     while (symtab.isConstant(nextSSAValue) || skip(nextSSAValue)) ++nextSSAValue;
     symtab.ensureSymbol(nextSSAValue);
-    int v = nextSSAValue++;
-    return v;
+    return nextSSAValue++;
   }
 
   @Override

--- a/cast/src/main/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
@@ -3811,14 +3811,13 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected boolean visitLoop(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
+  protected boolean visitLoop(CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
     // loop test block
     context.cfg().newBlock(true);
     PreBasicBlock headerB = context.cfg().getCurrentBlock();
     visitor.visit(n.getChild(0), context, visitor);
 
-    assert c.getValue(n.getChild(0)) != -1
+    assert context.getValue(n.getChild(0)) != -1
         : "error in loop test "
             + CAstPrinter.print(n.getChild(0), context.top().getSourceMap())
             + " of loop "
@@ -3830,7 +3829,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
                 context.cfg().currentInstruction,
                 translateConditionOpcode(CAstOperator.OP_EQ),
                 null,
-                c.getValue(n.getChild(0)),
+                context.getValue(n.getChild(0)),
                 context.currentScope().getConstantValue(0),
                 -1));
     PreBasicBlock branchB = context.cfg().getCurrentBlock();
@@ -3875,8 +3874,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
 
   @Override
   protected void leaveGetCaughtException(
-      CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
+      CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
     String nm = (String) n.getChild(0).getValue();
     context.currentScope().declare(new FinalCAstSymbol(nm, exceptionType()));
     int v = context.currentScope().allocateTempValue();
@@ -3917,23 +3915,21 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected boolean visitCall(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
+  protected boolean visitCall(CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
     int result = context.currentScope().allocateTempValue();
-    c.setValue(n, result);
+    context.setValue(n, result);
     return false;
   }
 
   @Override
-  protected void leaveCall(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
-    int result = c.getValue(n);
+  protected void leaveCall(CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
+    int result = context.getValue(n);
     int exp = context.currentScope().allocateTempValue();
-    int fun = c.getValue(n.getChild(0));
+    int fun = context.getValue(n.getChild(0));
     CAstNode functionName = n.getChild(1);
     int[] args = new int[n.getChildCount() - 2];
     for (int i = 0; i < args.length; i++) {
-      args[i] = c.getValue(n.getChild(i + 2));
+      args[i] = context.getValue(n.getChild(i + 2));
     }
     doCall(context, n, result, exp, functionName, fun, args);
   }
@@ -3945,8 +3941,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected void leaveVar(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
+  protected void leaveVar(CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
     String nm = (String) n.getChild(0).getValue();
     assert nm != null : "cannot find var for " + CAstPrinter.print(n, context.getSourceMap());
     Symbol s = context.currentScope().lookup(nm);
@@ -3956,11 +3951,11 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
         : "no type for " + nm + " at " + CAstPrinter.print(n, context.getSourceMap());
     TypeReference type = makeType(s.type());
     if (context.currentScope().isGlobal(s)) {
-      c.setValue(n, doGlobalRead(n, context, nm, type));
+      context.setValue(n, doGlobalRead(n, context, nm, type));
     } else if (context.currentScope().isLexicallyScoped(s)) {
-      c.setValue(n, doLexicallyScopedRead(n, context, nm, type));
+      context.setValue(n, doLexicallyScopedRead(n, context, nm, type));
     } else {
-      c.setValue(n, doLocalRead(context, nm, type));
+      context.setValue(n, doLocalRead(context, nm, type));
     }
   }
 
@@ -3971,16 +3966,15 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected void leaveConstant(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
-    c.setValue(n, context.currentScope().getConstantValue(n.getValue()));
+  protected void leaveConstant(CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
+    context.setValue(n, context.currentScope().getConstantValue(n.getValue()));
   }
 
   @Override
-  protected boolean visitBinaryExpr(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
+  protected boolean visitBinaryExpr(
+      CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
     int result = context.currentScope().allocateTempValue();
-    c.setValue(n, result);
+    context.setValue(n, result);
     return false;
   }
 
@@ -4011,13 +4005,13 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected void leaveBinaryExpr(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
-    int result = c.getValue(n);
+  protected void leaveBinaryExpr(
+      CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
+    int result = context.getValue(n);
     CAstNode l = n.getChild(1);
     CAstNode r = n.getChild(2);
-    assert c.getValue(r) != -1 : CAstPrinter.print(n);
-    assert c.getValue(l) != -1 : CAstPrinter.print(n);
+    assert context.getValue(r) != -1 : CAstPrinter.print(n);
+    assert context.getValue(l) != -1 : CAstPrinter.print(n);
 
     boolean mayBeInteger = handleBinaryOpThrow(n, n.getChild(0), context);
 
@@ -4031,8 +4025,8 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
                 false,
                 false,
                 result,
-                c.getValue(l),
-                c.getValue(r),
+                context.getValue(l),
+                context.getValue(r),
                 mayBeInteger));
     context
         .cfg()
@@ -4047,41 +4041,43 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected boolean visitUnaryExpr(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
+  protected boolean visitUnaryExpr(
+      CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
     int result = context.currentScope().allocateTempValue();
-    c.setValue(n, result);
+    context.setValue(n, result);
     return false;
   }
 
   @Override
-  protected void leaveUnaryExpr(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
-    int result = c.getValue(n);
+  protected void leaveUnaryExpr(CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
+    int result = context.getValue(n);
     CAstNode v = n.getChild(1);
     int currentInstruction = context.cfg().currentInstruction;
     context
         .cfg()
         .addInstruction(
             insts.UnaryOpInstruction(
-                currentInstruction, translateUnaryOpcode(n.getChild(0)), result, c.getValue(v)));
+                currentInstruction,
+                translateUnaryOpcode(n.getChild(0)),
+                result,
+                context.getValue(v)));
     context.cfg().noteOperands(currentInstruction, context.getSourceMap().getPosition(v));
   }
 
   @Override
-  protected boolean visitArrayLength(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
+  protected boolean visitArrayLength(
+      CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
     int result = context.currentScope().allocateTempValue();
-    c.setValue(n, result);
+    context.setValue(n, result);
     return false;
   }
 
   @Override
-  protected void leaveArrayLength(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
-    int result = c.getValue(n);
+  protected void leaveArrayLength(
+      CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
+    int result = context.getValue(n);
     CAstNode arrayExpr = n.getChild(0);
-    int arrayValue = c.getValue(arrayExpr);
+    int arrayValue = context.getValue(arrayExpr);
     int currentInstruction = context.cfg().currentInstruction;
     context
         .cfg()
@@ -4096,12 +4092,11 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected void leaveArrayRef(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
-    int arrayValue = c.getValue(n.getChild(0));
+  protected void leaveArrayRef(CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
+    int arrayValue = context.getValue(n.getChild(0));
     int result = context.currentScope().allocateTempValue();
-    c.setValue(n, result);
-    arrayOpHandler.doArrayRead(context, result, arrayValue, n, gatherArrayDims(c, n));
+    context.setValue(n, result);
+    arrayOpHandler.doArrayRead(context, result, arrayValue, n, gatherArrayDims(context, n));
   }
 
   @Override
@@ -4143,15 +4138,14 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected void leaveReturn(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
+  protected void leaveReturn(CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
     int currentInstruction = context.cfg().currentInstruction;
     if (n.getChildCount() > 0) {
       CAstNode returnExpr = n.getChild(0);
       context
           .cfg()
           .addInstruction(
-              insts.ReturnInstruction(currentInstruction, c.getValue(returnExpr), false));
+              insts.ReturnInstruction(currentInstruction, context.getValue(returnExpr), false));
       context
           .cfg()
           .noteOperands(currentInstruction, context.getSourceMap().getPosition(returnExpr));
@@ -4171,8 +4165,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected void leaveIfgoto(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
+  protected void leaveIfgoto(CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
     int currentInstruction = context.cfg().currentInstruction;
     switch (n.getChildCount()) {
       case 1:
@@ -4184,7 +4177,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
                     currentInstruction,
                     translateConditionOpcode(CAstOperator.OP_NE),
                     null,
-                    c.getValue(arg),
+                    context.getValue(arg),
                     context.currentScope().getConstantValue(0),
                     -1));
         context.cfg().noteOperands(currentInstruction, context.getSourceMap().getPosition(arg));
@@ -4200,8 +4193,8 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
                     currentInstruction,
                     translateConditionOpcode(op),
                     null,
-                    c.getValue(leftExpr),
-                    c.getValue(rightExpr),
+                    context.getValue(leftExpr),
+                    context.getValue(rightExpr),
                     -1));
         context
             .cfg()
@@ -4227,8 +4220,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected void leaveGoto(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
+  protected void leaveGoto(CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
     if (!context.cfg().isDeadBlock(context.cfg().getCurrentBlock())) {
       context.cfg().addPreNode(n, context.getUnwindState());
       CAstControlFlowMap controlFlowMap = context.getControlFlow();
@@ -4248,8 +4240,8 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected boolean visitLabelStmt(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
+  protected boolean visitLabelStmt(
+      CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
     if (!context.getControlFlow().getSourceNodes(n).isEmpty()) {
       context.cfg().newBlock(true);
       context.cfg().addPreNode(n, context.getUnwindState());
@@ -4263,8 +4255,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   protected void processIf(
-      CAstNode n, boolean isExpr, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
+      CAstNode n, boolean isExpr, WalkContext context, CAstVisitor<WalkContext> visitor) {
     PreBasicBlock trueB = null, falseB = null;
     // conditional
     CAstNode l = n.getChild(0);
@@ -4277,7 +4268,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
                 currentInstruction,
                 translateConditionOpcode(CAstOperator.OP_EQ),
                 null,
-                c.getValue(l),
+                context.getValue(l),
                 context.currentScope().getConstantValue(0),
                 -1));
     context.cfg().noteOperands(currentInstruction, context.getSourceMap().getPosition(l));
@@ -4290,7 +4281,8 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
       currentInstruction = context.cfg().getCurrentInstruction();
       context
           .cfg()
-          .addInstruction(new AssignInstruction(currentInstruction, c.getValue(n), c.getValue(r)));
+          .addInstruction(
+              new AssignInstruction(currentInstruction, context.getValue(n), context.getValue(r)));
       context.cfg().noteOperands(currentInstruction, context.getSourceMap().getPosition(r));
     }
     if (n.getChildCount() == 3) {
@@ -4311,7 +4303,8 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
         context
             .cfg()
             .addInstruction(
-                new AssignInstruction(currentInstruction, c.getValue(n), c.getValue(f)));
+                new AssignInstruction(
+                    currentInstruction, context.getValue(n), context.getValue(f)));
         context.cfg().noteOperands(currentInstruction, context.getSourceMap().getPosition(f));
       }
     }
@@ -4368,11 +4361,10 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected boolean visitIfExpr(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
+  protected boolean visitIfExpr(CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
     int result = context.currentScope().allocateTempValue();
-    c.setValue(n, result);
-    processIf(n, true, c, visitor);
+    context.setValue(n, result);
+    processIf(n, true, context, visitor);
     return true;
   }
 
@@ -4383,11 +4375,10 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected void leaveNew(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
+  protected void leaveNew(CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
 
     int result = context.currentScope().allocateTempValue();
-    c.setValue(n, result);
+    context.setValue(n, result);
 
     int[] arguments;
     if (n.getChildCount() <= 1) {
@@ -4395,7 +4386,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
     } else {
       arguments = new int[n.getChildCount() - 1];
       for (int i = 1; i < n.getChildCount(); i++) {
-        arguments[i - 1] = c.getValue(n.getChild(i));
+        arguments[i - 1] = context.getValue(n.getChild(i));
       }
     }
     doNewObject(context, n, result, n.getChild(0).getValue(), arguments);
@@ -4410,13 +4401,16 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
 
   @Override
   protected void leaveObjectLiteralFieldInit(
-      CAstNode n, int i, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
+      CAstNode n, int i, WalkContext context, CAstVisitor<WalkContext> visitor) {
     if (n.getChild(i).getKind() == CAstNode.EMPTY) {
       handleUnspecifiedLiteralKey();
     }
     doFieldWrite(
-        context, c.getValue(n.getChild(0)), n.getChild(i), n, c.getValue(n.getChild(i + 1)));
+        context,
+        context.getValue(n.getChild(0)),
+        n.getChild(i),
+        n,
+        context.getValue(n.getChild(i + 1)));
   }
 
   @Override
@@ -4438,14 +4432,13 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
 
   @Override
   protected void leaveArrayLiteralInitElement(
-      CAstNode n, int i, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
+      CAstNode n, int i, WalkContext context, CAstVisitor<WalkContext> visitor) {
     arrayOpHandler.doArrayWrite(
         context,
-        c.getValue(n.getChild(0)),
+        context.getValue(n.getChild(0)),
         n,
         new int[] {context.currentScope().getConstantValue(i - 1)},
-        c.getValue(n.getChild(i)));
+        context.getValue(n.getChild(i)));
   }
 
   @Override
@@ -4454,19 +4447,18 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected boolean visitObjectRef(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
+  protected boolean visitObjectRef(
+      CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
     int result = context.currentScope().allocateTempValue();
-    c.setValue(n, result);
+    context.setValue(n, result);
     return false;
   }
 
   @Override
-  protected void leaveObjectRef(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
-    int result = c.getValue(n);
+  protected void leaveObjectRef(CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
+    int result = context.getValue(n);
     CAstNode elt = n.getChild(1);
-    doFieldRead(context, result, c.getValue(n.getChild(0)), elt, n);
+    doFieldRead(context, result, context.getValue(n.getChild(0)), elt, n);
   }
 
   @Override
@@ -4492,9 +4484,8 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   /* Prereq: a.getKind() == ASSIGN_PRE_OP || a.getKind() == ASSIGN_POST_OP */
-  protected int processAssignOp(CAstNode v, CAstNode a, int temp, WalkContext c) {
-    WalkContext context = c;
-    int rval = c.getValue(v);
+  protected int processAssignOp(CAstNode v, CAstNode a, int temp, WalkContext context) {
+    int rval = context.getValue(v);
     CAstNode op = a.getChild(2);
     int temp2 = context.currentScope().allocateTempValue();
 
@@ -4529,11 +4520,11 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
 
   @Override
   protected void leaveArrayRefAssign(
-      CAstNode n, CAstNode v, CAstNode a, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
-    int rval = c.getValue(v);
-    c.setValue(n, rval);
-    arrayOpHandler.doArrayWrite(context, c.getValue(n.getChild(0)), n, gatherArrayDims(c, n), rval);
+      CAstNode n, CAstNode v, CAstNode a, WalkContext context, CAstVisitor<WalkContext> visitor) {
+    int rval = context.getValue(v);
+    context.setValue(n, rval);
+    arrayOpHandler.doArrayWrite(
+        context, context.getValue(n.getChild(0)), n, gatherArrayDims(context, n), rval);
   }
 
   @Override
@@ -4542,24 +4533,22 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
       CAstNode v,
       CAstNode a,
       boolean pre,
-      WalkContext c,
+      WalkContext context,
       CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
     int temp = context.currentScope().allocateTempValue();
-    int[] dims = gatherArrayDims(c, n);
-    arrayOpHandler.doArrayRead(context, temp, c.getValue(n.getChild(0)), n, dims);
-    int rval = processAssignOp(v, a, temp, c);
-    c.setValue(n, pre ? rval : temp);
-    arrayOpHandler.doArrayWrite(context, c.getValue(n.getChild(0)), n, dims, rval);
+    int[] dims = gatherArrayDims(context, n);
+    arrayOpHandler.doArrayRead(context, temp, context.getValue(n.getChild(0)), n, dims);
+    int rval = processAssignOp(v, a, temp, context);
+    context.setValue(n, pre ? rval : temp);
+    arrayOpHandler.doArrayWrite(context, context.getValue(n.getChild(0)), n, dims, rval);
   }
 
   @Override
   protected void leaveObjectRefAssign(
-      CAstNode n, CAstNode v, CAstNode a, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
-    int rval = c.getValue(v);
-    c.setValue(n, rval);
-    doFieldWrite(context, c.getValue(n.getChild(0)), n.getChild(1), n, rval);
+      CAstNode n, CAstNode v, CAstNode a, WalkContext context, CAstVisitor<WalkContext> visitor) {
+    int rval = context.getValue(v);
+    context.setValue(n, rval);
+    doFieldWrite(context, context.getValue(n.getChild(0)), n.getChild(1), n, rval);
   }
 
   @Override
@@ -4568,14 +4557,13 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
       CAstNode v,
       CAstNode a,
       boolean pre,
-      WalkContext c,
+      WalkContext context,
       CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
     int temp = context.currentScope().allocateTempValue();
-    doFieldRead(context, temp, c.getValue(n.getChild(0)), n.getChild(1), n);
-    int rval = processAssignOp(v, a, temp, c);
-    c.setValue(n, pre ? rval : temp);
-    doFieldWrite(context, c.getValue(n.getChild(0)), n.getChild(1), n, rval);
+    doFieldRead(context, temp, context.getValue(n.getChild(0)), n.getChild(1), n);
+    int rval = processAssignOp(v, a, temp, context);
+    context.setValue(n, pre ? rval : temp);
+    doFieldWrite(context, context.getValue(n.getChild(0)), n.getChild(1), n, rval);
   }
 
   @Override
@@ -4609,12 +4597,11 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
 
   @Override
   protected void leaveVarAssign(
-      CAstNode n, CAstNode v, CAstNode a, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
-    int rval = c.getValue(v);
+      CAstNode n, CAstNode v, CAstNode a, WalkContext context, CAstVisitor<WalkContext> visitor) {
+    int rval = context.getValue(v);
     String nm = (String) n.getChild(0).getValue();
     Symbol ls = context.currentScope().lookup(nm);
-    c.setValue(n, rval);
+    context.setValue(n, rval);
     assignValue(n, context, ls, nm, rval);
   }
 
@@ -4624,9 +4611,8 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
       CAstNode v,
       CAstNode a,
       boolean pre,
-      WalkContext c,
+      WalkContext context,
       CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
     String nm = (String) n.getChild(0).getValue();
     Symbol ls = context.currentScope().lookup(nm);
     TypeReference type = makeType(ls.type());
@@ -4646,13 +4632,13 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
       context
           .cfg()
           .noteOperands(currentInstruction, context.getSourceMap().getPosition(n.getChild(0)));
-      c.setValue(n, ret);
+      context.setValue(n, ret);
     }
 
-    int rval = processAssignOp(v, a, temp, c);
+    int rval = processAssignOp(v, a, temp, context);
 
     if (pre) {
-      c.setValue(n, rval);
+      context.setValue(n, rval);
     }
 
     if (context.currentScope().isGlobal(ls)) {
@@ -4831,8 +4817,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected boolean visitSwitch(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
+  protected boolean visitSwitch(CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
     if (isSimpleSwitch(n, context, visitor)) {
       doSimpleSwitch(n, context, visitor);
     } else {
@@ -4860,9 +4845,8 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected void leaveThrow(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
-    doThrow(context, c.getValue(n.getChild(0)));
+  protected void leaveThrow(CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
+    doThrow(context, context.getValue(n.getChild(0)));
 
     context.cfg().addPreNode(n, context.getUnwindState());
     context.cfg().newBlock(false);
@@ -4876,8 +4860,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected boolean visitCatch(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
+  protected boolean visitCatch(CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
 
     // unreachable catch block
     if (context.getControlFlow().getSourceNodes(n).isEmpty()) {
@@ -5014,9 +4997,8 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected void leaveEmpty(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
-    c.setValue(n, context.currentScope().getConstantValue(null));
+  protected void leaveEmpty(CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
+    context.setValue(n, context.currentScope().getConstantValue(null));
   }
 
   @Override
@@ -5026,10 +5008,9 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected void leavePrimitive(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
+  protected void leavePrimitive(CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
     int result = context.currentScope().allocateTempValue();
-    c.setValue(n, result);
+    context.setValue(n, result);
 
     doPrimitive(result, context, n);
   }
@@ -5052,11 +5033,10 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected void leaveAssert(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext context = c;
+  protected void leaveAssert(CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
     boolean fromSpec = true;
     CAstNode assertion = n.getChild(0);
-    int result = c.getValue(assertion);
+    int result = context.getValue(assertion);
     if (n.getChildCount() == 2) {
       assert n.getChild(1).getKind() == CAstNode.CONSTANT;
       assert n.getChild(1).getValue() instanceof Boolean;
@@ -5130,15 +5110,15 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected void leaveTypeLiteralExpr(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext wc = c;
+  protected void leaveTypeLiteralExpr(
+      CAstNode n, WalkContext wc, CAstVisitor<WalkContext> visitor) {
     assert n.getChild(0).getKind() == CAstNode.CONSTANT;
     String typeNameStr = (String) n.getChild(0).getValue();
     TypeName typeName = TypeName.string2TypeName(typeNameStr);
     TypeReference typeRef = TypeReference.findOrCreate(loader.getReference(), typeName);
 
     int result = wc.currentScope().allocateTempValue();
-    c.setValue(n, result);
+    wc.setValue(n, result);
 
     wc.cfg()
         .addInstruction(
@@ -5156,12 +5136,11 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected void leaveIsDefinedExpr(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext wc = c;
+  protected void leaveIsDefinedExpr(CAstNode n, WalkContext wc, CAstVisitor<WalkContext> visitor) {
     CAstNode refExpr = n.getChild(0);
-    int ref = c.getValue(refExpr);
+    int ref = wc.getValue(refExpr);
     int result = wc.currentScope().allocateTempValue();
-    c.setValue(n, result);
+    wc.setValue(n, result);
     if (n.getChildCount() == 1) {
       int currentInstruction = wc.cfg().getCurrentInstruction();
       wc.cfg().addInstruction(new AstIsDefinedInstruction(currentInstruction, result, ref));
@@ -5177,15 +5156,13 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected void leaveEcho(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext wc = c;
-
+  protected void leaveEcho(CAstNode n, WalkContext wc, CAstVisitor<WalkContext> visitor) {
     int rvals[] = new int[n.getChildCount()];
     Position rposs[] = new Position[n.getChildCount()];
     int i = 0;
     for (CAstNode child : n.getChildren()) {
-      rvals[i] = c.getValue(child);
-      rposs[i] = c.getSourceMap().getPosition(child);
+      rvals[i] = wc.getValue(child);
+      rposs[i] = wc.getSourceMap().getPosition(child);
       ++i;
     }
 
@@ -5200,15 +5177,13 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected void leaveYield(CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext wc = c;
-
+  protected void leaveYield(CAstNode n, WalkContext wc, CAstVisitor<WalkContext> visitor) {
     int rvals[] = new int[n.getChildCount()];
     Position rposs[] = new Position[n.getChildCount()];
     int i = 0;
     for (CAstNode child : n.getChildren()) {
-      rvals[i] = c.getValue(child);
-      rposs[i] = c.getSourceMap().getPosition(child);
+      rvals[i] = wc.getValue(child);
+      rposs[i] = wc.getSourceMap().getPosition(child);
       ++i;
     }
 
@@ -5227,9 +5202,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   }
 
   @Override
-  protected void leaveInclude(final CAstNode n, WalkContext c, CAstVisitor<WalkContext> visitor) {
-    WalkContext wc = c;
-
+  protected void leaveInclude(final CAstNode n, WalkContext wc, CAstVisitor<WalkContext> visitor) {
     CAstEntity included = getIncludedEntity(n);
 
     if (included == null) {

--- a/cast/src/main/java/com/ibm/wala/cast/ir/translator/ConstantFoldingRewriter.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/translator/ConstantFoldingRewriter.java
@@ -75,8 +75,7 @@ public abstract class ConstantFoldingRewriter extends CAstBasicRewriter<NonCopyi
 
     } else {
       List<CAstNode> children = copyChildrenArrayAndTargets(root, cfg, context, nodeMap);
-      CAstNode copy = Ast.makeNode(root.getKind(), children);
-      result = copy;
+      result = Ast.makeNode(root.getKind(), children);
     }
 
     nodeMap.put(Pair.make(root, context.key()), result);

--- a/cast/src/test/java/com/ibm/wala/cast/test/TestCAstTranslator.java
+++ b/cast/src/test/java/com/ibm/wala/cast/test/TestCAstTranslator.java
@@ -131,9 +131,7 @@ public abstract class TestCAstTranslator {
 
     AnalysisScope scope = CAstCallGraphUtil.makeScope(fileNames, loaders, getLanguage());
 
-    ClassHierarchy cha = ClassHierarchyFactory.make(scope, loaders, getLanguage());
-
-    return cha;
+    return ClassHierarchyFactory.make(scope, loaders, getLanguage());
   }
 
   protected void dump(ClassHierarchy cha) {

--- a/core/src/main/java/com/ibm/wala/analysis/arraybounds/ArrayBoundsGraphBuilder.java
+++ b/core/src/main/java/com/ibm/wala/analysis/arraybounds/ArrayBoundsGraphBuilder.java
@@ -80,7 +80,6 @@ public class ArrayBoundsGraphBuilder {
   private void addConstructionLength() {
 
     for (final Integer array : this.lowerBoundGraph.getArrayLength().keySet()) {
-      final Integer tmp = array;
 
       final SSAInstruction instruction = this.defUse.getDef(array);
       if (instruction != null) {
@@ -92,11 +91,11 @@ public class ArrayBoundsGraphBuilder {
                 if (instruction.getNumberOfUses() == 1) {
                   final int constructionLength = instruction.getUse(0);
                   Integer arraysNode =
-                      ArrayBoundsGraphBuilder.this.lowerBoundGraph.getArrayLength().get(tmp);
+                      ArrayBoundsGraphBuilder.this.lowerBoundGraph.getArrayLength().get(array);
                   ArrayBoundsGraphBuilder.this.lowerBoundGraph.addEdge(
                       arraysNode, constructionLength);
                   arraysNode =
-                      ArrayBoundsGraphBuilder.this.upperBoundGraph.getArrayLength().get(tmp);
+                      ArrayBoundsGraphBuilder.this.upperBoundGraph.getArrayLength().get(array);
                   ArrayBoundsGraphBuilder.this.upperBoundGraph.addEdge(
                       arraysNode, constructionLength);
 

--- a/core/src/main/java/com/ibm/wala/analysis/exceptionanalysis/ExceptionAnalysis2EdgeFilter.java
+++ b/core/src/main/java/com/ibm/wala/analysis/exceptionanalysis/ExceptionAnalysis2EdgeFilter.java
@@ -31,9 +31,7 @@ public class ExceptionAnalysis2EdgeFilter implements EdgeFilter<ISSABasicBlock> 
 
   @Override
   public boolean hasNormalEdge(ISSABasicBlock src, ISSABasicBlock dst) {
-    boolean originalEdge =
-        node.getIR().getControlFlowGraph().getNormalSuccessors(src).contains(dst);
-    boolean result = originalEdge;
+    boolean result = node.getIR().getControlFlowGraph().getNormalSuccessors(src).contains(dst);
     SSAInstruction instruction = IntraproceduralExceptionAnalysis.getThrowingInstruction(src);
     if (instruction != null) {
       if (analysis.getFilter().getFilter(node).alwaysThrowsException(instruction)) {
@@ -45,9 +43,7 @@ public class ExceptionAnalysis2EdgeFilter implements EdgeFilter<ISSABasicBlock> 
 
   @Override
   public boolean hasExceptionalEdge(ISSABasicBlock src, ISSABasicBlock dst) {
-    boolean originalEdge =
-        node.getIR().getControlFlowGraph().getExceptionalSuccessors(src).contains(dst);
-    boolean result = originalEdge;
+    boolean result = node.getIR().getControlFlowGraph().getExceptionalSuccessors(src).contains(dst);
 
     if (dst.isCatchBlock()) {
       if (!analysis.catchesException(node, src, dst)) {

--- a/core/src/main/java/com/ibm/wala/analysis/reflection/FactoryBypassInterpreter.java
+++ b/core/src/main/java/com/ibm/wala/analysis/reflection/FactoryBypassInterpreter.java
@@ -113,8 +113,7 @@ public class FactoryBypassInterpreter extends AbstractReflectionInterpreter {
     // }
     // }
 
-    Set<TypeReference> types = map.get(context);
-    return types;
+    return map.get(context);
   }
 
   /**

--- a/core/src/main/java/com/ibm/wala/analysis/reflection/GetMethodContextSelector.java
+++ b/core/src/main/java/com/ibm/wala/analysis/reflection/GetMethodContextSelector.java
@@ -134,8 +134,7 @@ public class GetMethodContextSelector implements ContextSelector {
    */
   protected static ConstantKey<String> makeConstantKey(IClassHierarchy cha, String str) {
     IClass cls = cha.lookupClass(TypeReference.JavaLangString);
-    ConstantKey<String> ck = new ConstantKey<>(str, cls);
-    return ck;
+    return new ConstantKey<>(str, cls);
   }
 
   private static final Collection<MethodReference> UNDERSTOOD_METHOD_REFS = HashSetFactory.make();

--- a/core/src/main/java/com/ibm/wala/analysis/stackMachine/AbstractIntStackMachine.java
+++ b/core/src/main/java/com/ibm/wala/analysis/stackMachine/AbstractIntStackMachine.java
@@ -112,11 +112,7 @@ public abstract class AbstractIntStackMachine implements FixedPointConstants {
           public UnaryOperator<MachineState> getNodeTransferFunction(final BasicBlock node) {
             return new UnaryOperator<>() {
               @Override
-              public byte evaluate(MachineState lhs, MachineState rhs) {
-
-                MachineState exit = lhs;
-                MachineState entry = rhs;
-
+              public byte evaluate(MachineState exit, MachineState entry) {
                 MachineState newExit = flow.flow(entry, node);
                 if (newExit.stateEquals(exit)) {
                   return NOT_CHANGED;
@@ -148,11 +144,7 @@ public abstract class AbstractIntStackMachine implements FixedPointConstants {
               final BasicBlock from, final BasicBlock to) {
             return new UnaryOperator<>() {
               @Override
-              public byte evaluate(MachineState lhs, MachineState rhs) {
-
-                MachineState exit = lhs;
-                MachineState entry = rhs;
-
+              public byte evaluate(MachineState exit, MachineState entry) {
                 MachineState newExit = flow.flow(entry, from, to);
                 if (newExit.stateEquals(exit)) {
                   return NOT_CHANGED;
@@ -204,9 +196,8 @@ public abstract class AbstractIntStackMachine implements FixedPointConstants {
           protected MachineState makeEdgeVariable(BasicBlock from, BasicBlock to) {
             assert from != null;
             assert to != null;
-            MachineState result = new MachineState(from);
 
-            return result;
+            return new MachineState(from);
           }
 
           @Override

--- a/core/src/main/java/com/ibm/wala/cfg/ShrikeCFG.java
+++ b/core/src/main/java/com/ibm/wala/cfg/ShrikeCFG.java
@@ -417,8 +417,7 @@ public class ShrikeCFG extends AbstractCFG<IInstruction, ShrikeCFG.BasicBlock>
         Assertions.UNREACHABLE();
         handlers = null;
       }
-      ExceptionHandler[] hs = handlers[getLastInstructionIndex()];
-      return hs;
+      return handlers[getLastInstructionIndex()];
     }
 
     private void addNormalEdgeTo(BasicBlock b) {

--- a/core/src/main/java/com/ibm/wala/cfg/cdg/ControlDependenceGraph.java
+++ b/core/src/main/java/com/ibm/wala/cfg/cdg/ControlDependenceGraph.java
@@ -107,8 +107,7 @@ public class ControlDependenceGraph<T> extends AbstractNumberedGraph<T> {
         }
         for (Map.Entry<T, Set<T>> entry : forwardEdges.entrySet()) {
           for (T t : entry.getValue()) {
-            Object n = t;
-            backwardEdges.get(n).add(entry.getKey());
+            backwardEdges.get(t).add(entry.getKey());
           }
         }
       }

--- a/core/src/main/java/com/ibm/wala/cfg/exc/inter/InterprocNullPointerAnalysis.java
+++ b/core/src/main/java/com/ibm/wala/cfg/exc/inter/InterprocNullPointerAnalysis.java
@@ -277,9 +277,8 @@ public final class InterprocNullPointerAnalysis {
       final PartialCallGraph partialCG1 = PartialCallGraph.make(fullCG, partialRoots, nodes);
 
       // delete the nodes not reachable by root (consider the different implementations of "make")
-      final PartialCallGraph partialCG2 = PartialCallGraph.make(partialCG1, partialRoots);
 
-      return partialCG2;
+      return PartialCallGraph.make(partialCG1, partialRoots);
     }
   }
 }

--- a/core/src/main/java/com/ibm/wala/cfg/exc/intra/IntraprocNullPointerAnalysis.java
+++ b/core/src/main/java/com/ibm/wala/cfg/exc/intra/IntraprocNullPointerAnalysis.java
@@ -155,9 +155,7 @@ public class IntraprocNullPointerAnalysis<T extends ISSABasicBlock> {
         }
         final NegativeGraphFilter<T> filter = new NegativeGraphFilter<>(deleted);
 
-        final PrunedCFG<SSAInstruction, T> newCfg = PrunedCFG.make(cfg, filter);
-
-        pruned = newCfg;
+        pruned = PrunedCFG.make(cfg, filter);
       }
     }
   }
@@ -168,9 +166,7 @@ public class IntraprocNullPointerAnalysis<T extends ISSABasicBlock> {
       nCFGbuilder.work(bb);
     }
 
-    Graph<T> deleted = nCFGbuilder.getNegativeCFG();
-
-    return deleted;
+    return nCFGbuilder.getNegativeCFG();
   }
 
   ControlFlowGraph<SSAInstruction, T> getPrunedCFG() {

--- a/core/src/main/java/com/ibm/wala/classLoader/ClassLoaderImpl.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/ClassLoaderImpl.java
@@ -584,8 +584,7 @@ public class ClassLoaderImpl implements IClassLoader {
       }
     }
     // delegating failed. Try our own namespace.
-    IClass result = loadedClasses.get(className);
-    return result;
+    return loadedClasses.get(className);
   }
 
   /** Method getParent. */

--- a/core/src/main/java/com/ibm/wala/classLoader/JVMClass.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/JVMClass.java
@@ -38,20 +38,17 @@ public abstract class JVMClass<T extends IClassLoader> extends BytecodeClass<T> 
 
   @Override
   public boolean isPublic() {
-    boolean result = ((modifiers & Constants.ACC_PUBLIC) != 0);
-    return result;
+    return ((modifiers & Constants.ACC_PUBLIC) != 0);
   }
 
   @Override
   public boolean isPrivate() {
-    boolean result = ((modifiers & Constants.ACC_PRIVATE) != 0);
-    return result;
+    return ((modifiers & Constants.ACC_PRIVATE) != 0);
   }
 
   @Override
   public boolean isInterface() {
-    boolean result = ((modifiers & Constants.ACC_INTERFACE) != 0);
-    return result;
+    return ((modifiers & Constants.ACC_INTERFACE) != 0);
   }
 
   /**
@@ -59,8 +56,7 @@ public abstract class JVMClass<T extends IClassLoader> extends BytecodeClass<T> 
    */
   @Override
   public boolean isAbstract() {
-    boolean result = ((modifiers & Constants.ACC_ABSTRACT) != 0);
-    return result;
+    return ((modifiers & Constants.ACC_ABSTRACT) != 0);
   }
 
   /**
@@ -68,8 +64,7 @@ public abstract class JVMClass<T extends IClassLoader> extends BytecodeClass<T> 
    */
   @Override
   public boolean isSynthetic() {
-    boolean result = ((modifiers & Constants.ACC_SYNTHETIC) != 0);
-    return result;
+    return ((modifiers & Constants.ACC_SYNTHETIC) != 0);
   }
 
   /**

--- a/core/src/main/java/com/ibm/wala/classLoader/ShrikeClass.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/ShrikeClass.java
@@ -451,8 +451,7 @@ public final class ShrikeClass extends JVMClass<IClassLoader> {
           String outer = r.getOuterClass(s);
           if (outer != null) {
             int modifiers = r.getAccessFlags(s);
-            boolean result = ((modifiers & Constants.ACC_STATIC) != 0);
-            return result;
+            return ((modifiers & Constants.ACC_STATIC) != 0);
           }
         }
       }

--- a/core/src/main/java/com/ibm/wala/core/tests/callGraph/CallGraphTestUtil.java
+++ b/core/src/main/java/com/ibm/wala/core/tests/callGraph/CallGraphTestUtil.java
@@ -36,8 +36,7 @@ public class CallGraphTestUtil {
 
   public static AnalysisOptions makeAnalysisOptions(
       AnalysisScope scope, Iterable<Entrypoint> entrypoints) {
-    AnalysisOptions options = new AnalysisOptions(scope, entrypoints);
-    return options;
+    return new AnalysisOptions(scope, entrypoints);
   }
 
   public static String REGRESSION_EXCLUSIONS = "Java60RegressionExclusions.txt";
@@ -54,10 +53,8 @@ public class CallGraphTestUtil {
 
   public static AnalysisScope makeJ2SEAnalysisScope(
       String scopeFile, String exclusionsFile, ClassLoader myClassLoader) throws IOException {
-    AnalysisScope scope =
-        AnalysisScopeReader.instance.readJavaScope(
-            scopeFile, new FileProvider().getFile(exclusionsFile), myClassLoader);
-    return scope;
+    return AnalysisScopeReader.instance.readJavaScope(
+        scopeFile, new FileProvider().getFile(exclusionsFile), myClassLoader);
   }
 
   public static CallGraph buildRTA(

--- a/core/src/main/java/com/ibm/wala/core/viz/PDFViewUtil.java
+++ b/core/src/main/java/com/ibm/wala/core/viz/PDFViewUtil.java
@@ -86,8 +86,7 @@ public class PDFViewUtil {
       SSACFG.BasicBlock bb = (SSACFG.BasicBlock) issaBasicBlock;
       labelMap.put(bb, getNodeLabel(ir, bb));
     }
-    NodeDecorator<ISSABasicBlock> labels = labelMap::get;
-    return labels;
+    return labelMap::get;
   }
 
   /**

--- a/core/src/main/java/com/ibm/wala/dataflow/IFDS/ICFGSupergraph.java
+++ b/core/src/main/java/com/ibm/wala/dataflow/IFDS/ICFGSupergraph.java
@@ -56,8 +56,7 @@ public class ICFGSupergraph
   }
 
   public static ICFGSupergraph make(CallGraph cg) {
-    ICFGSupergraph w = new ICFGSupergraph(ExplodedInterproceduralCFG.make(cg));
-    return w;
+    return new ICFGSupergraph(ExplodedInterproceduralCFG.make(cg));
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/dataflow/IFDS/TabulationSolver.java
+++ b/core/src/main/java/com/ibm/wala/dataflow/IFDS/TabulationSolver.java
@@ -187,8 +187,7 @@ public class TabulationSolver<T, P, F> {
     try {
       initialize();
       forwardTabulateSLRPs();
-      Result r = new Result();
-      return r;
+      return new Result();
     } catch (CancelException | CancelRuntimeException e) {
       // store a partially-tabulated result in the thrown exception.
       Result r = new Result();
@@ -693,8 +692,7 @@ public class TabulationSolver<T, P, F> {
     if (DEBUG_LEVEL > 0) {
       System.err.println("got binary flow function " + f);
     }
-    IntSet result = f.getTargets(call_d, exit_d);
-    return result;
+    return f.getTargets(call_d, exit_d);
   }
 
   /**
@@ -792,8 +790,7 @@ public class TabulationSolver<T, P, F> {
         if ((size == 0) || ((size == 1) && preExistFacts.contains(j))) {
           return j;
         } else {
-          int result = alpha.merge(preExistFacts, j);
-          return result;
+          return alpha.merge(preExistFacts, j);
         }
       }
     } else {

--- a/core/src/main/java/com/ibm/wala/demandpa/alg/CallStack.java
+++ b/core/src/main/java/com/ibm/wala/demandpa/alg/CallStack.java
@@ -45,8 +45,7 @@ import com.ibm.wala.util.collections.ImmutableStack;
 public class CallStack extends ImmutableStack<CallerSiteContext> implements State {
 
   public static CallStack emptyCallStack() {
-    CallStack ret = new CallStack(new CallerSiteContext[0]);
-    return ret;
+    return new CallStack(new CallerSiteContext[0]);
   }
 
   protected CallStack(CallerSiteContext[] entries) {
@@ -65,13 +64,11 @@ public class CallStack extends ImmutableStack<CallerSiteContext> implements Stat
 
   @Override
   public CallStack pop() {
-    final CallStack ret = (CallStack) super.pop();
-    return ret;
+    return (CallStack) super.pop();
   }
 
   @Override
   public CallStack push(CallerSiteContext entry) {
-    final CallStack ret = (CallStack) super.push(entry);
-    return ret;
+    return (CallStack) super.push(entry);
   }
 }

--- a/core/src/main/java/com/ibm/wala/demandpa/alg/DemandRefinementPointsTo.java
+++ b/core/src/main/java/com/ibm/wala/demandpa/alg/DemandRefinementPointsTo.java
@@ -272,10 +272,8 @@ public class DemandRefinementPointsTo extends AbstractDemandPointsTo {
       System.err.println("answering query for " + pk);
     }
     startNewQuery();
-    Pair<PointsToResult, Collection<InstanceKeyAndState>> p =
-        outerRefinementLoop(
-            new PointerKeyAndState(queriedPk, stateMachine.getStartState()), ikeyPred);
-    return p;
+    return outerRefinementLoop(
+        new PointerKeyAndState(queriedPk, stateMachine.getStartState()), ikeyPred);
   }
 
   /**
@@ -287,10 +285,8 @@ public class DemandRefinementPointsTo extends AbstractDemandPointsTo {
     if (p2SetWithStates == null) {
       throw new IllegalArgumentException("p2SetWithStates == null");
     }
-    Collection<T> finalP2Set =
-        Iterator2Collection.toSet(
-            new MapIterator<WithState<T>, T>(p2SetWithStates.iterator(), WithState::getWrapped));
-    return finalP2Set;
+    return Iterator2Collection.toSet(
+        new MapIterator<WithState<T>, T>(p2SetWithStates.iterator(), WithState::getWrapped));
   }
 
   /**

--- a/core/src/main/java/com/ibm/wala/examples/drivers/DemandCastChecker.java
+++ b/core/src/main/java/com/ibm/wala/examples/drivers/DemandCastChecker.java
@@ -217,9 +217,8 @@ public class DemandCastChecker {
       IR ir = node.getIR();
       if (ir == null) continue;
       SSAInstruction[] instrs = ir.getInstructions();
-      for (SSAInstruction instr : instrs) {
+      for (SSAInstruction instruction : instrs) {
         if ((long) numSafe + numMightFail > MAX_CASTS) break outer;
-        SSAInstruction instruction = instr;
         if (instruction instanceof SSACheckCastInstruction) {
           SSACheckCastInstruction castInstr = (SSACheckCastInstruction) instruction;
           final TypeReference[] declaredResultTypes = castInstr.getDeclaredResultTypes();

--- a/core/src/main/java/com/ibm/wala/examples/drivers/PDFCallGraph.java
+++ b/core/src/main/java/com/ibm/wala/examples/drivers/PDFCallGraph.java
@@ -157,9 +157,7 @@ public class PDFCallGraph {
 
     System.err.println(CallGraphStats.getStats(cg));
 
-    Graph<CGNode> g = pruneForAppLoader(cg);
-
-    return g;
+    return pruneForAppLoader(cg);
   }
 
   public static Graph<CGNode> pruneForAppLoader(CallGraph g) {

--- a/core/src/main/java/com/ibm/wala/examples/properties/WalaExamplesProperties.java
+++ b/core/src/main/java/com/ibm/wala/examples/properties/WalaExamplesProperties.java
@@ -27,11 +27,8 @@ public final class WalaExamplesProperties {
   public static Properties loadProperties() {
 
     try {
-      Properties result =
-          WalaProperties.loadPropertiesFromFile(
-              WalaExamplesProperties.class.getClassLoader(), PROPERTY_FILENAME);
-
-      return result;
+      return WalaProperties.loadPropertiesFromFile(
+          WalaExamplesProperties.class.getClassLoader(), PROPERTY_FILENAME);
     } catch (Exception e) {
       e.printStackTrace();
       throw new IllegalStateException("Unable to set up wala examples properties ", e);

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/AnalysisScope.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/AnalysisScope.java
@@ -529,8 +529,6 @@ public class AnalysisScope {
       ldrImplLines.add(ldrImplDescrLine);
     }
 
-    ShallowAnalysisScope shallowScope =
-        new ShallowAnalysisScope(getExclusions(), moduleLines, ldrImplLines);
-    return shallowScope;
+    return new ShallowAnalysisScope(getExclusions(), moduleLines, ldrImplLines);
   }
 }

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/ExplicitCallGraph.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/ExplicitCallGraph.java
@@ -140,8 +140,7 @@ public class ExplicitCallGraph extends BasicCallGraph<SSAContextInterpreter>
       if (result == null) {
         return Collections.emptySet();
       } else if (result instanceof CGNode) {
-        Set<CGNode> s = Collections.singleton((CGNode) result);
-        return s;
+        return Collections.singleton((CGNode) result);
       } else {
         IntSet s = (IntSet) result;
         HashSet<CGNode> h = HashSetFactory.make(s.size());

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/UnionContextSelector.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/UnionContextSelector.java
@@ -59,8 +59,7 @@ public class UnionContextSelector implements ContextSelector {
     } else if (ctxB == null) {
       return ctxA;
     } else {
-      final Context ctxU = new DelegatingContext(ctxA, ctxB);
-      return ctxU;
+      return new DelegatingContext(ctxA, ctxB);
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/Util.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/Util.java
@@ -873,20 +873,18 @@ public class Util {
     addDefaultBypassLogic(options, Util.class.getClassLoader(), cha);
     ContextSelector appSelector = null;
     SSAContextInterpreter appInterpreter = null;
-    SSAPropagationCallGraphBuilder result =
-        new nObjBuilder(
-            n,
-            cha,
-            options,
-            cache,
-            appSelector,
-            appInterpreter,
-            ZeroXInstanceKeys.ALLOCATIONS
-                | ZeroXInstanceKeys.SMUSH_MANY
-                | ZeroXInstanceKeys.SMUSH_PRIMITIVE_HOLDERS
-                | ZeroXInstanceKeys.SMUSH_STRINGS
-                | ZeroXInstanceKeys.SMUSH_THROWABLES);
-    return result;
+    return new nObjBuilder(
+        n,
+        cha,
+        options,
+        cache,
+        appSelector,
+        appInterpreter,
+        ZeroXInstanceKeys.ALLOCATIONS
+            | ZeroXInstanceKeys.SMUSH_MANY
+            | ZeroXInstanceKeys.SMUSH_PRIMITIVE_HOLDERS
+            | ZeroXInstanceKeys.SMUSH_STRINGS
+            | ZeroXInstanceKeys.SMUSH_THROWABLES);
   }
 
   /**
@@ -920,10 +918,8 @@ public class Util {
     addDefaultBypassLogic(options, Util.class.getClassLoader(), cha);
     ContextSelector appSelector = null;
     SSAContextInterpreter appInterpreter = null;
-    SSAPropagationCallGraphBuilder result =
-        new nObjBuilder(
-            n, cha, options, cache, appSelector, appInterpreter, ZeroXInstanceKeys.ALLOCATIONS);
-    return result;
+    return new nObjBuilder(
+        n, cha, options, cache, appSelector, appInterpreter, ZeroXInstanceKeys.ALLOCATIONS);
   }
 
   /**

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/AllocationSiteInNodeFactory.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/AllocationSiteInNodeFactory.java
@@ -96,9 +96,7 @@ public class AllocationSiteInNodeFactory implements InstanceKeyFactory {
       }
     }
 
-    InstanceKey key = new NormalAllocationInNode(nodeToUse, allocation, type);
-
-    return key;
+    return new NormalAllocationInNode(nodeToUse, allocation, type);
   }
 
   @Override
@@ -109,9 +107,8 @@ public class AllocationSiteInNodeFactory implements InstanceKeyFactory {
     if (type == null) {
       return null;
     }
-    InstanceKey key = new MultiNewArrayInNode(node, allocation, type, dim);
 
-    return key;
+    return new MultiNewArrayInNode(node, allocation, type, dim);
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/ClassBasedInstanceKeys.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/ClassBasedInstanceKeys.java
@@ -61,9 +61,7 @@ public class ClassBasedInstanceKeys implements InstanceKeyFactory {
       return null;
     }
 
-    ConcreteTypeKey key = new ConcreteTypeKey(type);
-
-    return key;
+    return new ConcreteTypeKey(type);
   }
 
   /**
@@ -102,9 +100,8 @@ public class ClassBasedInstanceKeys implements InstanceKeyFactory {
     if (type == null) {
       return null;
     }
-    ConcreteTypeKey key = new ConcreteTypeKey(type);
 
-    return key;
+    return new ConcreteTypeKey(type);
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/InstanceFieldKey.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/InstanceFieldKey.java
@@ -34,8 +34,7 @@ public class InstanceFieldKey extends AbstractFieldPointerKey {
     if (obj instanceof InstanceFieldKey) {
       if (obj.getClass().equals(getClass())) {
         InstanceFieldKey other = (InstanceFieldKey) obj;
-        boolean result = field.equals(other.field) && instance.equals(other.instance);
-        return result;
+        return field.equals(other.field) && instance.equals(other.instance);
       } else {
         return false;
       }

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationCallGraphBuilder.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationCallGraphBuilder.java
@@ -249,10 +249,8 @@ public abstract class PropagationCallGraphBuilder implements CallGraphBuilder<In
     try {
       solver.solve(monitor);
     } catch (CancelException | CancelRuntimeException e) {
-      CallGraphBuilderCancelException c =
-          CallGraphBuilderCancelException.createCallGraphBuilderCancelException(
-              e, callGraph, system.extractPointerAnalysis(this));
-      throw c;
+      throw CallGraphBuilderCancelException.createCallGraphBuilderCancelException(
+          e, callGraph, system.extractPointerAnalysis(this));
     }
 
     return callGraph;
@@ -953,7 +951,7 @@ public abstract class PropagationCallGraphBuilder implements CallGraphBuilder<In
     }
 
     @Override
-    public byte evaluate(PointsToSetVariable rhs) {
+    public byte evaluate(PointsToSetVariable ref) {
       if (DEBUG_GET) {
         String S =
             "EVAL GetField "
@@ -961,14 +959,13 @@ public abstract class PropagationCallGraphBuilder implements CallGraphBuilder<In
                 + ' '
                 + getFixedSet().getPointerKey()
                 + ' '
-                + rhs.getPointerKey()
+                + ref.getPointerKey()
                 + getFixedSet()
                 + ' '
-                + rhs;
+                + ref;
         System.err.println(S);
       }
 
-      PointsToSetVariable ref = rhs;
       if (ref.size() == 0) {
         return NOT_CHANGED;
       }
@@ -1185,8 +1182,7 @@ public abstract class PropagationCallGraphBuilder implements CallGraphBuilder<In
 
     /** Simply add the instance to each relevant points-to set. */
     @Override
-    public byte evaluate(PointsToSetVariable dummyLHS, PointsToSetVariable var) {
-      PointsToSetVariable ref = var;
+    public byte evaluate(PointsToSetVariable dummyLHS, PointsToSetVariable ref) {
       if (ref.size() == 0) {
         return NOT_CHANGED;
       }
@@ -1251,8 +1247,7 @@ public abstract class PropagationCallGraphBuilder implements CallGraphBuilder<In
 
     /** Simply add the instance to each relevant points-to set. */
     @Override
-    public byte evaluate(PointsToSetVariable dummyLHS, PointsToSetVariable var) {
-      PointsToSetVariable arrayref = var;
+    public byte evaluate(PointsToSetVariable dummyLHS, PointsToSetVariable arrayref) {
       if (arrayref.size() == 0) {
         return NOT_CHANGED;
       }

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationGraph.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationGraph.java
@@ -759,8 +759,7 @@ public class PropagationGraph implements IFixedPointSystem<PointsToSetVariable> 
       for (Map.Entry<UnaryOperator<PointsToSetVariable>, IBinaryNaturalRelation> entry :
           implicitUnaryMap.entrySet()) {
         count++;
-        Map.Entry<?, IBinaryNaturalRelation> e = entry;
-        IBinaryNaturalRelation R = e.getValue();
+        IBinaryNaturalRelation R = entry.getValue();
         System.err.println(("entry " + count));
         R.performVerboseAction();
         HeapTracer.Result result = HeapTracer.traceHeap(Collections.singleton(R), false);

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationSystem.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationSystem.java
@@ -449,8 +449,7 @@ public class PropagationSystem extends DefaultFixedPointSolver<PointsToSetVariab
 
     assert !klass.getReference().equals(TypeReference.JavaLangObject);
 
-    IClass T = klass;
-    registerInstanceWithAllSuperclasses(index, T);
+    registerInstanceWithAllSuperclasses(index, klass);
     registerInstanceWithAllInterfaces(klass, index);
 
     if (klass.isArrayClass()) {

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/SSAPropagationCallGraphBuilder.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/SSAPropagationCallGraphBuilder.java
@@ -572,8 +572,7 @@ public abstract class SSAPropagationCallGraphBuilder extends PropagationCallGrap
     protected IntSet getParamObjects(int paramIndex, @SuppressWarnings("unused") int rhsi) {
       int paramVn = call.getUse(paramIndex);
       PointerKey var = getPointerKeyForLocal(caller, paramVn);
-      IntSet s = system.findOrCreatePointsToSet(var).getValue();
-      return s;
+      return system.findOrCreatePointsToSet(var).getValue();
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/SmushedAllocationSiteInstanceKeys.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/SmushedAllocationSiteInstanceKeys.java
@@ -60,9 +60,7 @@ public class SmushedAllocationSiteInstanceKeys implements InstanceKeyFactory {
       }
     }
 
-    InstanceKey key = new SmushedAllocationSiteInNode(node, type);
-
-    return key;
+    return new SmushedAllocationSiteInNode(node, type);
   }
 
   @Override
@@ -73,9 +71,8 @@ public class SmushedAllocationSiteInstanceKeys implements InstanceKeyFactory {
     if (type == null) {
       return null;
     }
-    InstanceKey key = new MultiNewArrayInNode(node, allocation, type, dim);
 
-    return key;
+    return new MultiNewArrayInNode(node, allocation, type, dim);
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/ZeroXCFABuilder.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/ZeroXCFABuilder.java
@@ -64,8 +64,7 @@ public class ZeroXCFABuilder extends SSAPropagationCallGraphBuilder {
       AnalysisOptions options,
       SSAContextInterpreter contextInterpreter,
       int instancePolicy) {
-    ZeroXInstanceKeys zik = new ZeroXInstanceKeys(options, cha, contextInterpreter, instancePolicy);
-    return zik;
+    return new ZeroXInstanceKeys(options, cha, contextInterpreter, instancePolicy);
   }
 
   /**

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/AbstractRTABuilder.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/AbstractRTABuilder.java
@@ -370,9 +370,9 @@ public abstract class AbstractRTABuilder extends PropagationCallGraphBuilder {
 
   protected ContextSelector makeContextSelector(ContextSelector appContextSelector) {
     ContextSelector def = new DefaultContextSelector(options, cha);
-    ContextSelector contextSelector =
-        appContextSelector == null ? def : new DelegatingContextSelector(appContextSelector, def);
-    return contextSelector;
+    return appContextSelector == null
+        ? def
+        : new DelegatingContextSelector(appContextSelector, def);
   }
 
   protected SSAContextInterpreter makeContextInterpreter(
@@ -384,11 +384,9 @@ public abstract class AbstractRTABuilder extends PropagationCallGraphBuilder {
             ReflectionContextInterpreter.createReflectionContextInterpreter(
                 cha, getOptions(), getAnalysisCache()),
             defI);
-    SSAContextInterpreter contextInterpreter =
-        appContextInterpreter == null
-            ? defI
-            : new DelegatingSSAContextInterpreter(appContextInterpreter, defI);
-    return contextInterpreter;
+    return appContextInterpreter == null
+        ? defI
+        : new DelegatingSSAContextInterpreter(appContextInterpreter, defI);
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/BasicRTABuilder.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/BasicRTABuilder.java
@@ -112,8 +112,7 @@ public class BasicRTABuilder extends AbstractRTABuilder {
 
     @SuppressWarnings("unused")
     @Override
-    public byte evaluate(PointsToSetVariable lhs, PointsToSetVariable rhs) {
-      PointsToSetVariable receivers = rhs;
+    public byte evaluate(PointsToSetVariable lhs, PointsToSetVariable receivers) {
 
       // compute the set of pointers that were not previously handled
       IntSet value = receivers.getValue();

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/TypeBasedPointerAnalysis.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/TypeBasedPointerAnalysis.java
@@ -133,8 +133,7 @@ public class TypeBasedPointerAnalysis extends AbstractPointerAnalysis {
         c.add(klass);
       }
     }
-    OrdinalSet<InstanceKey> result = toOrdinalInstanceKeySet(c);
-    return result;
+    return toOrdinalInstanceKeySet(c);
   }
 
   private OrdinalSet<InstanceKey> toOrdinalInstanceKeySet(Collection<IClass> c) {

--- a/core/src/main/java/com/ibm/wala/ipa/cfg/AbstractInterproceduralCFG.java
+++ b/core/src/main/java/com/ibm/wala/ipa/cfg/AbstractInterproceduralCFG.java
@@ -214,8 +214,7 @@ public abstract class AbstractInterproceduralCFG<T extends ISSABasicBlock>
 
   protected SSAInstruction getLastInstructionForBlock(T pb, SSAInstruction[] instrs) {
     int index = pb.getLastInstructionIndex();
-    SSAInstruction inst = instrs[index];
-    return inst;
+    return instrs[index];
   }
 
   /**
@@ -863,8 +862,7 @@ public abstract class AbstractInterproceduralCFG<T extends ISSABasicBlock>
 
     Function<T, BasicBlockInContext<T>> toContext =
         object -> {
-          T b = object;
-          return new BasicBlockInContext<>(node, b);
+          return new BasicBlockInContext<>(node, object);
         };
     MapIterator<T, BasicBlockInContext<T>> m = new MapIterator<>(it, toContext);
     return new FilterIterator<>(m, isCall);

--- a/core/src/main/java/com/ibm/wala/ipa/slicer/HeapReachingDefs.java
+++ b/core/src/main/java/com/ibm/wala/ipa/slicer/HeapReachingDefs.java
@@ -520,8 +520,7 @@ public class HeapReachingDefs<T extends InstanceKey> {
   private static OrdinalSetMapping<Statement> createStatementDomain(
       Collection<Statement> statements) {
     Statement[] arr = new Statement[statements.size()];
-    OrdinalSetMapping<Statement> domain = new ObjectArrayMapping<>(statements.toArray(arr));
-    return domain;
+    return new ObjectArrayMapping<>(statements.toArray(arr));
   }
 
   /** Reaching def flow functions */

--- a/core/src/main/java/com/ibm/wala/ipa/slicer/SliceFunctions.java
+++ b/core/src/main/java/com/ibm/wala/ipa/slicer/SliceFunctions.java
@@ -29,8 +29,7 @@ public class SliceFunctions implements IPartiallyBalancedFlowFunctions<Statement
     if (src == null) {
       throw new IllegalArgumentException("src is null");
     }
-    Statement s = src;
-    switch (s.getKind()) {
+    switch (src.getKind()) {
       case NORMAL_RET_CALLER:
       case PARAM_CALLER:
       case EXC_RET_CALLER:
@@ -55,7 +54,7 @@ public class SliceFunctions implements IPartiallyBalancedFlowFunctions<Statement
           return ReachabilityFunctions.KILL_FLOW;
         }
       default:
-        Assertions.UNREACHABLE(s.getKind().toString());
+        Assertions.UNREACHABLE(src.getKind().toString());
         return null;
     }
   }

--- a/core/src/main/java/com/ibm/wala/ipa/slicer/thin/CISlicer.java
+++ b/core/src/main/java/com/ibm/wala/ipa/slicer/thin/CISlicer.java
@@ -90,13 +90,11 @@ public class CISlicer {
   }
 
   public Collection<Statement> computeBackwardThinSlice(Statement seed) {
-    Collection<Statement> slice = DFS.getReachableNodes(depGraph, Collections.singleton(seed));
-    return slice;
+    return DFS.getReachableNodes(depGraph, Collections.singleton(seed));
   }
 
   public Collection<Statement> computeBackwardThinSlice(Collection<Statement> seeds) {
-    Collection<Statement> slice = DFS.getReachableNodes(depGraph, seeds);
-    return slice;
+    return DFS.getReachableNodes(depGraph, seeds);
   }
 
   /** Compute the set of pointer keys each statement mods */

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/BypassSyntheticClassLoader.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/BypassSyntheticClassLoader.java
@@ -91,8 +91,7 @@ public class BypassSyntheticClassLoader implements IClassLoader {
   public IClass lookupClass(TypeName className) {
     IClass pc = parent.lookupClass(className);
     if (pc == null) {
-      IClass c = syntheticClasses.get(className);
-      return c;
+      return syntheticClasses.get(className);
     } else {
       return pc;
     }

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/LambdaSummaryClass.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/LambdaSummaryClass.java
@@ -402,8 +402,7 @@ public class LambdaSummaryClass extends SyntheticClass {
       throw new RuntimeException(e);
     }
 
-    SummarizedMethod method = new SummarizedMethod(ref, summary, LambdaSummaryClass.this);
-    return method;
+    return new SummarizedMethod(ref, summary, this);
   }
 
   private static Dispatch getDispatchForMethodHandleKind(int kind) {

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/SummarizedMethodWithNames.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/SummarizedMethodWithNames.java
@@ -177,16 +177,14 @@ public class SummarizedMethodWithNames extends SummarizedMethod {
   @Override
   public IR makeIR(Context context, SSAOptions options) {
     final SSAInstruction instrs[] = getStatements(options);
-    final IR ir =
-        new SyntheticIRWithNames(
-            this,
-            Everywhere.EVERYWHERE,
-            makeControlFlowGraph(instrs),
-            instrs,
-            options,
-            summary.getConstants(),
-            localNames);
 
-    return ir;
+    return new SyntheticIRWithNames(
+        this,
+        Everywhere.EVERYWHERE,
+        makeControlFlowGraph(instrs),
+        instrs,
+        options,
+        summary.getConstants(),
+        localNames);
   }
 }

--- a/core/src/main/java/com/ibm/wala/ssa/IR.java
+++ b/core/src/main/java/com/ibm/wala/ssa/IR.java
@@ -570,8 +570,7 @@ public abstract class IR implements IRView {
 
   /** Return the instruction index corresponding to an allocation site */
   public int getNewInstructionIndex(NewSiteReference site) {
-    Integer i = newSiteMapping.get(site);
-    return i;
+    return newSiteMapping.get(site);
   }
 
   /**

--- a/core/src/main/java/com/ibm/wala/types/MethodReference.java
+++ b/core/src/main/java/com/ibm/wala/types/MethodReference.java
@@ -222,12 +222,10 @@ public final class MethodReference extends MemberReference {
   @Override
   public String getSignature() {
     // TODO: check that we're not calling this often.
-    String s =
-        getDeclaringClass().getName().toString().substring(1).replace('/', '.')
-            + '.'
-            + getName()
-            + getDescriptor();
-    return s;
+    return getDeclaringClass().getName().toString().substring(1).replace('/', '.')
+        + '.'
+        + getName()
+        + getDescriptor();
   }
 
   /**

--- a/core/src/main/java/com/ibm/wala/types/TypeReference.java
+++ b/core/src/main/java/com/ibm/wala/types/TypeReference.java
@@ -501,9 +501,8 @@ public final class TypeReference implements Serializable {
     }
 
     Key key = new Key(cl, typeName);
-    TypeReference val = dictionary.get(key);
 
-    return val;
+    return dictionary.get(key);
   }
 
   public static TypeReference findOrCreateArrayOf(TypeReference t) {

--- a/core/src/main/java/com/ibm/wala/types/annotations/Annotation.java
+++ b/core/src/main/java/com/ibm/wala/types/annotations/Annotation.java
@@ -81,8 +81,7 @@ public class Annotation {
       AnnotationsReader r, ClassLoaderReference clRef) throws InvalidClassFileException {
     if (r != null) {
       AnnotationAttribute[] allAnnotations = r.getAllAnnotations();
-      Collection<Annotation> result = convertToAnnotations(clRef, allAnnotations);
-      return result;
+      return convertToAnnotations(clRef, allAnnotations);
     } else {
       return Collections.emptySet();
     }

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/CallGraphTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/CallGraphTest.java
@@ -596,9 +596,8 @@ public class CallGraphTest extends WalaTestCase {
        * @see com.ibm.wala.util.graph.EdgeManager#getPredNodes(java.lang.Object)
        */
       @Override
-      public Iterator<MethodReference> getPredNodes(MethodReference N) {
+      public Iterator<MethodReference> getPredNodes(MethodReference methodReference) {
         Set<MethodReference> pred = HashSetFactory.make(10);
-        MethodReference methodReference = N;
         for (CGNode cgNode : cg.getNodes(methodReference))
           for (CGNode p : Iterator2Iterable.make(cg.getPredNodes(cgNode)))
             pred.add(p.getMethod().getReference());
@@ -618,9 +617,8 @@ public class CallGraphTest extends WalaTestCase {
        * @see com.ibm.wala.util.graph.EdgeManager#getSuccNodes(java.lang.Object)
        */
       @Override
-      public Iterator<MethodReference> getSuccNodes(MethodReference N) {
+      public Iterator<MethodReference> getSuccNodes(MethodReference methodReference) {
         Set<MethodReference> succ = HashSetFactory.make(10);
-        MethodReference methodReference = N;
         for (CGNode node : cg.getNodes(methodReference))
           for (CGNode p : Iterator2Iterable.make(cg.getSuccNodes(node)))
             succ.add(p.getMethod().getReference());

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/KawaCallGraphTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/KawaCallGraphTest.java
@@ -106,13 +106,11 @@ public class KawaCallGraphTest extends DynamicCallGraphTestBase {
   }
 
   private static Set<CGNode> getNodes(CallGraph CG, String cls, String method, String descr) {
-    Set<CGNode> nodes =
-        CG.getNodes(
-            MethodReference.findOrCreate(
-                TypeReference.find(ClassLoaderReference.Application, cls),
-                Atom.findOrCreateUnicodeAtom(method),
-                Descriptor.findOrCreateUTF8(descr)));
-    return nodes;
+    return CG.getNodes(
+        MethodReference.findOrCreate(
+            TypeReference.find(ClassLoaderReference.Application, cls),
+            Atom.findOrCreateUnicodeAtom(method),
+            Descriptor.findOrCreateUTF8(descr)));
   }
 
   /** Maximum number of outer fixed point iterations to use when building the Kawa call graph. */

--- a/core/src/test/java/com/ibm/wala/core/tests/demandpa/AbstractPtrTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/demandpa/AbstractPtrTest.java
@@ -175,8 +175,7 @@ public abstract class AbstractPtrTest {
     // query it
     CGNode mainMethod = AbstractPtrTest.findMainMethod(dmp.getBaseCallGraph());
     InstanceKey keyToQuery = getFlowsToInstanceKey(mainMethod, dmp.getHeapModel());
-    Collection<PointerKey> flowsTo = dmp.getFlowsTo(keyToQuery).snd;
-    return flowsTo;
+    return dmp.getFlowsTo(keyToQuery).snd;
   }
 
   /** returns the instance key corresponding to the single allocation site of type FlowsToType */
@@ -215,8 +214,7 @@ public abstract class AbstractPtrTest {
     // find the testThisVar call, and check the parameter's points-to set
     CGNode mainMethod = AbstractPtrTest.findMainMethod(dmp.getBaseCallGraph());
     PointerKey keyToQuery = AbstractPtrTest.getParam(mainMethod, "testThisVar", dmp.getHeapModel());
-    Collection<InstanceKey> pointsTo = dmp.getPointsTo(keyToQuery);
-    return pointsTo;
+    return dmp.getPointsTo(keyToQuery);
   }
 
   protected DemandRefinementPointsTo makeDemandPointerAnalysis(String mainClass)

--- a/core/src/test/java/com/ibm/wala/core/tests/slicer/SlicerTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/slicer/SlicerTest.java
@@ -143,10 +143,9 @@ public class SlicerTest {
     System.err.println("Statement: " + s);
     // compute a data slice
     final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-    Collection<Statement> computeBackwardSlice =
+    Collection<Statement> slice =
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
-    Collection<Statement> slice = computeBackwardSlice;
     SlicerUtil.dumpSlice(slice);
 
     int i = 0;
@@ -182,10 +181,9 @@ public class SlicerTest {
     System.err.println("Statement: " + s);
     // compute a data slice
     final PointerAnalysis<InstanceKey> pointerAnalysis = builder.getPointerAnalysis();
-    Collection<Statement> computeBackwardSlice =
+    Collection<Statement> slice =
         Slicer.computeBackwardSlice(
             s, cg, pointerAnalysis, DataDependenceOptions.FULL, ControlDependenceOptions.NONE);
-    Collection<Statement> slice = computeBackwardSlice;
     SlicerUtil.dumpSlice(slice);
 
     assertThat(SlicerUtil.countNormals(slice)).as(slice::toString).isEqualTo(9);

--- a/core/src/test/java/com/ibm/wala/demandpa/driver/CompareToZeroOneCFADriver.java
+++ b/core/src/test/java/com/ibm/wala/demandpa/driver/CompareToZeroOneCFADriver.java
@@ -230,11 +230,9 @@ public class CompareToZeroOneCFADriver {
     SSAPropagationCallGraphBuilder builder =
         Util.makeVanillaZeroOneCFABuilder(Language.JAVA, options, new AnalysisCacheImpl(), cha);
     // return new TestNewGraphPointsTo(cg, builder, fam, cha, warnings);
-    DemandRefinementPointsTo fullDemandPointsTo =
-        DemandRefinementPointsTo.makeWithDefaultFlowGraph(
-            cg, builder, fam, cha, options, new DummyStateMachine.Factory<>());
     // fullDemandPointsTo.setOnTheFly(true);
     // fullDemandPointsTo.setRefineFields(true);
-    return fullDemandPointsTo;
+    return DemandRefinementPointsTo.makeWithDefaultFlowGraph(
+        cg, builder, fam, cha, options, new DummyStateMachine.Factory<>());
   }
 }

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexCFG.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexCFG.java
@@ -551,8 +551,7 @@ public class DexCFG extends AbstractCFG<Instruction, DexCFG.BasicBlock> implemen
     private ExceptionHandler[] getExceptionHandlers() {
       ExceptionHandler[][] handlers;
       handlers = dexMethod.getHandlers();
-      ExceptionHandler[] hs = handlers[getLastInstructionIndex()];
-      return hs;
+      return handlers[getLastInstructionIndex()];
     }
 
     private void addNormalEdgeTo(BasicBlock b) {

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/dex/instructions/Branch.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/dex/instructions/Branch.java
@@ -163,7 +163,6 @@ public abstract class Branch extends Instruction {
   @Override
   public int[] getBranchTargets() {
     this.label = method.getInstructionIndex(pc + offset);
-    int[] r = {label};
-    return r;
+    return new int[] {label};
   }
 }

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/dex/instructions/Goto.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/dex/instructions/Goto.java
@@ -69,8 +69,7 @@ public class Goto extends Instruction {
   @Override
   public int[] getBranchTargets() {
     if (label == null) {
-      int[] l = {method.getInstructionIndex(pc + destination)};
-      this.label = l;
+      this.label = new int[] {method.getInstructionIndex(pc + destination)};
     }
     return label;
   }

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModel.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModel.java
@@ -810,9 +810,7 @@ public class AndroidModel /* makes SummarizedMethod */ implements IClassHierarch
                       + asMethod);
             }
             redirect.setLocalNames(pm.makeLocalNames());
-            SummarizedMethod override =
-                new SummarizedMethodWithNames(mRef, redirect, declaringClass);
-            return override;
+            return new SummarizedMethodWithNames(mRef, redirect, declaringClass);
           } else if (this instanceof ExternalModel) {
             final SSAValue trash = pm.getUnmanaged(AndroidTypes.Intent, "trash");
             invokation =
@@ -889,13 +887,12 @@ public class AndroidModel /* makes SummarizedMethod */ implements IClassHierarch
       }
       // TODO: Throw into an other loader
       redirect.setLocalNames(pm.makeLocalNames());
-      SummarizedMethod override = new SummarizedMethodWithNames(mRef, redirect, declaringClass);
 
       // assert(asMethod.getReturnType().equals(TypeReference.Void)) : "getMethodAs does not support
       // return values. Requested: " +
       //    asMethod.getReturnType().toString();                  // TODO: Implement
 
-      return override;
+      return new SummarizedMethodWithNames(mRef, redirect, declaringClass);
 
     } catch (Exception e) {
       e.printStackTrace();

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/MiniModel.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/MiniModel.java
@@ -90,9 +90,7 @@ public class MiniModel extends AndroidModel {
 
   @Override
   public Descriptor getDescriptor() throws CancelException {
-    final Descriptor descr = super.getDescriptor();
-
-    return descr;
+    return super.getDescriptor();
   }
 
   public MiniModel(

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/AndroidModelParameterManager.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/AndroidModelParameterManager.java
@@ -397,8 +397,7 @@ public class AndroidModelParameterManager {
    * @return SSA-Variable
    */
   public int getUnmanaged() {
-    int ret = nextLocal++;
-    return ret;
+    return nextLocal++;
   }
 
   /**

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/impl/DexEntryPoint.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/impl/DexEntryPoint.java
@@ -76,7 +76,6 @@ public class DexEntryPoint extends DefaultEntrypoint implements IClassHierarchyD
   /* END Custom change */
   @Override
   protected TypeReference[] makeParameterTypes(IMethod method, int i) {
-    TypeReference[] trA = new TypeReference[] {method.getParameterType(i)};
-    return trA;
+    return new TypeReference[] {method.getParameterType(i)};
   }
 }

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentContextInterpreter.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentContextInterpreter.java
@@ -126,8 +126,7 @@ public class IntentContextInterpreter implements SSAContextInterpreter {
       } else {
         // TODO: Go interactive and ask user?
         final Iterator<AndroidComponent> it = possibleTargets.iterator();
-        final AndroidComponent targetComponent = it.next();
-        return targetComponent;
+        return it.next();
       }
     }
   }

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentContextSelector.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentContextSelector.java
@@ -129,16 +129,15 @@ public class IntentContextSelector implements ContextSelector {
       Intent intent = null;
       { // Seach intent
         for (InstanceKey actualParameter : actualParameters) {
-          final InstanceKey param = actualParameter;
-          if (param == null) {
+          if (actualParameter == null) {
             continue;
-          } else if (param.getConcreteType().getName().equals(AndroidTypes.IntentName)) {
-            if (!intents.contains(param)) {
+          } else if (actualParameter.getConcreteType().getName().equals(AndroidTypes.IntentName)) {
+            if (!intents.contains(actualParameter)) {
               logger.error("Unable to resolve Intent called from {}", caller.getMethod());
-              logger.error("Search Key: {} hash: {}", param, param.hashCode());
+              logger.error("Search Key: {} hash: {}", actualParameter, actualParameter.hashCode());
               break;
             } else {
-              intent = intents.find(param);
+              intent = intents.find(actualParameter);
               break;
             }
           }

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentMap.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentMap.java
@@ -179,8 +179,7 @@ import java.util.Map;
       return intent;
     } else {
 
-      final Intent intent = create(key, action);
-      return intent;
+      return create(key, action);
     }
   }
 

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ssa/AbstractIntRegisterMachine.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ssa/AbstractIntRegisterMachine.java
@@ -125,11 +125,7 @@ public abstract class AbstractIntRegisterMachine implements FixedPointConstants 
           public UnaryOperator<MachineState> getNodeTransferFunction(final BasicBlock node) {
             return new UnaryOperator<>() {
               @Override
-              public byte evaluate(MachineState lhs, MachineState rhs) {
-
-                MachineState exit = lhs;
-                MachineState entry = rhs;
-
+              public byte evaluate(MachineState exit, MachineState entry) {
                 MachineState newExit = flow.flow(entry, node);
                 if (newExit.stateEquals(exit)) {
                   return NOT_CHANGED;
@@ -161,11 +157,7 @@ public abstract class AbstractIntRegisterMachine implements FixedPointConstants 
               final BasicBlock from, final BasicBlock to) {
             return new UnaryOperator<>() {
               @Override
-              public byte evaluate(MachineState lhs, MachineState rhs) {
-
-                MachineState exit = lhs;
-                MachineState entry = rhs;
-
+              public byte evaluate(MachineState exit, MachineState entry) {
                 MachineState newExit = flow.flow(entry, from, to);
                 if (newExit.stateEquals(exit)) {
                   return NOT_CHANGED;
@@ -217,9 +209,7 @@ public abstract class AbstractIntRegisterMachine implements FixedPointConstants 
           protected MachineState makeEdgeVariable(BasicBlock from, BasicBlock to) {
             assert from != null;
             assert to != null;
-            MachineState result = new MachineState(from);
-
-            return result;
+            return new MachineState(from);
           }
 
           @Override
@@ -363,12 +353,9 @@ public abstract class AbstractIntRegisterMachine implements FixedPointConstants 
    */
   private static boolean meetForCatchBlock(
       IVariable lhs, IVariable[] rhs, BasicBlock bb, Meeter meeter) {
-
-    boolean changed = meetLocals(lhs, rhs, bb, meeter);
-
     //      int meet = meeter.meetStackAtCatchBlock(bb);
     //      boolean changed = meetLocals(lhs, rhs, bb, meeter);
-    return changed;
+    return meetLocals(lhs, rhs, bb, meeter);
   }
 
   //  /**

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidEntryPointLocator.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidEntryPointLocator.java
@@ -278,10 +278,8 @@ public final class AndroidEntryPointLocator {
       compo = AndroidComponent.from(method, cha);
       if (compo == AndroidComponent.UNKNOWN) {}
     }
-    final AndroidEntryPoint ep =
-        new AndroidEntryPoint(selectPositionForHeuristic(), method, cha, compo);
 
-    return ep;
+    return new AndroidEntryPoint(selectPositionForHeuristic(), method, cha, compo);
   }
 
   /**

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidEntryPointManager.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidEntryPointManager.java
@@ -396,17 +396,15 @@ public final /* singleton */ class AndroidEntryPointManager implements Serializa
         logger.error("guessPackage() called when no entrypoints had been set");
         return null;
       }
-      final String first =
-          ENTRIES
-              .get(0)
-              .getMethod()
-              .getReference()
-              .getDeclaringClass()
-              .getName()
-              .getPackage()
-              .toString();
       // TODO: Iterate all?
-      return first;
+      return ENTRIES
+          .get(0)
+          .getMethod()
+          .getReference()
+          .getDeclaringClass()
+          .getName()
+          .getPackage()
+          .toString();
     }
   }
 

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidPreFlightChecks.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidPreFlightChecks.java
@@ -127,13 +127,12 @@ public class AndroidPreFlightChecks {
    * @return if check passed TODO: this doesn't check anything yet
    */
   public boolean checkOverridesInPlace() {
-    boolean pass = true;
 
     // TODO: Check StartComponentMethodTargetSelector
     // TODO: Check IntentContextInterpreter
     // TODO: Check IntentContextSelector
 
-    return pass;
+    return true;
   }
 
   /**

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/util/Util.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/util/Util.java
@@ -44,8 +44,7 @@ public class Util {
   public static String getJavaJar(AnalysisScope javaScope) throws IOException {
     Module javaJar = javaScope.getModules(javaScope.getApplicationLoader()).iterator().next();
     if (javaJar instanceof JarFileModule) {
-      String javaJarPath = ((JarFileModule) javaJar).getAbsolutePath();
-      return javaJarPath;
+      return ((JarFileModule) javaJar).getAbsolutePath();
     } else {
       assert javaJar instanceof NestedJarFileModule : javaJar;
       File F = File.createTempFile("android", ".jar");

--- a/ide/jdt/src/main/java/com/ibm/wala/ide/AbstractJavaAnalysisAction.java
+++ b/ide/jdt/src/main/java/com/ibm/wala/ide/AbstractJavaAnalysisAction.java
@@ -113,8 +113,7 @@ public abstract class AbstractJavaAnalysisAction
       e.printStackTrace();
       assert false;
     }
-    AnalysisScope scope = mergeProjectPaths(projectPaths);
-    return scope;
+    return mergeProjectPaths(projectPaths);
   }
 
   /** compute the java projects represented by the current selection */

--- a/ide/jdt/src/main/java/com/ibm/wala/ide/util/JdtUtil.java
+++ b/ide/jdt/src/main/java/com/ibm/wala/ide/util/JdtUtil.java
@@ -61,8 +61,7 @@ public class JdtUtil {
       if (p == null) {
         throw new IllegalArgumentException("javaElt has null path");
       }
-      String filePath = p.toString();
-      return filePath;
+      return p.toString();
     } catch (Exception e) {
       throw new IllegalArgumentException("malformed javaElt: " + javaElt, e);
     }
@@ -77,8 +76,7 @@ public class JdtUtil {
 
       // TODO: handle default package?
       if (pkgDecl != null && pkgDecl.length > 0) {
-        String packageName = pkgDecl[0].getElementName();
-        return packageName;
+        return pkgDecl[0].getElementName();
       }
     } catch (JavaModelException e) {
 
@@ -93,16 +91,14 @@ public class JdtUtil {
     ICompilationUnit cu = (ICompilationUnit) type.getParent();
     String packageName = getPackageName(cu);
     String className = type.getElementName();
-    String fullyQName = packageName + '.' + className;
-    return fullyQName;
+    return packageName + '.' + className;
   }
 
   public static String getClassName(IType type) {
     if (type == null) {
       throw new IllegalArgumentException("type is null");
     }
-    String className = type.getElementName();
-    return className;
+    return type.getElementName();
   }
 
   /**
@@ -143,8 +139,7 @@ public class JdtUtil {
     if (javaElt == null) {
       throw new IllegalArgumentException("javaElt is null");
     }
-    IJavaProject javaProject = javaElt.getJavaProject();
-    return javaProject;
+    return javaElt.getJavaProject();
   }
 
   public static String getProjectName(IJavaProject javaProject) {
@@ -161,8 +156,7 @@ public class JdtUtil {
    *     Signature} for details.
    */
   public static String getHumanReadableType(String typeSignature) {
-    String simpleName = Signature.getSignatureSimpleName(typeSignature);
-    return simpleName;
+    return Signature.getSignatureSimpleName(typeSignature);
   }
 
   public static IJavaProject getJavaProject(IFile appJar) {
@@ -594,15 +588,13 @@ public class JdtUtil {
     for (String projectName : projectNames) {
       projects[i++] = getJavaProject(projectName);
     }
-    StructuredSelection selection = new StructuredSelection(projects);
-    return selection;
+    return new StructuredSelection(projects);
   }
 
   public static IJavaProject getNamedProject(String projectName) {
     IWorkspaceRoot workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
     IJavaModel javaModel = JavaCore.create(workspaceRoot);
-    IJavaProject helloWorldProject = javaModel.getJavaProject(projectName);
-    return helloWorldProject;
+    return javaModel.getJavaProject(projectName);
   }
 
   public static ASTNode getAST(IFile javaSourceFile) {

--- a/ide/jsdt/src/main/java/com/ibm/wala/ide/util/JavaScriptHeadlessUtil.java
+++ b/ide/jsdt/src/main/java/com/ibm/wala/ide/util/JavaScriptHeadlessUtil.java
@@ -17,21 +17,19 @@ import org.eclipse.wst.jsdt.core.JavaScriptCore;
 public class JavaScriptHeadlessUtil extends HeadlessUtil {
 
   public static IJavaScriptProject getJavaScriptProjectFromWorkspace(final String projectName) {
-    IJavaScriptProject jp =
-        getProjectFromWorkspace(
-            p -> {
-              try {
-                if (p.hasNature(JavaScriptCore.NATURE_ID)) {
-                  IJavaScriptProject jp1 = JavaScriptCore.create(p);
-                  if (jp1 != null && jp1.getElementName().equals(projectName)) {
-                    return jp1;
-                  }
-                }
-              } catch (CoreException e) {
+    return getProjectFromWorkspace(
+        p -> {
+          try {
+            if (p.hasNature(JavaScriptCore.NATURE_ID)) {
+              IJavaScriptProject jp1 = JavaScriptCore.create(p);
+              if (jp1 != null && jp1.getElementName().equals(projectName)) {
+                return jp1;
               }
-              // failed to match
-              return null;
-            });
-    return jp;
+            }
+          } catch (CoreException e) {
+          }
+          // failed to match
+          return null;
+        });
   }
 }

--- a/ide/src/main/java/com/ibm/wala/ide/ui/ViewIFDSLocalAction.java
+++ b/ide/src/main/java/com/ibm/wala/ide/ui/ViewIFDSLocalAction.java
@@ -202,9 +202,8 @@ public class ViewIFDSLocalAction<T, P, F> extends Action {
       throw new UnsupportedOperationException(
           "did not expect selection of size " + selection.size());
     }
-    P first = (P) selection.getFirstElement();
 
-    return first;
+    return (P) selection.getFirstElement();
   }
 
   protected SWTTreeViewer<P> getViewer() {

--- a/ide/src/main/java/com/ibm/wala/ide/ui/ViewIRAction.java
+++ b/ide/src/main/java/com/ibm/wala/ide/ui/ViewIRAction.java
@@ -103,8 +103,7 @@ public class ViewIRAction<P> extends Action {
       throw new UnsupportedOperationException(
           "did not expect selection of size " + selection.size());
     }
-    CGNode first = (CGNode) selection.getFirstElement();
-    return first;
+    return (CGNode) selection.getFirstElement();
   }
 
   protected SWTTreeViewer<P> getViewer() {

--- a/ide/tests/src/testFixtures/java/com/ibm/wala/ide/tests/util/EclipseTestUtil.java
+++ b/ide/tests/src/testFixtures/java/com/ibm/wala/ide/tests/util/EclipseTestUtil.java
@@ -128,8 +128,7 @@ public class EclipseTestUtil {
     assert url != null : bundle.toString() + " path " + path.toString();
     try {
       URL fileURL = FileLocator.toFileURL(url);
-      File file = new File(fileURL.getPath());
-      return file;
+      return new File(fileURL.getPath());
     } catch (IOException e) {
       reportException(e);
     }

--- a/scandroid/src/main/java/org/scandroid/domain/CodeElement.java
+++ b/scandroid/src/main/java/org/scandroid/domain/CodeElement.java
@@ -57,7 +57,6 @@ public abstract class CodeElement {
   public static Set<CodeElement> valueElements(int valueNumber) {
     // System.out.println("ValueNumber: " + valueNumber + ", Node: " +
     // node.getMethod().getSignature());
-    Set<CodeElement> elements = Collections.singleton(new LocalElement(valueNumber));
     //        PointerKey pk = new LocalPointerKey(node, valueNumber);
     //        OrdinalSet<InstanceKey> m = pa.getPointsToSet(pk);
     //        if(m != null) {
@@ -65,7 +64,7 @@ public abstract class CodeElement {
     //                elements.add(new InstanceKeyElement(keyIter.next()));
     //            }
     //        }
-    return elements;
+    return Collections.singleton(new LocalElement(valueNumber));
   }
 
   @Override

--- a/scandroid/src/main/java/org/scandroid/flow/FlowAnalysis.java
+++ b/scandroid/src/main/java/org/scandroid/flow/FlowAnalysis.java
@@ -191,14 +191,13 @@ public class FlowAnalysis {
             );
 
     try {
-      TabulationResult<BasicBlockInContext<E>, CGNode, DomainElement> flowResult = solver.solve();
       //        	if (options.ifdsExplorer()) {
       //        		for (int i = 1; i < domain.getSize(); i++) {
       //
       //        		}
       //        		GraphUtil.exploreIFDS(flowResult);
       //        	}
-      return flowResult;
+      return solver.solve();
     } catch (CancelException e) {
       throw new CancelRuntimeException(e);
     }

--- a/scandroid/src/main/java/org/scandroid/flow/functions/IFDSTaintFlowFunctionProvider.java
+++ b/scandroid/src/main/java/org/scandroid/flow/functions/IFDSTaintFlowFunctionProvider.java
@@ -362,8 +362,7 @@ public class IFDSTaintFlowFunctionProvider<E extends ISSABasicBlock>
       // possibly ignored in the exclusions file or just not included in the scope
       if (staticClass == null) return null;
 
-      IField staticField = staticClass.getField(declaredField.getName());
-      return staticField;
+      return staticClass.getField(declaredField.getName());
     }
 
     private void addTargets(CodeElement d1, MutableIntSet set, FlowType<E> taintType) {

--- a/scandroid/src/main/java/org/scandroid/spec/MethodNamePattern.java
+++ b/scandroid/src/main/java/org/scandroid/spec/MethodNamePattern.java
@@ -139,7 +139,6 @@ public class MethodNamePattern {
     String className = methodRef.getDeclaringClass().getName().toUnicodeString();
     String methodName = methodRef.getName().toUnicodeString();
     String descriptor = methodRef.getDescriptor().toUnicodeString();
-    MethodNamePattern pattern = new MethodNamePattern(className, methodName, descriptor);
-    return pattern;
+    return new MethodNamePattern(className, methodName, descriptor);
   }
 }

--- a/scandroid/src/main/java/org/scandroid/spec/StaticFieldSinkSpec.java
+++ b/scandroid/src/main/java/org/scandroid/spec/StaticFieldSinkSpec.java
@@ -72,10 +72,8 @@ public class StaticFieldSinkSpec extends SinkSpec {
   @Override
   public <E extends ISSABasicBlock> Collection<FlowType<E>> getFlowType(
       BasicBlockInContext<E> block) {
-    Collection<FlowType<E>> flow =
-        HashSetFactory.make(
-            Collections.singleton((FlowType<E>) new StaticFieldFlow<>(block, field, false)));
-    return flow;
+    return HashSetFactory.make(
+        Collections.singleton((FlowType<E>) new StaticFieldFlow<>(block, field, false)));
   }
 
   @Override

--- a/scandroid/src/main/java/org/scandroid/synthmethod/XMLSummaryWriter.java
+++ b/scandroid/src/main/java/org/scandroid/synthmethod/XMLSummaryWriter.java
@@ -268,7 +268,6 @@ public class XMLSummaryWriter {
     } else {
       typeSigs.append(returnType.getName().toUnicodeString()).append(';');
     }
-    String descriptor = typeSigs.toString();
-    return descriptor;
+    return typeSigs.toString();
   }
 }

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/Compiler.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/Compiler.java
@@ -374,18 +374,17 @@ public abstract class Compiler implements Constants {
 
       int[] bt = instr.getBranchTargets();
       for (int element : bt) {
-        int t = element;
-        if (t < 0 || t >= visited.length) {
+        if (element < 0 || element >= visited.length) {
           throw new IllegalArgumentException(
               "Branch target at offset "
                   + i
                   + " is out of bounds: "
-                  + t
+                  + element
                   + " (max "
                   + visited.length
                   + ')');
         }
-        if (!visited[t]) {
+        if (!visited[element]) {
           computeStackWordsAt(element, stackLen, stackWords.clone(), visited);
         }
       }

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/ConditionalBranchInstruction.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/ConditionalBranchInstruction.java
@@ -74,8 +74,7 @@ public final class ConditionalBranchInstruction extends Instruction
 
   @Override
   public int[] getBranchTargets() {
-    int[] r = {label};
-    return r;
+    return new int[] {label};
   }
 
   @Override

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/ConstantInstruction.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/ConstantInstruction.java
@@ -212,8 +212,7 @@ public abstract class ConstantInstruction extends Instruction {
     }
 
     private static ConstLong[] preallocate() {
-      ConstLong[] r = {new ConstLong(OP_lconst_0, 0), new ConstLong(OP_lconst_1, 1)};
-      return r;
+      return new ConstLong[] {new ConstLong(OP_lconst_0, 0), new ConstLong(OP_lconst_1, 1)};
     }
 
     static ConstLong makeInternal(long v) {
@@ -284,12 +283,11 @@ public abstract class ConstantInstruction extends Instruction {
     }
 
     private static ConstFloat[] preallocate() {
-      ConstFloat[] r = {
+      return new ConstFloat[] {
         new ConstFloat(OP_fconst_0, 0),
         new ConstFloat(OP_fconst_1, 1),
         new ConstFloat(OP_fconst_2, 2)
       };
-      return r;
     }
 
     static ConstFloat makeInternal(float v) {
@@ -360,7 +358,8 @@ public abstract class ConstantInstruction extends Instruction {
     }
 
     private static ConstDouble[] preallocate() {
-      ConstDouble[] r = {new ConstDouble(OP_dconst_0, 0), new ConstDouble(OP_dconst_1, 1)};
+      ConstDouble[] r;
+      r = new ConstDouble[] {new ConstDouble(OP_dconst_0, 0), new ConstDouble(OP_dconst_1, 1)};
       return r;
     }
 

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/GotoInstruction.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/GotoInstruction.java
@@ -18,8 +18,7 @@ public final class GotoInstruction extends Instruction {
 
   private GotoInstruction(int label) {
     super(OP_goto);
-    int[] l = {label};
-    this.label = l;
+    this.label = new int[] {label};
   }
 
   private static final GotoInstruction[] preallocated = preallocate();

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/InvokeDynamicInstruction.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/InvokeDynamicInstruction.java
@@ -164,8 +164,7 @@ public class InvokeDynamicInstruction extends Instruction implements IInvokeInst
           IllegalArgumentException,
           InvocationTargetException,
           NoSuchFieldException {
-    ClassLoader classLoader = cl.getClassLoader();
-    ClassLoader bootstrapCL = classLoader;
+    ClassLoader bootstrapCL = cl.getClassLoader();
 
     Class<?> bootstrapClass =
         Class.forName(getBootstrap().methodClass().replace('/', '.'), false, bootstrapCL);
@@ -187,7 +186,7 @@ public class InvokeDynamicInstruction extends Instruction implements IInvokeInst
     // new Lookup object
     args[0] = lutrusted;
     args[1] = getMethodName();
-    args[2] = makeMethodType(classLoader, getMethodSignature());
+    args[2] = makeMethodType(bootstrapCL, getMethodSignature());
     for (int i = 3; i < bt.parameterCount(); i++) {
       args[i] = getBootstrap().callArgument(bootstrapCL, i - 3);
     }
@@ -208,8 +207,7 @@ public class InvokeDynamicInstruction extends Instruction implements IInvokeInst
     for (int i = 0; i < paramTypes.length; i++) {
       paramClasses[i] = Class.forName(Util.makeClass(paramTypes[i]), false, classLoader);
     }
-    MethodType mt = MethodType.methodType(returnClass, paramClasses);
-    return mt;
+    return MethodType.methodType(returnClass, paramClasses);
   }
 
   static InvokeDynamicInstruction make(ConstantPoolReader cp, int index, int mode) {

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/MethodEditor.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/MethodEditor.java
@@ -644,8 +644,7 @@ public final class MethodEditor {
           adjustedHandlers = new IdentityHashMap<>();
         }
 
-        for (ExceptionHandler element : hs) {
-          ExceptionHandler h = element;
+        for (ExceptionHandler h : hs) {
           if (!adjustedHandlers.containsKey(h)) {
             adjustedHandlers.put(h, null);
             h.handler = labelDefs[h.handler]; // breaks invariant of ExceptionHandler: immutable!

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/analysis/Analyzer.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/analysis/Analyzer.java
@@ -226,9 +226,7 @@ public class Analyzer {
       return topType;
     }
 
-    String x = ClassHierarchy.findCommonSupertype(hierarchy, patchType(t1), patchType(t2));
-
-    return x;
+    return ClassHierarchy.findCommonSupertype(hierarchy, patchType(t1), patchType(t2));
   }
 
   public final BitSet getBasicBlockStarts() {

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/analysis/ClassHierarchy.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/analysis/ClassHierarchy.java
@@ -41,8 +41,7 @@ public final class ClassHierarchy {
     }
 
     int r = NO;
-    for (String iface2 : ifaces) {
-      String iface = iface2;
+    for (String iface : ifaces) {
       if (visited.add(iface)) {
         if (iface.equals(t2)) {
           return YES;
@@ -114,12 +113,11 @@ public final class ClassHierarchy {
 
     int r = NO;
     for (String subtype : subtypes) {
-      String subt = subtype;
-      if (visited.add(subt)) {
-        if (subt.equals(t2)) {
+      if (visited.add(subtype)) {
+        if (subtype.equals(t2)) {
           return YES;
         } else {
-          int v = checkSubtypesContain(hierarchy, subt, t2, visited);
+          int v = checkSubtypesContain(hierarchy, subtype, t2, visited);
           switch (v) {
             case YES:
               return YES;

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/shrikeCT/CTCompiler.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/shrikeCT/CTCompiler.java
@@ -118,8 +118,6 @@ public final class CTCompiler extends Compiler {
   @Override
   protected String createHelperMethod(boolean isStatic, String sig) {
     long r = Math.abs(random.nextLong());
-    String name = "_helper_" + r;
-
-    return name;
+    return "_helper_" + r;
   }
 }

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/tools/MethodOptimizer.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/tools/MethodOptimizer.java
@@ -134,8 +134,7 @@ public final class MethodOptimizer {
 
     for (int i = 0; i < instructions.length; i++) {
       int[] targets = instructions[i].getBranchTargets();
-      for (int target2 : targets) {
-        int target = target2;
+      for (int target : targets) {
         backEdges[target][backEdgeCount[target]] = i;
         backEdgeCount[target]++;
       }

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/AnnotationsReader.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/AnnotationsReader.java
@@ -326,6 +326,7 @@ public class AnnotationsReader extends AttributeReader {
                 cr.getCP().getCPUtf8(nextShort), cr.getCP().getCPUtf8(cr.getUShort(offset + 3))),
             5);
       case '[': // array
+        @SuppressWarnings("UnnecessaryLocalVariable")
         int numValues = nextShort;
         int numArrayBytes = 3; // start with 3 for the tag and num_values bytes
         ElementValue[] vals = new ElementValue[numValues];

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/StackMapTableReader.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/StackMapTableReader.java
@@ -35,6 +35,7 @@ public class StackMapTableReader extends AttributeReader {
     for (int i = 0; i < entries; i++) {
       int frameType = (0x000000ff & cr.getByte(ptr++));
       if (frameType < 64) {
+        @SuppressWarnings("UnnecessaryLocalVariable")
         int offset = frameType;
         frames.add(new StackMapFrame(frameType, offset, new StackMapType[0], new StackMapType[0]));
       } else if (frameType < 128) {

--- a/util/src/main/java/com/ibm/wala/fixedpoint/impl/DefaultFixedPointSystem.java
+++ b/util/src/main/java/com/ibm/wala/fixedpoint/impl/DefaultFixedPointSystem.java
@@ -118,8 +118,7 @@ public class DefaultFixedPointSystem<T extends IVariable<T>> implements IFixedPo
       graph.addNode(lhs);
       graph.addEdge(s, lhs);
     }
-    for (IVariable<?> v : rhs) {
-      IVariable<?> variable = v;
+    for (IVariable<?> variable : rhs) {
       if (variable != null) {
         variables.add(variable);
         graph.addNode(variable);

--- a/util/src/main/java/com/ibm/wala/fixpoint/IntSetVariable.java
+++ b/util/src/main/java/com/ibm/wala/fixpoint/IntSetVariable.java
@@ -49,8 +49,7 @@ public abstract class IntSetVariable<T extends IntSetVariable<T>> extends Abstra
       V = IntSetUtil.getDefaultIntSetFactory().makeCopy(B);
       return !B.isEmpty();
     } else {
-      boolean result = V.addAll(B);
-      return result;
+      return V.addAll(B);
     }
   }
 
@@ -65,8 +64,7 @@ public abstract class IntSetVariable<T extends IntSetVariable<T>> extends Abstra
       return (V != null);
     } else {
       if (other.V != null) {
-        boolean result = addAll(other.V);
-        return result;
+        return addAll(other.V);
       } else {
         return false;
       }
@@ -155,8 +153,7 @@ public abstract class IntSetVariable<T extends IntSetVariable<T>> extends Abstra
       return (V != null);
     } else {
       if (other.V != null) {
-        boolean result = addAllInIntersection(other.V, filter);
-        return result;
+        return addAllInIntersection(other.V, filter);
       } else {
         return false;
       }
@@ -172,8 +169,7 @@ public abstract class IntSetVariable<T extends IntSetVariable<T>> extends Abstra
       }
       return (V != null);
     } else {
-      boolean result = V.addAllInIntersection(other, filter);
-      return result;
+      return V.addAllInIntersection(other, filter);
     }
   }
 

--- a/util/src/main/java/com/ibm/wala/util/collections/MapUtil.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/MapUtil.java
@@ -143,8 +143,7 @@ public class MapUtil {
     if (M == null) {
       throw new IllegalArgumentException("M is null");
     }
-    WeakHashMap<K, V> result = M.computeIfAbsent(key, k -> new WeakHashMap<>(2));
-    return result;
+    return M.computeIfAbsent(key, k -> new WeakHashMap<>(2));
   }
 
   /**

--- a/util/src/main/java/com/ibm/wala/util/collections/ParanoidHashSet.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/ParanoidHashSet.java
@@ -73,8 +73,7 @@ public class ParanoidHashSet<T> extends LinkedHashSet<T> {
       } else {
         if (s.size() == BAD_HC) {
           for (T t : s) {
-            Object o = t;
-            System.err.println(o + " " + o.hashCode());
+            System.err.println(t + " " + t.hashCode());
           }
           assert false : "bad hc " + arg0.getClass() + ' ' + arg0;
         } else {

--- a/util/src/main/java/com/ibm/wala/util/collections/Util.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/Util.java
@@ -299,8 +299,7 @@ public class Util {
       throw new IllegalArgumentException("typeStr == null");
     }
     int dollarIndex = typeStr.indexOf('$');
-    String topLevelTypeStr = dollarIndex == -1 ? typeStr : typeStr.substring(0, dollarIndex);
-    return topLevelTypeStr;
+    return dollarIndex == -1 ? typeStr : typeStr.substring(0, dollarIndex);
   }
 
   public static <T> void addIfNotNull(T val, Collection<T> vals) {
@@ -318,8 +317,7 @@ public class Util {
     long totalMemory = Runtime.getRuntime().totalMemory();
     gc();
     long freeMemory = Runtime.getRuntime().freeMemory();
-    long usedMemory = totalMemory - freeMemory;
-    return usedMemory;
+    return totalMemory - freeMemory;
   }
 
   private static void gc() {

--- a/util/src/main/java/com/ibm/wala/util/graph/GraphIntegrity.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/GraphIntegrity.java
@@ -110,9 +110,8 @@ public class GraphIntegrity {
       n1 = G.getNumberOfNodes();
       n2 = 0;
       for (T t : G) {
-        Object n = t;
         if (DEBUG_LEVEL > 1) {
-          System.err.println(("n2 loop: " + n));
+          System.err.println(("n2 loop: " + t));
         }
         n2++;
       }

--- a/util/src/main/java/com/ibm/wala/util/graph/GraphSlicer.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/GraphSlicer.java
@@ -53,9 +53,7 @@ public class GraphSlicer {
       }
     }
 
-    Set<T> result = DFS.getReachableNodes(GraphInverter.invert(g), roots);
-
-    return result;
+    return DFS.getReachableNodes(GraphInverter.invert(g), roots);
   }
 
   /** Prune a graph to only the nodes accepted by the {@link Predicate} p */
@@ -153,31 +151,29 @@ public class GraphSlicer {
             return g.hasEdge(src, dst) && p.test(src) && p.test(dst);
           }
         };
-    AbstractGraph<T> output =
-        new AbstractGraph<>() {
 
-          @SuppressWarnings({"unchecked", "rawtypes"})
-          @Override
-          protected String nodeString(T n, boolean forEdge) {
-            if (g instanceof AbstractGraph) {
-              return ((AbstractGraph) g).nodeString(n, forEdge);
-            } else {
-              return super.nodeString(n, forEdge);
-            }
-          }
+    return new AbstractGraph<>() {
 
-          @Override
-          protected NodeManager<T> getNodeManager() {
-            return n;
-          }
+      @SuppressWarnings({"unchecked", "rawtypes"})
+      @Override
+      protected String nodeString(T n1, boolean forEdge) {
+        if (g instanceof AbstractGraph) {
+          return ((AbstractGraph) g).nodeString(n1, forEdge);
+        } else {
+          return super.nodeString(n1, forEdge);
+        }
+      }
 
-          @Override
-          protected EdgeManager<T> getEdgeManager() {
-            return e;
-          }
-        };
+      @Override
+      protected NodeManager<T> getNodeManager() {
+        return n;
+      }
 
-    return output;
+      @Override
+      protected EdgeManager<T> getEdgeManager() {
+        return e;
+      }
+    };
   }
 
   public static <E> AbstractGraph<E> project(final Graph<E> G, final Predicate<E> fmember) {

--- a/util/src/main/java/com/ibm/wala/util/graph/impl/DelegatingNumberedEdgeManager.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/impl/DelegatingNumberedEdgeManager.java
@@ -68,8 +68,7 @@ public class DelegatingNumberedEdgeManager<T extends INodeWithNumberedEdges>
     if (N == null) {
       throw new IllegalArgumentException("N cannot be null");
     }
-    INodeWithNumberedEdges en = N;
-    IntSet pred = en.getPredNumbers();
+    IntSet pred = N.getPredNumbers();
     Iterator<T> empty = EmptyIterator.instance();
     return (pred == null) ? empty : (Iterator<T>) new IntSetNodeIterator(pred.intIterator());
   }
@@ -79,8 +78,7 @@ public class DelegatingNumberedEdgeManager<T extends INodeWithNumberedEdges>
     if (node == null) {
       throw new IllegalArgumentException("N cannot be null");
     }
-    INodeWithNumberedEdges en = node;
-    IntSet pred = en.getPredNumbers();
+    IntSet pred = node.getPredNumbers();
     return (pred == null) ? new SparseIntSet() : pred;
   }
 
@@ -92,8 +90,7 @@ public class DelegatingNumberedEdgeManager<T extends INodeWithNumberedEdges>
     if (N == null) {
       throw new IllegalArgumentException("N cannot be null");
     }
-    INodeWithNumberedEdges en = N;
-    IntSet s = en.getPredNumbers();
+    IntSet s = N.getPredNumbers();
     if (s == null) {
       return 0;
     } else {
@@ -109,8 +106,7 @@ public class DelegatingNumberedEdgeManager<T extends INodeWithNumberedEdges>
     if (N == null) {
       throw new IllegalArgumentException("N cannot be null");
     }
-    INodeWithNumberedEdges en = N;
-    IntSet succ = en.getSuccNumbers();
+    IntSet succ = N.getSuccNumbers();
     Iterator<T> empty = EmptyIterator.instance();
     return (succ == null) ? empty : (Iterator<T>) new IntSetNodeIterator(succ.intIterator());
   }
@@ -123,8 +119,7 @@ public class DelegatingNumberedEdgeManager<T extends INodeWithNumberedEdges>
     if (N == null) {
       throw new IllegalArgumentException("N is null");
     }
-    INodeWithNumberedEdges en = N;
-    IntSet s = en.getSuccNumbers();
+    IntSet s = N.getSuccNumbers();
     return s == null ? 0 : s.size();
   }
 
@@ -153,8 +148,7 @@ public class DelegatingNumberedEdgeManager<T extends INodeWithNumberedEdges>
     if (node == null) {
       throw new IllegalArgumentException("node is null");
     }
-    INodeWithNumberedEdges n = node;
-    n.removeAllIncidentEdges();
+    node.removeAllIncidentEdges();
   }
 
   /**
@@ -165,8 +159,7 @@ public class DelegatingNumberedEdgeManager<T extends INodeWithNumberedEdges>
     if (node == null) {
       throw new IllegalArgumentException("node cannot be null");
     }
-    INodeWithNumberedEdges n = node;
-    n.removeIncomingEdges();
+    node.removeIncomingEdges();
   }
 
   /**
@@ -177,8 +170,7 @@ public class DelegatingNumberedEdgeManager<T extends INodeWithNumberedEdges>
     if (node == null) {
       throw new IllegalArgumentException("node cannot be null");
     }
-    INodeWithNumberedEdges n = node;
-    n.removeOutgoingEdges();
+    node.removeOutgoingEdges();
   }
 
   @Override
@@ -194,8 +186,7 @@ public class DelegatingNumberedEdgeManager<T extends INodeWithNumberedEdges>
     if (node == null) {
       throw new IllegalArgumentException("node cannot be null");
     }
-    INodeWithNumberedEdges en = node;
-    IntSet succ = en.getSuccNumbers();
+    IntSet succ = node.getSuccNumbers();
     return (succ == null) ? new SparseIntSet() : succ;
   }
 }

--- a/util/src/main/java/com/ibm/wala/util/graph/impl/DelegatingNumberedNodeManager.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/impl/DelegatingNumberedNodeManager.java
@@ -45,8 +45,7 @@ public class DelegatingNumberedNodeManager<T extends INodeWithNumber>
     if (N == null) {
       throw new IllegalArgumentException("N is null");
     }
-    INodeWithNumber n = N;
-    return n.getGraphNodeId();
+    return N.getGraphNodeId();
   }
 
   @Override
@@ -138,11 +137,10 @@ public class DelegatingNumberedNodeManager<T extends INodeWithNumber>
     if (n == null) {
       throw new IllegalArgumentException("n is null");
     }
-    INodeWithNumber N = n;
-    int number = N.getGraphNodeId();
+    int number = n.getGraphNodeId();
     if (number == -1) {
       maxNumber++;
-      N.setGraphNodeId(maxNumber);
+      n.setGraphNodeId(maxNumber);
       number = maxNumber;
     } else {
       if (number > maxNumber) {
@@ -150,10 +148,10 @@ public class DelegatingNumberedNodeManager<T extends INodeWithNumber>
       }
     }
     ensureCapacity(number);
-    if (nodes[number] != null && nodes[number] != N) {
-      Assertions.UNREACHABLE("number: " + number + " N: " + N + " nodes[number]: " + nodes[number]);
+    if (nodes[number] != null && nodes[number] != n) {
+      Assertions.UNREACHABLE("number: " + number + " N: " + n + " nodes[number]: " + nodes[number]);
     }
-    nodes[number] = N;
+    nodes[number] = n;
     numberOfNodes++;
   }
 
@@ -172,8 +170,7 @@ public class DelegatingNumberedNodeManager<T extends INodeWithNumber>
     if (n == null) {
       throw new IllegalArgumentException("n is null");
     }
-    INodeWithNumber N = n;
-    int number = N.getGraphNodeId();
+    int number = n.getGraphNodeId();
     if (number == -1) {
       throw new IllegalArgumentException("Cannot remove node, not in graph");
     }
@@ -204,8 +201,7 @@ public class DelegatingNumberedNodeManager<T extends INodeWithNumber>
     if (n == null) {
       throw new IllegalArgumentException("n is null");
     }
-    INodeWithNumber N = n;
-    int number = N.getGraphNodeId();
+    int number = n.getGraphNodeId();
     if (number == -1) {
       return false;
     }
@@ -217,7 +213,7 @@ public class DelegatingNumberedNodeManager<T extends INodeWithNumber>
               + " : "
               + n);
     }
-    if (nodes[number] != N) {
+    if (nodes[number] != n) {
       throw new IllegalArgumentException(
           "node already has a graph node id, but is not registered there in this graph\n"
               + "this graph implementation is fragile and won't support this kind of test\n"

--- a/util/src/main/java/com/ibm/wala/util/graph/impl/SlowNumberedNodeManager.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/impl/SlowNumberedNodeManager.java
@@ -36,8 +36,7 @@ public class SlowNumberedNodeManager<T> implements NumberedNodeManager<T>, Seria
     if (number < 0) {
       throw new IllegalArgumentException("number must be >= 0");
     }
-    T result = map.getMappedObject(number);
-    return result;
+    return map.getMappedObject(number);
   }
 
   @Override

--- a/util/src/main/java/com/ibm/wala/util/heapTrace/HeapTracer.java
+++ b/util/src/main/java/com/ibm/wala/util/heapTrace/HeapTracer.java
@@ -667,10 +667,9 @@ public class HeapTracer {
       TreeSet<Field> sortedDemo = new TreeSet<>(new SizeComparator());
       sortedDemo.addAll(roots.keySet());
       for (Field field : sortedDemo) {
-        Object root = field;
-        Demographics d = roots.get(root);
+        Demographics d = roots.get(field);
         if (d.getTotalSize() > 10000) {
-          result.append(" root: ").append(root).append('\n');
+          result.append(" root: ").append(field).append('\n');
           result.append(d);
         }
       }

--- a/util/src/main/java/com/ibm/wala/util/intset/FixedSizeBitVector.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/FixedSizeBitVector.java
@@ -319,8 +319,7 @@ public final class FixedSizeBitVector implements Cloneable, java.io.Serializable
     boolean needSeparator = false;
     buffer.append('{');
     // int limit = length();
-    int limit = this.nbits;
-    for (int i = 0; i < limit; i++) {
+    for (int i = 0; i < this.nbits; i++) {
       if (get(i)) {
         if (needSeparator) {
           buffer.append(", ");

--- a/util/src/main/java/com/ibm/wala/util/intset/IntSetUtil.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/IntSetUtil.java
@@ -143,9 +143,7 @@ public class IntSetUtil {
     if (A instanceof SparseIntSet && B instanceof SparseIntSet) {
       return SparseIntSet.diff((SparseIntSet) A, (SparseIntSet) B);
     } else if (A instanceof SemiSparseMutableIntSet && B instanceof SemiSparseMutableIntSet) {
-      IntSet d =
-          SemiSparseMutableIntSet.diff((SemiSparseMutableIntSet) A, (SemiSparseMutableIntSet) B);
-      return d;
+      return SemiSparseMutableIntSet.diff((SemiSparseMutableIntSet) A, (SemiSparseMutableIntSet) B);
     } else {
       return defaultSlowDiff(A, B, factory);
     }

--- a/util/src/main/java/com/ibm/wala/util/intset/MutableSparseIntSet.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/MutableSparseIntSet.java
@@ -210,11 +210,10 @@ public class MutableSparseIntSet extends SparseIntSet implements MutableIntSet {
   }
 
   @NullUnmarked
-  public void intersectWith(SparseIntSet set) {
-    if (set == null) {
+  public void intersectWith(SparseIntSet that) {
+    if (that == null) {
       throw new IllegalArgumentException("null set");
     }
-    SparseIntSet that = set;
     if (this.isEmpty()) {
       return;
     } else if (that.isEmpty()) {
@@ -330,8 +329,7 @@ public class MutableSparseIntSet extends SparseIntSet implements MutableIntSet {
 
     // common-case optimization
     if (that.size == 1) {
-      boolean result = add(that.elements[0]);
-      return result;
+      return add(that.elements[0]);
     }
 
     int[] br = that.elements;

--- a/util/src/main/java/com/ibm/wala/util/intset/MutableSparseIntSetFactory.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/MutableSparseIntSetFactory.java
@@ -36,8 +36,7 @@ public class MutableSparseIntSetFactory implements MutableIntSetFactory<MutableS
       for (Integer I : T) {
         copy[i++] = I;
       }
-      MutableSparseIntSet result = new MutableSparseIntSet(copy);
-      return result;
+      return new MutableSparseIntSet(copy);
     }
   }
 

--- a/util/src/main/java/com/ibm/wala/util/intset/MutableSparseLongSet.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/MutableSparseLongSet.java
@@ -175,11 +175,10 @@ public final class MutableSparseLongSet extends SparseLongSet implements Mutable
   }
 
   @NullUnmarked
-  public void intersectWith(SparseLongSet set) {
-    if (set == null) {
+  public void intersectWith(SparseLongSet that) {
+    if (that == null) {
       throw new IllegalArgumentException("null set");
     }
-    SparseLongSet that = set;
     if (this.isEmpty()) {
       return;
     } else if (that.isEmpty()) {
@@ -283,8 +282,7 @@ public final class MutableSparseLongSet extends SparseLongSet implements Mutable
 
     // common-case optimization
     if (that.size == 1) {
-      boolean result = add(that.elements[0]);
-      return result;
+      return add(that.elements[0]);
     }
 
     long[] br = that.elements;

--- a/util/src/main/java/com/ibm/wala/util/intset/MutableSparseLongSetFactory.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/MutableSparseLongSetFactory.java
@@ -37,8 +37,7 @@ public class MutableSparseLongSetFactory implements MutableLongSetFactory {
       for (Long I : T) {
         copy[i++] = I;
       }
-      MutableSparseLongSet result = new MutableSparseLongSet(copy);
-      return result;
+      return new MutableSparseLongSet(copy);
     }
   }
 

--- a/util/src/main/java/com/ibm/wala/util/io/FileUtil.java
+++ b/util/src/main/java/com/ibm/wala/util/io/FileUtil.java
@@ -160,8 +160,7 @@ public class FileUtil {
         out.write(b, 0, n);
         n = s.read(b);
       }
-      byte[] bb = out.toByteArray();
-      return bb;
+      return out.toByteArray();
     }
   }
 

--- a/util/src/main/java/com/ibm/wala/util/io/Streams.java
+++ b/util/src/main/java/com/ibm/wala/util/io/Streams.java
@@ -32,7 +32,6 @@ public class Streams {
       in.read(data);
       b.write(data);
     }
-    byte[] data = b.toByteArray();
-    return data;
+    return b.toByteArray();
   }
 }

--- a/util/src/main/java/com/ibm/wala/util/processes/JavaLauncher.java
+++ b/util/src/main/java/com/ibm/wala/util/processes/JavaLauncher.java
@@ -151,9 +151,11 @@ public class JavaLauncher extends Launcher {
    * @return the string that identifies the java executable file
    */
   public static String defaultJavaExe() {
-    String java =
-        System.getProperty("java.home") + File.separatorChar + "bin" + File.separatorChar + "java";
-    return java;
+    return System.getProperty("java.home")
+        + File.separatorChar
+        + "bin"
+        + File.separatorChar
+        + "java";
   }
 
   /** Launch the java process. */

--- a/util/src/main/java/com/ibm/wala/util/processes/Launcher.java
+++ b/util/src/main/java/com/ibm/wala/util/processes/Launcher.java
@@ -93,8 +93,7 @@ public abstract class Launcher {
       logger.info("spawning process " + cmd);
     }
     String[] ev = getEnv() == null ? null : buildEnv(getEnv());
-    Process p = Runtime.getRuntime().exec(cmd, ev, getWorkingDir());
-    return p;
+    return Runtime.getRuntime().exec(cmd, ev, getWorkingDir());
   }
 
   /**
@@ -110,8 +109,7 @@ public abstract class Launcher {
       logger.info("spawning process " + Arrays.toString(cmd));
     }
     String[] ev = getEnv() == null ? null : buildEnv(getEnv());
-    Process p = Runtime.getRuntime().exec(cmd, ev, getWorkingDir());
-    return p;
+    return Runtime.getRuntime().exec(cmd, ev, getWorkingDir());
   }
 
   private static String[] buildEnv(Map<String, String> ev) {


### PR DESCRIPTION
"Redundant" can be subjective, but JetBrains offers an inspection that uses a reasonable definition:

> Reports unnecessary local variables that add nothing to the comprehensibility of a method, including:
>
> * Local variables that are immediately returned.
>
> * Local variables that are immediately assigned to another variable and then not used.
>
> * Local variables that always have the same value as another local variable or parameter.