### PR TITLE
Avoid pre-sized array in `Collections.toArray()` call

### DIFF
--- a/core/src/main/java/com/ibm/wala/types/generics/TypeSignature.java
+++ b/core/src/main/java/com/ibm/wala/types/generics/TypeSignature.java
@@ -184,7 +184,7 @@ public abstract class TypeSignature extends Signature {
           break;
         case (byte) ')': // end of parameter list
         case (byte) '>': // end of type argument list
-          return sigs.toArray(new String[sigs.size()]);
+          return sigs.toArray(new String[0]);
         default:
           throw new IllegalArgumentException("bad type signature list " + typeSigs);
       }


### PR DESCRIPTION
Pre-sizing the destination array used to be more efficient.  In OpenJDK 6 and later, though, the empty array style is as fast or faster.  The empty array style also avoids a potential race if the size of the `Collection` being copied might change due to activity in other threads.