### PR TITLE
Improve links to standard Oracle Javadoc

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/javadoc.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/javadoc.gradle.kts
@@ -19,6 +19,9 @@ tasks.withType<Javadoc>().configureEach {
   with(options as StandardJavadocDocletOptions) {
     addBooleanOption("Xdoclint:all,-missing", true)
     encoding = "UTF-8"
+    links(
+        "https://docs.oracle.com/en/java/javase/${javadocTool.get().metadata.languageVersion}/docs/api/"
+    )
     quiet()
     tags!!.add("apiNote:a:API Note:")
   }

--- a/util/build.gradle.kts
+++ b/util/build.gradle.kts
@@ -13,14 +13,3 @@ dependencies {
   testFixturesApi(libs.assertj.core)
   testImplementation(libs.junit.jupiter.api)
 }
-
-tasks.named<Javadoc>("javadoc") {
-  val currentJavaVersion = JavaVersion.current()
-  val linksPrefix = if (currentJavaVersion >= JavaVersion.VERSION_11) "en/java/" else ""
-  (options as StandardJavadocDocletOptions).run {
-    links(
-        "https://docs.oracle.com/${linksPrefix}javase/${currentJavaVersion.majorVersion}/docs/api/"
-    )
-    source = "8" // workaround https://bugs.openjdk.java.net/browse/JDK-8212233.
-  }
-}


### PR DESCRIPTION
Previously, Javadoc for the `util` project linked to Oracle's documentation for standard library components.  That's a very useful feature, not just for `util`, but for all of our documentation.  Now we enable this feature everywhere.

Previously we linked to Oracle's documentation for the version of Java that was running Gradle itself.  Now we use the version of Java that corresponds to the current Java toolchain, which includes the Javadoc tool itself.

Due to decisions made quite a while ago, that Java toolchain will always be Java 11 or later.  So there's no longer any need to generate links into Oracle's Javadoc for Java 10 or earlier.