### PR TITLE
Upgrade to Spotless Gradle plugin 8.0.0

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
   implementation(libs.gradle.spotless.plugin)
 }
 
-kotlin.jvmToolchain(11)
+kotlin.jvmToolchain(17)
 
 spotless {
   val ktfmtVersion = libs.versions.ktfmt.get()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ eclipse-wst-jsdt = "1.0.201.v2010012803"
 #noinspection UnusedVersionCatalogEntry
 google-java-format = "1.28.0"
 ktfmt = "0.58"
-spotless = "7.2.1"
+spotless = "8.0.0"
 
 [libraries]
 android-tools = "com.android.tools:r8:8.2.46"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,7 +6,7 @@ pluginManagement {
       settings.rootDir.resolve("foojay-resolver-convention-version.txt").readText().trim()
 }
 
-buildscript { dependencies { classpath("com.diffplug.spotless:spotless-lib-extra:3.1.2") } }
+buildscript { dependencies.classpath("com.diffplug.spotless:spotless-lib-extra:4.0.0") }
 
 plugins {
   id("com.diffplug.configuration-cache-for-platform-specific-build") version "4.3.0"


### PR DESCRIPTION
This plugin version requires Java 17 or newer.  Specifically, the JVM that is running Gradle itself must be Java 17+.  However, that's not a new requirement for us:  we committed to requiring Java 17+ to run Gradle back in revision 292991c802bb2317beef8cc613e6b9c77cf9ee0c, in late June of this year.

That being said, when compiling the Kotlin code in `build-logic`, we were still targeting Java 11.  Some of that code configures the Spotless Gradle plugin, so we need to move `build-logic` to Java 17+ in order for it to talk to the Spotless Gradle plugin's Java 17+ code. I'm not too concerned about that change:  as I said, we've required that Gradle use Java 17+ for a few months now.