### PR TITLE
Leverage return value of AssertJ `fail`

### DIFF
--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
@@ -501,8 +501,7 @@ public abstract class IRTests {
         return loader.getReference();
       }
     }
-    fail("This code should be unreachable");
-    return null;
+    return fail("This code should be unreachable");
   }
 
   public static void populateScope(

--- a/core/src/test/java/com/ibm/wala/core/tests/shrike/FloatingPointsTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/shrike/FloatingPointsTest.java
@@ -218,8 +218,7 @@ public class FloatingPointsTest extends WalaTestCase {
         }
       }
     }
-    fail("No ConstantInstruction with type '" + type + "' found");
-    return null;
+    return fail("No ConstantInstruction with type '" + type + "' found");
   }
 
   private MethodData getMethodData(String signature) throws InvalidClassFileException {
@@ -237,7 +236,6 @@ public class FloatingPointsTest extends WalaTestCase {
         }
       }
     }
-    fail("Method data not found. Check the signature");
-    return null;
+    return fail("Method data not found. Check the signature");
   }
 }


### PR DESCRIPTION
`fail` will never actually return.  However, it pretends to return any type that is needed.