### PR TITLE
Remove a dead conditional branch

### DIFF
--- a/core/src/main/java/com/ibm/wala/core/util/ssa/SSAValueManager.java
+++ b/core/src/main/java/com/ibm/wala/core/util/ssa/SSAValueManager.java
@@ -256,10 +256,10 @@ public class SSAValueManager {
           if (param.status == ValueStatus.INVALIDATED) {
             info("Closing SSA Value {} in scope {}", param.value, param.setInScope);
             param.status = ValueStatus.CLOSED;
-          } else if (param.status == ValueStatus.FREE_INVALIDATED) { // TODO: FREE CLOSED
-            info("Closing free SSA Value {} in scope {}", param.value, param.setInScope);
-            param.status = ValueStatus.FREE_CLOSED;
           }
+          // TODO: FREE CLOSED
+          // info("Closing free SSA Value {} in scope {}", param.value, param.setInScope);
+          // param.status = ValueStatus.FREE_CLOSED;
         }
         //        else if (param.setInScope < currentScope) {
         //          // param.status = ValueStatus.INVALIDATED;


### PR DESCRIPTION
`param.status` can never be `ValueStatus.FREE_INVALIDATED` here.  That case would instead have been handled by the earlier three-alternative `if` at the very top of the body of the enclosing `for` statement.