### PR TITLE
Remove unused `AnnotationAssertions` class

### DIFF
--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
@@ -46,7 +46,6 @@ import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.TypeName;
 import com.ibm.wala.types.TypeReference;
-import com.ibm.wala.types.annotations.Annotation;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.NullProgressMonitor;
 import com.ibm.wala.util.collections.HashSetFactory;
@@ -254,75 +253,6 @@ public abstract class IRTests {
       }
 
       return false;
-    }
-  }
-
-  protected static class AnnotationAssertions implements IRAssertion {
-
-    public static class ClassAnnotation {
-      private final String className;
-      private final String annotationTypeName;
-
-      public ClassAnnotation(String className, String annotationTypeName) {
-        this.className = className;
-        this.annotationTypeName = annotationTypeName;
-      }
-    }
-
-    public static class MethodAnnotation {
-      private final String methodSig;
-      private final String annotationTypeName;
-
-      public MethodAnnotation(String methodSig, String annotationTypeName) {
-        this.methodSig = methodSig;
-        this.annotationTypeName = annotationTypeName;
-      }
-    }
-
-    public final Set<ClassAnnotation> classAnnotations = HashSetFactory.make();
-    public final Set<MethodAnnotation> methodAnnotations = HashSetFactory.make();
-
-    @Override
-    public void check(CallGraph cg) {
-      classes:
-      for (ClassAnnotation ca : classAnnotations) {
-        IClass cls =
-            cg.getClassHierarchy()
-                .lookupClass(
-                    TypeReference.findOrCreate(ClassLoaderReference.Application, ca.className));
-        IClass at =
-            cg.getClassHierarchy()
-                .lookupClass(
-                    TypeReference.findOrCreate(
-                        ClassLoaderReference.Application, ca.annotationTypeName));
-        for (Annotation a : cls.getAnnotations()) {
-          if (a.getType().equals(at.getReference())) {
-            continue classes;
-          }
-        }
-
-        fail("cannot find %s in %s", at, cls);
-      }
-
-      annot:
-      for (MethodAnnotation ma : methodAnnotations) {
-        IClass at =
-            cg.getClassHierarchy()
-                .lookupClass(
-                    TypeReference.findOrCreate(
-                        ClassLoaderReference.Application, ma.annotationTypeName));
-        for (CGNode n : cg) {
-          if (n.getMethod().getSignature().equals(ma.methodSig)) {
-            for (Annotation a : n.getMethod().getAnnotations()) {
-              if (a.getType().equals(at.getReference())) {
-                continue annot;
-              }
-            }
-
-            fail("cannot find %s", at);
-          }
-        }
-      }
     }
   }
 


### PR DESCRIPTION
This class was added in commit afccdd2189f5239cf676e41aa947c503c3b4c6bc, back in February 2013.  However, nothing else in that commit actually _used_ this class, and nothing else has used it since.  Let's remove it unless we really think someone is going to use it eventually.