### PR TITLE
Remove redundant `keySet()` call

### DIFF
--- a/core/src/main/java/com/ibm/wala/ipa/cha/ClassHierarchy.java
+++ b/core/src/main/java/com/ibm/wala/ipa/cha/ClassHierarchy.java
@@ -1151,7 +1151,7 @@ public class ClassHierarchy implements IClassHierarchy {
    */
   @Override
   public int getNumberOfClasses() {
-    return map.keySet().size();
+    return map.size();
   }
 
   @Override


### PR DESCRIPTION
The size of `Map` is the same as the size of its set of keys.