### PR TITLE
Avoid redundant map lookups in `cast/js/rhino`

### DIFF
--- a/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
+++ b/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
@@ -53,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import org.jspecify.annotations.NonNull;
 import org.mozilla.javascript.CompilerEnvirons;
 import org.mozilla.javascript.ErrorReporter;
 import org.mozilla.javascript.EvaluatorException;
@@ -386,7 +387,7 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
 
     private final int kind;
 
-    private final Map<CAstNode, Collection<CAstEntity>> subs;
+    private final Map<CAstNode, @NonNull Collection<CAstEntity>> subs;
 
     private final CAstNode ast;
 
@@ -496,8 +497,8 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
 
     @Override
     public Iterator<CAstEntity> getScopedEntities(CAstNode construct) {
-      if (subs.containsKey(construct)) return subs.get(construct).iterator();
-      else return EmptyIterator.instance();
+      Collection<CAstEntity> cAstEntities = subs.get(construct);
+      return cAstEntities == null ? EmptyIterator.instance() : cAstEntities.iterator();
     }
 
     @Override

--- a/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/rhino/test/HTMLCGBuilder.java
+++ b/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/rhino/test/HTMLCGBuilder.java
@@ -164,17 +164,10 @@ public class HTMLCGBuilder {
       src = tmpFile.getAbsolutePath();
     }
 
-    int timeout;
-    if (parsedArgs.containsKey("timeout")) {
-      timeout = Integer.parseInt(parsedArgs.getProperty("timeout"));
-    } else {
-      timeout = DEFAULT_TIMEOUT;
-    }
+    String timeoutText = parsedArgs.getProperty("timeout");
+    int timeout = timeoutText == null ? DEFAULT_TIMEOUT : Integer.parseInt(timeoutText);
 
-    String reachableName = null;
-    if (parsedArgs.containsKey("reachable")) {
-      reachableName = parsedArgs.getProperty("reachable");
-    }
+    String reachableName = parsedArgs.getProperty("reachable");
 
     // suppress debug output
     JavaScriptFunctionDotCallTargetSelector.WARN_ABOUT_IMPRECISE_CALLGRAPH = false;

--- a/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/test/TestRhinoSourceMap.java
+++ b/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/test/TestRhinoSourceMap.java
@@ -25,6 +25,7 @@ import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.ipa.callgraph.AnalysisScope;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
+import com.ibm.wala.types.TypeName;
 import com.ibm.wala.util.collections.HashMapFactory;
 import java.io.IOException;
 import java.util.Map;
@@ -169,13 +170,12 @@ public class TestRhinoSourceMap {
         // System.err.println(fun.getDeclaringClass().getName() + " " + fun.getSourcePosition());
         SourceBuffer sb = new SourceBuffer(fun.getSourcePosition());
         // System.err.println(sb);
-        if (sources.containsKey(fun.getDeclaringClass().getName().toString())) {
+        TypeName declaringClassName = fun.getDeclaringClass().getName();
+        String expectedToString = sources.get(declaringClassName.toString());
+        if (expectedToString != null) {
           System.err.println(
-              "checking source of "
-                  + fun.getDeclaringClass().getName()
-                  + " at "
-                  + fun.getSourcePosition());
-          assertThat(sb).hasToString(sources.get(fun.getDeclaringClass().getName().toString()));
+              "checking source of " + declaringClassName + " at " + fun.getSourcePosition());
+          assertThat(sb).hasToString(expectedToString);
         }
       }
     }


### PR DESCRIPTION
Remove some redundant `Map` lookups, such as calling `containsKey` immediately before `get`.  That's redundant as long as we never map to `null`, which appears to be the case for the maps we're modifying here.

Also codify the existing `null`-avoidance policy for these maps by adding JSpecify annotations.  It's not clear how thoroughly current tools check this annotation when used on a `Map`'s value type.  But even if current tools don't check them, it's worth adding these annotations as documentation and (hopefully) as hints for future checkers.