### PR TITLE
Stop using a deprecated `Runtime.exec` overload

### DIFF
--- a/core/src/testFixtures/java/com/ibm/wala/core/tests/shrike/DynamicCallGraphTestBase.java
+++ b/core/src/testFixtures/java/com/ibm/wala/core/tests/shrike/DynamicCallGraphTestBase.java
@@ -133,9 +133,9 @@ public abstract class DynamicCallGraphTestBase extends WalaTestCase {
     Files.deleteIfExists(cgLocation);
 
     childJvm.init();
-    String commandLine = childJvm.getCommandLine().toString();
+    final var commandLine = childJvm.getCommandLine();
     System.err.println(commandLine);
-    Process x = Runtime.getRuntime().exec(commandLine, null, new File("build"));
+    Process x = Runtime.getRuntime().exec(commandLine.getCommandline(), null, new File("build"));
     x.waitFor();
 
     assertThat(cgLocation).exists();


### PR DESCRIPTION
The deprecated overload of this method takes a single `String` as the command to execute, which it parses into a command vector using a `StringTokenizer`.  The preferred (non-deprecated) overload takes a command vector directly as a `String[]`.  The latter is less error-prone.  Conveniently, we _do_ already have a way to get at the correct `String[]` command vector.