### PR TITLE
Reduce visibility scope of a method

### DIFF
--- a/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
+++ b/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
@@ -600,7 +600,7 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
     }
   }
 
-  protected CAstNode noteSourcePosition(WalkContext context, CAstNode n, AstNode p) {
+  private CAstNode noteSourcePosition(WalkContext context, CAstNode n, AstNode p) {
     if (p.getLineno() != -1 && context.pos().getPosition(n) == null) {
       pushSourcePosition(context, n, makePosition(p));
     }


### PR DESCRIPTION
`noteSourcePosition` expects a `WalkContext` formal parameter, but `WalkContext` is a `private` nested class.  Nobody outside of this class would ever be able to call `noteSourcePosition`.  So that method may as well be `private` too.