### PR TITLE
Factor out helpers for using version catalogs

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/NullAway.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/NullAway.gradle.kts
@@ -9,8 +9,8 @@ plugins {
 }
 
 dependencies {
-  annotationProcessor(versionCatalogs.named("libs").findLibrary("nullaway").get())
-  compileOnly(versionCatalogs.named("libs").findLibrary("nullaway-annotations").get())
+  annotationProcessor(catalogLibrary("nullaway"))
+  compileOnly(catalogLibrary("nullaway-annotations"))
 }
 
 tasks.withType<JavaCompile>().configureEach {

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/eclipse-maven-central.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/eclipse-maven-central.gradle.kts
@@ -58,14 +58,10 @@ open class WalaMavenCentralReleaseConfigurerExtension @Inject constructor(projec
    */
   private val configurer =
       project.run {
-        eclipseMavenCentral
-            .ReleaseConfigurer(
-                official(versionCatalogs.named("libs").findVersion("eclipse").get().toString())
-            )
-            .apply {
-              constrainTransitivesToThisRelease()
-              useNativesForRunningPlatform()
-            }
+        eclipseMavenCentral.ReleaseConfigurer(official(catalogVersion("eclipse"))).apply {
+          constrainTransitivesToThisRelease()
+          useNativesForRunningPlatform()
+        }
       }
 
   /**

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -41,19 +41,17 @@ configurations {
   named("javadocClasspath") { extendsFrom(compileClasspath.get()) }
 }
 
-fun findLibrary(alias: String) = versionCatalogs.named("libs").findLibrary(alias).get()
-
 dependencies {
-  "ecj"(findLibrary("eclipse-ecj"))
-  "errorprone"(findLibrary("errorprone-core"))
+  "ecj"(catalogLibrary("eclipse-ecj"))
+  "errorprone"(catalogLibrary("errorprone-core"))
   "javadocSource"(sourceSets.main.get().allJava)
 
-  testFixturesImplementation(platform(findLibrary("junit-bom")))
+  testFixturesImplementation(platform(catalogLibrary("junit-bom")))
 
-  testImplementation(platform(findLibrary("junit-bom")))
-  testRuntimeOnly(findLibrary("junit-jupiter-engine"))
-  testRuntimeOnly(findLibrary("junit-platform-launcher"))
-  testRuntimeOnly(findLibrary("junit-vintage-engine"))
+  testImplementation(platform(catalogLibrary("junit-bom")))
+  testRuntimeOnly(catalogLibrary("junit-jupiter-engine"))
+  testRuntimeOnly(catalogLibrary("junit-platform-launcher"))
+  testRuntimeOnly(catalogLibrary("junit-vintage-engine"))
 }
 
 tasks.withType<JavaCompile>().configureEach {
@@ -161,13 +159,7 @@ if (gradle.parent != null) {
   }
 }
 
-spotless {
-  java {
-    googleJavaFormat(
-        versionCatalogs.named("libs").findVersion("google-java-format").get().toString()
-    )
-  }
-}
+spotless { java { googleJavaFormat(catalogVersion("google-java-format")) } }
 
 // Google Java Format versions 1.25.0 and higher require Java 17
 tasks.named("spotlessJava") {

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/project.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/project.gradle.kts
@@ -26,5 +26,5 @@ tasks.register<DependencyReportTask>("allDeps") {}
 spotless {
   providers.gradleProperty("spotless.ratchet.from").orNull?.let(::ratchetFrom)
 
-  kotlinGradle { ktfmt(versionCatalogs.named("libs").findVersion("ktfmt").get().toString()) }
+  kotlinGradle { ktfmt(catalogVersion("ktfmt")) }
 }

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/version-catalog.kt
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/version-catalog.kt
@@ -1,0 +1,53 @@
+/**
+ * Utilities for working with
+ * [the Gradle version catalog](https://docs.gradle.org/current/userguide/version_catalogs.html) in
+ * build logic.
+ *
+ * This file defines [Project] extension methods that resolve library and version aliases from the
+ * `libs` version catalog, or fail fast if a requested alias is not found.
+ *
+ * Motivation: Gradle’s [VersionCatalog] API returns [Optional] values which force repetitive
+ * presence checks at call sites. Centralizing the checks here keeps build logic concise and
+ * produces consistent, descriptive error messages.
+ *
+ * Note on future compatibility: if Gradle eventually
+ * [makes type-safe version catalog accessors accessible from precompiled script plugins](https://github.com/gradle/gradle/issues/15383),
+ * then these helper functions will no longer be necessary and can be removed in favor of the
+ * official API.
+ */
+package com.ibm.wala.gradle
+
+import java.util.Optional
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalog
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.the
+
+private fun <T> Project.requireAlias(
+    finder: VersionCatalog.(String) -> Optional<T>,
+    alias: String,
+    kind: String,
+) =
+    the<VersionCatalogsExtension>().named("libs").finder(alias).orElseThrow {
+      NoSuchElementException("No $kind with alias `$alias` found in `libs` version catalog")
+    }!!
+
+/**
+ * Looks up a library dependency by alias from the `libs` version catalog.
+ *
+ * @param alias the library alias as defined in the version catalog
+ * @return the resolved library dependency provider associated with [alias]
+ * @throws NoSuchElementException if no library with the given [alias] exists in the catalog
+ */
+fun Project.catalogLibrary(alias: String) =
+    requireAlias(VersionCatalog::findLibrary, alias, "library")
+
+/**
+ * Looks up a version by alias from the `libs` version catalog.
+ *
+ * @param alias the version alias as defined in the version catalog
+ * @return a string representation of the resolved version constraint associated with [alias]
+ * @throws NoSuchElementException if no version with the given [alias] exists in the catalog
+ */
+fun Project.catalogVersion(alias: String) =
+    requireAlias(VersionCatalog::findVersion, alias, "version").toString()

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/xml-apis-ext.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/xml-apis-ext.gradle.kts
@@ -11,5 +11,5 @@ configurations.all {
   // `org.apache.xmlgraphics:batik-css:1.17`, which depends on `xml-apis:xml-apis-ext:1.3.04`, which
   // is available from Maven Central.  So force that version of `xml-apis-ext` to be used instead of
   // the missing one.
-  resolutionStrategy.force(versionCatalogs.named("libs").findLibrary("xml-apis-ext").get())
+  resolutionStrategy.force(catalogLibrary("xml-apis-ext"))
 }


### PR DESCRIPTION
Gradle generates type-safe accessors for version catalog entries. Unfortunately, those accessors are not available to precompiled script plugins, which requires the latter to use lower-level APIs.  We use those lower-level APIs quite a bit in our `build-logic` code.  They are not as friendly as the generated accessors, but we can do a few things to make using them more convenient.

While we're doing that, we can also provide friendlier error messages if a requested catalog entry cannot be found.  That never seemed worth doing at any individual place where we were using the lower-level APIs. But now that we're factoring this code out and implementing it just once, it's worth the additional effort to make that code as helpful as possible.