### PR TITLE
Update ECJ dependency

### DIFF
--- a/cast/js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/WorklistBasedOptimisticCallgraphBuilder.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/WorklistBasedOptimisticCallgraphBuilder.java
@@ -159,7 +159,7 @@ public class WorklistBasedOptimisticCallgraphBuilder extends FieldBasedCallGraph
               FuncVertex fv = mapping.getMappedObject(mappedFuncs.next());
               if (wReach.add(mapping.getMappedIndex(fv))) {
                 changed = true;
-                MapUtil.findOrCreateSet(pendingReflectiveCallWorklist, (VarVertex) w).add(fv);
+                MapUtil.findOrCreateSet(pendingReflectiveCallWorklist, w).add(fv);
               }
             }
           } else {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ assertj-core = "org.assertj:assertj-core:3.27.6"
 commons-cli = "commons-cli:commons-cli:1.11.0"
 commons-io = "commons-io:commons-io:2.21.0"
 dexlib2 = "org.smali:dexlib2:2.5.2"
-eclipse-ecj = "org.eclipse.jdt:ecj:3.43.0"
+eclipse-ecj = "org.eclipse.jdt:ecj:3.44.0"
 eclipse-osgi = "org.eclipse.platform:org.eclipse.osgi:3.24.0"
 eclipse-wst-jsdt-core = { module = "org.eclipse.wst.jsdt:core", version.ref = "eclipse-wst-jsdt" }
 eclipse-wst-jsdt-ui = { module = "org.eclipse.wst.jsdt:ui", version.ref = "eclipse-wst-jsdt" }

--- a/scandroid/src/main/java/org/scandroid/flow/functions/IFDSTaintFlowFunctionProvider.java
+++ b/scandroid/src/main/java/org/scandroid/flow/functions/IFDSTaintFlowFunctionProvider.java
@@ -108,6 +108,7 @@ public class IFDSTaintFlowFunctionProvider<E extends ISSABasicBlock>
   private final ISupergraph<BasicBlockInContext<E>, CGNode> graph;
   private final PointerAnalysis<InstanceKey> pa;
 
+  @Deprecated
   public IFDSTaintFlowFunctionProvider(
       IFDSTaintDomain<E> domain,
       ISupergraph<BasicBlockInContext<E>, CGNode> graph,
@@ -394,6 +395,7 @@ public class IFDSTaintFlowFunctionProvider<E extends ISSABasicBlock>
     }
   }
 
+  @Deprecated
   @Override
   public IUnaryFlowFunction getCallFlowFunction(
       BasicBlockInContext<E> src, BasicBlockInContext<E> dest, BasicBlockInContext<E> ret) {
@@ -444,6 +446,7 @@ public class IFDSTaintFlowFunctionProvider<E extends ISSABasicBlock>
     };
   }
 
+  @Deprecated
   @Override
   public IUnaryFlowFunction getCallNoneToReturnFlowFunction(
       BasicBlockInContext<E> src, BasicBlockInContext<E> dest) {
@@ -463,6 +466,7 @@ public class IFDSTaintFlowFunctionProvider<E extends ISSABasicBlock>
     return new DefUse(dest);
   }
 
+  @Deprecated
   @Override
   public IUnaryFlowFunction getCallToReturnFlowFunction(
       BasicBlockInContext<E> src, BasicBlockInContext<E> dest) {
@@ -484,6 +488,7 @@ public class IFDSTaintFlowFunctionProvider<E extends ISSABasicBlock>
     return new DefUse(dest);
   }
 
+  @Deprecated
   public class ReturnDefUse extends DefUse {
     CodeElement callSet;
     Set<CodeElement> receivers = new HashSet<>();
@@ -557,6 +562,7 @@ public class IFDSTaintFlowFunctionProvider<E extends ISSABasicBlock>
     }
   }
 
+  @Deprecated
   @Override
   public IFlowFunction getReturnFlowFunction(
       BasicBlockInContext<E> call, BasicBlockInContext<E> src, BasicBlockInContext<E> dest) {

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/tools/MethodOptimizer.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/tools/MethodOptimizer.java
@@ -58,8 +58,9 @@ public final class MethodOptimizer {
   // instruction
   // or -1 if there is more than one such instruction.
 
-  static final int[] noEdges = new int[0];
+  @Deprecated static final int[] noEdges = new int[0];
 
+  @Deprecated
   public MethodOptimizer(MethodData d, MethodEditor e) {
     if (d == null) {
       throw new IllegalArgumentException("null d");

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/tools/OfflineInstrumenterBase.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/tools/OfflineInstrumenterBase.java
@@ -419,7 +419,6 @@ public abstract class OfflineInstrumenterBase {
         throw new IllegalStateException("Output file was not set");
       }
 
-      @SuppressWarnings("resource")
       final FileOutputStream out = new FileOutputStream(outputFile);
       outputJar = new JarOutputStream(out);
     }

--- a/util/src/main/java/com/ibm/wala/util/config/SetOfClasses.java
+++ b/util/src/main/java/com/ibm/wala/util/config/SetOfClasses.java
@@ -24,12 +24,15 @@ public abstract class SetOfClasses implements StringFilter {
 
   private static final long serialVersionUID = -3048222852073799533L;
 
+  @Deprecated
   @Override
   public boolean test(String klassName) {
     return contains(klassName);
   }
 
+  @Deprecated
   public abstract boolean contains(String klassName);
 
+  @Deprecated
   public abstract void add(String klass);
 }


### PR DESCRIPTION
See [these release
notes](https://eclipse.dev/eclipse/markdown/?f=news/4.38/jdt.md#new-support-for-reacting-to-problem-reporting-changes) for more discussion of the change that necessitated adding `@Deprecated` annotations to members of deprecated classes.