### PR TITLE
Record Git commit ID in published build scans

### DIFF
--- a/.idea/dictionaries/project.xml
+++ b/.idea/dictionaries/project.xml
@@ -36,6 +36,7 @@
       <w>dconst</w>
       <w>ddiv</w>
       <w>delegatecomment</w>
+      <w>develocity</w>
       <w>dmul</w>
       <w>dreturn</w>
       <w>dtrans</w>


### PR DESCRIPTION
I occasionally use `./gradlew --scan ...` to get deeper insight into the effects of my changes to our build logic.  Often that means comparing scans before and after some candidate change.  However, it's very easy to lose track of which scan corresponded to which version of a change that I'm working on.

This change adds "Git Commit ID" as a custom value in each published build scan.  You can see this custom value on the "Custom values" tab when viewing a build scan in your web browser.  Its value is the current Git commit hash, with `-dirty` appended if there were uncommitted changes in the tree at the time of the build.