### PR TITLE
Leverage AssertJ's implicit format strings

### DIFF
--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
@@ -319,7 +319,7 @@ public abstract class IRTests {
               }
             }
 
-            fail("cannot find " + at);
+            fail("cannot find %s", at);
           }
         }
       }

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/JavaIRTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/JavaIRTests.java
@@ -212,7 +212,7 @@ public abstract class JavaIRTests extends IRTests {
                 final Integer valueAssigned = (Integer) symbolTable.getConstantValue(as.getValue());
 
                 assertThat(valueAssigned.intValue())
-                    .as("Expected an array store to 'y' with value " + (valueOfArrayIndex + 1))
+                    .as("Expected an array store to 'y' with value %d", valueOfArrayIndex + 1)
                     .isEqualTo(valueOfArrayIndex + 1);
               }
             }
@@ -551,7 +551,7 @@ public abstract class JavaIRTests extends IRTests {
             }
             final String allIks = allIksBuilder.toString();
             assertThat(allIks)
-                .as("assertion failed: expecting ik \"LSub,\" in method, got \"" + allIks + "\"\n")
+                .as("assertion failed: expecting ik \"LSub,\" in method, got \"%s\"\n", allIks)
                 .isEqualTo("LSub,");
 
             break;

--- a/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/rhino/test/HTMLCGBuilder.java
+++ b/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/rhino/test/HTMLCGBuilder.java
@@ -81,7 +81,7 @@ public class HTMLCGBuilder {
     try {
       url = toUrl(src);
     } catch (MalformedURLException | URISyntaxException e1) {
-      fail("Could not find page to analyse: " + src);
+      fail("Could not find page to analyse: %s", src);
     }
     com.ibm.wala.cast.js.ipa.callgraph.JSCallGraphUtil.setTranslatorFactory(
         new CAstRhinoTranslatorFactory());

--- a/core/src/test/java/com/ibm/wala/core/tests/arraybounds/PruneArrayOutOfBoundExceptionEdge.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/arraybounds/PruneArrayOutOfBoundExceptionEdge.java
@@ -185,7 +185,7 @@ public class PruneArrayOutOfBoundExceptionEdge {
      */
     softly
         .assertThat(numberOfDeletedExceptionEdges)
-        .as(() -> "Number of deleted edges is not as expected for " + iClass.getName().toString())
+        .as("Number of deleted edges is not as expected for %s", iClass.getName())
         .isEqualTo(expectedNumberOfArrayAccesses);
   }
 

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/CloneTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/CloneTest.java
@@ -67,7 +67,7 @@ public class CloneTest extends WalaTestCase {
             for (CGNode cgNode : targets) {
               System.err.println("  " + cgNode);
             }
-            fail("found " + targets.size() + " targets for " + site + " in " + node);
+            fail("found %d targets for %s in %s", targets.size(), site, node);
           }
         }
       }

--- a/core/src/test/java/com/ibm/wala/core/tests/shrike/FloatingPointsTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/shrike/FloatingPointsTest.java
@@ -218,7 +218,7 @@ public class FloatingPointsTest extends WalaTestCase {
         }
       }
     }
-    return fail("No ConstantInstruction with type '" + type + "' found");
+    return fail("No ConstantInstruction with type '%s' found", type);
   }
 
   private MethodData getMethodData(String signature) throws InvalidClassFileException {


### PR DESCRIPTION
Some AssertJ APIs take a `%`-based format string along with arguments to fill in those placeholders.  I find `%`-based format strings more readable than `+`-based string concatenations, so let's prefer the former.

In the case of `.as(…)`, there's also a minuscule performance advantage to format strings.  `as("checked " + 123)` _always_ builds the `"checked 123"` string but `as("checked %s", 123)` only builds that string if the assertion being described fails.