### PR TITLE
Modernize `package.html` as `package-info.java`

### DIFF
--- a/.idea/inspectionProfiles/No_Back_Sliding.xml
+++ b/.idea/inspectionProfiles/No_Back_Sliding.xml
@@ -468,6 +468,7 @@
     <inspection_tool class="OverflowingLoopIndex" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Java Sources as Test Subjects" level="WARNING" enabled="false" />
     </inspection_tool>
+    <inspection_tool class="PackageDotHtmlMayBePackageInfo" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="PackageJsonMismatchedDependency" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="ParameterCanBeLocal" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="PointlessArithmeticExpression" enabled="true" level="WARNING" enabled_by_default="true">

--- a/core/src/main/java/com/ibm/wala/analysis/pointers/package-info.java
+++ b/core/src/main/java/com/ibm/wala/analysis/pointers/package-info.java
@@ -1,0 +1,2 @@
+/** This package defines utilities to help navigate pointer analysis results. */
+package com.ibm.wala.analysis.pointers;

--- a/core/src/main/java/com/ibm/wala/analysis/pointers/package.html
+++ b/core/src/main/java/com/ibm/wala/analysis/pointers/package.html
@@ -1,5 +1,0 @@
-<HTML>
-<BODY>
-This package defines utilities to help navigate pointer analysis results.
-</BODY>
-</HTML>

--- a/core/src/main/java/com/ibm/wala/analysis/reflection/package-info.java
+++ b/core/src/main/java/com/ibm/wala/analysis/reflection/package-info.java
@@ -1,0 +1,2 @@
+/** This package provides functions to deal with reflection. */
+package com.ibm.wala.analysis.reflection;

--- a/core/src/main/java/com/ibm/wala/analysis/reflection/package.html
+++ b/core/src/main/java/com/ibm/wala/analysis/reflection/package.html
@@ -1,5 +1,0 @@
-<HTML>
-<BODY>
-This package provides functions to deal with reflection.
-</BODY>
-</HTML>

--- a/core/src/main/java/com/ibm/wala/analysis/stackMachine/package-info.java
+++ b/core/src/main/java/com/ibm/wala/analysis/stackMachine/package-info.java
@@ -1,0 +1,2 @@
+/** This package provides a layer to perform abstract interpretation over the JVM stack machine. */
+package com.ibm.wala.analysis.stackMachine;

--- a/core/src/main/java/com/ibm/wala/analysis/stackMachine/package.html
+++ b/core/src/main/java/com/ibm/wala/analysis/stackMachine/package.html
@@ -1,6 +1,0 @@
-<HTML>
-<BODY>
-This package provides a layer to perform abstract interpretation over 
-the JVM stack machine.
-</BODY>
-</HTML>

--- a/core/src/main/java/com/ibm/wala/analysis/typeInference/package-info.java
+++ b/core/src/main/java/com/ibm/wala/analysis/typeInference/package-info.java
@@ -1,0 +1,2 @@
+/** This package provides intraprocedural type inference over the SSA form. */
+package com.ibm.wala.analysis.typeInference;

--- a/core/src/main/java/com/ibm/wala/analysis/typeInference/package.html
+++ b/core/src/main/java/com/ibm/wala/analysis/typeInference/package.html
@@ -1,5 +1,0 @@
-<HTML>
-<BODY>
-This package provides intraprocedural type inference over the SSA form.
-</BODY>
-</HTML>

--- a/core/src/main/java/com/ibm/wala/cfg/cdg/package-info.java
+++ b/core/src/main/java/com/ibm/wala/cfg/cdg/package-info.java
@@ -1,0 +1,2 @@
+/** This package supports a control-dependence graph. */
+package com.ibm.wala.cfg.cdg;

--- a/core/src/main/java/com/ibm/wala/cfg/cdg/package.html
+++ b/core/src/main/java/com/ibm/wala/cfg/cdg/package.html
@@ -1,5 +1,0 @@
-<HTML>
-<BODY>
-This package supports a control-dependence graph.
-</BODY>
-</HTML>

--- a/core/src/main/java/com/ibm/wala/cfg/package-info.java
+++ b/core/src/main/java/com/ibm/wala/cfg/package-info.java
@@ -1,0 +1,2 @@
+/** This package provides control-flow graph utilities. */
+package com.ibm.wala.cfg;

--- a/core/src/main/java/com/ibm/wala/cfg/package.html
+++ b/core/src/main/java/com/ibm/wala/cfg/package.html
@@ -1,5 +1,0 @@
-<HTML>
-<BODY>
-This package provides control-flow graph utilities.
-</BODY>
-</HTML>

--- a/core/src/main/java/com/ibm/wala/classLoader/package-info.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * This package provides functionality related to class loading and management of loaded classes.
+ */
+package com.ibm.wala.classLoader;

--- a/core/src/main/java/com/ibm/wala/classLoader/package.html
+++ b/core/src/main/java/com/ibm/wala/classLoader/package.html
@@ -1,6 +1,0 @@
-<HTML>
-<BODY>
-This package provides functionality related to class loading and
-management of loaded classes.
-</BODY>
-</HTML>

--- a/core/src/main/java/com/ibm/wala/client/package-info.java
+++ b/core/src/main/java/com/ibm/wala/client/package-info.java
@@ -1,0 +1,2 @@
+/** This package provides interfaces for some base utilities for use by WALA clients. */
+package com.ibm.wala.client;

--- a/core/src/main/java/com/ibm/wala/client/package.html
+++ b/core/src/main/java/com/ibm/wala/client/package.html
@@ -1,5 +1,0 @@
-<HTML>
-<BODY>
-This package provides interfaces for some base utilities for use by WALA clients.
-</BODY>
-</HTML>

--- a/core/src/main/java/com/ibm/wala/core/plugin/package-info.java
+++ b/core/src/main/java/com/ibm/wala/core/plugin/package-info.java
@@ -1,0 +1,2 @@
+/** This package provides a plugin class for Eclipse integration. */
+package com.ibm.wala.core.plugin;

--- a/core/src/main/java/com/ibm/wala/core/plugin/package.html
+++ b/core/src/main/java/com/ibm/wala/core/plugin/package.html
@@ -1,5 +1,0 @@
-<HTML>
-<BODY>
-This package provides a plugin class for Eclipse integration.
-</BODY>
-</HTML>

--- a/core/src/main/java/com/ibm/wala/core/util/bytecode/package-info.java
+++ b/core/src/main/java/com/ibm/wala/core/util/bytecode/package-info.java
@@ -1,0 +1,2 @@
+/** This package provides miscellaneous utilities for manipulating bytecode. */
+package com.ibm.wala.core.util.bytecode;

--- a/core/src/main/java/com/ibm/wala/core/util/bytecode/package.html
+++ b/core/src/main/java/com/ibm/wala/core/util/bytecode/package.html
@@ -1,5 +1,0 @@
-<HTML>
-<BODY>
-This package provides miscellaneous utilities for manipulating bytecode.
-</BODY>
-</HTML>

--- a/core/src/main/java/com/ibm/wala/core/util/config/package-info.java
+++ b/core/src/main/java/com/ibm/wala/core/util/config/package-info.java
@@ -1,0 +1,2 @@
+/** This package provides miscellaneous utilities for configuration of the analysis. */
+package com.ibm.wala.core.util.config;

--- a/core/src/main/java/com/ibm/wala/core/util/config/package.html
+++ b/core/src/main/java/com/ibm/wala/core/util/config/package.html
@@ -1,5 +1,0 @@
-<HTML>
-<BODY>
-This package provides miscellaneous utilities for configuration of the analysis.
-</BODY>
-</HTML>

--- a/core/src/main/java/com/ibm/wala/core/util/package-info.java
+++ b/core/src/main/java/com/ibm/wala/core/util/package-info.java
@@ -1,0 +1,2 @@
+/** This package provides miscellaneous utilities. */
+package com.ibm.wala.core.util;

--- a/core/src/main/java/com/ibm/wala/core/util/package.html
+++ b/core/src/main/java/com/ibm/wala/core/util/package.html
@@ -1,5 +1,0 @@
-<HTML>
-<BODY>
-This package provides miscellaneous utilities.
-</BODY>
-</HTML>

--- a/core/src/main/java/com/ibm/wala/core/util/warnings/package-info.java
+++ b/core/src/main/java/com/ibm/wala/core/util/warnings/package-info.java
@@ -1,0 +1,2 @@
+/** This package provides miscellaneous utilities for tracking analysis warnings. */
+package com.ibm.wala.core.util.warnings;

--- a/core/src/main/java/com/ibm/wala/core/util/warnings/package.html
+++ b/core/src/main/java/com/ibm/wala/core/util/warnings/package.html
@@ -1,5 +1,0 @@
-<HTML>
-<BODY>
-This package provides miscellaneous utilities for tracking analysis warnings.
-</BODY>
-</HTML>

--- a/core/src/main/java/com/ibm/wala/dataflow/IFDS/package-info.java
+++ b/core/src/main/java/com/ibm/wala/dataflow/IFDS/package-info.java
@@ -1,0 +1,2 @@
+/** This package provides an RHS solver for IFDS problems. */
+package com.ibm.wala.dataflow.IFDS;

--- a/core/src/main/java/com/ibm/wala/dataflow/IFDS/package.html
+++ b/core/src/main/java/com/ibm/wala/dataflow/IFDS/package.html
@@ -1,5 +1,0 @@
-<HTML>
-<BODY>
-This package provides an RHS solver for IFDS problems.
-</BODY>
-</HTML>

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/package-info.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * This package provides some implementations of basic functions needed for various call graph
+ * construction algorithms.
+ */
+package com.ibm.wala.ipa.callgraph.impl;

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/package.html
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/package.html
@@ -1,6 +1,0 @@
-<HTML>
-<BODY>
-This package provides some implementations of basic functions needed for 
-various call graph construction algorithms.
-</BODY>
-</HTML>

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/package-info.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/package-info.java
@@ -1,0 +1,2 @@
+/** This package provides basic interfaces and functions for call graph construction. */
+package com.ibm.wala.ipa.callgraph;

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/package.html
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/package.html
@@ -1,6 +1,0 @@
-<HTML>
-<BODY>
-This package provides basic interfaces and functions for call graph
-construction.
-</BODY>
-</HTML>

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/package-info.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/package-info.java
@@ -1,0 +1,2 @@
+/** This package provides RTA call graph construction. */
+package com.ibm.wala.ipa.callgraph.propagation.cfa;

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/package.html
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/package.html
@@ -1,6 +1,0 @@
-<HTML>
-<BODY>
-This package provides RTA call graph
-construction.
-</BODY>
-</HTML>

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/package-info.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * This package provides the base layer for propagation-based call graph construction and pointer
+ * analysis.
+ */
+package com.ibm.wala.ipa.callgraph.propagation;

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/package.html
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/package.html
@@ -1,6 +1,0 @@
-<HTML>
-<BODY>
-This package provides the base layer for propagation-based call graph
-construction and pointer analysis.
-</BODY>
-</HTML>

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/package-info.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/package-info.java
@@ -1,0 +1,2 @@
+/** This package provides CFA-style call graph construction and pointer analysis. */
+package com.ibm.wala.ipa.callgraph.propagation.rta;

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/package.html
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/package.html
@@ -1,6 +1,0 @@
-<HTML>
-<BODY>
-This package provides CFA-style call graph
-construction and pointer analysis.
-</BODY>
-</HTML>

--- a/core/src/main/java/com/ibm/wala/ipa/cfg/package-info.java
+++ b/core/src/main/java/com/ibm/wala/ipa/cfg/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * This package supports interprocedural control-flow graphs, and control-flow graphs specialized
+ * for context.
+ */
+package com.ibm.wala.ipa.cfg;

--- a/core/src/main/java/com/ibm/wala/ipa/cfg/package.html
+++ b/core/src/main/java/com/ibm/wala/ipa/cfg/package.html
@@ -1,6 +1,0 @@
-<HTML>
-<BODY>
-This package supports interprocedural control-flow graphs, and control-flow
-graphs specialized for context.
-</BODY>
-</HTML>

--- a/core/src/main/java/com/ibm/wala/ipa/cha/package-info.java
+++ b/core/src/main/java/com/ibm/wala/ipa/cha/package-info.java
@@ -1,0 +1,2 @@
+/** This package provides functionality related to class hierarchies. */
+package com.ibm.wala.ipa.cha;

--- a/core/src/main/java/com/ibm/wala/ipa/cha/package.html
+++ b/core/src/main/java/com/ibm/wala/ipa/cha/package.html
@@ -1,5 +1,0 @@
-<HTML>
-<BODY>
-This package provides functionality related to class hierarchies.
-</BODY>
-</HTML>

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/package-info.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/package-info.java
@@ -1,0 +1,2 @@
+/** This package provides class hierarchy analysis. */
+package com.ibm.wala.ipa.summaries;

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/package.html
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/package.html
@@ -1,5 +1,0 @@
-<HTML>
-<BODY>
-This package provides class hierarchy analysis.
-</BODY>
-</HTML>

--- a/core/src/main/java/com/ibm/wala/ssa/analysis/package-info.java
+++ b/core/src/main/java/com/ibm/wala/ssa/analysis/package-info.java
@@ -1,0 +1,2 @@
+/** This package provides analyses over the WALA SSA IR. */
+package com.ibm.wala.ssa.analysis;

--- a/core/src/main/java/com/ibm/wala/ssa/analysis/package.html
+++ b/core/src/main/java/com/ibm/wala/ssa/analysis/package.html
@@ -1,5 +1,0 @@
-<HTML>
-<BODY>
-This package provides analyses over the WALA SSA IR.
-</BODY>
-</HTML>

--- a/core/src/main/java/com/ibm/wala/ssa/package-info.java
+++ b/core/src/main/java/com/ibm/wala/ssa/package-info.java
@@ -1,0 +1,2 @@
+/** This package provides the WALA SSA IR. */
+package com.ibm.wala.ssa;

--- a/core/src/main/java/com/ibm/wala/ssa/package.html
+++ b/core/src/main/java/com/ibm/wala/ssa/package.html
@@ -1,5 +1,0 @@
-<HTML>
-<BODY>
-This package provides the WALA SSA IR.
-</BODY>
-</HTML>

--- a/core/src/main/java/com/ibm/wala/types/package-info.java
+++ b/core/src/main/java/com/ibm/wala/types/package-info.java
@@ -1,0 +1,2 @@
+/** This package provides abstractions for the Java type system. */
+package com.ibm.wala.types;

--- a/core/src/main/java/com/ibm/wala/types/package.html
+++ b/core/src/main/java/com/ibm/wala/types/package.html
@@ -1,5 +1,0 @@
-<HTML>
-<BODY>
-This package provides abstractions for the Java type system.
-</BODY>
-</HTML>

--- a/util/src/main/java/com/ibm/wala/dataflow/graph/package-info.java
+++ b/util/src/main/java/com/ibm/wala/dataflow/graph/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * This package provides a Killdall-style dataflow layer for a system of equations induced over a
+ * graph.
+ */
+package com.ibm.wala.dataflow.graph;

--- a/util/src/main/java/com/ibm/wala/dataflow/graph/package.html
+++ b/util/src/main/java/com/ibm/wala/dataflow/graph/package.html
@@ -1,6 +1,0 @@
-<HTML>
-<BODY>
-This package provides a Killdall-style dataflow layer for a system
-of equations induced over a graph.
-</BODY>
-</HTML>

--- a/util/src/main/java/com/ibm/wala/fixpoint/package-info.java
+++ b/util/src/main/java/com/ibm/wala/fixpoint/package-info.java
@@ -1,0 +1,2 @@
+/** This package provides general utilities for fixed-point solvers. */
+package com.ibm.wala.fixpoint;

--- a/util/src/main/java/com/ibm/wala/fixpoint/package.html
+++ b/util/src/main/java/com/ibm/wala/fixpoint/package.html
@@ -1,5 +1,0 @@
-<HTML>
-<BODY>
-This package provides general utilities for fixed-point solvers.
-</BODY>
-</HTML>

--- a/util/src/main/java/com/ibm/wala/util/collections/package-info.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/package-info.java
@@ -1,0 +1,2 @@
+/** Sets and collections */
+package com.ibm.wala.util.collections;

--- a/util/src/main/java/com/ibm/wala/util/collections/package.html
+++ b/util/src/main/java/com/ibm/wala/util/collections/package.html
@@ -1,5 +1,0 @@
-<HTML>
-<BODY>
-Sets and collections
-</BODY>
-</HTML>

--- a/util/src/main/java/com/ibm/wala/util/debug/package-info.java
+++ b/util/src/main/java/com/ibm/wala/util/debug/package-info.java
@@ -1,0 +1,2 @@
+/** Debugging utilities */
+package com.ibm.wala.util.debug;

--- a/util/src/main/java/com/ibm/wala/util/debug/package.html
+++ b/util/src/main/java/com/ibm/wala/util/debug/package.html
@@ -1,5 +1,0 @@
-<HTML>
-<BODY>
-Debugging utilities
-</BODY>
-</HTML>

--- a/util/src/main/java/com/ibm/wala/util/graph/impl/package-info.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/impl/package-info.java
@@ -1,0 +1,2 @@
+/** Graph implementations */
+package com.ibm.wala.util.graph.impl;

--- a/util/src/main/java/com/ibm/wala/util/graph/impl/package.html
+++ b/util/src/main/java/com/ibm/wala/util/graph/impl/package.html
@@ -1,5 +1,0 @@
-<HTML>
-<BODY>
-Graph implementations
-</BODY>
-</HTML>

--- a/util/src/main/java/com/ibm/wala/util/graph/package-info.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/package-info.java
@@ -1,0 +1,2 @@
+/** Graph interfaces */
+package com.ibm.wala.util.graph;

--- a/util/src/main/java/com/ibm/wala/util/graph/package.html
+++ b/util/src/main/java/com/ibm/wala/util/graph/package.html
@@ -1,5 +1,0 @@
-<HTML>
-<BODY>
-Graph interfaces
-</BODY>
-</HTML>

--- a/util/src/main/java/com/ibm/wala/util/graph/traverse/package-info.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/traverse/package-info.java
@@ -1,0 +1,2 @@
+/** Graph traversal algorithms */
+package com.ibm.wala.util.graph.traverse;

--- a/util/src/main/java/com/ibm/wala/util/graph/traverse/package.html
+++ b/util/src/main/java/com/ibm/wala/util/graph/traverse/package.html
@@ -1,5 +1,0 @@
-<HTML>
-<BODY>
-Graph traversal algorithms
-</BODY>
-</HTML>

--- a/util/src/main/java/com/ibm/wala/util/heapTrace/package-info.java
+++ b/util/src/main/java/com/ibm/wala/util/heapTrace/package-info.java
@@ -1,0 +1,2 @@
+/** This package provides a utility which analyzes heap usage by heap-walking via reflection. */
+package com.ibm.wala.util.heapTrace;

--- a/util/src/main/java/com/ibm/wala/util/heapTrace/package.html
+++ b/util/src/main/java/com/ibm/wala/util/heapTrace/package.html
@@ -1,5 +1,0 @@
-<HTML>
-<BODY>
-This package provides a utility which analyzes heap usage by heap-walking via reflection.
-</BODY>
-</HTML>

--- a/util/src/main/java/com/ibm/wala/util/intset/package-info.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/package-info.java
@@ -1,0 +1,2 @@
+/** BitVector and vector utilities */
+package com.ibm.wala.util.intset;

--- a/util/src/main/java/com/ibm/wala/util/intset/package.html
+++ b/util/src/main/java/com/ibm/wala/util/intset/package.html
@@ -1,5 +1,0 @@
-<HTML>
-<BODY>
-BitVector and vector utilities
-</BODY>
-</HTML>

--- a/util/src/main/java/com/ibm/wala/util/math/package-info.java
+++ b/util/src/main/java/com/ibm/wala/util/math/package-info.java
@@ -1,0 +1,2 @@
+/** Math utilities */
+package com.ibm.wala.util.math;

--- a/util/src/main/java/com/ibm/wala/util/math/package.html
+++ b/util/src/main/java/com/ibm/wala/util/math/package.html
@@ -1,5 +1,0 @@
-<HTML>
-<BODY>
-Math utilities
-</BODY>
-</HTML>


### PR DESCRIPTION
The latter has been preferred over the former since Java 1.5.