### PR TITLE
Upgrade OCaml-Java

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -229,7 +229,7 @@ val collectJLex by
 //  generate "hello_hash.jar"
 //
 
-val ocamlJavaVersion = "2.0-alpha1"
+val ocamlJavaVersion = "2.0-alpha3"
 
 val downloadOcamlJava =
     adHocDownload(


### PR DESCRIPTION
Previously we were using an alpha OCaml-Java release that was eleven years old.  Now we're using an alpha release that is only ten years old. Progress!  :laughing: