### PR TITLE
Factor out dropping the top directory

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/AbstractCopyTask-dropTopDirectory.kt
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/AbstractCopyTask-dropTopDirectory.kt
@@ -1,0 +1,22 @@
+package com.ibm.wala.gradle
+
+import org.gradle.api.file.RelativePath
+import org.gradle.api.tasks.AbstractCopyTask
+
+/**
+ * Drops the top-level directory from the destination path of every file copied by this task.
+ *
+ * Effectively, this “unwraps” a directory layout by removing the first path segment from each
+ * file's [relative path][RelativePath]. For example:
+ * - `foo/bar.txt` ↦ `bar.txt`
+ * - `foo/baz/qux.txt` ↦ `baz/qux.txt`
+ *
+ * In addition, empty directories are excluded by setting [AbstractCopyTask.includeEmptyDirs] to
+ * false to avoid creating orphan directories after paths are rewritten.
+ */
+fun AbstractCopyTask.dropTopDirectory() {
+  eachFile {
+    relativePath = RelativePath(!isDirectory, *relativePath.segments.drop(1).toTypedArray())
+  }
+  includeEmptyDirs = false
+}

--- a/cast/js/build.gradle.kts
+++ b/cast/js/build.gradle.kts
@@ -1,5 +1,6 @@
 import com.ibm.wala.gradle.CreatePackageList
 import com.ibm.wala.gradle.adHocDownload
+import com.ibm.wala.gradle.dropTopDirectory
 
 plugins {
   id("com.ibm.wala.gradle.java")
@@ -48,13 +49,9 @@ val downloadAjaxslt =
 
 val unpackAjaxslt by
     tasks.registering(Sync::class) {
-      from({ tarTree(downloadAjaxslt.singleFile) }) {
-        eachFile {
-          val newSegments = relativePath.segments.drop(1).toTypedArray()
-          relativePath = RelativePath(!isDirectory, *newSegments)
-        }
-      }
+      from({ tarTree(downloadAjaxslt.singleFile) })
       into(layout.buildDirectory.dir(name))
+      dropTopDirectory()
     }
 
 val processTestResources by tasks.existing(Copy::class) { from(unpackAjaxslt) { into("ajaxslt") } }

--- a/dalvik/build.gradle.kts
+++ b/dalvik/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.ibm.wala.gradle.adHocDownload
+import com.ibm.wala.gradle.dropTopDirectory
 
 plugins {
   id("com.ibm.wala.gradle.java")
@@ -118,15 +119,9 @@ val downloadDroidBench =
 
 val unpackDroidBench by
     tasks.registering(Sync::class) {
-      from({ zipTree(downloadDroidBench.singleFile) }) {
-        include("*/apk/**")
-        eachFile {
-          relativePath = RelativePath(!isDirectory, *relativePath.segments.drop(1).toTypedArray())
-        }
-      }
-
+      from({ zipTree(downloadDroidBench.singleFile) }) { include("*/apk/**") }
       into(layout.buildDirectory.dir("DroidBench"))
-      includeEmptyDirs = false
+      dropTopDirectory()
     }
 
 val downloadAndroidSdk = run {


### PR DESCRIPTION
Several Gradle `Copy` or `Sync` tasks need to strip off a single topmost directory from a source tree.  We can extract that logic into a helpful extension method that any `AbstractCopyTask` can use.