### PR TITLE
Avoid a known-insecure NPM dependency

### DIFF
--- a/cast/js/nodejs/src/test/resources/NodejsRequireJsonTest/package.json
+++ b/cast/js/nodejs/src/test/resources/NodejsRequireJsonTest/package.json
@@ -10,6 +10,6 @@
   "license": "ISC",
   "dependencies": {
     "poc-lettersonly-gm": "^1.0.1",
-    "validator": "^5.5.0"
+    "validator": "^13.15.23"
   }
 }


### PR DESCRIPTION
The dependency version we're using here shouldn't matter much, given that the JavaScript code under analysis doesn't actually use it.  But the version we were using before was old enough to have at least one known security vulnerability, which in turn has been triggering [alert messages from Dependabot](https://github.com/wala/WALA/security/dependabot/6).