### PR TITLE
Leverage Guava's bidirectional map type

### DIFF
--- a/cast/build.gradle.kts
+++ b/cast/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
   api(projects.shrike)
   api(projects.util)
   implementation(libs.commons.io)
+  implementation(libs.guava)
   castJsJavadocDestinationDirectory(
       project(mapOf("path" to ":cast:js", "configuration" to "javadocDestinationDirectory"))
   )

--- a/cast/smoke_main/build.gradle.kts
+++ b/cast/smoke_main/build.gradle.kts
@@ -8,6 +8,8 @@ import org.gradle.api.attributes.LibraryElements.RESOURCES
 import org.gradle.api.attributes.Usage.JAVA_RUNTIME
 import org.gradle.api.attributes.Usage.NATIVE_RUNTIME
 import org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE
+import org.gradle.api.attributes.java.TargetJvmEnvironment.STANDARD_JVM
+import org.gradle.api.attributes.java.TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE
 import org.gradle.language.cpp.CppBinary.OPTIMIZED_ATTRIBUTE
 
 plugins {
@@ -27,6 +29,10 @@ val coreResources by
 val smokeMainExtraPathElements by
     configurations.registering {
       isCanBeConsumed = false
+      attributes.attribute(
+          TARGET_JVM_ENVIRONMENT_ATTRIBUTE,
+          objects.named(TargetJvmEnvironment::class, STANDARD_JVM),
+      )
       attributes.attribute(USAGE_ATTRIBUTE, objects.named(Usage::class, JAVA_RUNTIME))
     }
 

--- a/cast/src/main/java/com/ibm/wala/cast/tree/impl/CAstControlFlowRecorder.java
+++ b/cast/src/main/java/com/ibm/wala/cast/tree/impl/CAstControlFlowRecorder.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.cast.tree.impl;
 
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
 import com.ibm.wala.cast.tree.CAstControlFlowMap;
 import com.ibm.wala.cast.tree.CAstNode;
 import com.ibm.wala.cast.tree.CAstSourcePositionMap;
@@ -38,9 +40,9 @@ import java.util.Set;
 public class CAstControlFlowRecorder implements CAstControlFlowMap {
   private final CAstSourcePositionMap src;
 
-  private final Map<CAstNode, Object> CAstToNode = new LinkedHashMap<>();
+  private final BiMap<CAstNode, Object> CAstToNode = HashBiMap.create();
 
-  private final Map<Object, CAstNode> nodeToCAst = new LinkedHashMap<>();
+  private final BiMap<Object, CAstNode> nodeToCAst = CAstToNode.inverse();
 
   private final Map<Key, Object> table = new LinkedHashMap<>();
 
@@ -172,7 +174,6 @@ public class CAstControlFlowRecorder implements CAstControlFlowMap {
         : node + " already mapped:\n" + this;
     assert !CAstToNode.containsKey(ast) || CAstToNode.get(ast) == node
         : ast + " already mapped:\n" + this;
-    nodeToCAst.put(node, ast);
     cachedMappedNodes = null;
     CAstToNode.put(ast, node);
   }


### PR DESCRIPTION
The `CAstToNode` and `nodeToCAst` fields of a `CAstControlFlowRecorder` instance were already both one-to-one maps and inverses of each other. Guava's `BiMap` is perfectly suited to managing that kind of data. `BiMap` also makes explicit the relationship between these two maps, which was otherwise just implied by their names and types.

The change to `smokeMainExtraPathElements` in
`cast/smoke_main/build.gradle.kts` is needed now to clarify that we want JRE variants of dependencies.  Guava is available for JRE and for Android.  In theory, either variant should work in either environment, though each variant might work better in the environment for which it is optimized. Without this clarifying attribute, though, Gradle cannot pick between the two and therefore dependency resolution fails.  With this attribute, Gradle knows that we prefer the JRE variant, not the Android variant.