### PR TITLE
Remove obsolete workaround for an Eclipse IDE bug

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/project.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/project.gradle.kts
@@ -1,8 +1,5 @@
 package com.ibm.wala.gradle
 
-import org.gradle.plugins.ide.eclipse.model.AbstractClasspathEntry
-import org.gradle.plugins.ide.eclipse.model.Classpath
-
 // Build configuration shared by all projects *including* the root project.
 
 plugins {
@@ -11,20 +8,6 @@ plugins {
 }
 
 repositories.mavenCentral()
-
-////////////////////////////////////////////////////////////////////////
-//
-//  Eclipse IDE integration
-//
-
-// workaround for <https://github.com/gradle/gradle/issues/4802>
-eclipse.classpath.file.whenMerged {
-  this as Classpath
-  entries.forEach {
-    if (it is AbstractClasspathEntry && it.entryAttributes["gradle_used_by_scope"] == "test")
-        it.entryAttributes["test"] = true
-  }
-}
 
 ////////////////////////////////////////////////////////////////////////
 //


### PR DESCRIPTION
The bug in question was fixed quite some time ago.