### PR TITLE
Refactor Gradle CI/CD command across platforms

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -46,14 +46,13 @@ jobs:
           distribution: 'zulu'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-      - name: Build and test using Gradle with ECJ
-        # use xvfb-gradle.sh to avoid headless test failures on Linux
-        run: ./xvfb-gradle.sh aggregatedJavadocs build publishAllPublicationsToFakeRemoteRepository shellcheck --no-configuration-cache "-Pcom.ibm.wala.jdk-version=${{ matrix.java }}"
-        # testing ECJ compilation on any one OS is sufficient; we choose Linux arbitrarily
+      - name: Choose extra Linux-only Gradle tasks
+        run: echo OS_SPECIFIC_GRADLE_TASKS='publishAllPublicationsToFakeRemoteRepository shellcheck' >> $GITHUB_ENV
         if: runner.os == 'Linux'
-      - name: Build and test using Gradle but without ECJ
-        run: ./gradlew aggregatedJavadocs javadoc build --no-configuration-cache "-Pcom.ibm.wala.jdk-version=${{ matrix.java }}"
-        if: runner.os != 'Linux'
+      - name: Build and test using Gradle
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: ./gradlew --no-configuration-cache "-Pcom.ibm.wala.jdk-version=${{ matrix.java }}" aggregatedJavadocs javadoc build ${{ env.OS_SPECIFIC_GRADLE_TASKS }}
       - name: Check for Git cleanliness after build and test
         run: ./check-git-cleanliness.sh
         # not running in Borne or POSIX shell on Windows


### PR DESCRIPTION
Previously we ran Gradle using either of two distinct `run` steps: one for Linux and one for non-Linux.  However, these two steps had much in common.  The only two differences were that Linux ran Gradle under Xvfb and that Linux used a few extra Gradle build tasks.

Now we've factored out these differences more cleanly:

For using Xvfb only on Linux, we now rely on a helpful GitHub action. This `GabrielBB/xvfb-action` action runs a command under Xvfb on Linux, or without Xvfb on non-Linux.  Perfect!

For adding some extra Gradle build tasks, we conditionally set an `OS_SPECIFIC_GRADLE_TASKS` environment variable to those extra tasks, if any.  Later, we insert the value of that variable at the appropriate place in the Gradle command line.