### PR TITLE
Add and use a variadic `HashSetFactory` builder

### DIFF
--- a/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJJava17IRTest.java
+++ b/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJJava17IRTest.java
@@ -97,15 +97,14 @@ public class ECJJava17IRTest extends ECJIRTests {
 
         @Override
         public void check(CallGraph cg) {
-          Set<IClass> expectedTypes = HashSetFactory.make();
-          expectedTypes.add(
-              cg.getClassHierarchy().lookupClass(TypeReference.JavaLangArithmeticException));
-          expectedTypes.add(
-              cg.getClassHierarchy()
-                  .lookupClass(
-                      TypeReference.findOrCreate(
-                          ClassLoaderReference.Primordial,
-                          "Ljava/lang/IndexOutOfBoundsException")));
+          final var expectedTypes =
+              HashSetFactory.of(
+                  cg.getClassHierarchy().lookupClass(TypeReference.JavaLangArithmeticException),
+                  cg.getClassHierarchy()
+                      .lookupClass(
+                          TypeReference.findOrCreate(
+                              ClassLoaderReference.Primordial,
+                              "Ljava/lang/IndexOutOfBoundsException")));
 
           cg.getNodes(testMethod)
               .forEach(

--- a/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/examples/hybrid/HybridAnalysisScope.java
+++ b/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/examples/hybrid/HybridAnalysisScope.java
@@ -10,14 +10,8 @@ import java.util.Set;
 
 public class HybridAnalysisScope extends AnalysisScope {
 
-  private static final Set<Language> languages;
-
-  static {
-    languages = HashSetFactory.make();
-
-    languages.add(Language.JAVA);
-    languages.add(JavaScriptLoader.JS);
-  }
+  private static final Set<Language> languages =
+      HashSetFactory.of(Language.JAVA, JavaScriptLoader.JS);
 
   public HybridAnalysisScope() {
     super(languages);

--- a/util/src/main/java/com/ibm/wala/util/collections/HashSetFactory.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/HashSetFactory.java
@@ -10,6 +10,7 @@
  */
 package com.ibm.wala.util.collections;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -57,5 +58,15 @@ public class HashSetFactory {
     } else {
       return new LinkedHashSet<>(s);
     }
+  }
+
+  /**
+   * @return A {@link ParanoidHashSet} if {@link #DEBUG} is {@code true}, a {@link HashSet}
+   *     otherwise
+   * @see java.util.Set#of(Object[])
+   */
+  @SafeVarargs
+  public static <T, U extends T> HashSet<T> of(U... elements) {
+    return make(Arrays.asList(elements));
   }
 }


### PR DESCRIPTION
`HashSetFactory.of` behaves like `Set.of`, but always selects the same kind of `HashSet` implementation that the existing `HashSet.make` overloads would use.  This helper function can be useful when building a small set of elements whose exact number is always fixed at compile time.