### PR TITLE
Improve lazy adding of `Map` entries

### DIFF
--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/CAstRewriterExt.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/CAstRewriterExt.java
@@ -106,16 +106,14 @@ public abstract class CAstRewriterExt extends CAstRewriter<NodePos, NoKey> {
   private final ArrayDeque<CAstEntity> entities = new ArrayDeque<>();
 
   public CAstNode addNode(CAstNode node, CAstControlFlowMap flow) {
-    Set<CAstNode> nodes = extra_nodes.get(flow);
-    if (nodes == null) extra_nodes.put(flow, nodes = HashSetFactory.make());
-    nodes.add(node);
+    extra_nodes.computeIfAbsent(flow, key -> HashSetFactory.make()).add(node);
     return node;
   }
 
   public CAstNode addFlow(CAstNode node, Object label, CAstNode target, CAstControlFlowMap flow) {
-    Set<Edge> edges = extra_flow.get(flow);
-    if (edges == null) extra_flow.put(flow, edges = HashSetFactory.make());
-    edges.add(new Edge(node, label, target));
+    extra_flow
+        .computeIfAbsent(flow, key -> HashSetFactory.make())
+        .add(new Edge(node, label, target));
     return node;
   }
 


### PR DESCRIPTION
The previous style looked up each novel key twice; the new approach does so just once.