### PR TITLE
Remove redundant conditions

### DIFF
--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/ArgumentSpecialization.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/ArgumentSpecialization.java
@@ -215,7 +215,7 @@ public class ArgumentSpecialization {
                   } else {
                     return Ast.makeNode(CAstNode.VAR, Ast.makeConstant("$arg" + arg));
                   }
-                } else if (x instanceof String && "length".equals(x)) {
+                } else if ("length".equals(x)) {
                   return Ast.makeConstant(v.getValue());
                 }
               }

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/DelegatingExplicitCallGraph.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/DelegatingExplicitCallGraph.java
@@ -77,7 +77,7 @@ public class DelegatingExplicitCallGraph extends ExplicitCallGraph {
     @Override
     public Set<CGNode> getPossibleTargets(CallSiteReference site) {
       Object result = targets.get(site.getProgramCounter());
-      if (result != null && result instanceof CallSite) {
+      if (result instanceof CallSite) {
         CallSite p = (CallSite) result;
         CGNode n = p.getNode();
         CallSiteReference s = p.getSite();
@@ -90,7 +90,7 @@ public class DelegatingExplicitCallGraph extends ExplicitCallGraph {
     @Override
     public IntSet getPossibleTargetNumbers(CallSiteReference site) {
       Object t = targets.get(site.getProgramCounter());
-      if (t != null && t instanceof CallSite) {
+      if (t instanceof CallSite) {
         CallSite p = (CallSite) t;
         DelegatingCGNode n = (DelegatingCGNode) p.getNode();
         CallSiteReference s = p.getSite();
@@ -122,7 +122,7 @@ public class DelegatingExplicitCallGraph extends ExplicitCallGraph {
     @Override
     public int getNumberOfTargets(CallSiteReference site) {
       Object result = targets.get(site.getProgramCounter());
-      if (result != null && result instanceof CallSite) {
+      if (result instanceof CallSite) {
         CallSite p = (CallSite) result;
         CGNode n = p.getNode();
         CallSiteReference s = p.getSite();

--- a/core/src/main/java/com/ibm/wala/ssa/SSAInstruction.java
+++ b/core/src/main/java/com/ibm/wala/ssa/SSAInstruction.java
@@ -195,7 +195,7 @@ public abstract class SSAInstruction {
   @Override
   public final boolean equals(Object obj) {
     if (this == obj) return true;
-    if (obj != null && obj instanceof SSAInstruction)
+    if (obj instanceof SSAInstruction)
       return this.instructionIndex == ((SSAInstruction) obj).instructionIndex;
     else return false;
   }

--- a/core/src/main/java/com/ibm/wala/types/TypeReference.java
+++ b/core/src/main/java/com/ibm/wala/types/TypeReference.java
@@ -662,7 +662,7 @@ public final class TypeReference implements Serializable {
 
     @Override
     public final boolean equals(Object other) {
-      assert other != null && other instanceof Key;
+      assert other instanceof Key;
       Key that = (Key) other;
       return (name.equals(that.name) && classloader.equals(that.classloader));
     }

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/ReuseParameters.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/ReuseParameters.java
@@ -195,7 +195,7 @@ public class ReuseParameters {
     final MethodReference inCall;
     /*final*/ String withName;
 
-    if ((inCallTo != null) && (inCallTo != ALL_TARGETS)) {
+    if (inCallTo != ALL_TARGETS) {
       final int bcIndex = 0; // The PC to get the variable name from
       final int localNumber = ssaFor(inCallTo, firstOf(param, inCallTo));
       try {

--- a/scandroid/src/main/java/org/scandroid/domain/FieldElement.java
+++ b/scandroid/src/main/java/org/scandroid/domain/FieldElement.java
@@ -77,7 +77,7 @@ public class FieldElement extends CodeElement {
 
   @Override
   public boolean equals(Object other) {
-    if (other != null && other instanceof FieldElement) {
+    if (other instanceof FieldElement) {
       FieldElement otherFE = (FieldElement) other;
       return object.equals(otherFE.object) && fieldRef.equals(otherFE.fieldRef);
     }

--- a/scandroid/src/main/java/org/scandroid/domain/InstanceKeyElement.java
+++ b/scandroid/src/main/java/org/scandroid/domain/InstanceKeyElement.java
@@ -58,8 +58,7 @@ public class InstanceKeyElement extends CodeElement {
 
   @Override
   public boolean equals(Object other) {
-    if (other != null && other instanceof InstanceKeyElement)
-      return ((InstanceKeyElement) other).ik.equals(this.ik);
+    if (other instanceof InstanceKeyElement) return ((InstanceKeyElement) other).ik.equals(this.ik);
     return false;
   }
 

--- a/scandroid/src/main/java/org/scandroid/domain/ReturnElement.java
+++ b/scandroid/src/main/java/org/scandroid/domain/ReturnElement.java
@@ -51,7 +51,7 @@ public class ReturnElement extends CodeElement {
 
   @Override
   public boolean equals(Object other) {
-    return other != null && other instanceof ReturnElement;
+    return other instanceof ReturnElement;
   }
 
   @Override

--- a/scandroid/src/main/java/org/scandroid/flow/OutflowAnalysis.java
+++ b/scandroid/src/main/java/org/scandroid/flow/OutflowAnalysis.java
@@ -333,7 +333,7 @@ public class OutflowAnalysis {
         while (it.hasNext()) {
           BasicBlockInContext<IExplodedBasicBlock> realBlock = it.next();
           final SSAInstruction inst = realBlock.getLastInstruction();
-          if (null != inst && inst instanceof SSAReturnInstruction) {
+          if (inst instanceof SSAReturnInstruction) {
             PointerKey pk = new LocalPointerKey(node, inst.getUse(0));
             for (InstanceKey ik : pa.getPointsToSet(pk)) {
               for (DomainElement ikElement :

--- a/scandroid/src/main/java/org/scandroid/flow/functions/TaintTransferFunctions.java
+++ b/scandroid/src/main/java/org/scandroid/flow/functions/TaintTransferFunctions.java
@@ -307,7 +307,7 @@ public class TaintTransferFunctions<E extends ISSABasicBlock>
   public IFlowFunction getReturnFlowFunction(
       BasicBlockInContext<E> call, BasicBlockInContext<E> src, BasicBlockInContext<E> dest) {
     final SSAInstruction inst = call.getLastInstruction();
-    if (null == inst || !(inst instanceof SSAInvokeInstruction)) {
+    if (!(inst instanceof SSAInvokeInstruction)) {
       // if we don't have an invoke, just punt and hope the necessary
       // information is already in global elements
 

--- a/scandroid/src/main/java/org/scandroid/util/DexDotUtil.java
+++ b/scandroid/src/main/java/org/scandroid/util/DexDotUtil.java
@@ -250,7 +250,7 @@ public class DexDotUtil extends DotUtil {
   }
 
   private static String cleanUpString(String s) {
-    if (!s.isEmpty() && s.startsWith("Node: ")) {
+    if (s.startsWith("Node: ")) {
       String[] nodeString = s.split(",");
       if (nodeString.length >= 3) {
         String className = nodeString[1];

--- a/util/src/main/java/com/ibm/wala/util/collections/ImmutableStack.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/ImmutableStack.java
@@ -92,7 +92,7 @@ public class ImmutableStack<T> implements Iterable<T> {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o != null && o instanceof ImmutableStack) {
+    if (o instanceof ImmutableStack) {
       ImmutableStack other = (ImmutableStack) o;
       return Arrays.equals(entries, other.entries);
     }

--- a/util/src/main/java/com/ibm/wala/util/intset/BitVector.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/BitVector.java
@@ -362,7 +362,7 @@ public class BitVector extends BitVectorBase<BitVector> {
    */
   @Override
   public boolean equals(Object obj) {
-    if ((obj != null) && (obj instanceof BitVector)) {
+    if (obj instanceof BitVector) {
       if (this == obj) { // should help alias analysis
         return true;
       }

--- a/util/src/main/java/com/ibm/wala/util/intset/FixedSizeBitVector.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/FixedSizeBitVector.java
@@ -272,7 +272,7 @@ public final class FixedSizeBitVector implements Cloneable, java.io.Serializable
    */
   @Override
   public boolean equals(Object obj) {
-    if ((obj != null) && (obj instanceof FixedSizeBitVector)) {
+    if (obj instanceof FixedSizeBitVector) {
       if (this == obj) { // should help alias analysis
         return true;
       }

--- a/util/src/main/java/com/ibm/wala/util/intset/OffsetBitVector.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/OffsetBitVector.java
@@ -216,7 +216,7 @@ public final class OffsetBitVector extends BitVectorBase<OffsetBitVector> {
    */
   @Override
   public boolean equals(Object obj) {
-    if ((obj != null) && (obj instanceof OffsetBitVector)) {
+    if (obj instanceof OffsetBitVector) {
       if (this == obj) { // should help alias analysis
         return true;
       }


### PR DESCRIPTION
Each removed Boolean condition is redundant, as it is covered by some other subsequent condition.  For example, the `null` check is redundant in "`x != null && x instanceof C`", because "`null instanceof C`" always evaluates to `false`.