### PR TITLE
Postpone turning archives into `FileTree`s

### DIFF
--- a/cast/js/build.gradle.kts
+++ b/cast/js/build.gradle.kts
@@ -48,7 +48,7 @@ val downloadAjaxslt =
 
 val unpackAjaxslt by
     tasks.registering(Sync::class) {
-      from(tarTree { downloadAjaxslt.singleFile }) {
+      from({ tarTree(downloadAjaxslt.singleFile) }) {
         eachFile {
           val newSegments = relativePath.segments.drop(1).toTypedArray()
           relativePath = RelativePath(!isDirectory, *newSegments)

--- a/cast/js/nodejs/build.gradle.kts
+++ b/cast/js/nodejs/build.gradle.kts
@@ -21,7 +21,7 @@ val downloadNodeJS =
 
 val unpackNodeJSLib by
     tasks.registering(Sync::class) {
-      from(tarTree { downloadNodeJS.singleFile }) {
+      from({ tarTree(downloadNodeJS.singleFile) }) {
         include("*/lib/*.js")
         eachFile { path = name }
       }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -181,7 +181,7 @@ val downloadBcel =
 
 val extractBcel by
     tasks.registering(Sync::class) {
-      from(tarTree { downloadBcel.singleFile })
+      from({ tarTree(downloadBcel.singleFile) })
       include("**/*.jar")
       into(layout.buildDirectory.map { "$it/$name" })
       eachFile { relativePath = RelativePath.parse(!isDirectory, relativePath.lastName) }
@@ -240,7 +240,7 @@ val downloadOcamlJava =
         "bin",
     )
 
-// Ideally this would be a `Sync` task using `from(tarTree { downloadOcamlJava.singleFile })`.
+// Ideally this would be a `Sync` task using `from({ tarTree(downloadOcamlJava.singleFile) })`.
 // However, this specific tar archive contains a member with a leading slash, and that apparently
 // causes Gradle's native tar support to fail.
 val unpackOcamlJava by

--- a/dalvik/build.gradle.kts
+++ b/dalvik/build.gradle.kts
@@ -22,7 +22,7 @@ interface InstallAndroidSdkServices {
 
 val installAndroidSdk by
     tasks.registering(Sync::class) {
-      from(zipTree { downloadAndroidSdk.singleFile })
+      from({ zipTree(downloadAndroidSdk.singleFile) })
       into(layout.buildDirectory.dir(name))
 
       // When the task is actually executing (i.e.,in the `doLast` code below), the Gradle
@@ -118,7 +118,7 @@ val downloadDroidBench =
 
 val unpackDroidBench by
     tasks.registering(Sync::class) {
-      from(zipTree { downloadDroidBench.singleFile }) {
+      from({ zipTree(downloadDroidBench.singleFile) }) {
         include("*/apk/**")
         eachFile {
           relativePath = RelativePath(!isDirectory, *relativePath.segments.drop(1).toTypedArray())


### PR DESCRIPTION
By fiddling with parentheses and braces a bit, we slightly postpone calls to `tarTree` and `zipTree`, potentially avoiding them entirely if the enclosing task is configured but not executed.  In general, Gradle performance is helped by delaying as much computation as possible.