### PR TITLE
Avoid deprecated URL constructors

### DIFF
--- a/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/ecj/ECJSourceModuleTranslator.java
+++ b/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/ecj/ECJSourceModuleTranslator.java
@@ -99,7 +99,7 @@ public class ECJSourceModuleTranslator implements SourceModuleTranslator {
         @Override
         public URL getURL() {
           try {
-            return new URL("file://" + fullPath);
+            return new File(fullPath).toURI().toURL();
           } catch (MalformedURLException e) {
             assert false : fullPath;
             return null;

--- a/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJSyncDuplicatorTest.java
+++ b/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJSyncDuplicatorTest.java
@@ -34,8 +34,8 @@ import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.config.StringFilter;
+import java.io.File;
 import java.net.MalformedURLException;
-import java.net.URL;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
@@ -91,7 +91,7 @@ public class ECJSyncDuplicatorTest extends SyncDuplicatorTests {
                           public Position makePosition(int start, int end) {
                             try {
                               return new RangePosition(
-                                  new URL("file://" + fullPath),
+                                  new File(fullPath).toURI().toURL(),
                                   this.cu.getLineNumber(start),
                                   start,
                                   end);

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/html/DefaultSourceExtractor.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/html/DefaultSourceExtractor.java
@@ -15,6 +15,7 @@ import com.ibm.wala.cast.tree.CAstSourcePositionMap.Position;
 import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.collections.Pair;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayDeque;
 import java.util.HashMap;
@@ -58,7 +59,7 @@ public class DefaultSourceExtractor extends DomLessSourceExtractor {
             writeEntrypoint(
                 "           " + v.substring(11),
                 e.getValue().snd,
-                new URL(tag.getElementPosition().getURL().toString() + '#' + a),
+                URI.create(tag.getElementPosition().getURL().toString() + '#' + a).toURL(),
                 true);
           } catch (MalformedURLException ex) {
             writeEntrypoint(v.substring(11), e.getValue().snd, entrypointUrl, false);

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/html/DomLessSourceExtractor.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/html/DomLessSourceExtractor.java
@@ -23,6 +23,7 @@ import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.io.Reader;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -109,7 +110,7 @@ public class DomLessSourceExtractor extends JSSourceExtractor {
 
         URL url = entrypointUrl;
         try {
-          url = new URL(entrypointUrl, "#" + scriptNodeCounter);
+          url = URI.create(entrypointUrl.toString() + '#' + scriptNodeCounter).toURL();
         } catch (MalformedURLException e) {
           // TODO Auto-generated catch block
           e.printStackTrace();
@@ -167,7 +168,11 @@ public class DomLessSourceExtractor extends JSSourceExtractor {
         Entry<String, Pair<String, Position>> a, String funcName, ITag tag) {
       URL url = entrypointUrl;
       try {
-        url = new URL(entrypointUrl, "#" + tag.getElementPosition().getFirstOffset());
+        url =
+            java.net
+                .URI
+                .create(entrypointUrl.toString() + '#' + tag.getElementPosition().getFirstOffset())
+                .toURL();
       } catch (MalformedURLException e) {
         // TODO Auto-generated catch block
         if (DEBUG) {
@@ -244,7 +249,7 @@ public class DomLessSourceExtractor extends JSSourceExtractor {
 
     private void getScriptFromUrl(String urlAsString, ITag scriptTag)
         throws IOException, MalformedURLException {
-      URL scriptSrc = new URL(entrypointUrl, urlAsString);
+      URL scriptSrc = UrlManipulator.relativeToAbsoluteUrl(urlAsString, entrypointUrl);
       BOMInputStream bs;
       try {
         @SuppressWarnings("resource")
@@ -366,7 +371,7 @@ public class DomLessSourceExtractor extends JSSourceExtractor {
     //    DomLessSourceExtractor domLessScopeGenerator = new DomLessSourceExtractor();
     JSSourceExtractor domLessScopeGenerator = new DefaultSourceExtractor();
     JSSourceExtractor.DELETE_UPON_EXIT = false;
-    URL entrypointUrl = new URL(args[0]);
+    URL entrypointUrl = URI.create(args[0]).toURL();
     IHtmlParser htmlParser = new JerichoHtmlParser();
     IUrlResolver urlResolver = new IdentityUrlResolver();
     @SuppressWarnings("resource")

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/html/WebUtil.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/html/WebUtil.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.Set;
@@ -61,7 +62,7 @@ public class WebUtil {
   public static void main(String[] args) throws MalformedURLException, Error {
     System.err.println(
         extractScriptFromHTML(
-            new URL(args[0]),
+            URI.create(args[0]).toURL(),
             Boolean.parseBoolean(args[1])
                 ? DefaultSourceExtractor.factory
                 : DomLessSourceExtractor.factory));

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/html/jericho/JerichoTag.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/html/jericho/JerichoTag.java
@@ -19,6 +19,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Map;
 import net.htmlparser.jericho.Attribute;
@@ -79,7 +80,7 @@ public class JerichoTag implements ITag {
       @Override
       public URL getURL() {
         try {
-          return new URL("file://" + sourceFile);
+          return URI.create("file://" + sourceFile).toURL();
         } catch (MalformedURLException e) {
           return null;
         }

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/LoadFileTargetSelector.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/LoadFileTargetSelector.java
@@ -10,6 +10,7 @@
  */
 package com.ibm.wala.cast.js.ipa.callgraph;
 
+import com.ibm.wala.cast.js.html.UrlManipulator;
 import com.ibm.wala.cast.js.loader.JavaScriptLoader;
 import com.ibm.wala.cast.js.types.JavaScriptTypes;
 import com.ibm.wala.cast.types.AstMethodReference;
@@ -74,7 +75,7 @@ public class LoadFileTargetSelector implements MethodTargetSelector {
           try {
             JavaScriptLoader cl =
                 (JavaScriptLoader) builder.getClassHierarchy().getLoader(JavaScriptTypes.jsLoader);
-            URL url = new URL(builder.getBaseURL(), str);
+            URL url = UrlManipulator.relativeToAbsoluteUrl(str, builder.getBaseURL());
             if (!loadedFiles.contains(url.toString())) {
               // try to open the input stream for the URL.  if it fails, we'll get an IOException
               // and fall through to default case

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/CorrelationFinder.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/CorrelationFinder.java
@@ -57,6 +57,7 @@ import com.ibm.wala.util.intset.OrdinalSetMapping;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -309,7 +310,7 @@ public class CorrelationFinder {
       File f = new FileProvider().getFileFromClassLoader(src, this.getClass().getClassLoader());
       return f.toURI().toURL();
     } catch (FileNotFoundException fnfe) {
-      return new URL(src);
+      return URI.create(src).toURL();
     }
   }
 }

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/summaries/JavaScriptConstructorFunctions.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/summaries/JavaScriptConstructorFunctions.java
@@ -43,6 +43,7 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Iterator;
 import java.util.Map;
@@ -565,7 +566,7 @@ public class JavaScriptConstructorFunctions {
                 @Override
                 public URL getURL() {
                   try {
-                    return new URL("file://" + fileName);
+                    return URI.create("file://" + fileName).toURL();
                   } catch (MalformedURLException e) {
                     assert false;
                     return null;

--- a/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestMediawikiCallGraphShape.java
+++ b/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestMediawikiCallGraphShape.java
@@ -15,6 +15,7 @@ import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.WalaException;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -27,7 +28,7 @@ public abstract class TestMediawikiCallGraphShape extends TestJSCallGraphShape {
   @Test
   public void testSwineFlu()
       throws IOException, IllegalArgumentException, CancelException, WalaException {
-    URL url = new URL("http://en.wikipedia.org/wiki/2009_swine_flu_outbreak");
+    URL url = URI.create("http://en.wikipedia.org/wiki/2009_swine_flu_outbreak").toURL();
     CallGraph CG = JSCallGraphBuilderUtil.makeHTMLCG(url);
     verifyGraphAssertions(CG, assertionsForSwineFlu);
   }

--- a/cast/src/main/java/com/ibm/wala/cast/tree/impl/CAstSourcePositionRecorder.java
+++ b/cast/src/main/java/com/ibm/wala/cast/tree/impl/CAstSourcePositionRecorder.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Iterator;
 import java.util.Map;
@@ -51,7 +52,7 @@ public class CAstSourcePositionRecorder implements CAstSourcePositionMap {
       final String url,
       final String file)
       throws MalformedURLException {
-    setPosition(n, fl, fc, ll, lc, new URL(url), new URL(file));
+    setPosition(n, fl, fc, ll, lc, URI.create(url).toURL(), URI.create(file).toURL());
   }
 
   public void setPosition(
@@ -114,7 +115,7 @@ public class CAstSourcePositionRecorder implements CAstSourcePositionMap {
 
   public void setPosition(CAstNode n, int lineNumber, String url, String file)
       throws MalformedURLException {
-    setPosition(n, lineNumber, new URL(url), new URL(file));
+    setPosition(n, lineNumber, URI.create(url).toURL(), URI.create(file).toURL());
   }
 
   public void setPosition(CAstNode n, int lineNumber, URL url, URL file) {

--- a/core/src/test/java/com/ibm/wala/util/io/FileProviderTest.java
+++ b/core/src/test/java/com/ibm/wala/util/io/FileProviderTest.java
@@ -15,7 +15,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.ibm.wala.core.util.io.FileProvider;
 import com.ibm.wala.util.PlatformUtil;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +38,7 @@ public class FileProviderTest {
   @Test
   public void testValidFile() throws MalformedURLException {
     // setup:
-    URL url = new URL("file:///c:/my/File.jar");
+    URL url = URI.create("file:///c:/my/File.jar").toURL();
     String expected = "/c:/my/File.jar";
     // exercise:
     String actual = new FileProvider().filePathFromURL(url);
@@ -46,7 +49,11 @@ public class FileProviderTest {
   @Test
   public void testURLWithInvalidURIChars() throws MalformedURLException {
     // setup:
-    URL url = new URL("file:///[Eclipse]/File.jar");
+    URL url =
+        URI.create(
+                String.format(
+                    "file:///%s/File.jar", URLEncoder.encode("[Eclipse]", StandardCharsets.UTF_8)))
+            .toURL();
     // exercise:
     String actual = new FileProvider().filePathFromURL(url);
     // verify:
@@ -56,7 +63,7 @@ public class FileProviderTest {
   @Test
   public void testURLWithSpace() throws MalformedURLException {
     // setup:
-    URL url = new URL("file:///With%20Space/File.jar");
+    URL url = URI.create("file:///With%20Space/File.jar").toURL();
     // exercise:
     String actual = new FileProvider().filePathFromURL(url);
     // verify:

--- a/ide/jdt/src/main/java/com/ibm/wala/ide/util/JdtPosition.java
+++ b/ide/jdt/src/main/java/com/ibm/wala/ide/util/JdtPosition.java
@@ -16,6 +16,7 @@ import com.ibm.wala.util.debug.Assertions;
 import java.io.IOException;
 import java.io.Reader;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import org.eclipse.core.resources.IFile;
 
@@ -68,7 +69,7 @@ public final class JdtPosition implements Position {
   @Override
   public URL getURL() {
     try {
-      return new URL("file:" + path);
+      return URI.create("file:" + path).toURL();
     } catch (MalformedURLException e) {
       Assertions.UNREACHABLE(e.toString());
       return null;


### PR DESCRIPTION
All `URL` constructors were deprecated in Java 20.  We're still building for Java 11, but that won't last forever.  Even now ECJ prints deprecation warnings for these uses.  Fortunately, there are non-deprecated alternatives that we can already start using under Java 11.