### PR TITLE
Remove redundant array creations in variadic calls

### DIFF
--- a/.idea/inspectionProfiles/No_Back_Sliding.xml
+++ b/.idea/inspectionProfiles/No_Back_Sliding.xml
@@ -493,6 +493,9 @@
     <inspection_tool class="ReassignedVariable" enabled="true" level="TEXT ATTRIBUTES" enabled_by_default="true">
       <scope name="Java Sources as Test Subjects" level="TEXT ATTRIBUTES" enabled="false" editorAttributes="REASSIGNED_LOCAL_VARIABLE_ATTRIBUTES" />
     </inspection_tool>
+    <inspection_tool class="RedundantArrayCreation" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="Java Sources as Test Subjects" level="WARNING" enabled="false" />
+    </inspection_tool>
     <inspection_tool class="RedundantBackticksAroundRawStringLiteral" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="RedundantCast" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="RedundantMethodOverride" enabled="true" level="WARNING" enabled_by_default="true">

--- a/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
+++ b/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
@@ -1501,7 +1501,7 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
     public CAstNode visitRegExpLiteral(RegExpLiteral node, WalkContext arg) {
       CAstNode flagsNode = Ast.makeConstant(node.getFlags());
       CAstNode valNode = Ast.makeConstant(node.getValue());
-      return handleNew(arg, "RegExp", Arrays.asList(new CAstNode[] {flagsNode, valNode}));
+      return handleNew(arg, "RegExp", Arrays.asList(flagsNode, valNode));
     }
 
     @Override

--- a/core/src/main/java/com/ibm/wala/classLoader/ClassLoaderFactoryImpl.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/ClassLoaderFactoryImpl.java
@@ -94,12 +94,10 @@ public class ClassLoaderFactoryImpl implements ClassLoaderFactory {
         Class<?> impl = Class.forName(implClass);
         Constructor<?> ctor =
             impl.getDeclaredConstructor(
-                new Class[] {
-                  ClassLoaderReference.class,
-                  IClassLoader.class,
-                  StringFilter.class,
-                  IClassHierarchy.class
-                });
+                ClassLoaderReference.class,
+                IClassLoader.class,
+                StringFilter.class,
+                IClassHierarchy.class);
         cl =
             (IClassLoader)
                 ctor.newInstance(new Object[] {classLoaderReference, parent, exclusions, cha});
@@ -108,13 +106,11 @@ public class ClassLoaderFactoryImpl implements ClassLoaderFactory {
           Class<?> impl = Class.forName(implClass);
           Constructor<?> ctor =
               impl.getDeclaredConstructor(
-                  new Class[] {
-                    ClassLoaderReference.class,
-                    ArrayClassLoader.class,
-                    IClassLoader.class,
-                    StringFilter.class,
-                    IClassHierarchy.class
-                  });
+                  ClassLoaderReference.class,
+                  ArrayClassLoader.class,
+                  IClassLoader.class,
+                  StringFilter.class,
+                  IClassHierarchy.class);
           cl =
               (IClassLoader)
                   ctor.newInstance(

--- a/core/src/main/java/com/ibm/wala/classLoader/JavaLanguage.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/JavaLanguage.java
@@ -459,39 +459,30 @@ public class JavaLanguage extends LanguageImpl implements BytecodeLanguage, Cons
   private static final Collection<TypeReference> arrayAccessExceptions =
       Collections.unmodifiableCollection(
           Arrays.asList(
-              new TypeReference[] {
-                TypeReference.JavaLangNullPointerException,
-                TypeReference.JavaLangArrayIndexOutOfBoundsException
-              }));
+              TypeReference.JavaLangNullPointerException,
+              TypeReference.JavaLangArrayIndexOutOfBoundsException));
 
   private static final Collection<TypeReference> aaStoreExceptions =
       Collections.unmodifiableCollection(
           Arrays.asList(
-              new TypeReference[] {
-                TypeReference.JavaLangNullPointerException,
-                TypeReference.JavaLangArrayIndexOutOfBoundsException,
-                TypeReference.JavaLangArrayStoreException
-              }));
+              TypeReference.JavaLangNullPointerException,
+              TypeReference.JavaLangArrayIndexOutOfBoundsException,
+              TypeReference.JavaLangArrayStoreException));
 
   private static final Collection<TypeReference> newScalarExceptions =
       Collections.unmodifiableCollection(
           Arrays.asList(
-              new TypeReference[] {
-                TypeReference.JavaLangExceptionInInitializerError,
-                TypeReference.JavaLangOutOfMemoryError
-              }));
+              TypeReference.JavaLangExceptionInInitializerError,
+              TypeReference.JavaLangOutOfMemoryError));
 
   private static final Collection<TypeReference> newArrayExceptions =
       Collections.unmodifiableCollection(
           Arrays.asList(
-              new TypeReference[] {
-                TypeReference.JavaLangOutOfMemoryError,
-                TypeReference.JavaLangNegativeArraySizeException
-              }));
+              TypeReference.JavaLangOutOfMemoryError,
+              TypeReference.JavaLangNegativeArraySizeException));
 
   private static final Collection<TypeReference> newSafeArrayExceptions =
-      Collections.unmodifiableCollection(
-          Arrays.asList(new TypeReference[] {TypeReference.JavaLangOutOfMemoryError}));
+      Collections.singleton(TypeReference.JavaLangOutOfMemoryError);
 
   private static final Collection<TypeReference> exceptionInInitializerError =
       Collections.singleton(TypeReference.JavaLangExceptionInInitializerError);

--- a/shrike/src/main/java/com/ibm/wala/shrike/sourcepos/CRTable.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/sourcepos/CRTable.java
@@ -91,7 +91,7 @@ public final class CRTable extends PositionsAttribute {
     for (int i = 0; i < crt.length; i++) {
       if ((crt[i] != null) && crt[i].isInRange(pc)) {
         if ((sourceInfo != null) && !sourceInfo.matches(crt[i]))
-          Debug.warn(WARN_CRT_ENTRIES_CONTRADICTORY, new Object[] {sourceInfoIndex, i});
+          Debug.warn(WARN_CRT_ENTRIES_CONTRADICTORY, sourceInfoIndex, i);
         if ((sourceInfo == null) || crt[i].isMorePrecise(sourceInfo)) {
           sourceInfo = crt[i];
           sourceInfoIndex = i;


### PR DESCRIPTION
When calling a variadic method, there's no need explicitly create an array for the `vararg` arguments.