### PR TITLE
In assertions, prefer "satisfy" over "match"

### DIFF
--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
@@ -188,7 +188,7 @@ public abstract class IRTests {
       MethodReference mref = descriptorToMethodRef(method, cg.getClassHierarchy());
 
       assertThat(cg.getNodes(mref))
-          .allMatch(cgNode -> cgNode.getMethod() instanceof AstMethod)
+          .allSatisfy(cgNode -> assertThat(cgNode.getMethod()).isInstanceOf(AstMethod.class))
           .anySatisfy(
               cgNode -> {
                 DebuggingInformation dbg = ((AstMethod) cgNode.getMethod()).debugInfo();
@@ -196,12 +196,14 @@ public abstract class IRTests {
                     .filteredOn(findInstruction)
                     .extracting(inst -> dbg.getOperandPosition(inst.iIndex(), operand))
                     .filteredOn(Objects::nonNull)
-                    .anyMatch(
+                    .anySatisfy(
                         pos ->
-                            pos.getFirstLine() == position[0]
-                                && pos.getFirstCol() == position[1]
-                                && pos.getLastLine() == position[2]
-                                && pos.getLastCol() == position[3]);
+                            assertThat(position)
+                                .containsExactly(
+                                    pos.getFirstLine(),
+                                    pos.getFirstCol(),
+                                    pos.getLastLine(),
+                                    pos.getLastCol()));
               });
     }
   }
@@ -222,7 +224,8 @@ public abstract class IRTests {
     @Override
     public void check(CallGraph cg) {
       MethodReference mref = descriptorToMethodRef(method, cg.getClassHierarchy());
-      assertThat(cg.getNodes(mref)).allMatch(cgNode -> check(cgNode.getMethod(), cgNode.getIR()));
+      assertThat(cg.getNodes(mref))
+          .allSatisfy(cgNode -> assertThat(check(cgNode.getMethod(), cgNode.getIR())).isTrue());
     }
 
     boolean check(IMethod m, IR ir) {

--- a/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/test/TestCallGraph2JSON.java
+++ b/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/test/TestCallGraph2JSON.java
@@ -42,7 +42,7 @@ public class TestCallGraph2JSON {
       if (entry.getKey().startsWith("simple.js@3")) {
         Map<String, String[]> callSites = entry.getValue();
         assertThat(getTargetsStartingWith(callSites, "simple.js@4"))
-            .anyMatch(s -> s.startsWith("simple.js@7"));
+            .anySatisfy(s -> assertThat(s).startsWith("simple.js@7"));
       }
     }
     Map<String, String[]> flattened = flattenParsedCG(parsedJSONCG);
@@ -67,17 +67,23 @@ public class TestCallGraph2JSON {
     CallGraph2JSON cg2JSON = new CallGraph2JSON(false, true);
     Map<String, String[]> parsed = getFlattenedJSONCG(cg, cg2JSON);
     assertThat(getTargetsStartingWith(parsed, "reflective_calls.js@10"))
-        .anyMatch(s -> s.startsWith("Function_prototype_call (Native) [reflective_calls.js@10"));
+        .anySatisfy(
+            s ->
+                assertThat(s)
+                    .startsWith("Function_prototype_call (Native) [reflective_calls.js@10"));
     assertThat(getTargetsStartingWith(parsed, "reflective_calls.js@11"))
-        .anyMatch(s -> s.startsWith("Function_prototype_apply (Native) [reflective_calls.js@11"));
+        .anySatisfy(
+            s ->
+                assertThat(s)
+                    .startsWith("Function_prototype_apply (Native) [reflective_calls.js@11"));
     assertThat(
             getTargetsStartingWith(
                 parsed, "Function_prototype_call (Native) [reflective_calls.js@10"))
-        .anyMatch(s -> s.startsWith("reflective_calls.js@1"));
+        .anySatisfy(s -> assertThat(s).startsWith("reflective_calls.js@1"));
     assertThat(
             getTargetsStartingWith(
                 parsed, "Function_prototype_apply (Native) [reflective_calls.js@11"))
-        .anyMatch(s -> s.startsWith("reflective_calls.js@5"));
+        .anySatisfy(s -> assertThat(s).startsWith("reflective_calls.js@5"));
   }
 
   @Test
@@ -89,7 +95,7 @@ public class TestCallGraph2JSON {
     assertThat(getTargetsStartingWith(parsed, "native_callback.js@2"))
         .isEqualTo(new String[] {"Array_prototype_map (Native)"});
     assertThat(getTargetsStartingWith(parsed, "Function_prototype_call (Native)"))
-        .anyMatch(s -> s.startsWith("native_callback.js@3"));
+        .anySatisfy(s -> assertThat(s).startsWith("native_callback.js@3"));
   }
 
   /**

--- a/cast/src/test/java/com/ibm/wala/cast/test/TestCAstPattern.java
+++ b/cast/src/test/java/com/ibm/wala/cast/test/TestCAstPattern.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.Test;
 
 public class TestCAstPattern {
@@ -64,7 +65,8 @@ public class TestCAstPattern {
     System.err.println(("testing with input " + CAstPrinter.print(n)));
 
     if (names == null) {
-      assertThat(p).doesNotMatch(pattern -> pattern.match(n, null));
+      assertThat(p)
+          .isNot(new Condition<>(pattern -> pattern.match(n, null), "pattern that matches %s", n));
     } else {
       Segments s = CAstPattern.match(p, n);
       assertThat(s).isNotNull();

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/CallGraphTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/CallGraphTest.java
@@ -177,7 +177,7 @@ public class CallGraphTest extends WalaTestCase {
         com.ibm.wala.ipa.callgraph.impl.Util.makeMainEntrypoints(cha, "LstaticInit/TestStaticInit");
     AnalysisOptions options = CallGraphTestUtil.makeAnalysisOptions(scope, entrypoints);
     CallGraph cg = CallGraphTestUtil.buildZeroCFA(options, new AnalysisCacheImpl(), cha, false);
-    assertThat(cg).anyMatch(n -> n.toString().contains("doNothing"), "name contains \"doNothing\"");
+    assertThat(cg).anySatisfy(n -> assertThat(n).asString().contains("doNothing"));
     options.setHandleStaticInit(false);
     cg = CallGraphTestUtil.buildZeroCFA(options, new AnalysisCacheImpl(), cha, false);
     for (CGNode n : cg) {
@@ -196,8 +196,7 @@ public class CallGraphTest extends WalaTestCase {
         com.ibm.wala.ipa.callgraph.impl.Util.makeMainEntrypoints(cha, "Llambda/SortingExample");
     AnalysisOptions options = CallGraphTestUtil.makeAnalysisOptions(scope, entrypoints);
     CallGraph cg = CallGraphTestUtil.buildZeroCFA(options, new AnalysisCacheImpl(), cha, false);
-    assertThat(cg)
-        .anyMatch(n -> n.toString().contains("sortForward"), "name contains \"sortForward\"");
+    assertThat(cg).anySatisfy(n -> assertThat(n).asString().contains("sortForward"));
   }
 
   @Test
@@ -223,9 +222,7 @@ public class CallGraphTest extends WalaTestCase {
         .first()
         .extracting(cg::getSuccNodes, iterator(CGNode.class))
         .toIterable()
-        .anyMatch(
-            callee -> callee.getMethod().getName().toString().equals("toCharArray"),
-            "called method name is \"toCharArray\"");
+        .anySatisfy(callee -> assertThat(callee.getMethod().getName()).hasToString("toCharArray"));
   }
 
   @Test

--- a/core/src/test/java/com/ibm/wala/core/tests/cfg/exc/inter/NullPointerExceptionInterTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/cfg/exc/inter/NullPointerExceptionInterTest.java
@@ -45,6 +45,7 @@ import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.NullProgressMonitor;
 import com.ibm.wala.util.WalaException;
 import com.ibm.wala.util.graph.GraphIntegrity.UnsoundGraphException;
+import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -62,6 +63,9 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
   private static CallGraph cg;
 
   private static IAnalysisCacheView cache;
+
+  private static final Condition<ExceptionPruningAnalysis<?, ?>> exceptions =
+      new Condition<>(ExceptionPruningAnalysis::hasExceptions, "has exceptions");
 
   @BeforeAll
   public static void beforeClass() throws Exception {
@@ -114,7 +118,7 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
     ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
         interExplodedCFG.getResult(callNode);
 
-    assertThat(intraExplodedCFG).matches(ExceptionPruningAnalysis::hasExceptions);
+    assertThat(intraExplodedCFG).has(exceptions);
   }
 
   @Test
@@ -133,7 +137,7 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
     ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
         interExplodedCFG.getResult(callNode);
 
-    assertThat(intraExplodedCFG).matches(ExceptionPruningAnalysis::hasExceptions);
+    assertThat(intraExplodedCFG).has(exceptions);
   }
 
   @Test
@@ -150,7 +154,7 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
 
     ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
         interExplodedCFG.getResult(callNode);
-    assertThat(intraExplodedCFG).doesNotMatch(ExceptionPruningAnalysis::hasExceptions);
+    assertThat(intraExplodedCFG).doesNotHave(exceptions);
   }
 
   @Test
@@ -168,7 +172,7 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
 
     ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
         interExplodedCFG.getResult(callNode);
-    assertThat(intraExplodedCFG).doesNotMatch(ExceptionPruningAnalysis::hasExceptions);
+    assertThat(intraExplodedCFG).doesNotHave(exceptions);
   }
 
   @Test
@@ -186,7 +190,7 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
     ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
         interExplodedCFG.getResult(callNode);
 
-    assertThat(intraExplodedCFG).matches(ExceptionPruningAnalysis::hasExceptions);
+    assertThat(intraExplodedCFG).has(exceptions);
   }
 
   @Test
@@ -205,7 +209,7 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
     ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
         interExplodedCFG.getResult(callNode);
 
-    assertThat(intraExplodedCFG).matches(ExceptionPruningAnalysis::hasExceptions);
+    assertThat(intraExplodedCFG).has(exceptions);
   }
 
   @Test
@@ -222,7 +226,7 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
 
     ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
         interExplodedCFG.getResult(callNode);
-    assertThat(intraExplodedCFG).doesNotMatch(ExceptionPruningAnalysis::hasExceptions);
+    assertThat(intraExplodedCFG).doesNotHave(exceptions);
   }
 
   @Test
@@ -240,7 +244,7 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
 
     ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
         interExplodedCFG.getResult(callNode);
-    assertThat(intraExplodedCFG).doesNotMatch(ExceptionPruningAnalysis::hasExceptions);
+    assertThat(intraExplodedCFG).doesNotHave(exceptions);
   }
 
   @Test
@@ -258,7 +262,7 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
     ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
         interExplodedCFG.getResult(callNode);
 
-    assertThat(intraExplodedCFG).matches(ExceptionPruningAnalysis::hasExceptions);
+    assertThat(intraExplodedCFG).has(exceptions);
   }
 
   @Test
@@ -277,6 +281,6 @@ public class NullPointerExceptionInterTest extends WalaTestCase {
     ExceptionPruningAnalysis<SSAInstruction, IExplodedBasicBlock> intraExplodedCFG =
         interExplodedCFG.getResult(callNode);
 
-    assertThat(intraExplodedCFG).matches(ExceptionPruningAnalysis::hasExceptions);
+    assertThat(intraExplodedCFG).has(exceptions);
   }
 }


### PR DESCRIPTION
Prefer to use AssertJ APIs in the "satisfy" style rather than in the "match" style.  The "match" style is often more concise.  But the "satisfy" style will give us much better diagnostic output if an assertion does fail, since more of the problem-detecting logic is visible to AssertJ.