### PR TITLE
Remove unnecessary delegating overrides

### DIFF
--- a/.idea/inspectionProfiles/No_Back_Sliding.xml
+++ b/.idea/inspectionProfiles/No_Back_Sliding.xml
@@ -503,6 +503,7 @@
     <inspection_tool class="RedundantCast" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="RedundantMethodOverride" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Java Sources as Test Subjects" level="WARNING" enabled="false" />
+      <option name="ignoreDelegates" value="false" />
     </inspection_tool>
     <inspection_tool class="RedundantOperationOnEmptyContainer" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Java Sources as Test Subjects" level="WARNING" enabled="false" />

--- a/core/src/main/java/com/ibm/wala/analysis/reflection/FactoryBypassInterpreter.java
+++ b/core/src/main/java/com/ibm/wala/analysis/reflection/FactoryBypassInterpreter.java
@@ -587,11 +587,6 @@ public class FactoryBypassInterpreter extends AbstractReflectionInterpreter {
     }
 
     @Override
-    public String toString() {
-      return super.toString();
-    }
-
-    @Override
     public SSAInstruction[] getStatements() {
       SSAInstruction[] result = new SSAInstruction[allInstructions.size()];
       int i = 0;

--- a/core/src/main/java/com/ibm/wala/core/util/ssa/ParameterAccessor.java
+++ b/core/src/main/java/com/ibm/wala/core/util/ssa/ParameterAccessor.java
@@ -123,11 +123,6 @@ public class ParameterAccessor {
     }
 
     @Override
-    public boolean equals(Object o) {
-      return super.equals(o);
-    }
-
-    @Override
     public int hashCode() {
       return this.type.hashCode();
     }

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationCallGraphBuilder.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationCallGraphBuilder.java
@@ -834,11 +834,6 @@ public abstract class PropagationCallGraphBuilder implements CallGraphBuilder<In
     }
 
     @Override
-    public boolean equals(Object o) {
-      return super.equals(o);
-    }
-
-    @Override
     protected boolean isLoadOperator() {
       return true;
     }
@@ -920,11 +915,6 @@ public abstract class PropagationCallGraphBuilder implements CallGraphBuilder<In
     @Override
     public boolean isComplex() {
       return true;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      return super.equals(o);
     }
 
     @Override

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/MiniModel.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/MiniModel.java
@@ -47,7 +47,6 @@ import com.ibm.wala.ipa.callgraph.AnalysisOptions;
 import com.ibm.wala.ipa.callgraph.IAnalysisCacheView;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.ipa.summaries.SummarizedMethod;
-import com.ibm.wala.types.Descriptor;
 import com.ibm.wala.util.CancelException;
 
 /**
@@ -86,11 +85,6 @@ public class MiniModel extends AndroidModel {
       return true;
     }
     return false;
-  }
-
-  @Override
-  public Descriptor getDescriptor() throws CancelException {
-    return super.getDescriptor();
   }
 
   public MiniModel(

--- a/scandroid/src/main/java/org/scandroid/prefixtransfer/UriPrefixContextSelector.java
+++ b/scandroid/src/main/java/org/scandroid/prefixtransfer/UriPrefixContextSelector.java
@@ -61,7 +61,6 @@ import com.ibm.wala.ipa.callgraph.propagation.cfa.CallerSiteContext;
 import com.ibm.wala.ipa.callgraph.propagation.cfa.CallerSiteContextPair;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.types.ClassLoaderReference;
-import com.ibm.wala.util.intset.IntSet;
 
 public class UriPrefixContextSelector extends DefaultContextSelector {
 
@@ -141,10 +140,5 @@ public class UriPrefixContextSelector extends DefaultContextSelector {
       // "+caller.getContext());
     }
     return super.getCalleeTarget(caller, site, callee, receivers);
-  }
-
-  @Override
-  public IntSet getRelevantParameters(CGNode node, CallSiteReference call) {
-    return super.getRelevantParameters(node, call);
   }
 }


### PR DESCRIPTION
Each of these overridden methods simply delegates to the superclass's method, so there's no point in overriding the latter.