### PR TITLE
Prefer parameterized log message over concatenation

### DIFF
--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/AndroidStartComponentTool.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/AndroidStartComponentTool.java
@@ -328,7 +328,7 @@ public class AndroidStartComponentTool {
 
       return androidContext;
     } else {
-      logger.debug("Can not handle the callers android-context of " + caller);
+      logger.debug("Can not handle the callers android-context of {}", caller);
       return null;
     }
   }

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidEntryPointLocator.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidEntryPointLocator.java
@@ -189,7 +189,7 @@ public final class AndroidEntryPointLocator {
           for (final AndroidComponent compo : AndroidComponent.values()) {
             if (compo == AndroidComponent.UNKNOWN) continue;
             if (compo.toReference() == null) {
-              logger.error("Null-Reference for " + compo);
+              logger.error("Null-Reference for {}", compo);
             } else {
               bases.add(compo.toReference());
             }

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidEntryPointManager.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidEntryPointManager.java
@@ -640,7 +640,7 @@ public final /* singleton */ class AndroidEntryPointManager implements Serializa
 
           if (ret == old) { // Yes, ==
             // This is an evil hack(tm). I should fix the Intent-Table!
-            logger.warn("Malformend Intent-Table, staying with " + ret + " for " + intent);
+            logger.warn("Malformend Intent-Table, staying with {} for {}", ret, intent);
             return ret;
           }
         }


### PR DESCRIPTION
Concatenation evaluates the complete log message regardless of whether it will actually be logged somewhere or not.  A parameterized message avoids that extra work if the logging level is set to discard the message anyway.