### PR TITLE
Avoid double lookups in `MapUtil.findOrCreate*()`

### DIFF
--- a/util/src/main/java/com/ibm/wala/util/collections/MapUtil.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/MapUtil.java
@@ -30,15 +30,7 @@ public class MapUtil {
    *     keys (optional)
    */
   public static <K, T> Set<T> findOrCreateSet(Map<K, Set<T>> M, K key) {
-    if (M == null) {
-      throw new IllegalArgumentException("M is null");
-    }
-    Set<T> result = M.get(key);
-    if (result == null) {
-      result = HashSetFactory.make(2);
-      M.put(key, result);
-    }
-    return result;
+    return findOrCreateValue(M, key, () -> HashSetFactory.make(2));
   }
 
   /**
@@ -47,15 +39,7 @@ public class MapUtil {
    *     keys (optional)
    */
   public static <K> MutableIntSet findOrCreateMutableIntSet(Map<K, MutableIntSet> M, K key) {
-    if (M == null) {
-      throw new IllegalArgumentException("M is null");
-    }
-    MutableIntSet mis = M.get(key);
-    if (mis == null) {
-      mis = MutableSparseIntSet.makeEmpty();
-      M.put(key, mis);
-    }
-    return mis;
+    return findOrCreateValue(M, key, MutableSparseIntSet::makeEmpty);
   }
 
   /**
@@ -65,15 +49,7 @@ public class MapUtil {
    *     keys (optional)
    */
   public static <K, T> Collection<T> findOrCreateCollection(Map<K, Collection<T>> M, K key) {
-    if (M == null) {
-      throw new IllegalArgumentException("M is null");
-    }
-    Collection<T> result = M.get(key);
-    if (result == null) {
-      result = HashSetFactory.make(2);
-      M.put(key, result);
-    }
-    return result;
+    return findOrCreateValue(M, key, () -> HashSetFactory.make(2));
   }
 
   /**
@@ -84,13 +60,7 @@ public class MapUtil {
    *     keys (optional)
    */
   public static <K, T> List<T> findOrCreateList(Map<K, List<T>> M, K key) {
-    if (M == null) {
-      throw new IllegalArgumentException("M is null");
-    }
-    if (!M.containsKey(key)) {
-      M.put(key, new ArrayList<>());
-    }
-    return M.get(key);
+    return findOrCreateValue(M, key, ArrayList::new);
   }
 
   /**
@@ -102,15 +72,7 @@ public class MapUtil {
    *     keys (optional)
    */
   public static <K, K2, V> Map<K2, V> findOrCreateMap(Map<K, Map<K2, V>> M, K key) {
-    if (M == null) {
-      throw new IllegalArgumentException("M is null");
-    }
-    Map<K2, V> result = M.get(key);
-    if (result == null) {
-      result = HashMapFactory.make(2);
-      M.put(key, result);
-    }
-    return result;
+    return findOrCreateValue(M, key, () -> HashMapFactory.make(2));
   }
 
   /**
@@ -122,12 +84,7 @@ public class MapUtil {
     if (M == null) {
       throw new IllegalArgumentException("M is null");
     }
-    V result = M.get(key);
-    if (result == null) {
-      result = factory.make();
-      M.put(key, result);
-    }
-    return result;
+    return M.computeIfAbsent(key, missing -> factory.make());
   }
 
   /**
@@ -140,10 +97,7 @@ public class MapUtil {
    */
   public static <K, V> WeakHashMap<K, V> findOrCreateWeakHashMap(
       Map<Object, WeakHashMap<K, V>> M, Object key) {
-    if (M == null) {
-      throw new IllegalArgumentException("M is null");
-    }
-    return M.computeIfAbsent(key, k -> new WeakHashMap<>(2));
+    return findOrCreateValue(M, key, () -> new WeakHashMap<>(2));
   }
 
   /**


### PR DESCRIPTION
Previously these methods required two `Map` lookups for any novel key. Now we use just one.  The implementations of these methods are also much simpler now:  everything funnels into `MapUtil.findOrCreateValue`, which in turn uses `Map.computeIfAbsent`.