### PR TITLE
Replace a utility for reading an `InputStream`

### DIFF
--- a/cast/js/nodejs/src/main/java/com/ibm/wala/cast/js/nodejs/NodejsRequiredSourceModule.java
+++ b/cast/js/nodejs/src/main/java/com/ibm/wala/cast/js/nodejs/NodejsRequiredSourceModule.java
@@ -13,7 +13,6 @@ package com.ibm.wala.cast.js.nodejs;
 import com.ibm.wala.cast.ipa.callgraph.CAstCallGraphUtil;
 import com.ibm.wala.classLoader.SourceFileModule;
 import com.ibm.wala.util.debug.Assertions;
-import com.ibm.wala.util.io.Streams;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -116,7 +115,7 @@ public class NodejsRequiredSourceModule extends SourceFileModule {
   private static String loadWrapperSource(String filename) throws IOException {
     try (final InputStream url =
         NodejsRequiredSourceModule.class.getClassLoader().getResourceAsStream(filename)) {
-      return new String(Streams.inputStream2ByteArray(url));
+      return new String(url.readAllBytes());
     }
   }
 

--- a/util/src/main/java/com/ibm/wala/util/io/Streams.java
+++ b/util/src/main/java/com/ibm/wala/util/io/Streams.java
@@ -15,12 +15,15 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /** utilities for IO streams */
+@Deprecated(since = "1.6.12", forRemoval = true)
 public class Streams {
 
   /**
    * @return byte[] holding the contents of the stream
    * @throws IllegalArgumentException if in == null
+   * @deprecated use {@link InputStream#readAllBytes()} instead.
    */
+  @Deprecated(since = "1.6.12", forRemoval = true)
   public static byte[] inputStream2ByteArray(InputStream in)
       throws IllegalArgumentException, IOException {
     if (in == null) {


### PR DESCRIPTION
`InputStream.readAllBytes()` does the same thing as `Stream.inputStream2ByteArray(InputStream)`, and has been available since Java 9.

`InputStream.readAllBytes()` also doesn't make the mistake of assuming that `InputStream.available()` predicts the exact number of bytes that the next `InputStream.read(byte[])` will receive. That is not guaranteed!