### PR TITLE
Run tests on JDK 11 on CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: Check out WALA sources
         uses: actions/checkout@v4
-      - name: 'Set up JDK ${{ matrix.java }}'
+      - name: 'Set up JDKs'
         uses: actions/setup-java@v5
         with:
           # Install all the JDK versions we use in the matrix.  We do JDK 25 last to use that


### PR DESCRIPTION
We add an appropriate entry in our CI matrix, and tweak our use of `setup-java` to just install all the JDK versions we might need.

Fixes #1718 