### PR TITLE
Simplify some Kotlin functions

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/Exec-useCurrentJavaHome.kt
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/Exec-useCurrentJavaHome.kt
@@ -3,6 +3,5 @@ package com.ibm.wala.gradle
 import org.gradle.api.tasks.Exec
 
 /** Configures this [Exec] task to run with `JAVA_HOME` set to the current Gradle JVM's home. */
-fun Exec.useCurrentJavaHome() {
-  environment("JAVA_HOME", project.providers.systemProperty("java.home").valueToString)
-}
+fun Exec.useCurrentJavaHome() =
+    environment("JAVA_HOME", project.providers.systemProperty("java.home").valueToString)

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/version-catalog.kt
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/version-catalog.kt
@@ -27,10 +27,10 @@ private fun <T> Project.requireAlias(
     finder: VersionCatalog.(String) -> Optional<T>,
     alias: String,
     kind: String,
-) =
+): T =
     the<VersionCatalogsExtension>().named("libs").finder(alias).orElseThrow {
       NoSuchElementException("No $kind with alias `$alias` found in `libs` version catalog")
-    }!!
+    }
 
 /**
  * Looks up a library dependency by alias from the `libs` version catalog.


### PR DESCRIPTION
A Kotlin function with a single-statement block body can use an expression body instead.

A Kotlin function that explicitly `null`-checks a platform type can use an explicit return type instead.