### PR TITLE
Avoid explicit control statements with assertions

### DIFF
--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/CallGraphTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/CallGraphTest.java
@@ -165,6 +165,10 @@ public class CallGraphTest extends WalaTestCase {
     doCallGraphs(options, new AnalysisCacheImpl(), cha);
   }
 
+  private static void nameContainsDoNothing(CGNode actual) {
+    assertThat(actual).asString().contains("doNothing");
+  }
+
   @Test
   public void testStaticInit()
       throws ClassHierarchyException, IllegalArgumentException, CancelException, IOException {
@@ -174,14 +178,14 @@ public class CallGraphTest extends WalaTestCase {
     ClassHierarchy cha = ClassHierarchyFactory.make(scope);
     Iterable<Entrypoint> entrypoints =
         com.ibm.wala.ipa.callgraph.impl.Util.makeMainEntrypoints(cha, "LstaticInit/TestStaticInit");
+
     AnalysisOptions options = CallGraphTestUtil.makeAnalysisOptions(scope, entrypoints);
     CallGraph cg = CallGraphTestUtil.buildZeroCFA(options, new AnalysisCacheImpl(), cha, false);
-    assertThat(cg).anySatisfy(n -> assertThat(n).asString().contains("doNothing"));
+    assertThat(cg).anySatisfy(CallGraphTest::nameContainsDoNothing);
+
     options.setHandleStaticInit(false);
     cg = CallGraphTestUtil.buildZeroCFA(options, new AnalysisCacheImpl(), cha, false);
-    for (CGNode n : cg) {
-      assertThat(n).asString().doesNotContain("doNothing");
-    }
+    assertThat(cg).noneSatisfy(CallGraphTest::nameContainsDoNothing);
   }
 
   @Test

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/ReflectionTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/ReflectionTest.java
@@ -47,7 +47,6 @@ import com.ibm.wala.util.WalaException;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.collections.Iterator2Iterable;
 import com.ibm.wala.util.collections.Pair;
-import com.ibm.wala.util.intset.OrdinalSet;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
@@ -741,17 +740,13 @@ public class ReflectionTest extends WalaTestCase {
     // get the pts corresponding to the 0th parameter of the Reflect24#doNothing() method
     CGNode cgNode = assertThat(nodes).singleElement().actual();
 
+    // the type corresponding to the 0th parameter should be Helper
     LocalPointerKey localPointerKey = new LocalPointerKey(cgNode, cgNode.getIR().getParameter(0));
-    OrdinalSet<InstanceKey> pts = pointerAnalysis.getPointsToSet(localPointerKey);
-    assertThat(pts).hasSize(1);
-
-    for (InstanceKey mappedObject : pts) {
-      // the type corresponding to the 0th parameter should be Helper
-      assertThat(mappedObject)
-          .asInstanceOf(type(ConstantKey.class))
-          .extracting(ConstantKey::getValue)
-          .isEqualTo(helperClass);
-    }
+    assertThat(pointerAnalysis.getPointsToSet(localPointerKey))
+        .singleElement()
+        .asInstanceOf(type(ConstantKey.class))
+        .extracting(ConstantKey::getValue)
+        .isEqualTo(helperClass);
   }
 
   /**

--- a/core/src/test/java/com/ibm/wala/core/tests/ir/DeterministicIRTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/ir/DeterministicIRTest.java
@@ -82,9 +82,7 @@ public abstract class DeterministicIRTest extends WalaTestCase {
   // The Tests ///////////////////////////////////////////////////////
 
   private static void checkNoneNull(Iterator<?> iterator) {
-    while (iterator.hasNext()) {
-      assertThat(iterator.next()).isNotNull();
-    }
+    assertThat(iterator).toIterable().doesNotContainNull();
   }
 
   private static void checkNotAllNull(SSAInstruction[] instructions) {


### PR DESCRIPTION
Prefer higher-level AssertJ features that allow writing assertions over multiple values at once.  These APIs produce more comprehensive diagnostic messages when assertions fail.  These APIS also make it easier to avoid vacuous successes that arise when an `if` inside a `for` never actually finds the thing it is looking for, and therefore performs no assertions.