### PR TITLE
Specify which `markdownlint-cli2` version to use

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -106,7 +106,7 @@ node {
 val lintMarkdown by
     tasks.registering(NpxTask::class) {
       group = "verification"
-      command = "markdownlint-cli2"
+      command = "markdownlint-cli2@0.18.1"
       val markdownFiles = fileTree(".") { include("*.md") }
       inputs.files(markdownFiles)
       inputs.file(".markdownlint-cli2.yaml")


### PR DESCRIPTION
We are explicit about the versions of other dependencies, including Node.js itself.  So we should be explicit about this dependency too.

I came across this while exploring issue #1766.  I don't believe that this change will fix that issue, but it still seems like a useful thing to do.