### PR TITLE
`checkSmokeMain` is a `verification` task

### DIFF
--- a/cast/smoke_main/build.gradle.kts
+++ b/cast/smoke_main/build.gradle.kts
@@ -75,6 +75,7 @@ application {
       if (isDebuggable && !isOptimized) {
         val checkSmokeMain by
             tasks.registering(Exec::class) {
+              group = "verification"
 
               // main executable to run for test
               inputs.file(linkedFile)


### PR DESCRIPTION
Categorizing tasks sensibly makes them easier to find in `./gradlew --tasks` output, IntelliJ IDEA's Gradle view, and elsewhere.