### PR TITLE
Add more String language injection annotations

### DIFF
--- a/core/src/main/java/com/ibm/wala/core/util/config/AnalysisScopeReader.java
+++ b/core/src/main/java/com/ibm/wala/core/util/config/AnalysisScopeReader.java
@@ -32,6 +32,7 @@ import java.net.URI;
 import java.net.URL;
 import java.util.StringTokenizer;
 import java.util.jar.JarFile;
+import org.intellij.lang.annotations.Language;
 
 /** Reads {@link AnalysisScope} from a text file. */
 public class AnalysisScopeReader {
@@ -184,6 +185,7 @@ public class AnalysisScopeReader {
 
     String language = toks.nextToken();
     String entryType = toks.nextToken();
+    @Language("jvm-class-name")
     String entryPathname = toks.nextToken();
     FileProvider fp = new FileProvider();
     if ("classFile".equals(entryType)) {

--- a/core/src/main/java/com/ibm/wala/core/util/strings/StringStuff.java
+++ b/core/src/main/java/com/ibm/wala/core/util/strings/StringStuff.java
@@ -70,6 +70,7 @@ public class StringStuff {
     dString = dString.replace('.', '/');
     int arrayIndex = dString.indexOf("[]");
     if (arrayIndex > -1) {
+      @org.intellij.lang.annotations.Language("jvm-class-name")
       String baseType = dString.substring(0, arrayIndex);
       int dim = (dString.length() - arrayIndex) / 2;
       baseType = deployment2CanonicalTypeString(baseType);
@@ -534,6 +535,7 @@ public class StringStuff {
     if (methodSig.lastIndexOf('.') < 0) {
       throw new IllegalArgumentException("ill-formed sig " + methodSig);
     }
+    @org.intellij.lang.annotations.Language("jvm-class-name")
     String type = methodSig.substring(0, methodSig.lastIndexOf('.'));
     type = deployment2CanonicalTypeString(type);
     TypeReference t = TypeReference.findOrCreate(ClassLoaderReference.Application, type);

--- a/core/src/main/java/com/ibm/wala/examples/drivers/ScopeFileCallGraph.java
+++ b/core/src/main/java/com/ibm/wala/examples/drivers/ScopeFileCallGraph.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Properties;
+import org.intellij.lang.annotations.Language;
 
 /**
  * Driver that constructs a call graph for an application specified via a scope file. Useful for
@@ -60,6 +61,7 @@ public class ScopeFileCallGraph {
     long start = System.currentTimeMillis();
     Properties p = CommandLine.parse(args);
     String scopeFile = p.getProperty("scopeFile");
+    @Language("jvm-class-name")
     String entryClass = p.getProperty("entryClass");
     String mainClass = p.getProperty("mainClass");
     String dump = p.getProperty("dump");
@@ -101,7 +103,7 @@ public class ScopeFileCallGraph {
   }
 
   private static Iterable<Entrypoint> makePublicEntrypoints(
-      IClassHierarchy cha, String entryClass) {
+      IClassHierarchy cha, @Language("jvm-class-name") String entryClass) {
     Collection<Entrypoint> result = new ArrayList<>();
     IClass klass =
         cha.lookupClass(

--- a/dalvik/build.gradle.kts
+++ b/dalvik/build.gradle.kts
@@ -84,6 +84,8 @@ dependencies {
   api(projects.shrike)
   api(projects.util)
 
+  compileOnly(libs.jetbrains.annotations)
+
   coreTestJar(project("path" to ":core", "configuration" to "testJarConfig"))
   extraTestResources(project("path" to ":core", "configuration" to "dalvikTestResources"))
 

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidComponent.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidComponent.java
@@ -47,6 +47,7 @@ import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.TypeName;
 import com.ibm.wala.types.TypeReference;
+import org.intellij.lang.annotations.Language;
 
 /**
  * Android Components like Activity, Service, ...
@@ -216,7 +217,7 @@ public enum AndroidComponent {
    *
    * @return The Element if found or AndroidComponent.UNKNOWN if not
    */
-  public static AndroidComponent explicit(String type) {
+  public static AndroidComponent explicit(@Language("jvm-class-name") String type) {
     if (!(type.startsWith("L") || type.contains("/"))) {
       type = StringStuff.deployment2CanonicalTypeString(type);
     }

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidEntryPointManager.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidEntryPointManager.java
@@ -68,6 +68,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import org.intellij.lang.annotations.Language;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -336,7 +337,7 @@ public final /* singleton */ class AndroidEntryPointManager implements Serializa
    * @throws IllegalArgumentException if the package has already been set and the value of the
    *     packages differ. Or if the given package is null.
    */
-  public void setPackage(String pack) {
+  public void setPackage(@Language("jvm-class-name") String pack) {
     if (pack == null) {
       throw new IllegalArgumentException("Setting the package to null is disallowed.");
     }

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
@@ -55,6 +55,7 @@ import java.util.Map;
 import java.util.Set;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
+import org.intellij.lang.annotations.Language;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.Attributes;
@@ -627,7 +628,7 @@ public class AndroidManifestXMLReader {
       */
 
       if (!names.isEmpty()) {
-        for (String name : names) {
+        for (@Language("jvm-class-name") String name : names) {
           if (urls.isEmpty()) urls.add(null);
           for (String url : urls) {
             logger.info("New Intent ({}, {})", name, url);
@@ -701,6 +702,7 @@ public class AndroidManifestXMLReader {
         pack = null;
       }
 
+      @Language("jvm-class-name")
       final String name;
       if (self == Tag.ALIAS) {
         name = (String) attributesHistory.get(Attr.TARGET).peek(); // TODO: Verify type!

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidSettingFactory.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidSettingFactory.java
@@ -43,6 +43,7 @@ package com.ibm.wala.dalvik.util;
 import com.ibm.wala.core.util.strings.Atom;
 import com.ibm.wala.core.util.strings.StringStuff;
 import com.ibm.wala.dalvik.ipa.callgraph.propagation.cfa.Intent;
+import org.intellij.lang.annotations.Language;
 
 /**
  * Generate a Settings-Object from a String-Representation.
@@ -213,7 +214,7 @@ public class AndroidSettingFactory {
    * @throws IllegalArgumentException If name was null or starts with a dot and pack is null TODO:
    *     Check Target-Types
    */
-  public static Intent intent(String pack, String name, String uri) {
+  public static Intent intent(String pack, @Language("jvm-class-name") String name, String uri) {
     if ((name == null) || name.isEmpty()) {
       throw new IllegalArgumentException("name may not be null or empty");
     }
@@ -271,7 +272,7 @@ public class AndroidSettingFactory {
   //
   //  Short-Hand functions follow...
   //
-  public static Intent intent(String fullyQualifiedAction, String uri) {
+  public static Intent intent(@Language("jvm-class-name") String fullyQualifiedAction, String uri) {
     if (fullyQualifiedAction.startsWith(".")) {
       String pack = AndroidEntryPointManager.MANAGER.getPackage();
       if (pack != null) {
@@ -288,7 +289,7 @@ public class AndroidSettingFactory {
     }
   }
 
-  public static Intent intent(String fullyQualifiedAction) {
+  public static Intent intent(@Language("jvm-class-name") String fullyQualifiedAction) {
     if (fullyQualifiedAction.startsWith(".")) {
       throw new IllegalArgumentException(
           "The action "


### PR DESCRIPTION
These `@Language` annotations work backwards transitively.  They annotate `String` variables and parameters that flow forward into other places that are already `@Language`-annotated.