### PR TITLE
Add some "see also" links to a comment

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/log-to-file.kt
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/log-to-file.kt
@@ -29,6 +29,10 @@ fun <T> T.logToFile(baseName: String) where T : Task, T : BaseExecSpec =
 
       // Try to close the `FileOutputStream` promptly when the task is finished. If the task fails,
       // then `doLast` will not run, so the stream will remain open until the garbage collector
-      // reclaims it.
+      // reclaims it. See also
+      // <https://discuss.gradle.org/t/close-fileoutputstream-after-javaexec-task/51592> for
+      // disucssion of alternative approaches and
+      // <https://github.com/gradle/gradle/issues/35066> for a Gradle feature request that would
+      // make a robust implementation much easier.
       doLast { standardOutput.close() }
     }


### PR DESCRIPTION
The first link is to a Gradle discussion forum exploring alternative approaches.  I think that the best solutions offered here are educational but overkill for our current needs.

The second link is to a Gradle feature request that would make a robust implementation much easier.  If that feature is added in the future, then we can adopt it here.