### PR TITLE
Test ECJ builds on all platforms

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -52,7 +52,7 @@ jobs:
         # testing ECJ compilation on any one OS is sufficient; we choose Linux arbitrarily
         if: runner.os == 'Linux'
       - name: Build and test using Gradle but without ECJ
-        run: ./gradlew aggregatedJavadocs javadoc build -PskipJavaUsingEcjTasks --no-configuration-cache "-Pcom.ibm.wala.jdk-version=${{ matrix.java }}"
+        run: ./gradlew aggregatedJavadocs javadoc build --no-configuration-cache "-Pcom.ibm.wala.jdk-version=${{ matrix.java }}"
         if: runner.os != 'Linux'
       - name: Check for Git cleanliness after build and test
         run: ./check-git-cleanliness.sh

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -139,11 +139,6 @@ tasks.withType<JavaCompile> {
 }
 
 tasks.withType<JavaCompileUsingEcj> {
-
-  // Allow skipping all ECJ compilation tasks by setting a project property.
-  val skipJavaUsingEcjTasks = providers.gradleProperty("skipJavaUsingEcjTasks").isPresent
-  onlyIf { !skipJavaUsingEcjTasks }
-
   // ECJ warning / error levels are set via a configuration file, not this argument
   options.compilerArgs.remove("-Werror")
 }


### PR DESCRIPTION
Previously Linux jobs included ECJ compilation but macOS and Windows jobs did not.  [Unfortunately, that allowed a Windows-specific ECJ compilation problem to go undetected.](https://github.com/wala/WALA/pull/1518)  In discussion of that fix, WALA maintainers agreed that testing ECJ on all platforms was advisable.