### PR TITLE
Factor out setting `$JAVA_HOME` for subprocesses

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/Exec-useCurrentJavaHome.kt
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/Exec-useCurrentJavaHome.kt
@@ -1,0 +1,8 @@
+package com.ibm.wala.gradle
+
+import org.gradle.api.tasks.Exec
+
+/** Configures this [Exec] task to run with `JAVA_HOME` set to the current Gradle JVM's home. */
+fun Exec.useCurrentJavaHome() {
+  environment("JAVA_HOME", project.providers.systemProperty("java.home").valueToString)
+}

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -2,6 +2,7 @@ import com.ibm.wala.gradle.CompileKawaScheme
 import com.ibm.wala.gradle.JavaCompileUsingEcj
 import com.ibm.wala.gradle.adHocDownload
 import com.ibm.wala.gradle.dropTopDirectory
+import com.ibm.wala.gradle.useCurrentJavaHome
 import com.ibm.wala.gradle.valueToString
 import kotlin.io.resolve
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
@@ -281,7 +282,7 @@ val generateHelloHashJar by
       )
 
       // use same JVM that is being used to run Gradle itself
-      environment("JAVA_HOME", providers.systemProperty("java.home").valueToString)
+      useCurrentJavaHome()
 
       objects.newInstance<ExtractServices>().run {
 


### PR DESCRIPTION
If a Gradle `Exec` task runs a subprocess that uses a JVM, that subprocess may need to know where to find a working Java installation. We know where to find the Java installation that is already running Gradle, so that's generally suitable for subprocesses to use too.

The logic to set `$JAVA_HOME` for an `Exec` task is not _terribly_ complicated, but it's not trivial either.  Let's extract it into an `Exec` extension method for easy reuse.  Right now there's just one such use, but I plan to add another soon in a separate commit.