### PR TITLE
Remove a redundant check for CFG integrity

### DIFF
--- a/core/src/test/java/com/ibm/wala/core/tests/ir/CFGTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/ir/CFGTest.java
@@ -79,16 +79,6 @@ public abstract class CFGTest extends WalaTestCase {
         System.err.println(ir);
         fail(" failed cfg integrity check for " + methodSig);
       }
-
-      try {
-        GraphIntegrity.check(cfg);
-      } catch (UnsoundGraphException e) {
-        //noinspection CallToPrintStackTrace
-        e.printStackTrace();
-        System.err.println(ir);
-        System.err.println(cfg);
-        fail(" failed 2-exit cfg integrity check for " + methodSig);
-      }
     } catch (Exception e) {
       //noinspection CallToPrintStackTrace
       e.printStackTrace();


### PR DESCRIPTION
We already tested `GraphIntegrity.check(cfg)` immediately above.  There is no evident reason to check it again. [@msridhar traced the origins of this redundancy](https://github.com/wala/WALA/pull/1723#discussion_r2424909038), which has been [present at least since 2006](https://github.com/wala/WALA/blame/fcab11e5b88ad091c6dcf87180c8d4cfb632d83e/com.ibm.wala.core.tests/src/com/ibm/wala/core/tests/ir/CFGTest.java#L98). @msridhar hypothesizes:

> Probably WALA used to have a way to create a CFG with a single unique exit, but AFAIK, now the only way to do things (for the Java frontends anyway) is to have both a normal and exceptional exit. So I think we can get rid of the redundant check!