### PR TITLE
Discard an empty task configuration block

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/project.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/project.gradle.kts
@@ -16,7 +16,7 @@ repositories.mavenCentral()
 
 // this task resolves dependencies in all sub-projects, making it easy to
 // generate lockfiles
-tasks.register<DependencyReportTask>("allDeps") {}
+tasks.register<DependencyReportTask>("allDeps")
 
 ////////////////////////////////////////////////////////////////////////
 //


### PR DESCRIPTION
When registering a Gradle task that requires no special configuration, it's not necessary to include an empty `{}` configuration block.