### PR TITLE
Replace a wide disjunction with a `switch`

### DIFF
--- a/core/src/main/java/com/ibm/wala/core/util/strings/StringStuff.java
+++ b/core/src/main/java/com/ibm/wala/core/util/strings/StringStuff.java
@@ -303,9 +303,14 @@ public class StringStuff {
   }
 
   public static boolean isTypeCodeChar(ImmutableByteArray name, int i) {
-    return name.b[i] == TypeReference.ArrayTypeCode
-        || name.b[i] == TypeReference.PointerTypeCode
-        || name.b[i] == TypeReference.ReferenceTypeCode;
+    switch (name.b[i]) {
+      case ArrayTypeCode:
+      case PointerTypeCode:
+      case ReferenceTypeCode:
+        return true;
+      default:
+        return false;
+    }
   }
 
   /**


### PR DESCRIPTION
A `switch` expression would be even more elegant here, but those were not yet available in Java 11.