### PR TITLE
Simplify some arithmetic expressions

### DIFF
--- a/core/src/test/java/com/ibm/wala/core/tests/arraybounds/PruneArrayOutOfBoundExceptionEdge.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/arraybounds/PruneArrayOutOfBoundExceptionEdge.java
@@ -76,6 +76,7 @@ public class PruneArrayOutOfBoundExceptionEdge {
    * The number of Basic Blocks, which have an exception edge, that should be removed. (#[array
    * access] + #[other])
    */
+  @SuppressWarnings("PointlessArithmeticExpression")
   private static final int NOT_DETECTABLE_EXPECTED_COUNT = 0 + 3;
 
   private static final String NOT_IN_BOUND_TESTDATA = "Larraybounds/NotInBound";
@@ -84,6 +85,7 @@ public class PruneArrayOutOfBoundExceptionEdge {
    * The number of Basic Blocks, which have an exception edge, that should be removed. (#[array
    * access] + #[other])
    */
+  @SuppressWarnings("PointlessArithmeticExpression")
   private static final int NOT_IN_BOUND_EXPECTED_COUNT = 0 + 1;
 
   private static IRFactory<IMethod> irFactory;

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/StackMapTableWriter.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/StackMapTableWriter.java
@@ -292,7 +292,7 @@ public class StackMapTableWriter extends Element {
 
   @Override
   public int copyInto(byte[] buf, int offset) {
-    System.arraycopy(data, 0, buf, offset + 0, data.length);
+    System.arraycopy(data, 0, buf, offset, data.length);
     return data.length + offset;
   }
 }

--- a/util/src/main/java/com/ibm/wala/util/intset/OffsetBitVector.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/OffsetBitVector.java
@@ -30,7 +30,7 @@ public final class OffsetBitVector extends BitVectorBase<OffsetBitVector> {
 
     int[] oldbits = bits;
     bits = new int[subscript(newCapacity) + 1];
-    System.arraycopy(oldbits, 0, bits, 0 - wordDiff, oldbits.length);
+    System.arraycopy(oldbits, 0, bits, -wordDiff, oldbits.length);
     offset = newOffset;
   }
 


### PR DESCRIPTION
In `PruneArrayOutOfBoundExceptionEdge`, two `static final int` fields are initialized to "`0 + …`".  We want to keep them in this form.  A comment for each of those fields makes it clear that the value is "#[array access] + #[other]", and we would lose that structure if we simplified.  So we suppress IntelliJ IDEA's warnings for these fields.

In the other cases, though, the simplification seems natural and useful.