### PR TITLE
Defend test against vacuous success and order changes

### DIFF
--- a/.idea/dictionaries/project.xml
+++ b/.idea/dictionaries/project.xml
@@ -142,6 +142,7 @@
       <w>lcorner</w>
       <w>ldataflow</w>
       <w>ldemandpa</w>
+      <w>lfunction</w>
       <w>libjvm</w>
       <w>liblit</w>
       <w>ljava</w>

--- a/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestSimpleCallGraphShape.java
+++ b/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestSimpleCallGraphShape.java
@@ -28,9 +28,8 @@ import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.MonitorUtil.IProgressMonitor;
 import com.ibm.wala.util.NullProgressMonitor;
 import com.ibm.wala.util.WalaException;
-import com.ibm.wala.util.collections.Iterator2Collection;
 import java.io.IOException;
-import java.util.List;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -493,16 +492,15 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
   public void testFunctionDotCall()
       throws IOException, IllegalArgumentException, CancelException, WalaException {
     CallGraph cg = JSCallGraphBuilderUtil.makeScriptCG("tests", "function_call.js");
-    for (CGNode n : cg) {
-      if (n.getMethod().getName().toString().equals("$$ call_4")) {
-        assertThat(cg.getSuccNodeCount(n)).isEqualTo(2);
-        // ugh
-        List<CGNode> succs = Iterator2Collection.toList(cg.getSuccNodes(n));
-        assertThat(succs)
-            .hasToString(
-                "[Node: <Code body of function Lfunction_call.js/bar> Context: Everywhere, Node: <Code body of function Lfunction_call.js/foo> Context: Everywhere]");
-      }
-    }
+    assertThat(cg)
+        .filteredOn(n -> n.getMethod().getName().toString().equals("$$ call_4"))
+        .singleElement()
+        .extracting(cg::getSuccNodes, InstanceOfAssertFactories.iterator(CGNode.class))
+        .toIterable()
+        .extracting(Object::toString)
+        .containsExactlyInAnyOrder(
+            "Node: <Code body of function Lfunction_call.js/bar> Context: Everywhere",
+            "Node: <Code body of function Lfunction_call.js/foo> Context: Everywhere");
   }
 
   private static final Object[][] assertionsForFunctionApply =


### PR DESCRIPTION
An earlier version of this test passed vacuously because it was looking for a node named `"call4"` instead of `"$$ call_4"`.  That mistake has already been corrected.  However, we can make this test even more robust by ensuring that the sought-after node appears exactly once.

Furthermore, when validating the contents of a list of successors, we should not assume that those successors are given in any particular order.

See #1726 for further discussion on recent corrections and improvements to this test.