### PR TITLE
Reduce use of immediate configuration closures

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
   implementation(libs.gradle.spotless.plugin)
 }
 
-kotlin.jvmToolchain { languageVersion = JavaLanguageVersion.of(11) }
+kotlin.jvmToolchain(11)
 
 spotless {
   val ktfmtVersion = libs.versions.ktfmt.get()

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -19,7 +19,7 @@ plugins {
   id("net.ltgt.errorprone")
 }
 
-jacoco { toolVersion = "0.8.13" }
+jacoco.toolVersion = "0.8.13"
 
 repositories {
   mavenCentral()

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/maven-eclipse-jsdt.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/maven-eclipse-jsdt.gradle.kts
@@ -1,9 +1,7 @@
 /** Define a Maven repository containing Eclipse JSDT packages. */
 package com.ibm.wala.gradle
 
-repositories {
-  maven {
-    url = uri("https://artifacts.alfresco.com/nexus/content/repositories/public/")
-    content { includeGroup("org.eclipse.wst.jsdt") }
-  }
+repositories.maven {
+  url = uri("https://artifacts.alfresco.com/nexus/content/repositories/public/")
+  content { includeGroup("org.eclipse.wst.jsdt") }
 }

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
@@ -120,12 +120,10 @@ publishing {
   }
 }
 
-signing {
-  setRequired {
-    // Signatures are a hard requirement if publishing a non-snapshot to Maven Central.
-    !isSnapshot &&
-        gradle.taskGraph.allTasks.any {
-          it is PublishToMavenRepository && it.name.endsWith("ToMavenCentralRepository")
-        }
-  }
+signing.setRequired {
+  // Signatures are a hard requirement if publishing a non-snapshot to Maven Central.
+  !isSnapshot &&
+      gradle.taskGraph.allTasks.any {
+        it is PublishToMavenRepository && it.name.endsWith("ToMavenCentralRepository")
+      }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,10 +26,8 @@ plugins {
   id("com.ibm.wala.gradle.project")
 }
 
-repositories {
-  // to get the google-java-format jar and dependencies
-  mavenCentral()
-}
+// to get the google-java-format jar and dependencies
+repositories.mavenCentral()
 
 JavaVersion.current().let {
   if (!it.isCompatibleWith(VERSION_17)) {

--- a/cast/java/ecj/build.gradle.kts
+++ b/cast/java/ecj/build.gradle.kts
@@ -7,12 +7,10 @@ plugins {
   id("com.ibm.wala.gradle.publishing")
 }
 
-walaEclipseMavenCentral {
-  implementation(
-      "org.eclipse.equinox.common",
-      "org.eclipse.jdt.core",
-  )
-}
+walaEclipseMavenCentral.implementation(
+    "org.eclipse.equinox.common",
+    "org.eclipse.jdt.core",
+)
 
 val runSourceDirectory by configurations.registering { isCanBeConsumed = false }
 

--- a/ide/jsdt/build.gradle.kts
+++ b/ide/jsdt/build.gradle.kts
@@ -4,15 +4,13 @@ plugins {
   id("com.ibm.wala.gradle.maven-eclipse-jsdt")
 }
 
-walaEclipseMavenCentral {
-  api(
-      "org.eclipse.core.resources",
-      "org.eclipse.core.runtime",
-      "org.eclipse.equinox.common",
-      "org.eclipse.osgi",
-      "org.eclipse.ui.workbench",
-  )
-}
+walaEclipseMavenCentral.api(
+    "org.eclipse.core.resources",
+    "org.eclipse.core.runtime",
+    "org.eclipse.equinox.common",
+    "org.eclipse.osgi",
+    "org.eclipse.ui.workbench",
+)
 
 dependencies {
   api(libs.eclipse.wst.jsdt.core)

--- a/ide/jsdt/tests/build.gradle.kts
+++ b/ide/jsdt/tests/build.gradle.kts
@@ -4,12 +4,10 @@ plugins {
   id("com.ibm.wala.gradle.maven-eclipse-jsdt")
 }
 
-walaEclipseMavenCentral {
-  testImplementation(
-      "org.eclipse.core.runtime",
-      "org.eclipse.equinox.common",
-  )
-}
+walaEclipseMavenCentral.testImplementation(
+    "org.eclipse.core.runtime",
+    "org.eclipse.equinox.common",
+)
 
 dependencies {
   testImplementation(libs.assertj.core)


### PR DESCRIPTION
If the actions in a `{ ... }` lambda are going to be applied immediately, and those "actions" are really just a single action, then we can often simplify by performing that action directly on the object to be configured.