### PR TITLE
Remove unnecessary `equals` overrides

### DIFF
--- a/cast/src/main/java/com/ibm/wala/cast/tree/CAstControlFlowMap.java
+++ b/cast/src/main/java/com/ibm/wala/cast/tree/CAstControlFlowMap.java
@@ -52,11 +52,6 @@ public interface CAstControlFlowMap {
         public int hashCode() {
           return getKind() * toString().hashCode();
         }
-
-        @Override
-        public boolean equals(Object o) {
-          return o == this;
-        }
       };
 
   /**

--- a/cast/src/main/java/com/ibm/wala/cast/tree/CAstMemberReference.java
+++ b/cast/src/main/java/com/ibm/wala/cast/tree/CAstMemberReference.java
@@ -33,11 +33,6 @@ public interface CAstMemberReference extends CAstReference {
         public int hashCode() {
           return toString().hashCode();
         }
-
-        @Override
-        public boolean equals(Object o) {
-          return o == this;
-        }
       };
 
   String member();

--- a/core/src/main/java/com/ibm/wala/classLoader/JarFileEntry.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/JarFileEntry.java
@@ -94,9 +94,4 @@ public class JarFileEntry implements ModuleEntry {
   public boolean isSourceFile() {
     return FileSuffixes.isSourceFile(getName());
   }
-
-  @Override
-  public boolean equals(Object obj) {
-    return this == obj;
-  }
 }

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/Everywhere.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/Everywhere.java
@@ -37,9 +37,4 @@ public class Everywhere implements Context {
   public int hashCode() {
     return 9851;
   }
-
-  @Override
-  public boolean equals(Object obj) {
-    return this == obj;
-  }
 }

--- a/core/src/main/java/com/ibm/wala/ipa/cha/ClassHierarchy.java
+++ b/core/src/main/java/com/ibm/wala/ipa/cha/ClassHierarchy.java
@@ -785,11 +785,6 @@ public class ClassHierarchy implements IClassHierarchy {
     public int hashCode() {
       return klass.hashCode() * 929;
     }
-
-    @Override
-    public boolean equals(Object obj) {
-      return this == obj;
-    }
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/ssa/InstanceOfPiPolicy.java
+++ b/core/src/main/java/com/ibm/wala/ssa/InstanceOfPiPolicy.java
@@ -58,11 +58,6 @@ public class InstanceOfPiPolicy implements SSAPiNodePolicy {
   }
 
   @Override
-  public boolean equals(Object obj) {
-    return this == obj;
-  }
-
-  @Override
   public int hashCode() {
     return 12;
   }

--- a/core/src/main/java/com/ibm/wala/types/Descriptor.java
+++ b/core/src/main/java/com/ibm/wala/types/Descriptor.java
@@ -97,11 +97,6 @@ public final class Descriptor {
   }
 
   @Override
-  public boolean equals(Object obj) {
-    return this == obj;
-  }
-
-  @Override
   public int hashCode() {
     return key.hashCode();
   }

--- a/core/src/main/java/com/ibm/wala/types/TypeName.java
+++ b/core/src/main/java/com/ibm/wala/types/TypeName.java
@@ -104,11 +104,6 @@ public final class TypeName implements Serializable {
   }
 
   @Override
-  public boolean equals(Object obj) {
-    return this == obj;
-  }
-
-  @Override
   public int hashCode() {
     return key.hashCode();
   }


### PR DESCRIPTION
Each of these `equals` methods is equivalent to the superclass's `equals` method, so there's no point in overriding the latter.