### PR TITLE
Avoid redundant map lookups in `ide/jdt`

### DIFF
--- a/ide/jdt/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTSourceModuleTranslator.java
+++ b/ide/jdt/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTSourceModuleTranslator.java
@@ -65,6 +65,7 @@ import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.ASTRequestor;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.jspecify.annotations.NonNull;
 
 /**
  * A SourceModuleTranslator whose implementation of loadAllSources() uses the PolyglotFrontEnd
@@ -162,16 +163,16 @@ public class JDTSourceModuleTranslator implements SourceModuleTranslator {
     // TODO: group by project and send 'em in
 
     // sort files into projects
-    Map<IProject, Map<ICompilationUnit, EclipseSourceFileModule>> projectsFiles = new HashMap<>();
+    Map<IProject, @NonNull Map<ICompilationUnit, EclipseSourceFileModule>> projectsFiles =
+        new HashMap<>();
     for (ModuleEntry m : modules) {
       assert m instanceof EclipseSourceFileModule
           : "Expecting EclipseSourceFileModule, not " + m.getClass();
       EclipseSourceFileModule entry = (EclipseSourceFileModule) m;
       IProject proj = entry.getIFile().getProject();
-      if (!projectsFiles.containsKey(proj)) {
-        projectsFiles.put(proj, new HashMap<>());
-      }
-      projectsFiles.get(proj).put(JavaCore.createCompilationUnitFrom(entry.getIFile()), entry);
+      projectsFiles
+          .computeIfAbsent(proj, absent -> new HashMap<>())
+          .put(JavaCore.createCompilationUnitFrom(entry.getIFile()), entry);
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
Remove some redundant `Map` lookups, such as calling `containsKey` immediately before `get`.  That's redundant as long as we never map to `null`, which appears to be the case for the maps we're modifying here.

Also codify the existing `null`-avoidance policy for these maps by adding JSpecify annotations.  It's not clear how thoroughly current tools check this annotation when used on a `Map`'s value type.  But even if current tools don't check them, it's worth adding these annotations as documentation and (hopefully) as hints for future checkers.