### PR TITLE
Add `HashMapFactory` and ``HashSetFactory` collectors

### DIFF
--- a/util/src/main/java/com/ibm/wala/util/collections/HashMapFactory.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/HashMapFactory.java
@@ -13,6 +13,10 @@ package com.ibm.wala.util.collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A debugging aid. When HashSetFactory.DEBUG is set, this class creates ParanoidHashMaps.
@@ -54,5 +58,26 @@ public class HashMapFactory {
     } else {
       return new LinkedHashMap<>(t);
     }
+  }
+
+  /**
+   * Returns a {@code Collector} that accumulates the input elements into a new {@code HashMap} as
+   * provided by {@link #make()}.
+   *
+   * @param <T> the type of the input elements
+   * @param <K> the type of the result map's keys
+   * @param <V> the type of the result map's values
+   * @return a {@link Collector} that collects all the input elements into a {@link HashMap}
+   */
+  public static <T, K, V> @NotNull Collector<T, ?, HashMap<K, V>> toMap(
+      @NotNull Function<? super T, ? extends K> keyMapper,
+      @NotNull Function<? super T, ? extends V> valueMapper) {
+    return Collectors.toMap(
+        keyMapper,
+        valueMapper,
+        (left, right) -> {
+          throw new IllegalArgumentException("cannot build `Map` with duplicate keys");
+        },
+        HashMapFactory::make);
   }
 }

--- a/util/src/main/java/com/ibm/wala/util/collections/HashSetFactory.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/HashSetFactory.java
@@ -14,6 +14,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A debugging aid. When HashSetFactory.DEBUG is set, this class creates ParanoidHashSets.
@@ -68,5 +72,16 @@ public class HashSetFactory {
   @SafeVarargs
   public static <T, U extends T> HashSet<T> of(U... elements) {
     return make(Arrays.asList(elements));
+  }
+
+  /**
+   * Returns a {@code Collector} that accumulates the input elements into a new {@code HashSet} as
+   * provided by {@link #make()}.
+   *
+   * @param <T> the type of the input elements
+   * @return a {@link Collector} that collects all the input elements into a {@link HashSet}
+   */
+  public static <T> @NotNull Collector<T, ?, Set<T>> toSet() {
+    return Collectors.toCollection(HashSetFactory::make);
   }
 }


### PR DESCRIPTION
These `Collector`-building methods are similar to `Collectors.toMap` and `Collectors.toSet`.  However, they always create instances of the same mutable `HashMap` and `HashSet` implementations that the rest of `HashMapFactory` and `HashSetFactory` use.

Nothing currently uses these `Collector`s, because WALA in general does not use `Stream`s much.  But writing them was slightly subtle, especially the co- and contra-variant types.  So I think that they are worth keeping around for possible future use.