### PR TITLE
Remove some dead assignments; allow others

### DIFF
--- a/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/AbstractFieldBasedTest.java
+++ b/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/AbstractFieldBasedTest.java
@@ -59,7 +59,7 @@ public abstract class AbstractFieldBasedTest extends TestJSCallGraphShape {
   protected JSCallGraph runBoundedTest(
       String script, Object[][] assertions, BuilderType builderType, int bound)
       throws WalaException, Error, CancelException {
-    JSCallGraph cg = null;
+    final JSCallGraph cg;
     JavaScriptLoaderFactory loaders = new JavaScriptLoaderFactory(new CAstRhinoTranslatorFactory());
     IProgressMonitor monitor = ProgressMaster.make(new NullProgressMonitor(), 45000, true);
     List<Module> scripts = new ArrayList<>();

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionApplyContextInterpreter.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/JavaScriptFunctionApplyContextInterpreter.java
@@ -117,6 +117,7 @@ public class JavaScriptFunctionApplyContextInterpreter
 
     // function being invoked is in v2
     int resultVal = curValNum++;
+    @SuppressWarnings("UnusedAssignment")
     int excVal = curValNum++;
     S.addStatement(
         insts.Invoke(S.getNumberOfStatements(), 2, resultVal, paramsToPassToInvoked, excVal, cs));

--- a/cast/src/main/java/com/ibm/wala/cast/util/SourceBuffer.java
+++ b/cast/src/main/java/com/ibm/wala/cast/util/SourceBuffer.java
@@ -150,11 +150,9 @@ public class SourceBuffer {
           currentLine = reader.readLine();
 
           if (currentLine == null) {
-            offset = p.getLastOffset();
             break;
-          } else {
-            offset += currentLine.length() + 1;
           }
+          offset += currentLine.length() + 1;
           line++;
           if (p.getLastOffset() >= 0) {
             if (offset > p.getLastOffset()) {

--- a/core/src/main/java/com/ibm/wala/analysis/arraybounds/ArrayOutOfBoundsAnalysis.java
+++ b/core/src/main/java/com/ibm/wala/analysis/arraybounds/ArrayOutOfBoundsAnalysis.java
@@ -87,7 +87,6 @@ public class ArrayOutOfBoundsAnalysis {
     for (final SSAArrayReferenceInstruction instruction : builder.getArrayReferenceInstructions()) {
       this.boundsCheckUnnecessary.put(instruction, UnnecessaryCheck.NONE);
     }
-    builder = null;
   }
 
   /** compute lower bound */

--- a/core/src/main/java/com/ibm/wala/analysis/reflection/GetClassContextInterpeter.java
+++ b/core/src/main/java/com/ibm/wala/analysis/reflection/GetClassContextInterpeter.java
@@ -111,6 +111,7 @@ public class GetClassContextInterpeter implements SSAContextInterpreter {
   private static SSAInstruction[] makeStatements(Context context) {
     ArrayList<SSAInstruction> statements = new ArrayList<>();
     int nextLocal = 2;
+    @SuppressWarnings("UnusedAssignment")
     int retValue = nextLocal++;
     TypeReference tr = ((TypeAbstraction) context.get(ContextKey.RECEIVER)).getTypeReference();
     SSAInstructionFactory insts =

--- a/core/src/main/java/com/ibm/wala/analysis/reflection/ReflectiveInvocationInterpreter.java
+++ b/core/src/main/java/com/ibm/wala/analysis/reflection/ReflectiveInvocationInterpreter.java
@@ -243,6 +243,7 @@ public class ReflectiveInvocationInterpreter extends AbstractReflectionInterpret
 
     // emit the dispatch and return instructions
     if (method.getReference().equals(CTOR_NEW_INSTANCE)) {
+      //noinspection UnusedAssignment
       m.addInstruction(
           null,
           insts.InvokeInstruction(
@@ -258,6 +259,7 @@ public class ReflectiveInvocationInterpreter extends AbstractReflectionInterpret
     } else {
       Dispatch d = target.isStatic() ? Dispatch.STATIC : Dispatch.VIRTUAL;
       if (target.getReturnType().equals(TypeReference.Void)) {
+        //noinspection UnusedAssignment
         m.addInstruction(
             null,
             insts.InvokeInstruction(
@@ -268,7 +270,9 @@ public class ReflectiveInvocationInterpreter extends AbstractReflectionInterpret
                 null),
             false);
       } else {
+        //noinspection UnusedAssignment
         result = nextLocal++;
+        //noinspection UnusedAssignment
         m.addInstruction(
             null,
             insts.InvokeInstruction(

--- a/core/src/main/java/com/ibm/wala/demandpa/util/PointerParamValueNumIterator.java
+++ b/core/src/main/java/com/ibm/wala/demandpa/util/PointerParamValueNumIterator.java
@@ -84,7 +84,7 @@ public class PointerParamValueNumIterator implements Iterator<Integer> {
         break;
       }
     }
-    paramInd = ++i;
+    paramInd = i + 1;
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/examples/drivers/DemandCastChecker.java
+++ b/core/src/main/java/com/ibm/wala/examples/drivers/DemandCastChecker.java
@@ -113,9 +113,8 @@ public class DemandCastChecker {
       throws IllegalArgumentException, IOException {
     System.err.println("=====BENCHMARK " + benchName + "=====");
     System.err.println("analyzing " + benchName);
-    DemandRefinementPointsTo dmp = null;
     try {
-      dmp = makeDemandPointerAnalysis(scopeFile, mainClass, benchName);
+      final var dmp = makeDemandPointerAnalysis(scopeFile, mainClass, benchName);
       findFailingCasts(dmp.getBaseCallGraph(), dmp);
     } catch (ClassHierarchyException e) {
       e.printStackTrace();
@@ -164,8 +163,8 @@ public class DemandCastChecker {
   /** builds a call graph, and sets the corresponding heap model for analysis */
   private static Pair<CallGraph, PointerAnalysis<InstanceKey>> buildCallGraph(
       ClassHierarchy cha, AnalysisOptions options) throws IllegalArgumentException {
-    CallGraph retCG = null;
-    PointerAnalysis<InstanceKey> retPA = null;
+    CallGraph retCG;
+    PointerAnalysis<InstanceKey> retPA;
     final IAnalysisCacheView cache = new AnalysisCacheImpl();
     CallGraphBuilder<InstanceKey> builder;
     if (CHEAP_CG) {

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/cha/CHACallGraph.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/cha/CHACallGraph.java
@@ -206,7 +206,7 @@ public class CHACallGraph extends BasicCallGraph<CHAContextInterpreter> {
         IMethod trampoline = lambdaSummaryClass.getDeclaredMethods().iterator().next();
         CGNode callee = getNode(trampoline, Everywhere.EVERYWHERE);
         if (callee == null) {
-          callee = findOrCreateNode(trampoline, Everywhere.EVERYWHERE);
+          findOrCreateNode(trampoline, Everywhere.EVERYWHERE);
         }
       }
     }

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/LambdaMethodTargetSelector.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/LambdaMethodTargetSelector.java
@@ -167,7 +167,7 @@ public class LambdaMethodTargetSelector implements MethodTargetSelector {
               lambda.getField(LambdaSummaryClass.getCaptureFieldName(i)).getReference()));
     }
     // return the anonymous class instance
-    summary.addStatement(insts.ReturnInstruction(index++, v, false));
+    summary.addStatement(insts.ReturnInstruction(index, v, false));
     return summary;
   }
 }

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/LambdaSummaryClass.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/LambdaSummaryClass.java
@@ -373,6 +373,7 @@ public class LambdaSummaryClass extends SyntheticClass {
       }
 
       if (lambdaBodyCallee.getReturnType().equals(TypeReference.Void)) {
+        //noinspection UnusedAssignment
         summary.addStatement(
             insts.InvokeInstruction(
                 inst++,
@@ -382,10 +383,12 @@ public class LambdaSummaryClass extends SyntheticClass {
                 null));
         if (isNew) {
           // trampoline needs to return the new object
+          //noinspection UnusedAssignment
           summary.addStatement(insts.ReturnInstruction(inst++, newValNum, false));
         }
       } else {
         int ret = curValNum++;
+        //noinspection UnusedAssignment
         summary.addStatement(
             insts.InvokeInstruction(
                 inst++,
@@ -394,6 +397,7 @@ public class LambdaSummaryClass extends SyntheticClass {
                 curValNum++,
                 CallSiteReference.make(inst, lambdaBodyCallee, code),
                 null));
+        //noinspection UnusedAssignment
         summary.addStatement(
             insts.ReturnInstruction(
                 inst++, ret, lambdaBodyCallee.getReturnType().isPrimitiveType()));

--- a/core/src/test/java/com/ibm/wala/core/tests/basic/PrimitivesTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/basic/PrimitivesTest.java
@@ -178,7 +178,7 @@ public class PrimitivesTest extends WalaTestCase {
     assertThat(a).isNot(subsetOf(b));
     a.remove(1);
     assertThat(a).isEmpty();
-    IntSet ignored = a.intersection(temp);
+    a.intersection(temp);
     assertThat(a).isEmpty();
 
     temp2 = factory.make();
@@ -285,7 +285,7 @@ public class PrimitivesTest extends WalaTestCase {
     assertThat(a).isNot(subsetOf(b));
     a.remove(1);
     assertThat(a).isEmpty();
-    ignored = a.intersection(temp);
+    a.intersection(temp);
     assertThat(a).isEmpty();
 
     temp2 = factory.make();
@@ -466,7 +466,7 @@ public class PrimitivesTest extends WalaTestCase {
     assertThat(a).isNot(subsetOf(b));
     a.remove(1);
     assertThat(a).isEmpty();
-    LongSet ignored = a.intersection(temp);
+    a.intersection(temp);
     assertThat(a).isEmpty();
 
     temp2 = factory.make();
@@ -570,7 +570,7 @@ public class PrimitivesTest extends WalaTestCase {
     assertThat(a).isNot(subsetOf(b));
     a.remove(1);
     assertThat(a).isEmpty();
-    ignored = a.intersection(temp);
+    a.intersection(temp);
     assertThat(a).isEmpty();
 
     temp2 = factory.make();

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexFileModule.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexFileModule.java
@@ -88,11 +88,7 @@ public class DexFileModule implements Module {
     }
   }
 
-  private static File tf(JarFile f) throws IOException {
-    String name = f.getName();
-    if (name.indexOf('/') >= 0) {
-      name = name.substring(name.lastIndexOf('/') + 1);
-    }
+  private static File tf() throws IOException {
     File tf = Files.createTempFile("name", "_classes.dex").toFile();
     tf.deleteOnExit();
     System.err.println("using " + tf);
@@ -100,7 +96,7 @@ public class DexFileModule implements Module {
   }
 
   private DexFileModule(JarFile f) throws IllegalArgumentException, IOException {
-    this(TemporaryFile.streamToFile(tf(f), f.getInputStream(f.getEntry("classes.dex"))));
+    this(TemporaryFile.streamToFile(tf(), f.getInputStream(f.getEntry("classes.dex"))));
   }
 
   private DexFileModule(File f) throws IllegalArgumentException {

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModel.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModel.java
@@ -354,15 +354,11 @@ public class AndroidModel /* makes SummarizedMethod */ implements IClassHierarch
       // this.mRef, toolInfo.getFlags(),
       //                    /* caller */ null, tsif, modelAcc, this.paramManager, this.body, /* self
       // */ null, toolInfo, /* callerNd */ null);
-      final SSAValue application;
       {
         final SSAValue tmpApp = modelAcc.firstExtends(AndroidTypes.ApplicationName, this.cha);
-        if (tmpApp != null) {
-          application = tmpApp;
-        } else {
+        if (tmpApp == null) {
           // Generate a real one?
-
-          application = paramManager.getUnmanaged(AndroidTypes.Application, "app");
+          final var application = paramManager.getUnmanaged(AndroidTypes.Application, "app");
           this.body.addConstant(application.getNumber(), new ConstantValue(null));
           application.setAssigned();
         }

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/LoopAndroidModel.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/LoopAndroidModel.java
@@ -107,7 +107,7 @@ public class LoopAndroidModel extends SingleStartAndroidModel {
     logger.info("PC {} is the jump target of START_OF_LOOP", PC);
 
     this.outerLoopPC = PC;
-    PC = body.getNextProgramCounter();
+    body.getNextProgramCounter();
     paramManager.scopeDown(true);
 
     // Top-Half of Phi-Handling
@@ -126,8 +126,7 @@ public class LoopAndroidModel extends SingleStartAndroidModel {
     body.reserveProgramCounters(outerPhisNeeded.size());
     // Actual Phis will be placed by the bottom-half handler...
 
-    PC = body.getNextProgramCounter(); // Needed if no calls
-    return PC;
+    return body.getNextProgramCounter(); // Needed if no calls
   }
 
   /**

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/LoopKillAndroidModel.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/LoopKillAndroidModel.java
@@ -103,7 +103,7 @@ public class LoopKillAndroidModel extends LoopAndroidModel {
     logger.info("PC {} is the jump target of START_OF_LOOP", PC);
 
     this.outerLoopPC = PC;
-    PC = body.getNextProgramCounter();
+    body.getNextProgramCounter();
     paramManager.scopeDown(true);
 
     // Top-Half of Phi-Handling
@@ -122,8 +122,7 @@ public class LoopKillAndroidModel extends LoopAndroidModel {
     body.reserveProgramCounters(outerPhisNeeded.size());
     // Actual Phis will be placed by the bottom-half handler...
 
-    PC = body.getNextProgramCounter(); // Needed if no calls
-    return PC;
+    return body.getNextProgramCounter(); // Needed if no calls
   }
 
   /**

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/SingleStartAndroidModel.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/structure/SingleStartAndroidModel.java
@@ -106,7 +106,7 @@ public class SingleStartAndroidModel extends AbstractAndroidModel {
   protected int enterMULTIPLE_TIMES_IN_LOOP(int PC) {
     logger.info("PC {} is the jump target of START_OF_LOOP", PC);
     this.outerLoopPC = PC;
-    PC = body.getNextProgramCounter();
+    body.getNextProgramCounter();
     paramManager.scopeDown(true);
 
     // Top-Half of Phi-Handling
@@ -125,8 +125,7 @@ public class SingleStartAndroidModel extends AbstractAndroidModel {
     body.reserveProgramCounters(outerPhisNeeded.size());
     // Actual Phis will be placed by the bottom-half handler...
 
-    PC = body.getNextProgramCounter(); // Needed if no calls
-    return PC;
+    return body.getNextProgramCounter(); // Needed if no calls
   }
 
   /**

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/ExternalModel.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/ExternalModel.java
@@ -283,6 +283,7 @@ public class ExternalModel extends AndroidModel {
           CallSiteReference.make(callPC, mRef, IInvokeInstruction.Dispatch.VIRTUAL);
       final SSAValue exception =
           new SSAValue(nextLocal++, TypeReference.JavaLangException, this.mRef, "exception");
+      //noinspection UnusedAssignment
       outIntent = new SSAValue(nextLocal++, inIntent);
       final List<SSAValue> params = new ArrayList<>(3);
       params.add(inIntent);

--- a/dalvik/src/test/java/com/ibm/wala/dalvik/test/cha/MultiDexScopeTest.java
+++ b/dalvik/src/test/java/com/ibm/wala/dalvik/test/cha/MultiDexScopeTest.java
@@ -53,7 +53,7 @@ public class MultiDexScopeTest {
   private static void addAPKtoScope(
       ClassLoaderReference loader, AnalysisScope scope, final Path fileName) {
     final var apkFile = fileName.toFile();
-    MultiDexContainer<? extends DexBackedDexFile> multiDex = null;
+    final MultiDexContainer<? extends DexBackedDexFile> multiDex;
     try {
       multiDex = DexFileFactory.loadDexContainer(apkFile, Opcodes.forApi(24));
     } catch (IOException e) {

--- a/scandroid/src/main/java/org/scandroid/prefixtransfer/StringBuilderUseAnalysis.java
+++ b/scandroid/src/main/java/org/scandroid/prefixtransfer/StringBuilderUseAnalysis.java
@@ -236,8 +236,7 @@ public class StringBuilderUseAnalysis {
     final HashSet<ISSABasicBlock> blocksSeen = new HashSet<>();
     final ArrayList<Integer> concatenatedInstanceKeys = new ArrayList<>();
 
-    ISSABasicBlock bPrev = bbs[0];
-    ISSABasicBlock bNext = blockOrdering.get(bPrev);
+    ISSABasicBlock bNext = blockOrdering.get(bbs[0]);
     while (bNext != null) {
       // detect loops
       if (blocksSeen.contains(bNext)) {
@@ -271,7 +270,6 @@ public class StringBuilderUseAnalysis {
             mapping.getMappedIndex(k), concatenatedInstanceKeys);
       }
 
-      bPrev = bNext;
       bNext = blockOrdering.get(bNext);
     }
 

--- a/scandroid/src/main/java/org/scandroid/util/EntryPoints.java
+++ b/scandroid/src/main/java/org/scandroid/util/EntryPoints.java
@@ -195,10 +195,10 @@ public class EntryPoints {
       BufferedReader stdError = new BufferedReader(new InputStreamReader(p.getErrorStream()));
 
       // read the output from the command
-      String s;
-      while ((s = stdInput.readLine()) != null) {}
+      while (stdInput.readLine() != null) {}
 
       // read any errors from the attempted command
+      String s;
       while ((s = stdError.readLine()) != null) {
         System.err.println(s);
       }

--- a/shrike/src/main/java/com/ibm/wala/shrike/bench/InterfaceAnalyzer.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/bench/InterfaceAnalyzer.java
@@ -44,7 +44,7 @@ public class InterfaceAnalyzer {
 
     try (final Writer w = new BufferedWriter(new OutputStreamWriter(System.out))) {
 
-      args = instrumenter.parseStandardArgs(args);
+      instrumenter.parseStandardArgs(args);
 
       instrumenter.beginTraversal();
       ClassInstrumenter ci;

--- a/shrike/src/main/java/com/ibm/wala/shrike/cg/OfflineDynamicCallGraph.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/cg/OfflineDynamicCallGraph.java
@@ -146,7 +146,7 @@ public class OfflineDynamicCallGraph {
       }
 
       instrumenter = new OfflineInstrumenter();
-      args = instrumenter.parseStandardArgs(args);
+      instrumenter.parseStandardArgs(args);
 
       instrumenter.setPassUnmodifiedClasses(true);
 

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/shrikeCT/ClassInstrumenter.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/shrikeCT/ClassInstrumenter.java
@@ -469,6 +469,7 @@ public final class ClassInstrumenter {
       codeAttributes[codeAttrIndex++] = locals;
     }
     if (stacks != null) {
+      //noinspection UnusedAssignment
       codeAttributes[codeAttrIndex++] = stacks;
     }
     code.setAttributes(codeAttributes);

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/shrikeCT/tools/BootstrapInstrumentor.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/shrikeCT/tools/BootstrapInstrumentor.java
@@ -134,6 +134,7 @@ public class BootstrapInstrumentor {
                     m.methodClass(),
                     m.methodName(),
                     ((InvokeDynamicInstruction) inst).getInvocationCode());
+            //noinspection UnusedAssignment
             insts[arg++] = ReturnInstruction.make("Ljava/lang/invoke/CallSite;");
 
             result.add(

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/shrikeCT/tools/ClassPrinter.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/shrikeCT/tools/ClassPrinter.java
@@ -68,7 +68,7 @@ public class ClassPrinter {
 
   public static void main(String[] args) throws Exception {
     OfflineInstrumenter oi = new OfflineInstrumenter();
-    args = oi.parseStandardArgs(args);
+    oi.parseStandardArgs(args);
 
     PrintWriter w = new PrintWriter(new BufferedWriter(new OutputStreamWriter(System.out)));
 

--- a/util/src/main/java/com/ibm/wala/util/graph/traverse/Topological.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/traverse/Topological.java
@@ -46,6 +46,7 @@ public class Topological {
       Iterator<T> rev = ReverseIterator.reverse(finishTime);
       // the following statement helps out the GC; note that finishTime holds
       // on to a large array
+      //noinspection UnusedAssignment
       finishTime = null;
       Graph<T> G_T = GraphInverter.invert(graph);
       return DFS.iterateFinishTime(G_T, rev);


### PR DESCRIPTION
For many of these cases, the dead assignment is the result of incrementing some `int` cursor when there will be no subsequent uses of that new cursor value.  I'm allowing most of those to remain, since there is some readability value in knowing that the cursor steps forward in a systematic, uniform manner, even up to the very last use.  For example, if one were to add further uses of the cursor in the future, then it will be good to have had that last increment in place.

For the remaining cases, though, the assignment being removed seems to provide little or no value for future code readers or maintainers.