### PR TITLE
Simplify looped assertions

### DIFF
--- a/core/src/test/java/com/ibm/wala/core/tests/basic/PrimitivesTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/basic/PrimitivesTest.java
@@ -27,7 +27,6 @@ import com.ibm.wala.core.tests.util.WalaTestCase;
 import com.ibm.wala.util.collections.BimodalMap;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.collections.Iterator2Collection;
-import com.ibm.wala.util.collections.Iterator2Iterable;
 import com.ibm.wala.util.collections.SmallMap;
 import com.ibm.wala.util.graph.Graph;
 import com.ibm.wala.util.graph.NumberedGraph;
@@ -774,17 +773,7 @@ public class PrimitivesTest extends WalaTestCase {
         .toIterable()
         .containsExactly(nodes[4], nodes[7], nodes[8], nodes[5], nodes[10]);
 
-    int j = 0;
-    Object[] desired5 = new Object[] {nodes[8]};
-    for (Object o4 : Iterator2Iterable.make(D.dominatorTree().getSuccNodes(nodes[5]))) {
-      Object d = desired5[j++];
-      boolean ok = o4.equals(d);
-      if (!ok) {
-        System.err.println("O4: " + o4);
-        System.err.println("desired " + d);
-        assertThat(d).isEqualTo(o4);
-      }
-    }
+    assertThat(D.dominatorTree().getSuccNodes(nodes[5])).toIterable().containsExactly(nodes[8]);
 
     assertThat(D.dominatorTree().getSuccNodeCount(nodes[10])).isEqualTo(5);
   }

--- a/core/src/test/java/com/ibm/wala/core/tests/cfg/exc/intra/NullPointerExceptionIntraTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/cfg/exc/intra/NullPointerExceptionIntraTest.java
@@ -11,7 +11,6 @@
 package com.ibm.wala.core.tests.cfg.exc.intra;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 import com.ibm.wala.cfg.ControlFlowGraph;
 import com.ibm.wala.cfg.exc.ExceptionPruningAnalysis;
@@ -810,12 +809,14 @@ public class NullPointerExceptionIntraTest extends WalaTestCase {
       ISSABasicBlock returnNode,
       ControlFlowGraph<SSAInstruction, IExplodedBasicBlock> explodedCfg) {
     final IExplodedBasicBlock exit = explodedCfg.exit();
+    IExplodedBasicBlock match = null;
     for (IExplodedBasicBlock candidate : Iterator2Iterable.make(explodedCfg.getPredNodes(exit))) {
       if (candidate.getInstruction() == returnNode.getLastInstruction()) {
-        return candidate;
+        match = candidate;
+        break;
       }
     }
-    fail();
-    return null;
+    assertThat(match).as("expected a predecessor with the return instruction").isNotNull();
+    return match;
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/ir/DeterministicIRTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/ir/DeterministicIRTest.java
@@ -99,12 +99,9 @@ public abstract class DeterministicIRTest extends WalaTestCase {
   }
 
   private static void checkNotAllNull(SSAInstruction[] instructions) {
-    for (SSAInstruction instruction : instructions) {
-      if (instruction != null) {
-        return;
-      }
-    }
-    fail("no instructions generated");
+    assertThat(instructions)
+        .as("expected at least one non-null instruction")
+        .anySatisfy(inst -> assertThat(inst).isNotNull());
   }
 
   @Test

--- a/core/src/test/java/com/ibm/wala/examples/analysis/dataflow/DataflowTest.java
+++ b/core/src/test/java/com/ibm/wala/examples/analysis/dataflow/DataflowTest.java
@@ -164,30 +164,32 @@ public class DataflowTest extends WalaTestCase {
     ExplodedInterproceduralCFG icfg = ExplodedInterproceduralCFG.make(cg);
     ContextInsensitiveReachingDefs reachingDefs = new ContextInsensitiveReachingDefs(icfg, cha);
     BitVectorSolver<BasicBlockInContext<IExplodedBasicBlock>> solver = reachingDefs.analyze();
-    for (BasicBlockInContext<IExplodedBasicBlock> bb : icfg) {
-      if (bb.getNode().toString().contains("testInterproc")) {
-        IExplodedBasicBlock delegate = bb.getDelegate();
-        if (delegate.getNumber() == 4) {
-          IntSet solution = solver.getOut(bb).getValue();
-          IntIterator intIterator = solution.intIterator();
-          List<Pair<CGNode, Integer>> applicationDefs = new ArrayList<>();
-          while (intIterator.hasNext()) {
-            int next = intIterator.next();
-            final Pair<CGNode, Integer> def = reachingDefs.getNodeAndInstrForNumber(next);
-            if (def.fst
-                .getMethod()
-                .getDeclaringClass()
-                .getClassLoader()
-                .getReference()
-                .equals(ClassLoaderReference.Application)) {
-              System.out.println(def);
-              applicationDefs.add(def);
-            }
-          }
-          assertThat(applicationDefs).hasSize(2);
-        }
-      }
-    }
+    assertThat(icfg)
+        .filteredOn(
+            bb ->
+                bb.getNode().toString().contains("testInterproc")
+                    && bb.getDelegate().getNumber() == 4)
+        .singleElement()
+        .satisfies(
+            bb -> {
+              IntSet solution = solver.getOut(bb).getValue();
+              IntIterator intIterator = solution.intIterator();
+              List<Pair<CGNode, Integer>> applicationDefs = new ArrayList<>();
+              while (intIterator.hasNext()) {
+                int next = intIterator.next();
+                final Pair<CGNode, Integer> def = reachingDefs.getNodeAndInstrForNumber(next);
+                if (def.fst
+                    .getMethod()
+                    .getDeclaringClass()
+                    .getClassLoader()
+                    .getReference()
+                    .equals(ClassLoaderReference.Application)) {
+                  System.out.println(def);
+                  applicationDefs.add(def);
+                }
+              }
+              assertThat(applicationDefs).hasSize(2);
+            });
   }
 
   @Test
@@ -204,29 +206,31 @@ public class DataflowTest extends WalaTestCase {
         result = reachingDefs.analyze();
     ISupergraph<BasicBlockInContext<IExplodedBasicBlock>, CGNode> supergraph =
         reachingDefs.getSupergraph();
-    for (BasicBlockInContext<IExplodedBasicBlock> bb : supergraph) {
-      if (bb.getNode().toString().contains("testInterproc")) {
-        IExplodedBasicBlock delegate = bb.getDelegate();
-        if (delegate.getNumber() == 4) {
-          IntSet solution = result.getResult(bb);
-          IntIterator intIterator = solution.intIterator();
-          List<Pair<CGNode, Integer>> applicationDefs = new ArrayList<>();
-          while (intIterator.hasNext()) {
-            int next = intIterator.next();
-            final Pair<CGNode, Integer> def = reachingDefs.getDomain().getMappedObject(next);
-            if (def.fst
-                .getMethod()
-                .getDeclaringClass()
-                .getClassLoader()
-                .getReference()
-                .equals(ClassLoaderReference.Application)) {
-              System.out.println(def);
-              applicationDefs.add(def);
-            }
-          }
-          assertThat(applicationDefs).hasSize(1);
-        }
-      }
-    }
+    assertThat(supergraph)
+        .filteredOn(
+            bb ->
+                bb.getNode().toString().contains("testInterproc")
+                    && bb.getDelegate().getNumber() == 4)
+        .singleElement()
+        .satisfies(
+            bb -> {
+              IntSet solution = result.getResult(bb);
+              IntIterator intIterator = solution.intIterator();
+              List<Pair<CGNode, Integer>> applicationDefs = new ArrayList<>();
+              while (intIterator.hasNext()) {
+                int next = intIterator.next();
+                final Pair<CGNode, Integer> def = reachingDefs.getDomain().getMappedObject(next);
+                if (def.fst
+                    .getMethod()
+                    .getDeclaringClass()
+                    .getClassLoader()
+                    .getReference()
+                    .equals(ClassLoaderReference.Application)) {
+                  System.out.println(def);
+                  applicationDefs.add(def);
+                }
+              }
+              assertThat(applicationDefs).hasSize(1);
+            });
   }
 }


### PR DESCRIPTION
Prefer to use AssertJ API features to loop over collections of items rather than explicit control-flow statements.  Also prefer to avoid `fail()` calls where we can instead assert some explicit property.  If an assertion fails, these changes will give us more informative diagnostic output since more of the problem-detecting logic is visible to AssertJ.