### PR TITLE
Strengthen static types in `for`-each loops

### DIFF
--- a/cast/src/test/java/com/ibm/wala/cast/test/TestCAstTranslator.java
+++ b/cast/src/test/java/com/ibm/wala/cast/test/TestCAstTranslator.java
@@ -135,19 +135,15 @@ public abstract class TestCAstTranslator {
   }
 
   protected void dump(ClassHierarchy cha) {
-    for (Object name : cha) {
-      IClass cls = (IClass) name;
+    for (IClass cls : cha) {
       System.err.println(("class " + cls));
-      for (Object name2 : cls.getDeclaredInstanceFields()) {
-        IField fld = (IField) name2;
+      for (IField fld : cls.getDeclaredInstanceFields()) {
         System.err.println(("instance field " + fld));
       }
-      for (Object name2 : cls.getDeclaredStaticFields()) {
-        IField fld = (IField) name2;
+      for (IField fld : cls.getDeclaredStaticFields()) {
         System.err.println(("static field " + fld));
       }
-      for (Object name2 : cls.getDeclaredMethods()) {
-        IMethod mth = (IMethod) name2;
+      for (IMethod mth : cls.getDeclaredMethods()) {
         if (mth.isStatic()) System.err.print("static ");
         System.err.println(
             ("method " + mth + " with " + mth.getNumberOfParameters() + " parameters"));
@@ -168,8 +164,7 @@ public abstract class TestCAstTranslator {
     Map<Pair<String, Object>, Object> staticMethods = assertions.getStaticMethods();
 
     int clsCount = 0;
-    for (Object name : cha) {
-      IClass cls = (IClass) name;
+    for (IClass cls : cha) {
       clsCount++;
       assertThat(classes).contains(cls.getName().toString());
 
@@ -180,19 +175,16 @@ public abstract class TestCAstTranslator {
             .isEqualTo(cls.getSuperclass().getName().toString());
       }
 
-      for (Object name2 : cls.getDeclaredInstanceFields()) {
-        IField fld = (IField) name2;
+      for (IField fld : cls.getDeclaredInstanceFields()) {
         assertThat(instanceFields)
             .contains(Pair.make(cls.getName().toString(), fld.getName().toString()));
       }
 
-      for (Object name2 : cls.getDeclaredStaticFields()) {
-        IField fld = (IField) name2;
+      for (IField fld : cls.getDeclaredStaticFields()) {
         assertThat(staticFields).contains(make(cls.getName().toString(), fld.getName().toString()));
       }
 
-      for (Object name2 : cls.getDeclaredMethods()) {
-        IMethod mth = (IMethod) name2;
+      for (IMethod mth : cls.getDeclaredMethods()) {
         Integer np = mth.getNumberOfParameters();
         Pair<String, Object> key = Pair.make(cls.getName().toString(), mth.getName().toString());
 

--- a/cast/src/testFixtures/java/com/ibm/wala/cast/util/test/TestCallGraphShape.java
+++ b/cast/src/testFixtures/java/com/ibm/wala/cast/util/test/TestCallGraphShape.java
@@ -186,9 +186,9 @@ public abstract class TestCallGraphShape {
   public void verifyNoEdges(CallGraph CG, String sourceDescription, String destDescription) {
     Collection<CGNode> sources = getNodes(CG, sourceDescription);
     Collection<CGNode> dests = getNodes(CG, destDescription);
-    for (Object source : sources) {
+    for (CGNode source : sources) {
       for (Object dest : dests) {
-        for (CGNode n : Iterator2Iterable.make(CG.getSuccNodes((CGNode) source))) {
+        for (CGNode n : Iterator2Iterable.make(CG.getSuccNodes(source))) {
           if (n.equals(dest)) {
             assert false : "Found a link from " + source + " to " + dest;
           }

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/SSAPropagationCallGraphBuilder.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/SSAPropagationCallGraphBuilder.java
@@ -301,8 +301,7 @@ public abstract class SSAPropagationCallGraphBuilder extends PropagationCallGrap
         ++n;
       }
       assert n < controlFlowGraph.getPredNodeCount(sb);
-      for (SSAInstruction inst : Iterator2Iterable.make(sb.iteratePhis())) {
-        SSAPhiInstruction phi = (SSAPhiInstruction) inst;
+      for (SSAPhiInstruction phi : Iterator2Iterable.make(sb.iteratePhis())) {
         if (phi == null) {
           continue;
         }

--- a/util/src/main/java/com/ibm/wala/util/heapTrace/HeapTracer.java
+++ b/util/src/main/java/com/ibm/wala/util/heapTrace/HeapTracer.java
@@ -114,10 +114,9 @@ public class HeapTracer {
    */
   private static String[] generateRootClassesFromWorkspace() {
     String classpath = System.getProperty("java.class.path");
-    Object[] binDirectories = extractBinDirectories(classpath);
+    String[] binDirectories = extractBinDirectories(classpath);
     HashSet<String> classFileNames = HashSetFactory.make();
-    for (Object binDirectorie : binDirectories) {
-      String dir = (String) binDirectorie;
+    for (String dir : binDirectories) {
       File fdir = new File(dir);
       classFileNames.addAll(findClassNames(dir, fdir));
     }
@@ -152,7 +151,7 @@ public class HeapTracer {
   /**
    * @return duplicate-free array of strings that are names of directories that contain "bin"
    */
-  private static Object[] extractBinDirectories(String classpath) {
+  private static String[] extractBinDirectories(String classpath) {
     StringTokenizer t = new StringTokenizer(classpath, ";");
     HashSet<String> result = HashSetFactory.make();
     while (t.hasMoreTokens()) {
@@ -161,7 +160,7 @@ public class HeapTracer {
         result.add(n);
       }
     }
-    return result.toArray();
+    return result.toArray(new String[0]);
   }
 
   /** Trace the heap and return the results */


### PR DESCRIPTION
In each of these cases, we were using a fairly weak type for the variable controlled by the `for`-each loop, then casting to a stronger type, but we could have been using that stronger type right from the start.