### PR TITLE
Avoid ECJ warnings about missing classpath entries

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/JavaCompileUsingEcj.kt
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/JavaCompileUsingEcj.kt
@@ -59,7 +59,7 @@ abstract class JavaCompileUsingEcj : JavaCompile() {
             "-properties",
             jdtPrefs.toString(),
             "-classpath",
-            classpath.asPath,
+            classpath.filter(File::exists).asPath,
             "-d",
             destinationDirectory.get().toString(),
         )


### PR DESCRIPTION
The Eclipse Java compiler (ECJ) warns when the compilation classpath includes entries that don't actually exist:

> incorrect classpath: /no/such/path

Quite a few such entries arise in Gradle-managed classpaths.  These messages are harmless.  However, they are also distracting, because they certainly _look_ like something bad.

ECJ has no option to suppress these messages.  We can avoid them, though, by filtering the classpath entries that we pass through to the ECJ command line.