### PR TITLE
Ignore deprecation warnings in test subjects

### DIFF
--- a/.idea/inspectionProfiles/No_Back_Sliding.xml
+++ b/.idea/inspectionProfiles/No_Back_Sliding.xml
@@ -92,6 +92,9 @@
     <inspection_tool class="DanglingJavadoc" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Java Sources as Test Subjects" level="WARNING" enabled="false" />
     </inspection_tool>
+    <inspection_tool class="Deprecation" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="Java Sources as Test Subjects" level="WARNING" enabled="false" />
+    </inspection_tool>
     <inspection_tool class="DoubleLiteralMayBeFloatLiteral" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="DuplicateExpressions" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <scope name="Java Sources as Test Subjects" level="WEAK WARNING" enabled="false" />

--- a/cast/java/test/data/build.gradle.kts
+++ b/cast/java/test/data/build.gradle.kts
@@ -14,6 +14,7 @@ val compileTestSubjectsJava by
         // Some code in the test data is written in a deliberately bad style, so allow warnings
         compilerArgs.remove("-Werror")
         compilerArgs.add("-nowarn")
+        isDeprecation = false
       }
     }
 


### PR DESCRIPTION
Some of our test subjects contain code that would be considered deprecated by modern standards, such as calling the `Integer(in) constructor in JLex's `Main.java`. This is still code that we want to test on, though, so we have no plans to modernize those deprecated items.