### PR TITLE
Uninteresting change in IntelliJ IDEA XML formatting

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="Black">
     <option name="enabledOnReformat" value="true" />


### PR DESCRIPTION
IntelliJ IDEA 2025.3.1.1 prefers to write this XML file without the initial `<?xml ... ?>` declaration.  OK with me.