### PR TITLE
Avoid redundant map lookups in `util`

### DIFF
--- a/util/src/main/java/com/ibm/wala/util/graph/dominators/Dominators.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/dominators/Dominators.java
@@ -27,7 +27,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -133,7 +132,7 @@ public abstract class Dominators<T> {
 
       private final EdgeManager<T> edges =
           new EdgeManager<>() {
-            private final Map<T, @NonNull Set<T>> nextMap = HashMapFactory.make();
+            private final Map<T, Set<T>> nextMap = HashMapFactory.make();
 
             {
               for (T n : G) {

--- a/util/src/main/java/com/ibm/wala/util/graph/dominators/GenericDominators.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/dominators/GenericDominators.java
@@ -13,7 +13,6 @@ package com.ibm.wala.util.graph.dominators;
 import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.graph.Graph;
 import java.util.Map;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -34,7 +33,7 @@ public class GenericDominators<T> extends Dominators<T> {
   /*
    * Look-aside table for DominatorInfo objects
    */
-  private final Map<Object, @NonNull DominatorInfo> infoMap;
+  private final Map<Object, DominatorInfo> infoMap;
 
   @Override
   protected DominatorInfo getInfo(@Nullable T node) {

--- a/util/src/main/java/com/ibm/wala/util/graph/impl/ExtensionGraph.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/impl/ExtensionGraph.java
@@ -27,7 +27,6 @@ import com.ibm.wala.util.intset.MutableIntSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullUnmarked;
 import org.jspecify.annotations.Nullable;
 
@@ -39,8 +38,7 @@ public class ExtensionGraph<T> implements NumberedGraph<T> {
         private final Map<T, MutableIntSet> inEdges = HashMapFactory.make();
         private final Map<T, MutableIntSet> outEdges = HashMapFactory.make();
 
-        private Iterator<T> nodes(
-            final @Nullable T node, final Map<T, @NonNull ? extends IntSet> extra) {
+        private Iterator<T> nodes(final @Nullable T node, final Map<T, ? extends IntSet> extra) {
           IntSet intSet = extra.get(node);
           if (intSet != null) {
             return new Iterator<>() {

--- a/util/src/main/java/com/ibm/wala/util/graph/traverse/WelshPowell.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/traverse/WelshPowell.java
@@ -18,13 +18,12 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import org.jspecify.annotations.NonNull;
 
 public class WelshPowell<T> {
 
   public static class ColoredVertices<T> {
     private final boolean fullColoring;
-    private final Map<T, @NonNull Integer> colors;
+    private final Map<T, Integer> colors;
     private final int numColors;
 
     public boolean isFullColoring() {


### PR DESCRIPTION
Remove some redundant `Map` lookups, such as calling `containsKey` immediately before `get`.  That's redundant as long as we never map to `null`, which is the case for the maps we're modifying here.