### PR TITLE
Update a Gradle settings plugin

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,7 +9,7 @@ pluginManagement {
 buildscript { dependencies { classpath("com.diffplug.spotless:spotless-lib-extra:3.1.2") } }
 
 plugins {
-  id("com.diffplug.configuration-cache-for-platform-specific-build") version "4.3.0"
+  id("com.diffplug.configuration-cache-for-platform-specific-build") version "4.4.0"
   id("com.gradle.develocity") version "4.2"
   id("org.gradle.toolchains.foojay-resolver-convention")
 }


### PR DESCRIPTION
We need this plugin to make certain platform-querying methods compatible with the Gradle configuration cache.  For example, without this plugin, the `useNativesForRunningPlatform()` call in `WalaMavenCentralReleaseConfigurerExtension` eventually does things that are incompatible with the configuration cache.