### PR TITLE
Suppress an insecure HTTP warning that we cannot fix

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -213,6 +213,7 @@ val collectJLex by
 
 val ocamlJavaVersion = "2.0-alpha3"
 
+@Suppress("HttpUrlsUsage")
 val downloadOcamlJava =
     adHocDownload(
         uri("http://www.ocamljava.org/files/distrib"),


### PR DESCRIPTION
`www.ocaml.org` allows HTTPS connections, but it presents a certificate that only identifies the site as `cluster014.hosting.ovh.net`, not as `www.ocaml.org`.  So we're effectively stuck with HTTP.  No sense keeping a warning that we cannot fix on our end.