### PR TITLE
Use limited subset of Android SDK installation

### DIFF
--- a/dalvik/build.gradle.kts
+++ b/dalvik/build.gradle.kts
@@ -103,11 +103,6 @@ dependencies {
   testImplementation(projects.dalvik)
   testImplementation(testFixtures(projects.core))
   testImplementation(testFixtures(projects.util))
-
-  // directory containing "android.jar", which various tests want to find as a resource
-  testRuntimeOnly(
-      files(installAndroidSdk.map { "${it.outputs.files.singleFile}/platforms/$platformsVersion" })
-  )
 }
 
 val downloadDroidBench =
@@ -162,6 +157,11 @@ tasks.named<Copy>("processTestResources") {
   from(extractSampleCup)
   from(extraTestResources)
   from({ zipTree(coreTestJar.get().singleFile) })
+  from(
+      installAndroidSdk.map {
+        "${it.outputs.files.singleFile}/platforms/$platformsVersion/android.jar"
+      }
+  )
 }
 
 if (isWindows) tasks.named<Test>("test") { exclude("**/droidbench/**") }


### PR DESCRIPTION
Previously we included the directory containing `android.jar` in the classpath for `dalvik` tests, so that
`com.ibm.wala.dalvik.test.util.Util.androidJavaLib()` can find it using standard resource loaders.  However, this one file is the _only_ component of an Android SDK installation that we use during testing. Therefore, it is more proper to treat just the `android.jar` file as a test resource, without picking up everything else in that same directory.