### PR TITLE
Annotate (non-)nullability of some `Map` value types in `shrike`

### DIFF
--- a/shrike/src/main/java/com/ibm/wala/shrike/cg/OfflineDynamicCallGraph.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/cg/OfflineDynamicCallGraph.java
@@ -45,6 +45,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Map;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Class files are taken as input arguments (or if there are none, from standard input). The methods
@@ -183,7 +184,7 @@ public class OfflineDynamicCallGraph {
 
     final ClassReader r = ci.getReader();
 
-    final Map<Object, MethodData> methods = HashMapFactory.make();
+    final Map<Object, @NonNull MethodData> methods = HashMapFactory.make();
 
     for (int m = 0; m < ci.getReader().getMethodCount(); m++) {
       final MethodData d = ci.visitMethod(m);

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/MethodEditor.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/MethodEditor.java
@@ -13,6 +13,7 @@ package com.ibm.wala.shrike.shrikeBT;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.IdentityHashMap;
+import org.jspecify.annotations.Nullable;
 
 /**
  * The MethodEditor is the core of the ShrikeBT code rewriting mechanism. To rewrite code, construct
@@ -636,7 +637,7 @@ public final class MethodEditor {
     }
 
     // We want to update each exception handler array exactly once
-    IdentityHashMap<ExceptionHandler, Object> adjustedHandlers = null;
+    IdentityHashMap<ExceptionHandler, @Nullable Object> adjustedHandlers = null;
     for (int i = 0; i < handlers.length; i++) {
       ExceptionHandler[] hs = handlers[i];
       if (hs.length > 0 && (i == 0 || hs != handlers[i - 1])) {


### PR DESCRIPTION
It's not clear how thoroughly current tools check Jspecify nullability (or non-nullability) annotations when used on a `Map`'s value type. But even if current tools don't check them, it's worth adding these annotations as documentation and (hopefully) as hints for future checkers.