### PR TITLE
Revamp several `MapUtil` methods

### DIFF
--- a/util/src/main/java/com/ibm/wala/util/collections/MapUtil.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/MapUtil.java
@@ -110,14 +110,7 @@ public class MapUtil {
       throw new IllegalArgumentException("m is null");
     }
     Map<V, Set<K>> result = HashMapFactory.make(m.size());
-    for (Map.Entry<K, Set<V>> E : m.entrySet()) {
-      K key = E.getKey();
-      Set<V> values = E.getValue();
-      for (V v : values) {
-        Set<K> s = findOrCreateSet(result, v);
-        s.add(key);
-      }
-    }
+    m.forEach((key, values) -> values.forEach(value -> findOrCreateSet(result, value).add(key)));
     return result;
   }
 
@@ -133,14 +126,14 @@ public class MapUtil {
       throw new IllegalArgumentException("m is null");
     }
     Map<V, K> result = HashMapFactory.make(m.size());
-    for (Map.Entry<K, V> entry : m.entrySet()) {
-      K key = entry.getKey();
-      V val = entry.getValue();
-      if (result.containsKey(val)) {
-        throw new IllegalArgumentException("input map not one-to-one");
-      }
-      result.put(val, key);
-    }
+    m.forEach(
+        (key, value) ->
+            result.merge(
+                value,
+                key,
+                (oldValue, newValue) -> {
+                  throw new IllegalArgumentException("input map not one-to-one");
+                }));
     return result;
   }
 
@@ -148,18 +141,8 @@ public class MapUtil {
     if (m == null) {
       throw new IllegalArgumentException("m is null");
     }
-    Map<Set<K>, V> result = HashMapFactory.make();
     Map<V, Set<K>> valueToKeys = HashMapFactory.make();
-    for (Map.Entry<K, V> E : m.entrySet()) {
-      K key = E.getKey();
-      V value = E.getValue();
-      findOrCreateSet(valueToKeys, value).add(key);
-    }
-    for (Map.Entry<V, Set<K>> E : valueToKeys.entrySet()) {
-      V value = E.getKey();
-      Set<K> keys = E.getValue();
-      result.put(keys, value);
-    }
-    return result;
+    m.forEach((key, value) -> findOrCreateSet(valueToKeys, value).add(key));
+    return invertOneToOneMap(valueToKeys);
   }
 }


### PR DESCRIPTION
These rewrites focus on the `MapUtil` methods that are _not_ among the `findOrCreate*` group of methods. The general goals are to make better use of existing high-level `Map` operations, to avoid redundant `Map` lookups, and to reduce memory churn for temporary `Map.Entry` instances.