### PR TITLE
Extract a useful Gradle `Provider` extension

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/Provider-valueToString.kt
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/Provider-valueToString.kt
@@ -1,0 +1,21 @@
+package com.ibm.wala.gradle
+
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.AbstractExecTask
+import org.gradle.process.ProcessForkOptions
+
+/**
+ * Returns a proxy [Provider] whose [toString] uses the original [Provider]'s value at the moment
+ * the [String] is requested.
+ *
+ * Several Gradle APIs accept [Any] value but will ultimately convert that value to a [String] using
+ * [toString]. For example, [ProcessForkOptions.executable] follows this pattern, as does the second
+ * argument to the two-argument overload of [AbstractExecTask.environment]. We can use this
+ * extension property to postpone evaluating a [Provider] until the [String] representation of its
+ * value is actually needed.
+ */
+val <T : Any> Provider<T>.valueToString
+  get() =
+      object : Provider<T> by this {
+        override fun toString() = get().toString()
+      }

--- a/cast/smoke_main/build.gradle.kts
+++ b/cast/smoke_main/build.gradle.kts
@@ -2,6 +2,7 @@ import com.ibm.wala.gradle.cast.addJvmLibrary
 import com.ibm.wala.gradle.cast.addRpaths
 import com.ibm.wala.gradle.cast.configure
 import com.ibm.wala.gradle.logToFile
+import com.ibm.wala.gradle.valueToString
 import org.gradle.api.attributes.LibraryElements.CLASSES
 import org.gradle.api.attributes.LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE
 import org.gradle.api.attributes.LibraryElements.RESOURCES
@@ -77,13 +78,7 @@ application {
 
               // main executable to run for test
               inputs.file(linkedFile)
-              executable(
-                  object {
-                    val toString by lazy { linkedFile.get().asFile.toString() }
-
-                    override fun toString() = toString
-                  }
-              )
+              executable(linkedFile.valueToString)
 
               // xlator Java bytecode + implementation of native methods
               inputs.files(libxlatorTestConfig)


### PR DESCRIPTION
Sometimes it can be useful to have a Gradle `Provider` whose `toString` returns the `String` representation of the `Provider`'s current value. Previously we were doing that in just one place in one Gradle build script.  However, I will soon have other uses for this technique.  Thus, it's worth extracting into a reusable extension.