### PR TITLE
Ignore Android project metadata

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,4 +1,5 @@
 *.iml
+/AndroidProjectSystem.xml
 /aws.xml
 /compiler.xml
 /GitLink.xml


### PR DESCRIPTION
IntelliJ IDEA will create `.idea/AndroidProjectSystem.xml` if the Android plugin is installed.  However, there's nothing in that warrants tracking in Git.