### PR TITLE
Enable configuration cache in GitHub CI/CD actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Build and test using Gradle
         uses: GabrielBB/xvfb-action@v1
         with:
-          run: ./gradlew --no-configuration-cache "-Pcom.ibm.wala.jdk-version=${{ matrix.java }}" aggregatedJavadocs javadoc build ${{ env.OS_SPECIFIC_GRADLE_TASKS }}
+          run: ./gradlew "-Pcom.ibm.wala.jdk-version=${{ matrix.java }}" aggregatedJavadocs javadoc build ${{ env.OS_SPECIFIC_GRADLE_TASKS }}
       - name: Check for Git cleanliness after build and test
         run: ./check-git-cleanliness.sh
         # not running in Borne or POSIX shell on Windows


### PR DESCRIPTION
Gradle's configuration cache is "a preferred mode" as of Gradle 9.0.0, and the Gradle developers "now recommend enabling Configuration Cache in most scenarios."  We've been using it in development builds for a _long_ time.  Let's enable it in GitHub CI/CD actions too.  That should help us discover regressions in our configuration cache compatibility before they make it into the `master` branch.