### PR TITLE
Fix project vs. publication group confusion

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
@@ -97,7 +97,6 @@ publishing {
 
   publications.named<MavenPublication>("maven") {
     groupId = "com.ibm.wala"
-    group = "com.ibm.wala"
     artifactId = base.archivesName.get()
 
     val testFixturesCodeElementsNames =


### PR DESCRIPTION
A `MavenPublication` has a `groupId`, which defaults to the current `Project`'s `group`.  A `MavenPublication` does not have a `group`, though.  So when we were assigning to `group` inside a `publishing` block, we were actually changing the `group` of the `Project`, which is not a sensible or useful thing to do here.