### PR TITLE
Convert `assert` statements to AssertJ

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
   testFixturesImplementation(projects.util)
   implementation(libs.gson)
   testImplementation(libs.assertj.core)
+  testImplementation(libs.json.unit.assertj)
   testImplementation(libs.junit.jupiter.api)
   testImplementation(testFixtures(projects.util))
   testRuntimeOnly(sourceSets["testSubjects"].output.classesDirs)

--- a/core/src/test/java/com/ibm/wala/core/tests/basic/JGFTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/basic/JGFTest.java
@@ -10,10 +10,16 @@
  *******************************************************************************/
 package com.ibm.wala.core.tests.basic;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.ibm.wala.util.graph.Graph;
 import com.ibm.wala.util.graph.JGF;
 import com.ibm.wala.util.graph.NumberedGraph;
-import org.json.JSONArray;
+import java.util.Map;
+import net.javacrumbs.jsonunit.assertj.JsonAssert;
+import net.javacrumbs.jsonunit.assertj.JsonListAssert;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 
@@ -49,27 +55,21 @@ public class JGFTest {
                 return from + " --> " + to;
               }
             });
-    JSONObject nodes = JG.getJSONObject("nodes");
-    JSONArray edges = JG.getJSONArray("edges");
-    for (String n : G) {
-      assert nodes
-          .getJSONObject("" + G.getNumber(n))
-          .getJSONObject("metadata")
-          .getString("name")
-          .equals(n);
-      G.getSuccNodes(n)
-          .forEachRemaining(
-              s -> {
-                boolean found = false;
-                for (int i = 0; i < edges.length(); i++) {
-                  JSONObject e = edges.getJSONObject(i);
-                  if (e.getString("source").equals("" + G.getNumber(n))
-                      && e.getString("target").equals("" + G.getNumber(s))) {
-                    found = true;
-                  }
-                }
-                assert found;
-              });
-    }
+    JsonAssert assertThatGraph = assertThatJson(JG).when(IGNORING_EXTRA_FIELDS);
+    JsonAssert assertThatNodes = assertThatGraph.node("nodes");
+    JsonListAssert assertThatEdges = assertThatGraph.node("edges").isArray();
+    assertThat(G)
+        .allSatisfy(
+            node -> {
+              int number = G.getNumber(node);
+              assertThatNodes.node(number + ".metadata.name").isEqualTo(node);
+              assertThat(G.getSuccNodes(node))
+                  .toIterable()
+                  .allSatisfy(
+                      successor ->
+                          assertThatEdges.contains(
+                              Map.of(
+                                  "source", "" + number, "target", "" + G.getNumber(successor))));
+            });
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ jericho-html = "net.htmlparser.jericho:jericho-html:3.4"
 jetbrains-annotations = "org.jetbrains:annotations:26.0.2-1"
 jgit = "org.netbeans.external:org-eclipse-jgit:RELEASE190"
 json = "org.json:json:20251224"
+json-unit-assertj = "net.javacrumbs.json-unit:json-unit-assertj:2.40.1"
 jspecify = "org.jspecify:jspecify:1.0.0"
 junit-bom = "org.junit:junit-bom:5.14.2"
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }


### PR DESCRIPTION
The rest of WALA uses AssertJ for testing, so we should do that here too.  AssertJ's higher-level abstractions provide much richer diagnostics when checks fail.

The version of `json-unit-assertj` that we are using here isn't the newest release, but it is the last release compatible with Java 11. Fortunately, that release already had everything we need.