### PR TITLE
Convert `extractKawa` into a standard `Sync` task

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/CompileKawaScheme.kt
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/CompileKawaScheme.kt
@@ -23,7 +23,9 @@ abstract class CompileKawaScheme : JavaExec() {
   @get:OutputDirectory val outputDir: Provider<Directory> = project.layout.buildDirectory.dir(name)
 
   init {
-    classpath(project.tasks.named("extractKawa"))
+    classpath(
+        project.tasks.named("extractKawa").map { it.outputs.files.singleFile.resolve("kawa.jar") }
+    )
     mainClass = "kawa.repl"
 
     logging.captureStandardError(LogLevel.INFO)


### PR DESCRIPTION
We didn't really need to do anything more general than what `Sync` can do.  This change makes the task simpler and more concise.

Also rename `ExtractServices` to `GenerateHelloHashServices`, since the `generateHelloHash` task is the only remaining user of this interface.