### PR TITLE
Use overloaded assignment operator in Gradle Kotlin code

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/CompileKawaScheme.kt
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/CompileKawaScheme.kt
@@ -10,6 +10,7 @@ import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
+import org.gradle.kotlin.dsl.assign
 
 /** Specialized task for Kawa compilation into jar archive. */
 @CacheableTask
@@ -23,7 +24,7 @@ abstract class CompileKawaScheme : JavaExec() {
 
   init {
     classpath(project.tasks.named("extractKawa"))
-    mainClass.set("kawa.repl")
+    mainClass = "kawa.repl"
 
     args("-d", outputDir.get().asFile)
 

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/EclipseCompatibleJavaExtension.kt
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/EclipseCompatibleJavaExtension.kt
@@ -7,6 +7,7 @@ import org.gradle.api.provider.Provider
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JavaLauncher
 import org.gradle.jvm.toolchain.JavaToolchainService
+import org.gradle.kotlin.dsl.assign
 import org.gradle.kotlin.dsl.the
 
 /**
@@ -37,7 +38,7 @@ open class EclipseCompatibleJavaExtension @Inject constructor(private val projec
 
   val launcher: Provider<JavaLauncher> by lazy {
     project.the<JavaToolchainService>().launcherFor {
-      languageVersion.set(this@EclipseCompatibleJavaExtension.languageVersion)
+      languageVersion = this@EclipseCompatibleJavaExtension.languageVersion
     }
   }
 }

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/JavaCompileUsingEcj.kt
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/JavaCompileUsingEcj.kt
@@ -14,6 +14,7 @@ import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.kotlin.dsl.assign
 import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.the
 import org.gradle.process.ExecOperations
@@ -84,7 +85,7 @@ abstract class JavaCompileUsingEcj : JavaCompile() {
 
     // However, put generated class files in a different build directory to avoid conflict.
     val destinationSubdir = "ecjClasses/${sourceSet.java.name}/${sourceSet.name}"
-    destinationDirectory.set(project.layout.buildDirectory.dir(destinationSubdir))
+    destinationDirectory = project.layout.buildDirectory.dir(destinationSubdir)
   }
 
   companion object {


### PR DESCRIPTION
Gradle's Kotlin DSL offers an overloaded `assign` operator that we can use to set a `Property`'s value instead of calling `Property.set`.