### PR TITLE
Avoid redundant map lookups in `ide`

### DIFF
--- a/ide/build.gradle.kts
+++ b/ide/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
   api(libs.osgi.framework)
   api(projects.core)
   api(projects.util)
+  implementation(libs.jspecify)
 }
 
 dependencyAnalysis.issues {

--- a/ide/src/main/java/com/ibm/wala/ide/util/HeadlessUtil.java
+++ b/ide/src/main/java/com/ibm/wala/ide/util/HeadlessUtil.java
@@ -24,6 +24,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IPath;
+import org.jspecify.annotations.NonNull;
 
 public class HeadlessUtil {
 
@@ -85,15 +86,13 @@ public class HeadlessUtil {
 
   public static <Unit> void parseModules(Set<ModuleEntry> modules, EclipseCompiler<Unit> compiler) {
     // sort files into projects
-    Map<IProject, Map<Unit, EclipseSourceFileModule>> projectsFiles = new HashMap<>();
+    Map<IProject, @NonNull Map<Unit, EclipseSourceFileModule>> projectsFiles = new HashMap<>();
     for (ModuleEntry m : modules) {
       if (m instanceof EclipseSourceFileModule) {
         EclipseSourceFileModule entry = (EclipseSourceFileModule) m;
-        IProject proj = entry.getIFile().getProject();
-        if (!projectsFiles.containsKey(proj)) {
-          projectsFiles.put(proj, new HashMap<>());
-        }
-        projectsFiles.get(proj).put(compiler.getCompilationUnit(entry.getIFile()), entry);
+        projectsFiles
+            .computeIfAbsent(entry.getIFile().getProject(), absent -> new HashMap<>())
+            .put(compiler.getCompilationUnit(entry.getIFile()), entry);
       }
     }
 


### PR DESCRIPTION
Remove some redundant `Map` lookups, such as calling `containsKey` immediately before `get`.  That's redundant as long as we never map to `null`, which appears to be the case for the maps we're modifying here.

Also codify the existing `null`-avoidance policy for these maps by adding JSpecify annotations.  It's not clear how thoroughly current tools check this annotation when used on a `Map`'s value type.  But even if current tools don't check them, it's worth adding these annotations as documentation and (hopefully) as hints for future checkers.