### PR TITLE
Correct a test that was succeeding vacuously

### DIFF
--- a/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestSimpleCallGraphShape.java
+++ b/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestSimpleCallGraphShape.java
@@ -494,13 +494,13 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
       throws IOException, IllegalArgumentException, CancelException, WalaException {
     CallGraph cg = JSCallGraphBuilderUtil.makeScriptCG("tests", "function_call.js");
     for (CGNode n : cg) {
-      if (n.getMethod().getName().toString().equals("call4")) {
+      if (n.getMethod().getName().toString().equals("$$ call_4")) {
         assertThat(cg.getSuccNodeCount(n)).isEqualTo(2);
         // ugh
         List<CGNode> succs = Iterator2Collection.toList(cg.getSuccNodes(n));
         assertThat(succs)
             .hasToString(
-                "[Node: <Code body of function Lfunction_call.js/foo> Context: Everywhere, Node: <Code body of function Lfunction_call.js/bar> Context: Everywhere]");
+                "[Node: <Code body of function Lfunction_call.js/bar> Context: Everywhere, Node: <Code body of function Lfunction_call.js/foo> Context: Everywhere]");
       }
     }
   }


### PR DESCRIPTION
Previously `TestSimpleCallGraphShape.testFunctionDotCall` succeeded vacuously, because the call graph contains no node `n` such that `n.getMethod().getName().toString().equals("call4")` is true.  However, there is a node whose method name is `"$$ call_4"`.  I suspect that's the node that these assertions are intended to examine.

Correcting that name check reveals that the assertion on the string representation of this node's successor list also fails, apparently due to those two successors being in an unexpected order.  I've corrected that assertion as well.  However, are successor nodes guaranteed to be in any consistent order?  If not, then I would prefer to replace this assertion with one that is order-independent.  I'm happy to do that in a future commit if reviewers think that would be appropriate.