### PR TITLE
Remove an unused package-scoped method parameter

### DIFF
--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/FlatInstantiator.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/FlatInstantiator.java
@@ -181,7 +181,7 @@ public class FlatInstantiator implements IInstantiator {
           new SpecializedInstantiator(
               body, instructionFactory, pm, cha, scope, analysisScope, this);
       if (SpecializedInstantiator.understands(T)) {
-        return sInst.createInstance(T, asManaged, key, seen, currentDepth);
+        return sInst.createInstance(T, asManaged, key, currentDepth);
       }
     }
 

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/SpecializedInstantiator.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/SpecializedInstantiator.java
@@ -109,19 +109,11 @@ public class SpecializedInstantiator extends FlatInstantiator {
       final boolean asManaged,
       VariableKey key,
       Set<? extends SSAValue> seen) {
-    return createInstance(T, asManaged, key, seen, 0);
+    return createInstance(T, asManaged, key, 0);
   }
 
   /* package private */ SSAValue createInstance(
-      final TypeReference T,
-      final boolean asManaged,
-      VariableKey key,
-      Set<? extends SSAValue> seen,
-      int currentDepth) {
-    if (seen == null) {
-
-      seen = new HashSet<>();
-    }
+      final TypeReference T, final boolean asManaged, VariableKey key, int currentDepth) {
 
     if (currentDepth > this.maxDepth) {
       final SSAValue instance = this.pm.getUnmanaged(T, key);
@@ -276,7 +268,6 @@ public class SpecializedInstantiator extends FlatInstantiator {
 
   /** Satisfy the interface. */
   @Override
-  @SuppressWarnings("unchecked")
   public int createInstance(TypeReference type, Object... instantiatorArgs) {
     // public SSAValue createInstance(final TypeReference T, final boolean asManaged, VariableKey
     // key, Set<SSAValue> seen) {
@@ -316,11 +307,7 @@ public class SpecializedInstantiator extends FlatInstantiator {
     }
 
     return createInstance(
-            type,
-            (Boolean) instantiatorArgs[0],
-            (VariableKey) instantiatorArgs[1],
-            (Set<? extends SSAValue>) instantiatorArgs[2],
-            currentDepth)
+            type, (Boolean) instantiatorArgs[0], (VariableKey) instantiatorArgs[1], currentDepth)
         .getNumber();
   }
 }


### PR DESCRIPTION
The package-scoped overload of `SpecializedInstantiator.createInstance` had a `Set<? extends SSAValue> seen` formal parameter.  That parameter would be set to a new `HashSet` instance if initially `null`, but there were no other uses of this parameter in the method.  We may as well discard that parameter entirely.  Backward-compatibility should not be a problem, since this method was previously visible only to code in the `com.ibm.wala.dalvik.ipa.callgraph.androidModel.parameters` package.