### PR TITLE
Find foojay-resolver version file more robustly

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,7 +1,12 @@
-plugins {
-  id("org.gradle.toolchains.foojay-resolver-convention") version
-      File("foojay-resolver-convention-version.txt").readText().trim()
+pluginManagement {
+  plugins.id("org.gradle.toolchains.foojay-resolver-convention") version
+      settings.rootDir.parentFile
+          .resolve("foojay-resolver-convention-version.txt")
+          .readText()
+          .trim()
 }
+
+plugins { id("org.gradle.toolchains.foojay-resolver-convention") }
 
 rootProject.name = "build-logic"
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,13 +1,17 @@
 import java.io.ByteArrayOutputStream
 import org.gradle.kotlin.dsl.support.serviceOf
 
+pluginManagement {
+  plugins.id("org.gradle.toolchains.foojay-resolver-convention") version
+      settings.rootDir.resolve("foojay-resolver-convention-version.txt").readText().trim()
+}
+
 buildscript { dependencies { classpath("com.diffplug.spotless:spotless-lib-extra:3.1.2") } }
 
 plugins {
   id("com.diffplug.configuration-cache-for-platform-specific-build") version "4.3.0"
   id("com.gradle.develocity") version "4.2"
-  id("org.gradle.toolchains.foojay-resolver-convention") version
-      File("foojay-resolver-convention-version.txt").readText().trim()
+  id("org.gradle.toolchains.foojay-resolver-convention")
 }
 
 enableFeaturePreview("STABLE_CONFIGURATION_CACHE")


### PR DESCRIPTION
The previous approach for finding `foojay-resolver-convention-version.txt` failed when running a subproject's Gradle task in IntelliJ IDEA.  Our new approach takes advantage of the greater flexibility granted to `pluginManagement { plugins { ... } }` code, and should be more robust.