### PR TITLE
Avoid pre-sized array in `Collections.toArray()` call

### DIFF
--- a/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
+++ b/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
@@ -1306,7 +1306,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
           }
         }
       } else if (parameterNames != null) {
-        fParameterNames = parameterNames.toArray(new String[parameterNames.size()]);
+        fParameterNames = parameterNames.toArray(new String[0]);
         fParameterTypes = parameterTypes;
       } else {
         fParameterNames = new String[0];


### PR DESCRIPTION
Pre-sizing the destination array used to be more efficient. In OpenJDK 6 and later, though, the empty array style is as fast or faster. The empty array style also avoids a potential race if the size of the `Collection` being copied might change due to activity in other threads.