### PR TITLE
Install a suitable Node.js for Markdown linting

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,12 +89,19 @@ shellcheck {
   shellcheckBinary = "shellcheck"
   sourceFiles =
       fileTree(".") {
+        exclude("/.gradle/")
         exclude("**/build")
         include("**/*.sh")
       }
 }
 
 // Markdown
+
+node {
+  download = true
+  version = "24.10.0"
+}
+
 val lintMarkdown by
     tasks.registering(NpxTask::class) {
       group = "verification"


### PR DESCRIPTION
Previously we assumed that the build machine already had a reasonable version of the `npx` tool from Node.js.  Now we download and install a version that we know works.