### PR TITLE
Avoid redundant map lookups in `dalvik`

### DIFF
--- a/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexIClass.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexIClass.java
@@ -73,6 +73,7 @@ import org.jf.dexlib2.iface.ClassDef;
 import org.jf.dexlib2.iface.Field;
 import org.jf.dexlib2.iface.Method;
 import org.jf.dexlib2.iface.MethodParameter;
+import org.jspecify.annotations.NonNull;
 
 public class DexIClass extends BytecodeClass<IClassLoader> {
 
@@ -295,14 +296,13 @@ public class DexIClass extends BytecodeClass<IClassLoader> {
   }
 
   Map<Integer, List<Annotation>> getParameterAnnotations(Method m) {
-    Map<Integer, List<Annotation>> result = HashMapFactory.make();
+    Map<Integer, @NonNull List<Annotation>> result = HashMapFactory.make();
     int i = 0;
     for (MethodParameter as : m.getParameters()) {
       for (org.jf.dexlib2.iface.Annotation a : as.getAnnotations()) {
-        if (!result.containsKey(i)) {
-          result.put(i, new ArrayList<>());
-        }
-        result.get(i).add(DexUtil.getAnnotation(a, getClassLoader().getReference()));
+        result
+            .computeIfAbsent(i, absent -> new ArrayList<>())
+            .add(DexUtil.getAnnotation(a, getClassLoader().getReference()));
       }
       i++;
     }

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/InstructionArray.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/InstructionArray.java
@@ -47,6 +47,8 @@
 
 package com.ibm.wala.dalvik.classLoader;
 
+import static java.util.Objects.requireNonNullElseGet;
+
 import com.ibm.wala.dalvik.dex.instructions.Instruction;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -54,6 +56,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Collection of {@code Instruction} which allows getting an instruction from its table index id or
@@ -61,7 +64,7 @@ import java.util.Map;
  */
 public class InstructionArray implements Collection<Instruction> {
   List<Instruction> instructions;
-  Map<Integer, Integer> pc2index;
+  Map<Integer, @NonNull Integer> pc2index;
   List<Integer> index2pc;
 
   public InstructionArray() {
@@ -167,10 +170,7 @@ public class InstructionArray implements Collection<Instruction> {
    * @return The index of the instruction of given byte code index
    */
   public int getIndexFromPc(int pc) {
-    if (!pc2index.containsKey(pc) && pc2index.containsKey(pc + 1)) {
-      pc++;
-    }
-    return pc2index.get(pc);
+    return requireNonNullElseGet(pc2index.get(pc), () -> pc2index.get(pc + 1));
   }
 
   /**

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModel.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/AndroidModel.java
@@ -99,6 +99,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.jspecify.annotations.NonNull;
 
 // For debug:
 /**
@@ -584,7 +585,7 @@ public class AndroidModel /* makes SummarizedMethod */ implements IClassHierarch
    * @param callerNd CGNoodle of the caller - may be null
    * @return A wrapper that calls the model
    */
-  public SummarizedMethod getMethodAs(
+  public @NonNull SummarizedMethod getMethodAs(
       MethodReference asMethod,
       TypeReference caller,
       IntentStarters.StartInfo info,

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/AndroidModelParameterManager.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/AndroidModelParameterManager.java
@@ -40,6 +40,8 @@
 */
 package com.ibm.wala.dalvik.ipa.callgraph.androidModel.parameters;
 
+import static java.util.Objects.requireNonNullElseGet;
+
 import com.ibm.wala.core.util.ssa.ParameterAccessor;
 import com.ibm.wala.core.util.ssa.SSAValue;
 import com.ibm.wala.ssa.SSAInstruction;
@@ -49,6 +51,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Manages SSA-Numbers for the arguments to Entrypoints.
@@ -117,7 +121,7 @@ public class AndroidModelParameterManager {
   }
 
   /** The main data-structure of the management */
-  private final Map<TypeReference, List<ManagedParameter>> seenTypes = new HashMap<>();
+  private final Map<TypeReference, @NonNull List<ManagedParameter>> seenTypes = new HashMap<>();
 
   /**
    * Setting the behaviour may be handy in the later model.
@@ -183,41 +187,43 @@ public class AndroidModelParameterManager {
       throw new IllegalArgumentException("The SSA-Variable may not be zero or negative.");
     }
 
-    if (seenTypes.containsKey(type)) {
-      for (ManagedParameter param : seenTypes.get(type)) {
-        if (param.status == ValueStatus.UNALLOCATED) {
-          // XXX: Allow more?
-          assert param.type.equals(type) : "Inequal types";
+    seenTypes.compute(
+        type,
+        (key, priorValue) -> {
+          if (priorValue != null) {
+            for (ManagedParameter param : priorValue) {
+              if (param.status == ValueStatus.UNALLOCATED) {
+                // XXX: Allow more?
+                assert param.type.equals(type) : "Inequal types";
 
+                if ((ssaValue + 1) > nextLocal) {
+                  nextLocal = ssaValue + 1;
+                }
+
+                param.status = ValueStatus.ALLOCATED;
+                param.ssa = ssaValue;
+                param.setInScope = currentScope;
+                //                    param.setBy = setBy;
+
+                return priorValue;
+              }
+            }
+            throw new IllegalStateException(
+                "The parameter " + key.getName() + " has already been allocated!");
+          }
+          ManagedParameter param = new ManagedParameter();
+          param.status = ValueStatus.ALLOCATED;
+          param.type = key;
+          param.ssa = ssaValue;
           if ((ssaValue + 1) > nextLocal) {
             nextLocal = ssaValue + 1;
           }
-
-          param.status = ValueStatus.ALLOCATED;
-          param.ssa = ssaValue;
           param.setInScope = currentScope;
-          //                    param.setBy = setBy;
 
-          return;
-        }
-      }
-      throw new IllegalStateException(
-          "The parameter " + type.getName() + " has already been allocated!");
-    } else {
-      ManagedParameter param = new ManagedParameter();
-      param.status = ValueStatus.ALLOCATED;
-      param.type = type;
-      param.ssa = ssaValue;
-      if ((ssaValue + 1) > nextLocal) {
-        nextLocal = ssaValue + 1;
-      }
-      param.setInScope = currentScope;
-
-      List<ManagedParameter> aParam = new ArrayList<>();
-      aParam.add(param);
-
-      seenTypes.put(type, aParam);
-    }
+          List<ManagedParameter> aParam = new ArrayList<>();
+          aParam.add(param);
+          return aParam;
+        });
   }
 
   public void setAllocation(TypeReference type, int ssaValue) {
@@ -246,70 +252,75 @@ public class AndroidModelParameterManager {
       throw new IllegalArgumentException("The SSA-Variable may not be zero or negative.");
     }
 
-    boolean didPhi = false;
+    AtomicBoolean didPhi = new AtomicBoolean();
 
-    if (seenTypes.containsKey(type)) {
-      for (ManagedParameter param : seenTypes.get(type)) {
-        if ((param.status == ValueStatus.FREE)
-            || (param.status == ValueStatus.FREE_INVALIDATED)
-            || (param.status == ValueStatus.FREE_CLOSED)) {
-          // XXX: Allow more?
-          assert param.type.equals(type) : "Inequal types";
-          if (param.ssa != ssaValue) {
-            if ((param.status == ValueStatus.FREE) && (param.setInScope == currentScope)) {
-              param.status = ValueStatus.FREE_CLOSED;
+    seenTypes.compute(
+        type,
+        (key, priorValue) -> {
+          if (priorValue != null) {
+            for (ManagedParameter param : priorValue) {
+              if ((param.status == ValueStatus.FREE)
+                  || (param.status == ValueStatus.FREE_INVALIDATED)
+                  || (param.status == ValueStatus.FREE_CLOSED)) {
+                // XXX: Allow more?
+                assert param.type.equals(key) : "Inequal types";
+                if (param.ssa != ssaValue) {
+                  if ((param.status == ValueStatus.FREE) && (param.setInScope == currentScope)) {
+                    param.status = ValueStatus.FREE_CLOSED;
+                  }
+                  continue;
+                }
+
+                switch (param.status) {
+                  case FREE:
+                    param.status = ValueStatus.ALLOCATED;
+                    break;
+                  case FREE_INVALIDATED:
+                    param.status = ValueStatus.INVALIDATED;
+                    break;
+                  case FREE_CLOSED:
+                    param.status = ValueStatus.CLOSED;
+                    break;
+                }
+                param.setInScope = currentScope;
+                //                    param.setBy = setBy;
+
+                didPhi.set(true);
+              } else if (param.setInScope == currentScope) {
+                if (param.status == ValueStatus.INVALIDATED) {
+
+                  param.status = ValueStatus.CLOSED;
+                } else if (param.status == ValueStatus.FREE_INVALIDATED) { // TODO: FREE CLOSED
+
+                  param.status = ValueStatus.FREE_CLOSED;
+                }
+              }
+              //        else if (param.setInScope < currentScope) {
+              //            // param.status = ValueStatus.INVALIDATED;
+              //        } else {
+              //          // TODO: NO! I JUST WANTED TO ADD THEM! *grrr*
+              //          // logger.error("MISSING PHI for "
+              //          // throw new IllegalStateException(
+              //          //   "You forgot Phis in subordinate blocks");
+              //        }
             }
-            continue;
+            assert didPhi.get();
+            return priorValue;
+          } else {
+            ManagedParameter param = new ManagedParameter();
+            param.status = ValueStatus.ALLOCATED;
+            param.type = key;
+            param.setInScope = currentScope;
+            param.ssa = ssaValue;
+            if ((ssaValue + 1) > nextLocal) {
+              nextLocal = ssaValue + 1;
+            }
+
+            List<ManagedParameter> aParam = new ArrayList<>();
+            aParam.add(param);
+            return aParam;
           }
-
-          switch (param.status) {
-            case FREE:
-              param.status = ValueStatus.ALLOCATED;
-              break;
-            case FREE_INVALIDATED:
-              param.status = ValueStatus.INVALIDATED;
-              break;
-            case FREE_CLOSED:
-              param.status = ValueStatus.CLOSED;
-              break;
-          }
-          param.setInScope = currentScope;
-          //                    param.setBy = setBy;
-
-          didPhi = true;
-        } else if (param.setInScope == currentScope) {
-          if (param.status == ValueStatus.INVALIDATED) {
-
-            param.status = ValueStatus.CLOSED;
-          } else if (param.status == ValueStatus.FREE_INVALIDATED) { // TODO: FREE CLOSED
-
-            param.status = ValueStatus.FREE_CLOSED;
-          }
-        }
-        //        else if (param.setInScope < currentScope) {
-        //            // param.status = ValueStatus.INVALIDATED;
-        //        } else {
-        //          // TODO: NO! I JUST WANTED TO ADD THEM! *grrr*
-        //          // logger.error("MISSING PHI for "
-        //          // throw new IllegalStateException("You forgot Phis in subordinate blocks");
-        //        }
-      }
-      assert didPhi;
-    } else {
-      ManagedParameter param = new ManagedParameter();
-      param.status = ValueStatus.ALLOCATED;
-      param.type = type;
-      param.setInScope = currentScope;
-      param.ssa = ssaValue;
-      if ((ssaValue + 1) > nextLocal) {
-        nextLocal = ssaValue + 1;
-      }
-
-      List<ManagedParameter> aParam = new ArrayList<>();
-      aParam.add(param);
-
-      seenTypes.put(type, aParam);
-    }
+        });
   }
 
   /**
@@ -334,14 +345,7 @@ public class AndroidModelParameterManager {
     param.ssa = nextLocal++;
     param.setInScope = currentScope;
 
-    if (seenTypes.containsKey(type)) {
-      seenTypes.get(type).add(param);
-    } else {
-      List<ManagedParameter> aParam = new ArrayList<>();
-      aParam.add(param);
-
-      seenTypes.put(type, aParam);
-    }
+    seenTypes.computeIfAbsent(type, absent -> new ArrayList<>()).add(param);
 
     return param.ssa;
   }
@@ -360,12 +364,11 @@ public class AndroidModelParameterManager {
       throw new IllegalArgumentException("The argument type may not be null");
     }
 
-    if (seenTypes.containsKey(type)) {
-      for (ManagedParameter p : seenTypes.get(type)) {
-        if (p.status == ValueStatus.UNALLOCATED) {
-          throw new IllegalStateException(
-              "There may be only one unallocated instance to a type (" + type + ") at a time");
-        }
+    for (ManagedParameter p :
+        requireNonNullElseGet(seenTypes.get(type), List::<ManagedParameter>of)) {
+      if (p.status == ValueStatus.UNALLOCATED) {
+        throw new IllegalStateException(
+            "There may be only one unallocated instance to a type (" + type + ") at a time");
       }
     }
 
@@ -375,14 +378,7 @@ public class AndroidModelParameterManager {
     param.ssa = nextLocal++;
     param.setInScope = currentScope;
 
-    if (seenTypes.containsKey(type)) {
-      seenTypes.get(type).add(param);
-    } else {
-      List<ManagedParameter> aParam = new ArrayList<>();
-      aParam.add(param);
-
-      seenTypes.put(type, aParam);
-    }
+    seenTypes.computeIfAbsent(type, absent -> new ArrayList<>()).add(param);
 
     return param.ssa;
   }
@@ -415,8 +411,9 @@ public class AndroidModelParameterManager {
     int candidateSSA = -1;
     int candidateScope = -1;
 
-    if (seenTypes.containsKey(type)) {
-      for (ManagedParameter param : seenTypes.get(type)) {
+    List<ManagedParameter> managedParameters = seenTypes.get(type);
+    if (managedParameters != null) {
+      for (ManagedParameter param : managedParameters) {
         if ((param.status == ValueStatus.FREE) || (param.status == ValueStatus.ALLOCATED)) {
           assert param.type.equals(type) : "Inequal types";
           if (param.setInScope > currentScope) {
@@ -479,8 +476,9 @@ public class AndroidModelParameterManager {
 
     List<Integer> ret = new ArrayList<>();
 
-    if (seenTypes.containsKey(type)) {
-      for (ManagedParameter param : seenTypes.get(type)) {
+    List<ManagedParameter> managedParameters = seenTypes.get(type);
+    if (managedParameters != null) {
+      for (ManagedParameter param : managedParameters) {
         if ((param.status == ValueStatus.FREE) || (param.status == ValueStatus.ALLOCATED)) {
           assert param.type.equals(type) : "Inequal types";
 
@@ -510,16 +508,8 @@ public class AndroidModelParameterManager {
       throw new IllegalArgumentException("The argument type may not be null");
     }
 
-    if (withSuper) {
-      return seenTypes.containsKey(type);
-    } else {
-      if (seenTypes.containsKey(type)) {
-        if (seenTypes.get(type).get(0).type.equals(type)) {
-          return true;
-        }
-      }
-      return false;
-    }
+    List<ManagedParameter> managedParameters = seenTypes.get(type);
+    return managedParameters != null && (withSuper || managedParameters.get(0).type.equals(type));
   }
 
   public boolean isSeen(TypeReference type) {
@@ -538,15 +528,10 @@ public class AndroidModelParameterManager {
       throw new IllegalArgumentException("The argument type may not be null");
     }
 
-    if (seenTypes.containsKey(type)) {
-      if (seenTypes.get(type).size() > 1) { // TODO INCORRECT may all be UNALLOCATED
-        return false;
-      } else {
-        return (seenTypes.get(type).get(0).status == ValueStatus.UNALLOCATED);
-      }
-    } else {
-      return true;
-    }
+    List<ManagedParameter> managedParameters = seenTypes.get(type);
+    return managedParameters == null
+        || managedParameters.size() <= 1 /* TODO INCORRECT may all be UNALLOCATED */
+            && managedParameters.get(0).status == ValueStatus.UNALLOCATED;
   }
 
   /**
@@ -564,9 +549,10 @@ public class AndroidModelParameterManager {
 
     boolean seenLive = false;
 
-    if (seenTypes.containsKey(type)) {
+    List<ManagedParameter> managedParameters = seenTypes.get(type);
+    if (managedParameters != null) {
 
-      for (ManagedParameter param : seenTypes.get(type)) { // TODO: Check all these
+      for (ManagedParameter param : managedParameters) { // TODO: Check all these
         if ((param.status == ValueStatus.FREE)) { // TODO: What about scopes
           return true;
         }
@@ -594,20 +580,19 @@ public class AndroidModelParameterManager {
       throw new IllegalArgumentException("The argument type may not be null");
     }
 
-    if (seenTypes.containsKey(type)) {
-      for (ManagedParameter param : seenTypes.get(type)) {
-        if ((param.status != ValueStatus.CLOSED)
-            && (param.status != ValueStatus.FREE_CLOSED)
-            && (param.status != ValueStatus.FREE_INVALIDATED)
-            && (param.status != ValueStatus.INVALIDATED)
-            && (param.setInScope == currentScope)) {
-          assert param.type.equals(type);
+    for (ManagedParameter param :
+        requireNonNullElseGet(seenTypes.get(type), List::<ManagedParameter>of)) {
+      if ((param.status != ValueStatus.CLOSED)
+          && (param.status != ValueStatus.FREE_CLOSED)
+          && (param.status != ValueStatus.FREE_INVALIDATED)
+          && (param.status != ValueStatus.INVALIDATED)
+          && (param.setInScope == currentScope)) {
+        assert param.type.equals(type);
 
-          if (param.status == ValueStatus.FREE) {
-            param.status = ValueStatus.FREE_INVALIDATED;
-          } else {
-            param.status = ValueStatus.INVALIDATED;
-          }
+        if (param.status == ValueStatus.FREE) {
+          param.status = ValueStatus.FREE_INVALIDATED;
+        } else {
+          param.status = ValueStatus.INVALIDATED;
         }
       }
     }

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/DefaultInstantiationBehavior.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/DefaultInstantiationBehavior.java
@@ -52,6 +52,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Contains some predefined behaviors.
@@ -124,7 +125,7 @@ public class DefaultInstantiationBehavior extends IInstantiationBehavior {
     }
   }
 
-  private final Map<BehaviorKey<?>, BehviourValue> behaviours = new HashMap<>();
+  private final Map<BehaviorKey<?>, @NonNull BehviourValue> behaviours = new HashMap<>();
   private final transient IClassHierarchy cha;
 
   public DefaultInstantiationBehavior(final IClassHierarchy cha) {
@@ -208,8 +209,8 @@ public class DefaultInstantiationBehavior extends IInstantiationBehavior {
     }
 
     final BehaviorKey<TypeName> typeK = BehaviorKey.mk(type);
-    if (behaviours.containsKey(typeK)) {
-      BehviourValue typeV = behaviours.get(typeK);
+    BehviourValue typeV = behaviours.get(typeK);
+    if (typeV != null) {
       while (typeV.cacheFrom != null) {
         typeV = typeV.cacheFrom;
       }
@@ -221,9 +222,9 @@ public class DefaultInstantiationBehavior extends IInstantiationBehavior {
       final Atom pack = type.getPackage();
       if (pack != null) {
         final BehaviorKey<Atom> packK = BehaviorKey.mk(pack);
-        if (behaviours.containsKey(packK)) {
+        final BehviourValue packV = behaviours.get(packK);
+        if (packV != null) {
           // Add (cache) the result
-          final BehviourValue packV = behaviours.get(packK);
           final InstanceBehavior beh = packV.behaviour;
           behaviours.put(typeK, new BehviourValue(beh, Exactness.PACKAGE, packV));
           return beh;
@@ -244,9 +245,9 @@ public class DefaultInstantiationBehavior extends IInstantiationBehavior {
         }
         while (testClass != null) {
           final BehaviorKey<TypeName> testKey = BehaviorKey.mk(testClass.getName());
-          if (behaviours.containsKey(testKey)) {
+          final BehviourValue value = behaviours.get(testKey);
+          if (value != null) {
             // Add (cahce) the result
-            final BehviourValue value = behaviours.get(testKey);
             final InstanceBehavior beh = value.behaviour;
             behaviours.put(typeK, new BehviourValue(beh, Exactness.INHERITED, value));
             return beh;
@@ -264,9 +265,9 @@ public class DefaultInstantiationBehavior extends IInstantiationBehavior {
       while (prefix.contains("/")) {
         prefix = prefix.substring(0, prefix.lastIndexOf('/') - 1);
         final BehaviorKey<Atom> prefixKey = BehaviorKey.mk(Atom.findOrCreateAsciiAtom(prefix));
-        if (behaviours.containsKey(prefixKey)) {
+        final BehviourValue value = behaviours.get(prefixKey);
+        if (value != null) {
           // cache
-          final BehviourValue value = behaviours.get(prefixKey);
           final InstanceBehavior beh = value.behaviour;
           behaviours.put(typeK, new BehviourValue(beh, Exactness.PREFIX, value));
           return beh;

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/LoadedInstantiationBehavior.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/LoadedInstantiationBehavior.java
@@ -51,6 +51,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Behavior loaded from a file.
@@ -128,7 +129,7 @@ public class LoadedInstantiationBehavior extends IInstantiationBehavior {
   }
 
   private InstanceBehavior defaultBehavior = null;
-  private final Map<BehaviorKey<?>, BehviourValue> behaviours = new HashMap<>();
+  private final Map<BehaviorKey<?>, @NonNull BehviourValue> behaviours = new HashMap<>();
   private final IClassHierarchy cha;
 
   public LoadedInstantiationBehavior(IClassHierarchy cha) {
@@ -155,8 +156,8 @@ public class LoadedInstantiationBehavior extends IInstantiationBehavior {
     }
 
     final BehaviorKey<TypeName> typeK = BehaviorKey.mk(type);
-    if (behaviours.containsKey(typeK)) {
-      BehviourValue typeV = behaviours.get(typeK);
+    BehviourValue typeV = behaviours.get(typeK);
+    if (typeV != null) {
       while (typeV.cacheFrom != null) {
         typeV = typeV.cacheFrom;
       }
@@ -170,9 +171,9 @@ public class LoadedInstantiationBehavior extends IInstantiationBehavior {
       final Atom pack = type.getPackage();
       if (pack != null) {
         final BehaviorKey<Atom> packK = BehaviorKey.mk(pack);
-        if (behaviours.containsKey(packK)) {
+        final BehviourValue packV = behaviours.get(packK);
+        if (packV != null) {
           // Add (cache) the result
-          final BehviourValue packV = behaviours.get(packK);
           final InstanceBehavior beh = packV.behaviour;
           behaviours.put(typeK, new BehviourValue(beh, Exactness.PACKAGE, packV));
           return beh;
@@ -193,9 +194,9 @@ public class LoadedInstantiationBehavior extends IInstantiationBehavior {
         }
         while (testClass != null) {
           final BehaviorKey<TypeName> testKey = BehaviorKey.mk(testClass.getName());
-          if (behaviours.containsKey(testKey)) {
+          final BehviourValue value = behaviours.get(testKey);
+          if (value != null) {
             // Add (cache) the result
-            final BehviourValue value = behaviours.get(testKey);
             final InstanceBehavior beh = value.behaviour;
             behaviours.put(typeK, new BehviourValue(beh, Exactness.INHERITED, value));
             return beh;
@@ -213,9 +214,9 @@ public class LoadedInstantiationBehavior extends IInstantiationBehavior {
       while (prefix.contains("/")) {
         prefix = prefix.substring(0, prefix.lastIndexOf('/') - 1);
         final BehaviorKey<Atom> prefixKey = BehaviorKey.mk(Atom.findOrCreateAsciiAtom(prefix));
-        if (behaviours.containsKey(prefixKey)) {
+        final BehviourValue value = behaviours.get(prefixKey);
+        if (value != null) {
           // cache
-          final BehviourValue value = behaviours.get(prefixKey);
           final InstanceBehavior beh = value.behaviour;
           behaviours.put(typeK, new BehviourValue(beh, Exactness.PREFIX, value));
           return beh;

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/Overrides.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/Overrides.java
@@ -63,6 +63,7 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Context Free overrides for the startComponent-Methods.
@@ -100,7 +101,8 @@ public class Overrides {
      * @param child Ask child if unable to resolve. May be null
      */
     public StartComponentMethodTargetSelector(
-        HashMap<MethodReference, SummarizedMethod> syntheticMethods, MethodTargetSelector child) {
+        HashMap<MethodReference, @NonNull SummarizedMethod> syntheticMethods,
+        MethodTargetSelector child) {
       // for (MethodReference mRef : syntheticMethods.keySet()) {
       //
       // }
@@ -153,7 +155,8 @@ public class Overrides {
       }
 
       final MethodReference mRef = site.getDeclaredTarget();
-      if (syntheticMethods.containsKey(mRef)) {
+      SummarizedMethod summarizedMethod = syntheticMethods.get(mRef);
+      if (summarizedMethod != null) {
         if (caller != null) { // XXX: Debug remove
           // Context ctx = caller.getContext();
 
@@ -165,7 +168,7 @@ public class Overrides {
           // throw new IllegalArgumentException("site is null");
         }
 
-        return syntheticMethods.get(mRef);
+        return summarizedMethod;
       }
 
       if (this.child != null) {
@@ -189,7 +192,7 @@ public class Overrides {
    *     computation?
    */
   public MethodTargetSelector overrideAll() throws CancelException {
-    final HashMap<MethodReference, SummarizedMethod> overrides = HashMapFactory.make();
+    final HashMap<MethodReference, @NonNull SummarizedMethod> overrides = HashMapFactory.make();
     final Map<AndroidComponent, AndroidModel> callTo = new EnumMap<>(AndroidComponent.class);
     final IProgressMonitor monitor = AndroidEntryPointManager.MANAGER.getProgressMonitor();
     int monitorCounter = 0;
@@ -231,7 +234,7 @@ public class Overrides {
         for (final AndroidComponent target : possibleTargets) {
           final AndroidModel targetModel = callTo.get(target);
 
-          final SummarizedMethod override =
+          final @NonNull SummarizedMethod override =
               targetModel.getMethodAs(
                   overrideMe,
                   this.caller.getMethod().getReference().getDeclaringClass(),

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidEntryPointManager.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidEntryPointManager.java
@@ -69,6 +69,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import org.intellij.lang.annotations.Language;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -419,7 +420,7 @@ public final /* singleton */ class AndroidEntryPointManager implements Serializa
    * @see com.ibm.wala.dalvik.ipa.callgraph.propagation.cfa.Intent
    * @see com.ibm.wala.dalvik.ipa.callgraph.propagation.cfa.IntentContextInterpreter
    */
-  public final Map<Intent, Intent> overrideIntents = HashMapFactory.make();
+  public final Map<Intent, @NonNull Intent> overrideIntents = HashMapFactory.make();
 
   /**
    * Set more information to an Intent.
@@ -434,8 +435,8 @@ public final /* singleton */ class AndroidEntryPointManager implements Serializa
    * @see #registerIntentForce
    */
   public void registerIntent(Intent intent) {
-    if (overrideIntents.containsKey(intent)) {
-      final Intent original = overrideIntents.get(intent);
+    Intent original = overrideIntents.get(intent);
+    if (original != null) {
       final Intent.IntentType oriType = original.getType();
       final Intent.IntentType newType = intent.getType();
 
@@ -517,8 +518,8 @@ public final /* singleton */ class AndroidEntryPointManager implements Serializa
               + "alter Information on an Intent use registerIntent (you may register it multiple times).");
     }
 
-    if (overrideIntents.containsKey(from)) {
-      final Intent ori = overrideIntents.get(from);
+    Intent ori = overrideIntents.get(from);
+    if (ori != null) {
       final Intent source;
       if (ori == from) {
         // The Intent has been registered before. Set the registered variant as source so
@@ -627,8 +628,8 @@ public final /* singleton */ class AndroidEntryPointManager implements Serializa
    *     <p>TODO: TODO: Malicious Intent-Table could cause endless loops
    */
   public Intent getIntent(Intent intent) {
-    if (overrideIntents.containsKey(intent)) {
-      Intent ret = overrideIntents.get(intent);
+    Intent ret = overrideIntents.get(intent);
+    if (ret != null) {
       while (!ret.equals(intent)) {
         // Follow the chain of overrides
         if (!overrideIntents.containsKey(intent)) {

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
@@ -56,6 +56,7 @@ import java.util.Set;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
 import org.intellij.lang.annotations.Language;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.Attributes;
@@ -401,7 +402,7 @@ public class AndroidManifestXMLReader {
    *
    * <p>The Item that consumes an Attribute has to pop it.
    */
-  private static final Map<HistoryKey, ArrayDeque<Object>> attributesHistory =
+  private static final Map<HistoryKey, @NonNull ArrayDeque<Object>> attributesHistory =
       new HashMap<>(); // No EnumMap possible :(
 
   static {
@@ -479,11 +480,10 @@ public class AndroidManifestXMLReader {
           throw e;
         }
       }
-      if (attributesHistory.containsKey(self)
-          && attributesHistory.get(self) != null
-          && !attributesHistory.get(self).isEmpty()) {
+      ArrayDeque<Object> objects = attributesHistory.get(self);
+      if (objects != null && !objects.isEmpty()) {
         try {
-          attributesHistory.get(self).pop();
+          objects.pop();
         } catch (java.util.EmptyStackException e) {
           System.err.println("The Stack for " + self + " was Empty when trying to pop");
           throw e;


### PR DESCRIPTION
Remove some redundant `Map` lookups, such as calling `containsKey` immediately before `get`.  That's redundant as long as we never map to `null`, which appears to be the case for the maps we're modifying here.

Also codify the existing `null`-avoidance policy for these maps by adding JSpecify annotations.  It's not clear how thoroughly current tools check this annotation when used on a `Map`'s value type.  But even if current tools don't check them, it's worth adding these annotations as documentation and (hopefully) as hints for future checkers.