### PR TITLE
Don't check Eclipse settings for typos

### DIFF
--- a/.idea/inspectionProfiles/No_Back_Sliding.xml
+++ b/.idea/inspectionProfiles/No_Back_Sliding.xml
@@ -606,6 +606,16 @@
     <inspection_tool class="SizeReplaceableByIsEmpty" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Java Sources as Test Subjects" level="WARNING" enabled="false" />
     </inspection_tool>
+    <inspection_tool class="SpellCheckingInspection" enabled="true" level="TYPO" enabled_by_default="true">
+      <scope name="Eclipse Preferences" level="TYPO" enabled="false">
+        <option name="processCode" value="true" />
+        <option name="processLiterals" value="true" />
+        <option name="processComments" value="true" />
+      </scope>
+      <option name="processCode" value="true" />
+      <option name="processLiterals" value="true" />
+      <option name="processComments" value="true" />
+    </inspection_tool>
     <inspection_tool class="StringBufferReplaceableByStringBuilder" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Java Sources as Test Subjects" level="WARNING" enabled="false" />
     </inspection_tool>

--- a/.idea/scopes/Eclipse_Preferences.xml
+++ b/.idea/scopes/Eclipse_Preferences.xml
@@ -1,0 +1,3 @@
+<component name="DependencyValidationManager">
+  <scope name="Eclipse Preferences" pattern="file:.settings/*.prefs||file:*/.settings/*.prefs" />
+</component>


### PR DESCRIPTION
These files contain a few real spelling errors that we would want to correct if they appeared _anywhere_ else, such as "statment" and "delcaration".  My guess is that these were uncaught typos in the original Eclipse implementation, and now _everyone_ is stuck with them because they've become the names of specific configuration parameters.