### PR TITLE
Enable build cache for `lintMarkdown` task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -105,7 +105,10 @@ val lintMarkdown by
       inputs.files(markdownFiles)
       inputs.file(".markdownlint-cli2.yaml")
       args = markdownFiles.map { it.path }
-      outputs.file(layout.buildDirectory.file("$name.stamp"))
+      outputs.run {
+        file(layout.buildDirectory.file("$name.stamp"))
+        cacheIf { true }
+      }
       doLast { outputs.files.singleFile.createNewFile() }
     }
 


### PR DESCRIPTION
This task takes ~5 seconds to run.  It's computationally intensive, not I/O intensive.  The input files that it consumes rarely change.  All of that makes this task an excellent use case for Gradle's build cache.