### PR TITLE
Avoid redundant map lookups in `cast/java/ecj`

### DIFF
--- a/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDT2CAstUtils.java
+++ b/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDT2CAstUtils.java
@@ -58,6 +58,7 @@ import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.core.dom.InfixExpression;
 import org.eclipse.jdt.core.dom.Modifier;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.jspecify.annotations.NonNull;
 
 public class JDT2CAstUtils {
   public static Collection<CAstQualifier> mapModifiersToQualifiers(
@@ -174,19 +175,14 @@ public class JDT2CAstUtils {
     return null;
   }
 
-  private static final Map<ITypeBinding, Integer> ids = new IdentityHashMap<>();
+  private static final Map<ITypeBinding, @NonNull Integer> ids = new IdentityHashMap<>();
 
   static String anonTypeName(ITypeBinding ct) {
     String binName = ct.getBinaryName();
     int n;
     // synchronize defensively just in case this code ever runs in multiple threads
     synchronized (ids) {
-      if (ids.containsKey(ct)) {
-        n = ids.get(ct);
-      } else {
-        n = ids.size();
-        ids.put(ct, n);
-      }
+      n = ids.computeIfAbsent(ct, absent -> ids.size());
     }
 
     if (binName.contains("$")) {

--- a/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
+++ b/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
@@ -164,6 +164,7 @@ import org.eclipse.jdt.core.dom.VariableDeclarationExpression;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
 import org.eclipse.jdt.core.dom.WhileStatement;
+import org.jspecify.annotations.NonNull;
 
 // TO TEST:
 // "1/0" surrounded by catch ArithmeticException & RunTimeException (TryCatchContext.getCatchTypes"
@@ -1151,20 +1152,17 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
     }
 
     // From Code Body Entity
-    private final Map<CAstNode, Collection<CAstEntity>> fEntities;
+    private final Map<CAstNode, @NonNull Collection<CAstEntity>> fEntities;
 
     @Override
-    public Map<CAstNode, Collection<CAstEntity>> getAllScopedEntities() {
+    public Map<CAstNode, @NonNull Collection<CAstEntity>> getAllScopedEntities() {
       return Collections.unmodifiableMap(fEntities);
     }
 
     @Override
-    public Iterator<CAstEntity> getScopedEntities(CAstNode construct) {
-      if (fEntities.containsKey(construct)) {
-        return fEntities.get(construct).iterator();
-      } else {
-        return EmptyIterator.instance();
-      }
+    public @NonNull Iterator<CAstEntity> getScopedEntities(CAstNode construct) {
+      Collection<CAstEntity> cAstEntities = fEntities.get(construct);
+      return cAstEntities == null ? EmptyIterator.instance() : cAstEntities.iterator();
     }
 
     @Override


### PR DESCRIPTION
Remove some redundant `Map` lookups, such as calling `containsKey` immediately before `get`.  That's redundant as long as we never map to `null`, which appears to be the case for the maps we're modifying here.

Also codify the existing `null`-avoidance policy for these maps by adding JSpecify annotations.  It's not clear how thoroughly current tools check this annotation when used on a `Map`'s value type.  But even if current tools don't check them, it's worth adding these annotations as documentation and (hopefully) as hints for future checkers.