### PR TITLE
Factor out logging Gradle task output to a file

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/log-to-file.kt
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/log-to-file.kt
@@ -1,0 +1,28 @@
+package com.ibm.wala.gradle
+
+import org.gradle.api.Task
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Exec
+import org.gradle.api.tasks.JavaExec
+import org.gradle.process.BaseExecSpec
+
+/**
+ * Extension function to redirect standard output and error of an execution task (such as [Exec] or
+ * [JavaExec]) to a file under `build/`.
+ *
+ * @param baseName Base name (without extension) for the log file. The actual file will be created
+ *   as `build/<baseName>.log`.
+ * @return a [provider][Provider] for the log file, which is also registered as a
+ *   [task output][Task.outputs]. This can be used for wiring task dependencies or additional
+ *   configuration if needed.
+ */
+fun <T> T.logToFile(baseName: String) where T : Task, T : BaseExecSpec =
+    project.layout.buildDirectory.file("$baseName.log").also { logFile ->
+      outputs.file(logFile)
+      doFirst {
+        logFile.get().asFile.outputStream().let {
+          standardOutput = it
+          errorOutput = it
+        }
+      }
+    }

--- a/cast/java/ecj/build.gradle.kts
+++ b/cast/java/ecj/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.ibm.wala.gradle.logToFile
+
 plugins {
   application
   id("com.ibm.wala.gradle.eclipse-maven-central")
@@ -41,15 +43,8 @@ val run by
       }
 
       // log output to file, although we don"t validate it
-      val outFile = layout.buildDirectory.file("SourceDirCallGraph.log")
-      outputs.file(outFile)
+      logToFile(name)
       outputs.cacheIf { true }
-      doFirst {
-        outFile.get().asFile.outputStream().let {
-          standardOutput = it
-          errorOutput = it
-        }
-      }
     }
 
 // ensure the command-line driver for running ECJ works

--- a/cast/smoke_main/build.gradle.kts
+++ b/cast/smoke_main/build.gradle.kts
@@ -1,6 +1,7 @@
 import com.ibm.wala.gradle.cast.addJvmLibrary
 import com.ibm.wala.gradle.cast.addRpaths
 import com.ibm.wala.gradle.cast.configure
+import com.ibm.wala.gradle.logToFile
 import org.gradle.api.attributes.LibraryElements.CLASSES
 import org.gradle.api.attributes.LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE
 import org.gradle.api.attributes.LibraryElements.RESOURCES
@@ -103,14 +104,7 @@ application {
               argumentProviders.add { listOf(pathElements.get().joinToString(":")) }
 
               // log output to file, although we don"t validate it
-              val outFile = layout.buildDirectory.file("${name}.log")
-              outputs.file(outFile)
-              doFirst {
-                outFile.get().asFile.outputStream().let {
-                  standardOutput = it
-                  errorOutput = it
-                }
-              }
+              logToFile(name)
             }
 
         if (!targetPlatform.get().operatingSystem.isWindows) {


### PR DESCRIPTION
We already have two Gradle tasks that log their stdout and stderr to a file.  The nontrivial logic for doing that should be shared rather than cloned.