### PR TITLE
Simplify creating a subdirectory property

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -165,7 +165,7 @@ val extractBcel by
     tasks.registering(Sync::class) {
       from({ tarTree(downloadBcel.singleFile) })
       include("**/*.jar")
-      into(layout.buildDirectory.map { "$it/$name" })
+      into(layout.buildDirectory.dir(name))
       eachFile { relativePath = RelativePath.parse(!isDirectory, relativePath.lastName) }
       includeEmptyDirs = false
     }


### PR DESCRIPTION
Given a `DirectoryProperty` to start with, there's an easier way to create the `DirectoryProperty` that resolves to a subdirectory of the original.