### PR TITLE
Allow an `assert` with a side effect

### DIFF
--- a/cast/src/main/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
@@ -1457,6 +1457,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
               if (succs.hasNext()) {
                 PreBasicBlock target = succs.next();
                 assert liveBlocks.contains(target);
+                //noinspection AssertWithSideEffects
                 assert !succs.hasNext() || !liveBlocks.contains(succs.next())
                     : "unexpected successors for block " + block + ": " + this;
                 inst = insts.GotoInstruction(x, target.firstIndex);


### PR DESCRIPTION
IntelliJ IDEA warns that this `assert` has side effects.  In general, that's a likely bug because these effects would happen or not depending on the JVM's global `assert`-checking mode.  However, in this _specific_ case, the possible side effect is safe, because `succs` is never subsequently used after the `assert`.