### PR TITLE
Avoid redundant map lookups in `core`

### DIFF
--- a/core/src/main/java/com/ibm/wala/analysis/arraybounds/ArrayBoundsGraphBuilder.java
+++ b/core/src/main/java/com/ibm/wala/analysis/arraybounds/ArrayBoundsGraphBuilder.java
@@ -199,16 +199,19 @@ public class ArrayBoundsGraphBuilder {
 
       final HyperNode<Integer> node = edge.getDestination().iterator().next();
       if (!graph.getPhis().contains(node.getValue())) {
-        if (inEdges.containsKey(node)) {
-          final DirectedHyperEdge<Integer> inEdge = inEdges.get(node);
-          assert inEdge.getWeight().equals(edge.getWeight());
-          for (final HyperNode<Integer> src : edge.getSource()) {
-            inEdge.getSource().add(src);
-          }
-          graph.getEdges().remove(edge);
-        } else {
-          inEdges.put(node, edge);
-        }
+        inEdges.compute(
+            node,
+            (priorKey, priorInEdge) -> {
+              if (priorInEdge != null) {
+                assert priorInEdge.getWeight().equals(edge.getWeight());
+                for (final HyperNode<Integer> src : edge.getSource()) {
+                  priorInEdge.getSource().add(src);
+                }
+                graph.getEdges().remove(edge);
+                return priorInEdge;
+              }
+              return edge;
+            });
       }
     }
   }

--- a/core/src/main/java/com/ibm/wala/analysis/arraybounds/hypergraph/DirectedHyperGraph.java
+++ b/core/src/main/java/com/ibm/wala/analysis/arraybounds/hypergraph/DirectedHyperGraph.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Implementation of a directed hyper graph. In a hyper graph an edge can have more than one head
@@ -13,7 +14,7 @@ import java.util.Set;
  * @author Stephan Gocht {@code <stephan@gobro.de>}
  */
 public class DirectedHyperGraph<T> {
-  private final Map<T, HyperNode<T>> nodes;
+  private final Map<T, @NonNull HyperNode<T>> nodes;
   private final Set<DirectedHyperEdge<T>> edges;
 
   public DirectedHyperGraph() {
@@ -25,7 +26,7 @@ public class DirectedHyperGraph<T> {
     return this.edges;
   }
 
-  public Map<T, HyperNode<T>> getNodes() {
+  public Map<T, @NonNull HyperNode<T>> getNodes() {
     return this.nodes;
   }
 

--- a/core/src/main/java/com/ibm/wala/cfg/exc/inter/InterprocAnalysisResultWrapper.java
+++ b/core/src/main/java/com/ibm/wala/cfg/exc/inter/InterprocAnalysisResultWrapper.java
@@ -48,7 +48,8 @@ class InterprocAnalysisResultWrapper
 
   @Override
   public boolean containsResult(final CGNode n) {
-    return map.containsKey(n) && map.get(n).canBeAnalyzed();
+    IntraprocAnalysisState state = map.get(n);
+    return state != null && state.canBeAnalyzed();
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/classLoader/ClassLoaderImpl.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/ClassLoaderImpl.java
@@ -44,6 +44,7 @@ import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.JarInputStream;
+import org.jspecify.annotations.NonNull;
 
 /** A class loader that reads class definitions from a set of Modules. */
 public class ClassLoaderImpl implements IClassLoader {
@@ -279,7 +280,7 @@ public class ClassLoaderImpl implements IClassLoader {
   }
 
   @SuppressWarnings("unused")
-  private Map<String, Object> getAllClassAndSourceFileContents(
+  private Map<String, @NonNull Object> getAllClassAndSourceFileContents(
       byte[] jarFileContents, String fileName, Map<String, Map<String, Long>> entrySizes) {
     if (jarFileContents == null) {
       return null;
@@ -288,7 +289,7 @@ public class ClassLoaderImpl implements IClassLoader {
     if (entrySizesForFile == null) {
       return null;
     }
-    Map<String, Object> result = HashMapFactory.make();
+    Map<String, @NonNull Object> result = HashMapFactory.make();
     try (final JarInputStream s =
         new JarInputStream(new ByteArrayInputStream(jarFileContents), false)) {
       JarEntry entry;
@@ -299,16 +300,13 @@ public class ClassLoaderImpl implements IClassLoader {
         }
         String name = entry.getName();
         if (FileSuffixes.isJarFile(name) || FileSuffixes.isWarFile(name)) {
-          Map<String, Object> nestedResult =
+          Map<String, @NonNull Object> nestedResult =
               getAllClassAndSourceFileContents(entryBytes, name, entrySizes);
           if (nestedResult == null) {
             return null;
           }
-          for (Map.Entry<String, Object> nestedEntry : nestedResult.entrySet()) {
-            final String entryName = nestedEntry.getKey();
-            if (!result.containsKey(entryName)) {
-              result.put(entryName, nestedEntry.getValue());
-            }
+          for (Map.Entry<String, @NonNull Object> nestedEntry : nestedResult.entrySet()) {
+            result.computeIfAbsent(nestedEntry.getKey(), absent -> nestedEntry.getValue());
           }
         } else if (FileSuffixes.isClassFile(name) || FileSuffixes.isSourceFile(name)) {
           result.put(name, entryBytes);

--- a/core/src/main/java/com/ibm/wala/core/util/PrimitiveAssignability.java
+++ b/core/src/main/java/com/ibm/wala/core/util/PrimitiveAssignability.java
@@ -134,14 +134,23 @@ public class PrimitiveAssignability {
     assignability.get(Primitive.BYTE).put(Primitive.CHAR, AssignabilityKind.WIDENING_NARROWING);
   }
 
+  private static void put(final Primitive from, final Primitive to, final AssignabilityKind kind) {
+    assignability
+        .get(from)
+        .compute(
+            to,
+            (key, priorValue) -> {
+              assert priorValue == null;
+              return kind;
+            });
+  }
+
   private static void putNarrowing(final Primitive from, final Primitive to) {
-    assert !assignability.get(from).containsKey(to);
-    assignability.get(from).put(to, AssignabilityKind.NARROWING);
+    put(from, to, AssignabilityKind.NARROWING);
   }
 
   private static void putWidening(final Primitive from, final Primitive to) {
-    assert !assignability.get(from).containsKey(to);
-    assignability.get(from).put(to, AssignabilityKind.WIDENING);
+    put(from, to, AssignabilityKind.WIDENING);
   }
 
   private static final Map<TypeName, Primitive> namePrimitiveMap = new HashMap<>();

--- a/core/src/main/java/com/ibm/wala/core/util/strings/Atom.java
+++ b/core/src/main/java/com/ibm/wala/core/util/strings/Atom.java
@@ -14,6 +14,7 @@ import com.ibm.wala.util.collections.HashMapFactory;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.HashMap;
+import org.jspecify.annotations.NonNull;
 
 /**
  * An utf8-encoded byte string.
@@ -47,7 +48,7 @@ public final class Atom implements Serializable {
    * @param str atom value, as string literal whose characters are unicode
    * @return atom
    */
-  public static Atom findOrCreateUnicodeAtom(String str) {
+  public static @NonNull Atom findOrCreateUnicodeAtom(String str) {
     byte[] utf8 = UTF8Convert.toUTF8(str);
     return findOrCreate(utf8);
   }
@@ -112,7 +113,7 @@ public final class Atom implements Serializable {
     return findOrCreate(val);
   }
 
-  public static synchronized Atom findOrCreate(byte[] bytes) {
+  public static synchronized @NonNull Atom findOrCreate(byte[] bytes) {
     if (bytes == null) {
       throw new IllegalArgumentException("bytes is null");
     }

--- a/core/src/main/java/com/ibm/wala/demandpa/alg/DemandRefinementPointsTo.java
+++ b/core/src/main/java/com/ibm/wala/demandpa/alg/DemandRefinementPointsTo.java
@@ -135,6 +135,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import org.jspecify.annotations.NonNull;
 
 /** Demand-driven refinement-based points-to analysis. */
 public class DemandRefinementPointsTo extends AbstractDemandPointsTo {
@@ -767,7 +768,8 @@ public class DemandRefinementPointsTo extends AbstractDemandPointsTo {
         HashSetMultiMap.make();
 
     /** cache of the targets discovered for a call site during on-the-fly call graph construction */
-    private final MultiMap<CallerSiteContext, IMethod> callToOTFTargets = ArraySetMultiMap.make();
+    private final MultiMap<CallerSiteContext, @NonNull IMethod> callToOTFTargets =
+        ArraySetMultiMap.make();
 
     // alloc nodes to the fields we're looking to match on them,
     // matching getfield with putfield
@@ -1381,10 +1383,10 @@ public class DemandRefinementPointsTo extends AbstractDemandPointsTo {
               handler.handle(curPkAndState, retVal, ReturnLabel.make(callSiteAndCGNode));
             }
           } else {
-            if (callToOTFTargets.containsKey(callSiteAndCGNode)) {
+            @NonNull Set<IMethod> targetMethods = callToOTFTargets.get(callSiteAndCGNode);
+            if (!targetMethods.isEmpty()) {
               // already queried this call site
               // handle existing targets
-              Set<IMethod> targetMethods = callToOTFTargets.get(callSiteAndCGNode);
               for (CGNode callee : possibleCallees) {
                 if (targetMethods.contains(callee.getMethod())) {
                   if (hasNullIR(callee)) {
@@ -1695,10 +1697,10 @@ public class DemandRefinementPointsTo extends AbstractDemandPointsTo {
                 handler.handle(curPkAndState, paramVal, ParamBarLabel.make(callSiteAndCGNode));
               }
             } else {
-              if (callToOTFTargets.containsKey(callSiteAndCGNode)) {
+              @NonNull Set<IMethod> targetMethods = callToOTFTargets.get(callSiteAndCGNode);
+              if (!targetMethods.isEmpty()) {
                 // already queried this call site
                 // handle existing targets
-                Set<IMethod> targetMethods = callToOTFTargets.get(callSiteAndCGNode);
                 for (CGNode callee : possibleCallees) {
                   if (targetMethods.contains(callee.getMethod())) {
                     if (hasNullIR(callee)) {

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/BasicCallGraph.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/BasicCallGraph.java
@@ -370,11 +370,7 @@ public abstract class BasicCallGraph<T> extends AbstractNumberedGraph<CGNode> im
       String nm = nmBuilder.toString();
 
       do {
-        if (packages.containsKey(nm)) {
-          packages.put(nm, 1 + packages.get(nm));
-        } else {
-          packages.put(nm, 1);
-        }
+        packages.compute(nm, (key, priorValue) -> priorValue == null ? 1 : priorValue + 1);
 
         if (nm.indexOf('/') < 0) {
           break;

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/SelectiveCPAContext.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/SelectiveCPAContext.java
@@ -16,6 +16,7 @@ import com.ibm.wala.ipa.callgraph.ContextItem;
 import com.ibm.wala.ipa.callgraph.ContextKey;
 import com.ibm.wala.util.collections.HashMapFactory;
 import java.util.Map;
+import org.jspecify.annotations.NonNull;
 
 /**
  * A selective Cartesian product context that enforces object sensitivity on some set of parameter
@@ -26,7 +27,7 @@ public class SelectiveCPAContext implements Context {
   protected final Context base;
 
   // maps parameters to their abstract objects
-  private final Map<ContextKey, InstanceKey> parameterObjs;
+  private final Map<ContextKey, @NonNull InstanceKey> parameterObjs;
 
   // cached hash code
   private final int hashCode;
@@ -47,7 +48,7 @@ public class SelectiveCPAContext implements Context {
     this(base, makeMap(x));
   }
 
-  public SelectiveCPAContext(Context base, Map<ContextKey, InstanceKey> parameterObjs) {
+  public SelectiveCPAContext(Context base, Map<ContextKey, @NonNull InstanceKey> parameterObjs) {
     this.base = base;
     this.parameterObjs = parameterObjs;
     hashCode = base.hashCode() ^ parameterObjs.hashCode();
@@ -60,11 +61,10 @@ public class SelectiveCPAContext implements Context {
 
   @Override
   public ContextItem get(ContextKey name) {
-    if (parameterObjs.containsKey(name)) {
-      return new FilteredPointerKey.SingleInstanceFilter(parameterObjs.get(name));
-    } else {
-      return base.get(name);
-    }
+    InstanceKey instanceKey = parameterObjs.get(name);
+    return instanceKey == null
+        ? base.get(name)
+        : new FilteredPointerKey.SingleInstanceFilter(instanceKey);
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/pruned/PrunedCallGraph.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/pruned/PrunedCallGraph.java
@@ -28,12 +28,13 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.jspecify.annotations.NonNull;
 
 public class PrunedCallGraph implements CallGraph {
 
   private final CallGraph cg;
   private final Set<CGNode> keep;
-  private Map<CGNode, Set<CGNode>> remove = Collections.emptyMap();
+  private Map<CGNode, @NonNull Set<CGNode>> remove = Collections.emptyMap();
 
   /**
    * Create a pruned (filtered) view of an existing call graph.
@@ -55,7 +56,7 @@ public class PrunedCallGraph implements CallGraph {
         throw new IllegalArgumentException(String.format("%s does not contain %s", cg, keptNode));
   }
 
-  public PrunedCallGraph(CallGraph cg, Set<CGNode> keep, Map<CGNode, Set<CGNode>> remove) {
+  public PrunedCallGraph(CallGraph cg, Set<CGNode> keep, Map<CGNode, @NonNull Set<CGNode>> remove) {
     this(cg, keep);
     this.remove = remove;
   }
@@ -101,7 +102,8 @@ public class PrunedCallGraph implements CallGraph {
   }
 
   private boolean removedEdge(CGNode src, CGNode target) {
-    return remove.containsKey(src) && remove.get(src).contains(target);
+    Set<CGNode> nodes = remove.get(src);
+    return nodes != null && nodes.contains(target);
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/ipa/cfg/exceptionpruning/interprocedural/ArrayOutOfBoundInterFilter.java
+++ b/core/src/main/java/com/ibm/wala/ipa/cfg/exceptionpruning/interprocedural/ArrayOutOfBoundInterFilter.java
@@ -15,11 +15,12 @@ import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.cfg.exceptionpruning.ExceptionFilter;
 import com.ibm.wala.ipa.cfg.exceptionpruning.filter.ArrayOutOfBoundFilter;
 import com.ibm.wala.ssa.SSAInstruction;
+import org.jspecify.annotations.NonNull;
 
 public class ArrayOutOfBoundInterFilter extends StoringExceptionFilter<SSAInstruction> {
 
   @Override
-  protected ExceptionFilter<SSAInstruction> computeFilter(CGNode node) {
+  protected @NonNull ExceptionFilter<SSAInstruction> computeFilter(CGNode node) {
     ArrayOutOfBoundsAnalysis analysis = new ArrayOutOfBoundsAnalysis(node.getIR());
     return new ArrayOutOfBoundFilter(analysis);
   }

--- a/core/src/main/java/com/ibm/wala/ipa/cfg/exceptionpruning/interprocedural/NullPointerExceptionInterFilter.java
+++ b/core/src/main/java/com/ibm/wala/ipa/cfg/exceptionpruning/interprocedural/NullPointerExceptionInterFilter.java
@@ -15,11 +15,12 @@ import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.cfg.exceptionpruning.ExceptionFilter;
 import com.ibm.wala.ipa.cfg.exceptionpruning.filter.NullPointerExceptionFilter;
 import com.ibm.wala.ssa.SSAInstruction;
+import org.jspecify.annotations.NonNull;
 
 public class NullPointerExceptionInterFilter extends StoringExceptionFilter<SSAInstruction> {
 
   @Override
-  protected ExceptionFilter<SSAInstruction> computeFilter(CGNode node) {
+  protected @NonNull ExceptionFilter<SSAInstruction> computeFilter(CGNode node) {
     IntraproceduralNullPointerAnalysis analysis =
         new IntraproceduralNullPointerAnalysis(node.getIR());
     return new NullPointerExceptionFilter(analysis);

--- a/core/src/main/java/com/ibm/wala/ipa/cfg/exceptionpruning/interprocedural/StoringExceptionFilter.java
+++ b/core/src/main/java/com/ibm/wala/ipa/cfg/exceptionpruning/interprocedural/StoringExceptionFilter.java
@@ -14,25 +14,20 @@ import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.cfg.exceptionpruning.ExceptionFilter;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import org.jspecify.annotations.NonNull;
 
 public abstract class StoringExceptionFilter<Instruction>
     implements InterproceduralExceptionFilter<Instruction> {
-  private final Map<CGNode, ExceptionFilter<Instruction>> store;
+  private final Map<CGNode, @NonNull ExceptionFilter<Instruction>> store;
 
   public StoringExceptionFilter() {
     this.store = new LinkedHashMap<>();
   }
 
-  protected abstract ExceptionFilter<Instruction> computeFilter(CGNode node);
+  protected abstract @NonNull ExceptionFilter<Instruction> computeFilter(CGNode node);
 
   @Override
   public ExceptionFilter<Instruction> getFilter(CGNode node) {
-    if (store.containsKey(node)) {
-      return store.get(node);
-    } else {
-      ExceptionFilter<Instruction> filter = computeFilter(node);
-      store.put(node, filter);
-      return filter;
-    }
+    return store.computeIfAbsent(node, this::computeFilter);
   }
 }

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/BypassMethodTargetSelector.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/BypassMethodTargetSelector.java
@@ -30,6 +30,7 @@ import com.ibm.wala.util.collections.HashMapFactory;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import org.jspecify.annotations.Nullable;
 
 /**
  * "Non-standard" bypass rules to use during call graph construction.
@@ -72,7 +73,8 @@ public class BypassMethodTargetSelector implements MethodTargetSelector {
    * Mapping from MethodReference -&gt; SyntheticMethod We may call syntheticMethod.put(m,null) ..
    * in which case we use containsKey() to check for having already considered m.
    */
-  private final HashMap<MethodReference, SummarizedMethod> syntheticMethods = HashMapFactory.make();
+  private final HashMap<MethodReference, @Nullable SummarizedMethod> syntheticMethods =
+      HashMapFactory.make();
 
   public BypassMethodTargetSelector(
       MethodTargetSelector parent,

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/MethodSummary.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/MethodSummary.java
@@ -19,6 +19,8 @@ import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.collections.HashMapFactory;
 import java.util.ArrayList;
 import java.util.Map;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /** Summary information for a method. */
 public class MethodSummary {
@@ -32,7 +34,7 @@ public class MethodSummary {
   private ArrayList<SSAInstruction> statements;
 
   /** Map: value number -&gt; constant */
-  private Map<Integer, ConstantValue> constantValues;
+  private Map<Integer, @Nullable ConstantValue> constantValues;
 
   /** Some reason this method summary indicates a problem. */
   private String poison;
@@ -49,7 +51,7 @@ public class MethodSummary {
   private final int numberOfParameters;
 
   /** Known names for values */
-  private Map<Integer, Atom> valueNames = null;
+  private Map<Integer, @NonNull Atom> valueNames = null;
 
   public MethodSummary(MethodReference method) {
     this(method, -1);
@@ -63,16 +65,16 @@ public class MethodSummary {
     this.method = method;
   }
 
-  public void setValueNames(Map<Integer, Atom> nameTable) {
+  public void setValueNames(Map<Integer, @NonNull Atom> nameTable) {
     this.valueNames = nameTable;
   }
 
-  public Map<Integer, Atom> getValueNames() {
+  public Map<Integer, @NonNull Atom> getValueNames() {
     return valueNames;
   }
 
   public Atom getValue(Integer v) {
-    return valueNames != null && valueNames.containsKey(v) ? valueNames.get(v) : null;
+    return valueNames == null ? null : valueNames.get(v);
   }
 
   public int getNumberOfStatements() {

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/SyntheticIR.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/SyntheticIR.java
@@ -26,6 +26,7 @@ import com.ibm.wala.ssa.SSAPiInstruction;
 import com.ibm.wala.ssa.SymbolTable;
 import com.ibm.wala.util.debug.Assertions;
 import java.util.Map;
+import org.jspecify.annotations.NonNull;
 
 public class SyntheticIR extends IR {
 
@@ -47,7 +48,7 @@ public class SyntheticIR extends IR {
       AbstractCFG<?, ?> cfg,
       SSAInstruction[] instructions,
       SSAOptions options,
-      Map<Integer, ConstantValue> constants)
+      Map<Integer, @NonNull ConstantValue> constants)
       throws AssertionError {
     super(
         method,
@@ -82,7 +83,7 @@ public class SyntheticIR extends IR {
   private static SymbolTable makeSymbolTable(
       IMethod method,
       SSAInstruction[] instructions,
-      Map<Integer, ConstantValue> constants,
+      Map<Integer, @NonNull ConstantValue> constants,
       AbstractCFG<?, ?> cfg) {
     if (method == null) {
       throw new IllegalArgumentException("null method");
@@ -111,15 +112,19 @@ public class SyntheticIR extends IR {
   }
 
   private static void updateForInstruction(
-      Map<Integer, ConstantValue> constants, SymbolTable symbolTable, SSAInstruction s) {
+      Map<Integer, @NonNull ConstantValue> constants, SymbolTable symbolTable, SSAInstruction s) {
     for (int j = 0; j < s.getNumberOfDefs(); j++) {
       symbolTable.ensureSymbol(s.getDef(j));
     }
     for (int j = 0; j < s.getNumberOfUses(); j++) {
       int vn = s.getUse(j);
       symbolTable.ensureSymbol(vn);
-      if (constants != null && constants.containsKey(vn))
-        symbolTable.setConstantValue(vn, constants.get(vn));
+      if (constants != null) {
+        ConstantValue constantValue = constants.get(vn);
+        if (constantValue != null) {
+          symbolTable.setConstantValue(vn, constantValue);
+        }
+      }
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/ssa/IR.java
+++ b/core/src/main/java/com/ibm/wala/ssa/IR.java
@@ -27,6 +27,7 @@ import com.ibm.wala.util.debug.Assertions;
 import com.ibm.wala.util.intset.BasicNaturalRelation;
 import com.ibm.wala.util.intset.IntIterator;
 import com.ibm.wala.util.intset.IntSet;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
@@ -239,12 +240,9 @@ public abstract class IR implements IRView {
 
   private void addNames(int j, Map<Integer, Set<String>> valNames, int valNum) {
     if (getLocalNames(j, valNum) != null && getLocalNames(j, valNum).length > 0) {
-      if (!valNames.containsKey(valNum)) {
-        valNames.put(valNum, HashSetFactory.<String>make());
-      }
-      for (String s : getLocalNames(j, valNum)) {
-        valNames.get(valNum).add(s);
-      }
+      valNames
+          .computeIfAbsent(valNum, absent -> HashSetFactory.make())
+          .addAll(Arrays.asList(getLocalNames(j, valNum)));
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/ssa/ShrikeIndirectionData.java
+++ b/core/src/main/java/com/ibm/wala/ssa/ShrikeIndirectionData.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import org.jspecify.annotations.NonNull;
 
 /** An implementation of {@link SSAIndirectionData} specialized for IRs originated from Shrike. */
 public class ShrikeIndirectionData
@@ -54,9 +55,9 @@ public class ShrikeIndirectionData
     }
   }
 
-  private final Map<ShrikeLocalName, Integer>[] defs;
+  private final Map<ShrikeLocalName, @NonNull Integer>[] defs;
 
-  private final Map<ShrikeLocalName, Integer>[] uses;
+  private final Map<ShrikeLocalName, @NonNull Integer>[] uses;
 
   @SuppressWarnings("unchecked")
   public ShrikeIndirectionData(int instructionArrayLength) {
@@ -66,20 +67,12 @@ public class ShrikeIndirectionData
 
   @Override
   public int getDef(int instructionIndex, ShrikeLocalName name) {
-    if (defs[instructionIndex] == null || !defs[instructionIndex].containsKey(name)) {
-      return -1;
-    } else {
-      return defs[instructionIndex].get(name);
-    }
+    return defs[instructionIndex] == null ? -1 : defs[instructionIndex].getOrDefault(name, -1);
   }
 
   @Override
   public int getUse(int instructionIndex, ShrikeLocalName name) {
-    if (uses[instructionIndex] == null || !uses[instructionIndex].containsKey(name)) {
-      return -1;
-    } else {
-      return uses[instructionIndex].get(name);
-    }
+    return uses[instructionIndex] == null ? -1 : uses[instructionIndex].getOrDefault(name, -1);
   }
 
   @Override

--- a/core/src/test/java/com/ibm/wala/core/tests/basic/WelshPowellTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/basic/WelshPowellTest.java
@@ -21,23 +21,26 @@ import com.ibm.wala.util.graph.impl.NodeWithNumberedEdges;
 import com.ibm.wala.util.graph.traverse.WelshPowell;
 import com.ibm.wala.util.graph.traverse.WelshPowell.ColoredVertices;
 import java.util.Map;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
 
 public class WelshPowellTest {
 
-  public static <T> void assertColoring(Graph<T> G, Map<T, Integer> colors, boolean fullColor) {
+  public static <T> void assertColoring(
+      Graph<T> G, Map<T, @NonNull Integer> colors, boolean fullColor) {
     for (T n : G) {
+      Integer nColor = colors.get(n);
       for (T succ : Iterator2Iterable.make(G.getSuccNodes(n))) {
-        if (!fullColor && (!colors.containsKey(n) || !colors.containsKey(succ))) {
-          continue;
+        Integer succColor = colors.get(succ);
+        if (fullColor || (nColor != null && succColor != null)) {
+          assertThat(nColor).isNotEqualTo(succColor);
         }
-        assertThat(colors.get(n).intValue()).isNotEqualTo(colors.get(succ).intValue());
       }
       for (T pred : Iterator2Iterable.make(G.getPredNodes(n))) {
-        if (!fullColor && (!colors.containsKey(n) || !colors.containsKey(pred))) {
-          continue;
+        Integer predColor = colors.get(pred);
+        if (fullColor || (nColor != null && predColor != null)) {
+          assertThat(nColor).isNotEqualTo(predColor);
         }
-        assertThat(colors.get(n).intValue()).isNotEqualTo(colors.get(pred).intValue());
       }
     }
   }

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/AcyclicCallGraphTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/AcyclicCallGraphTest.java
@@ -1,5 +1,6 @@
 package com.ibm.wala.core.tests.callGraph;
 
+import static com.ibm.wala.util.collections.HashSetFactory.make;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.ibm.wala.core.tests.util.TestConstants;
@@ -16,7 +17,6 @@ import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.ipa.cha.ClassHierarchyFactory;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.collections.HashMapFactory;
-import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.collections.Iterator2Collection;
 import com.ibm.wala.util.graph.Acyclic;
 import com.ibm.wala.util.intset.IBinaryNaturalRelation;
@@ -48,10 +48,7 @@ public class AcyclicCallGraphTest extends WalaTestCase {
     Map<CGNode, Set<CGNode>> cgBackEdges = HashMapFactory.make();
     for (IntPair p : backEdges) {
       CGNode src = cg.getNode(p.getX());
-      if (!cgBackEdges.containsKey(src)) {
-        cgBackEdges.put(src, HashSetFactory.<CGNode>make());
-      }
-      cgBackEdges.get(src).add(cg.getNode(p.getY()));
+      cgBackEdges.computeIfAbsent(src, absent -> make()).add(cg.getNode(p.getY()));
     }
 
     PrunedCallGraph pcg =

--- a/core/src/test/java/com/ibm/wala/core/tests/exceptionpruning/ExceptionAnalysis2EdgeFilterTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/exceptionpruning/ExceptionAnalysis2EdgeFilterTest.java
@@ -41,6 +41,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -109,7 +110,7 @@ public class ExceptionAnalysis2EdgeFilterTest {
 
   @Test
   public void test() {
-    HashMap<String, Integer> deletedExceptional = new HashMap<>();
+    HashMap<String, @NonNull Integer> deletedExceptional = new HashMap<>();
     int deletedNormal = 0;
 
     ExceptionAnalysis analysis = new ExceptionAnalysis(cg, pointerAnalysis, cha, filter);
@@ -160,12 +161,9 @@ public class ExceptionAnalysis2EdgeFilterTest {
                   }
 
                   if (count) {
-                    Integer value = 0;
                     String key = node.getMethod().getName().toString();
-                    if (deletedExceptional.containsKey(key)) {
-                      value = deletedExceptional.get(key);
-                    }
-                    deletedExceptional.put(key, value + 1);
+                    deletedExceptional.compute(
+                        key, (priorKey, value) -> value == null ? 1 : value + 1);
                   }
                 }
               }


### PR DESCRIPTION
Remove some redundant `Map` lookups, such as calling `containsKey` immediately before `get`.  That's redundant as long as we never map to `null`, which appears to be the case for the maps we're modifying here.

Also codify the existing `null`-avoidance policy for these maps by adding JSpecify annotations.  It's not clear how thoroughly current tools check this annotation when used on a `Map`'s value type.  But even if current tools don't check them, it's worth adding these annotations as documentation and (hopefully) as hints for future checkers.

Conversely, add `@Nullable` to the value type for some maps that _can_ have `null` values.  This would be the assumed default anyway.  However, deciding whether `null` values are possible or not takes some effort. If I've invested that effort and determined that they are possible, then it is useful to write that down explicitly.  Otherwise, someone else might have to go through the same effort again in the future.