### PR TITLE
Improve task configuration avoidance

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/NullAway.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/NullAway.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
   compileOnly(versionCatalogs.named("libs").findLibrary("nullaway-annotations").get())
 }
 
-tasks.withType<JavaCompile> {
+tasks.withType<JavaCompile>().configureEach {
   options.errorprone {
     if (!name.contains("test", true)) {
       error("NullAway")

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -56,7 +56,7 @@ dependencies {
   testRuntimeOnly(findLibrary("junit-vintage-engine"))
 }
 
-tasks.withType<JavaCompile> {
+tasks.withType<JavaCompile>().configureEach {
   // Always compile with a recent JDK version, to get the latest bug fixes in the compiler toolchain
   javaCompiler = javaToolchains.compilerFor { languageVersion = JavaLanguageVersion.of(24) }
   // Generate JDK 11 bytecodes; that is the minimum version supported by WALA
@@ -130,7 +130,7 @@ val ecjCompileTaskProviders =
 
 tasks.named("check") { dependsOn(ecjCompileTaskProviders) }
 
-tasks.withType<JavaCompile> {
+tasks.withType<JavaCompile>().configureEach {
   options.run {
     encoding = "UTF-8"
     compilerArgs.add("-Werror")
@@ -138,7 +138,7 @@ tasks.withType<JavaCompile> {
   }
 }
 
-tasks.withType<JavaCompileUsingEcj> {
+tasks.withType<JavaCompileUsingEcj>().configureEach {
   // ECJ warning / error levels are set via a configuration file, not this argument
   options.compilerArgs.remove("-Werror")
 }

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/javadoc.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/javadoc.gradle.kts
@@ -15,7 +15,7 @@ tasks.named<Javadoc>("javadoc") {
   source(javadocSource)
 }
 
-tasks.withType<Javadoc> {
+tasks.withType<Javadoc>().configureEach {
   with(options as StandardJavadocDocletOptions) {
     addBooleanOption("Xdoclint:all,-missing", true)
     encoding = "UTF-8"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -210,7 +210,7 @@ tasks.register("checkInspectionResults") {
 //  Check for updated dependencies
 //
 
-tasks.withType<DependencyUpdatesTask> {
+tasks.withType<DependencyUpdatesTask>().configureEach {
   gradleReleaseChannel = "current"
   rejectVersionIf {
     candidate.run {


### PR DESCRIPTION
Some Gradle task-related APIs eagerly force tasks to be created.  Others are lazy, merely installing closures that may _eventually_ be called _if_ a suitable task is created.  We prefer the latter.  Unfortunately, it's hard to remember which APIs fall into which category.  For example, some `withType` methods of some classes are eager, while others with the same name (even within the same class) are lazy.  Oof!  I thought that we were already being quite lazy, but I missed a few cases, including some that are heavily used.

I assessed the impact of this change using `./gradlew build -PexcludeSlowTests --no-daemon --rerun-tasks --scan` in a clean build tree.  After these changes, 127 fewer tasks are created during Gradle's configuration phase.  85 of those are created during task graph calculation, i.e., 85 of these were still needed eventually in order to run the build.  The remaining 42, however, were not created at all.  So those were tasks that were previously being created too eagerly even though they were never actually used for this build.