### PR TITLE
Suppress warnings for seemingly unused catalog entries

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,9 @@
 [versions]
 com-uber-nullaway = "0.12.7"
+#noinspection UnusedVersionCatalogEntry
 eclipse = "4.30.0"
 eclipse-wst-jsdt = "1.0.201.v2010012803"
+#noinspection UnusedVersionCatalogEntry
 google-java-format = "1.28.0"
 ktfmt = "0.44"
 spotless = "7.2.1"
@@ -17,6 +19,7 @@ eclipse-ecj = "org.eclipse.jdt:ecj:3.42.0"
 eclipse-osgi = "org.eclipse.platform:org.eclipse.osgi:3.23.100"
 eclipse-wst-jsdt-core = { module = "org.eclipse.wst.jsdt:core", version.ref = "eclipse-wst-jsdt" }
 eclipse-wst-jsdt-ui = { module = "org.eclipse.wst.jsdt:ui", version.ref = "eclipse-wst-jsdt" }
+#noinspection UnusedVersionCatalogEntry
 errorprone-core = "com.google.errorprone:error_prone_core:2.40.0"
 gradle-errorprone-plugin = "net.ltgt.gradle:gradle-errorprone-plugin:4.2.0"
 gradle-goomph-plugin = "com.diffplug.gradle:goomph:4.3.0"
@@ -26,6 +29,7 @@ gson = "com.google.code.gson:gson:2.13.1"
 guava = "com.google.guava:guava:33.4.8-jre"
 htmlparser = "nu.validator.htmlparser:htmlparser:1.4"
 java_cup = "java_cup:java_cup:0.9e"
+#noinspection UnusedVersionCatalogEntry
 javax-annotation-api = "javax.annotation:javax.annotation-api:1.3.2"
 jetbrains-annotations = "org.jetbrains:annotations:24.0.0"
 jericho-html = "net.htmlparser.jericho:jericho-html:3.4"
@@ -33,22 +37,29 @@ json = "org.json:json:20250517"
 jspecify = "org.jspecify:jspecify:1.0.0"
 junit-bom = "org.junit:junit-bom:5.13.4"
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
+#noinspection UnusedVersionCatalogEntry
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params" }
 junit-platform-engine = { module = "org.junit.platform:junit-platform-engine" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+#noinspection UnusedVersionCatalogEntry
 junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine" }
+#noinspection UnusedVersionCatalogEntry
 nullaway = { module = "com.uber.nullaway:nullaway", version.ref = "com-uber-nullaway" }
+#noinspection UnusedVersionCatalogEntry
 nullaway-annotations = { module = "com.uber.nullaway:nullaway-annotations", version.ref = "com-uber-nullaway" }
 osgi-framework = "org.osgi:org.osgi.framework:1.10.0"
 rhino = "org.mozilla:rhino:1.8.0"
 slf4j-api = "org.slf4j:slf4j-api:2.0.17"
+#noinspection UnusedVersionCatalogEntry
 w3c-css-sac = "org.eclipse.birt.runtime:org.w3c.css.sac:1.3.1.v200903091627"
+#noinspection UnusedVersionCatalogEntry
 xml-apis-ext = "xml-apis:xml-apis-ext:1.3.04"
 
 [plugins]
 dependency-analysis = "com.autonomousapps.dependency-analysis:2.19.0"
 file-lister = "all.shared.gradle.file-lister:1.0.2"
+#noinspection UnusedVersionCatalogEntry
 google-java-format = "com.github.sherter.google-java-format:0.9"
 node = "com.github.node-gradle.node:7.1.0"
 shellcheck = "com.felipefzdz.gradle.shellcheck:1.5.0"


### PR DESCRIPTION
Each of these entries is actually used.  But those uses are in `build-logic` code that must look these entries up as strings instead of using generated Kotlin bindings.  That causes IntelliJ IDEA to mistakenly think that these entries are unused.

We could turn off that IntelliJ IDEA warning entirely, for the whole catalog.  But the vast majority of catalog entries are used in standard, detectable ways.  It's still useful to have this warning in case any of those stop being used in the future.