### PR TITLE
Resolve ECJ diagnostics about unused symbols

### DIFF
--- a/cast/.settings/org.eclipse.jdt.core.prefs
+++ b/cast/.settings/org.eclipse.jdt.core.prefs
@@ -113,7 +113,7 @@ org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownExceptionWhenOverridin
 org.eclipse.jdt.core.compiler.problem.unusedExceptionParameter=ignore
 org.eclipse.jdt.core.compiler.problem.unusedImport=error
 org.eclipse.jdt.core.compiler.problem.unusedLabel=error
-org.eclipse.jdt.core.compiler.problem.unusedLocal=ignore
+org.eclipse.jdt.core.compiler.problem.unusedLocal=error
 org.eclipse.jdt.core.compiler.problem.unusedObjectAllocation=error
 org.eclipse.jdt.core.compiler.problem.unusedParameter=error
 org.eclipse.jdt.core.compiler.problem.unusedParameterIncludeDocCommentReference=enabled

--- a/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/AstCallGraph.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/AstCallGraph.java
@@ -129,6 +129,7 @@ public class AstCallGraph extends ExplicitCallGraph {
         while (!done) {
           try {
             for (Function<Object, Object> function : callbacks) {
+              @SuppressWarnings("unused")
               Object ignored = function.apply(null);
             }
           } catch (ConcurrentModificationException e) {

--- a/dalvik/.settings/org.eclipse.jdt.core.prefs
+++ b/dalvik/.settings/org.eclipse.jdt.core.prefs
@@ -117,7 +117,7 @@ org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownExceptionWhenOverridin
 org.eclipse.jdt.core.compiler.problem.unusedExceptionParameter=ignore
 org.eclipse.jdt.core.compiler.problem.unusedImport=error
 org.eclipse.jdt.core.compiler.problem.unusedLabel=error
-org.eclipse.jdt.core.compiler.problem.unusedLocal=ignore
+org.eclipse.jdt.core.compiler.problem.unusedLocal=error
 org.eclipse.jdt.core.compiler.problem.unusedObjectAllocation=error
 org.eclipse.jdt.core.compiler.problem.unusedParameter=error
 org.eclipse.jdt.core.compiler.problem.unusedParameterIncludeDocCommentReference=enabled

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexCFG.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexCFG.java
@@ -135,7 +135,7 @@ public class DexCFG extends AbstractCFG<Instruction, DexCFG.BasicBlock> implemen
     boolean[] r = new boolean[getInstructions().length];
     boolean[] catchers = new boolean[getInstructions().length];
     // we initially start with both the entry and exit block.
-    @SuppressWarnings("UnusedVariable")
+    @SuppressWarnings("unused")
     int blockCount = 2;
 
     // Compute r so r[i] == true iff instruction i begins a basic block.

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/Intent.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/Intent.java
@@ -282,7 +282,7 @@ public class Intent implements Cloneable, ContextItem, Comparable<Intent> {
    *     relying on the packet name!
    */
   private static boolean isInternal(
-      @SuppressWarnings("unused") Intent intent) { // XXX: This may loop forever!
+      @SuppressWarnings("UnusedVariable") Intent intent) { // XXX: This may loop forever!
     /*final Intent override = AndroidEntryPointManager.MANAGER.getIntent(intent);
 
     logger.warn("Intent.isInternal(Intent) is an unsafe fallback!");

--- a/scandroid/.settings/org.eclipse.jdt.core.prefs
+++ b/scandroid/.settings/org.eclipse.jdt.core.prefs
@@ -103,7 +103,7 @@ org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownExceptionWhenOverridin
 org.eclipse.jdt.core.compiler.problem.unusedExceptionParameter=ignore
 org.eclipse.jdt.core.compiler.problem.unusedImport=error
 org.eclipse.jdt.core.compiler.problem.unusedLabel=error
-org.eclipse.jdt.core.compiler.problem.unusedLocal=ignore
+org.eclipse.jdt.core.compiler.problem.unusedLocal=error
 org.eclipse.jdt.core.compiler.problem.unusedObjectAllocation=error
 org.eclipse.jdt.core.compiler.problem.unusedParameter=error
 org.eclipse.jdt.core.compiler.problem.unusedParameterIncludeDocCommentReference=enabled

--- a/scandroid/src/main/java/org/scandroid/util/DexDotUtil.java
+++ b/scandroid/src/main/java/org/scandroid/util/DexDotUtil.java
@@ -201,7 +201,7 @@ public class DexDotUtil extends DotUtil {
     result.append('\"');
     result.append(getLabel(n, labels));
     result.append('\"');
-    result.append(decorateNode(n, labels));
+    result.append(" [ ]\n");
   }
 
   /** Compute the nodes to visualize */
@@ -211,15 +211,6 @@ public class DexDotUtil extends DotUtil {
 
   private static String getRankDir() {
     return null;
-  }
-
-  /**
-   * @param n node to decorate
-   * @param d decorating master
-   */
-  private static <T> String decorateNode(
-      @SuppressWarnings("unused") T n, @SuppressWarnings("unused") NodeDecorator<T> d) {
-    return " [ ]\n";
   }
 
   private static <T> String getLabel(T o, NodeDecorator<T> d) throws WalaException {

--- a/shrike/.settings/org.eclipse.jdt.core.prefs
+++ b/shrike/.settings/org.eclipse.jdt.core.prefs
@@ -123,7 +123,7 @@ org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownExceptionWhenOverridin
 org.eclipse.jdt.core.compiler.problem.unusedExceptionParameter=ignore
 org.eclipse.jdt.core.compiler.problem.unusedImport=error
 org.eclipse.jdt.core.compiler.problem.unusedLabel=error
-org.eclipse.jdt.core.compiler.problem.unusedLocal=ignore
+org.eclipse.jdt.core.compiler.problem.unusedLocal=error
 org.eclipse.jdt.core.compiler.problem.unusedObjectAllocation=error
 org.eclipse.jdt.core.compiler.problem.unusedParameter=error
 org.eclipse.jdt.core.compiler.problem.unusedParameterIncludeDocCommentReference=enabled

--- a/util/.settings/org.eclipse.jdt.core.prefs
+++ b/util/.settings/org.eclipse.jdt.core.prefs
@@ -111,7 +111,7 @@ org.eclipse.jdt.core.compiler.problem.unusedDeclaredThrownExceptionWhenOverridin
 org.eclipse.jdt.core.compiler.problem.unusedExceptionParameter=ignore
 org.eclipse.jdt.core.compiler.problem.unusedImport=error
 org.eclipse.jdt.core.compiler.problem.unusedLabel=error
-org.eclipse.jdt.core.compiler.problem.unusedLocal=ignore
+org.eclipse.jdt.core.compiler.problem.unusedLocal=error
 org.eclipse.jdt.core.compiler.problem.unusedObjectAllocation=error
 org.eclipse.jdt.core.compiler.problem.unusedParameter=error
 org.eclipse.jdt.core.compiler.problem.unusedParameterIncludeDocCommentReference=enabled

--- a/util/src/main/java/com/ibm/wala/util/graph/impl/DelegatingNumberedNodeManager.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/impl/DelegatingNumberedNodeManager.java
@@ -67,7 +67,6 @@ public class DelegatingNumberedNodeManager<T extends INodeWithNumber>
    * @see com.ibm.wala.util.graph.Graph#iterator()
    */
   @Override
-  @SuppressWarnings("unused")
   public Iterator<T> iterator() {
     final @Nullable INodeWithNumber[] arr = nodes;
     return new Iterator<T>() {


### PR DESCRIPTION
ECJ compilation was producing nine diagnostic `INFO` messages of the form:

> At least one of the problems in category 'unused' is not analysed due to a compiler option being ignored

These changes resolve all such messages.  In most cases, resolving the message required _strengthening_ ECJ's linting, which is generally a good thing to do anyway.