### PR TITLE
Postpone gathering Kawa compilation command line

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/CompileKawaScheme.kt
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/CompileKawaScheme.kt
@@ -26,10 +26,9 @@ abstract class CompileKawaScheme : JavaExec() {
     classpath(project.tasks.named("extractKawa"))
     mainClass = "kawa.repl"
 
-    args("-d", outputDir.get().asFile)
-
     logging.captureStandardError(LogLevel.INFO)
-    args("--main", "-C")
-    argumentProviders.add { listOf(schemeFile.get().toString()) }
+    argumentProviders.add {
+      listOf("-d", outputDir.get().toString(), "--main", "-C", schemeFile.get().toString())
+    }
   }
 }


### PR DESCRIPTION
Previously the `outputDir` was added to the command line quite early, as soon as a `CompileKawaScheme` task was instantiated.  We should delay that, though, because it's entirely possible (and supported) for a task to change its output directory during task configuration.