### PR TITLE
Avoid redundant map lookups in `scandroid`

### DIFF
--- a/scandroid/src/main/java/org/scandroid/domain/IFDSTaintDomain.java
+++ b/scandroid/src/main/java/org/scandroid/domain/IFDSTaintDomain.java
@@ -81,13 +81,14 @@ public class IFDSTaintDomain<E extends ISSABasicBlock>
 
   @Override
   public int add(DomainElement o) {
-    Integer i = table.get(o);
-    if (i == null) {
-      objects.add(o);
-      i = table.size() + 1;
-      table.put(o, i);
-      // System.out.println("Adding domain element "+i+": "+o);
-    }
+    int i =
+        table.computeIfAbsent(
+            o,
+            absent -> {
+              objects.add(o);
+              // System.out.println("Adding domain element " + (table.size() + 1) + ": " + o);
+              return table.size() + 1;
+            });
     index(o);
 
     return i;

--- a/scandroid/src/main/java/org/scandroid/flow/functions/IFDSTaintFlowFunctionProvider.java
+++ b/scandroid/src/main/java/org/scandroid/flow/functions/IFDSTaintFlowFunctionProvider.java
@@ -87,6 +87,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.jspecify.annotations.NonNull;
 import org.scandroid.domain.CodeElement;
 import org.scandroid.domain.DomainElement;
 import org.scandroid.domain.FieldElement;
@@ -419,7 +420,7 @@ public class IFDSTaintFlowFunctionProvider<E extends ISSABasicBlock>
     // dest.getMethod().getReference());
     //		}
 
-    final Map<CodeElement, CodeElement> parameterMap = HashMapFactory.make();
+    final Map<CodeElement, @NonNull CodeElement> parameterMap = HashMapFactory.make();
     for (int i = 0; i < instruction.getNumberOfPositionalParameters(); i++) {
       Set<CodeElement> elements = CodeElement.valueElements(instruction.getUse(i));
       for (CodeElement e : elements) {
@@ -433,10 +434,12 @@ public class IFDSTaintFlowFunctionProvider<E extends ISSABasicBlock>
         set.add(d1);
       }
       DomainElement de = domain.getMappedObject(d1);
-      if (de != null && parameterMap.containsKey(de.codeElement))
-        set.add(
-            domain.getMappedIndex(
-                new DomainElement(parameterMap.get(de.codeElement), de.taintSource)));
+      if (de != null) {
+        CodeElement codeElement = parameterMap.get(de.codeElement);
+        if (codeElement != null) {
+          set.add(domain.getMappedIndex(new DomainElement(codeElement, de.taintSource)));
+        }
+      }
       return set;
     };
   }

--- a/scandroid/src/main/java/org/scandroid/prefixtransfer/UriPrefixTransferGraph.java
+++ b/scandroid/src/main/java/org/scandroid/prefixtransfer/UriPrefixTransferGraph.java
@@ -79,6 +79,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.jspecify.annotations.NonNull;
 import org.scandroid.prefixtransfer.StringBuilderUseAnalysis.StringBuilderToStringInstanceKeySite;
 import org.scandroid.prefixtransfer.modeledAllocations.ConstantString;
 import org.scandroid.prefixtransfer.modeledAllocations.UriAppendString;
@@ -86,7 +87,7 @@ import org.scandroid.prefixtransfer.modeledAllocations.UriParseString;
 
 public class UriPrefixTransferGraph implements Graph<InstanceKeySite> {
 
-  public final Map<InstanceKey, InstanceKeySite> nodeMap = new HashMap<>();
+  public final Map<InstanceKey, @NonNull InstanceKeySite> nodeMap = new HashMap<>();
   public final Map<InstanceKey, StringBuilderUseAnalysis> sbuaMap = new HashMap<>();
 
   private final List<InstanceKeySite> nodes = new ArrayList<>();
@@ -243,14 +244,16 @@ public class UriPrefixTransferGraph implements Graph<InstanceKeySite> {
                     mapping.getMappedIndex(uriKey),
                     mapping.getMappedIndex(stringKey));
 
-            if (!nodeMap.containsKey(returnIK)) {
-              addNode(node);
-              nodeMap.put(returnIK, node);
-              final HashSet<InstanceKey> iks = new HashSet<>();
-              iks.add(uriKey);
-              iks.add(stringKey);
-              unresolvedDependencies.put(node, iks);
-            }
+            nodeMap.computeIfAbsent(
+                returnIK,
+                absent -> {
+                  addNode(node);
+                  final HashSet<InstanceKey> iks = new HashSet<>();
+                  iks.add(uriKey);
+                  iks.add(stringKey);
+                  unresolvedDependencies.put(node, iks);
+                  return node;
+                });
           }
         }
       }

--- a/scandroid/src/main/java/org/scandroid/synthmethod/SSAtoXMLVisitor.java
+++ b/scandroid/src/main/java/org/scandroid/synthmethod/SSAtoXMLVisitor.java
@@ -71,6 +71,7 @@ import java.io.UTFDataFormatException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.jspecify.annotations.NonNull;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -79,7 +80,7 @@ public class SSAtoXMLVisitor implements SSAInstruction.IVisitor {
   private int defCounter = 0;
 
   /** Map the known defNum to local def names. */
-  private final Map<Integer, String> localDefs = HashMapFactory.make();
+  private final Map<Integer, @NonNull String> localDefs = HashMapFactory.make();
 
   /** XML document to use for creating elements. */
   private final Document doc;
@@ -424,12 +425,9 @@ public class SSAtoXMLVisitor implements SSAInstruction.IVisitor {
     if (0 == defNum) {
       return "unknown";
     }
-    if (localDefs.containsKey(defNum)) {
-      return localDefs.get(defNum);
-    }
-    return XMLSummaryWriter.A_ARG + (defNum - 1);
-    //        throw new IllegalStateException("defNum: " + defNum
-    //                + " is not defined.");
+    String name = localDefs.get(defNum);
+    return name == null ? XMLSummaryWriter.A_ARG + (defNum - 1) : name;
+    // if (name == null) throw new IllegalStateException("defNum: " + defNum + " is not defined.");
   }
 
   public List<Element> getInstSummary() {


### PR DESCRIPTION
Remove some redundant `Map` lookups, such as calling `containsKey` immediately before `get`.  That's redundant as long as we never map to `null`, which appears to be the case for the maps we're modifying here.

Also codify the existing `null`-avoidance policy for these maps by adding JSpecify annotations.  It's not clear how thoroughly current tools check this annotation when used on a `Map`'s value type.  But even if current tools don't check them, it's worth adding these annotations as documentation and (hopefully) as hints for future checkers.