### PR TITLE
Try to use a Mirror for Kawa download

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -80,7 +80,7 @@ interface ExtractServices {
 //  download and extract kawa 3.0 "kawa.jar"
 //
 
-val kawa = adHocDownload(uri("https://ftpmirror.gnu.org/pub/gnu/kawa"), "kawa", "zip", "3.0")
+val kawa = adHocDownload(uri("https://ftpmirror.gnu.org/gnu/kawa"), "kawa", "zip", "3.0")
 
 val extractKawa by
     tasks.registering {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -80,7 +80,7 @@ interface ExtractServices {
 //  download and extract kawa 3.0 "kawa.jar"
 //
 
-val kawa = adHocDownload(uri("https://ftp.gnu.org/pub/gnu/kawa"), "kawa", "zip", "3.0")
+val kawa = adHocDownload(uri("https://ftpmirror.gnu.org/pub/gnu/kawa"), "kawa", "zip", "3.0")
 
 val extractKawa by
     tasks.registering {


### PR DESCRIPTION
CI jobs are failing due to `ftp.gnu.org` being down (from where we grab our Kawa download).  Using the mirror gateway for the download should be more robust.