### PR TITLE
Update Error Prone and NullAway to latest

### DIFF
--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/JSSSAPropagationCallGraphBuilder.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/JSSSAPropagationCallGraphBuilder.java
@@ -86,8 +86,8 @@ import com.ibm.wala.util.intset.MutableIntSet;
 import com.ibm.wala.util.intset.MutableMapping;
 import com.ibm.wala.util.intset.MutableSparseIntSet;
 import com.ibm.wala.util.intset.OrdinalSet;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
 /**
@@ -206,16 +206,10 @@ public class JSSSAPropagationCallGraphBuilder extends AstSSAPropagationCallGraph
   private static final FieldReference prototypeRef;
 
   static {
-    FieldReference x = null;
-    try {
-      byte[] utf8 = "__proto__".getBytes("UTF-8");
-      x =
-          FieldReference.findOrCreate(
-              JavaScriptTypes.Root, Atom.findOrCreate(utf8, 0, utf8.length), JavaScriptTypes.Root);
-    } catch (UnsupportedEncodingException e) {
-      assert false;
-    }
-    prototypeRef = x;
+    byte[] utf8 = "__proto__".getBytes(StandardCharsets.UTF_8);
+    prototypeRef =
+        FieldReference.findOrCreate(
+            JavaScriptTypes.Root, Atom.findOrCreate(utf8, 0, utf8.length), JavaScriptTypes.Root);
   }
 
   public PointerKey getPointerKeyForGlobalVar(String varName) {

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/loader/JavaScriptLoader.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/loader/JavaScriptLoader.java
@@ -117,8 +117,7 @@ import com.ibm.wala.types.TypeName;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.collections.Pair;
-import com.ibm.wala.util.debug.Assertions;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -290,20 +289,15 @@ public class JavaScriptLoader extends CAstAbstractModuleLoader {
 
             @Override
             public SSAPutInstruction PutInstruction(int iindex, int ref, int value, String field) {
-              try {
-                byte[] utf8 = field.getBytes("UTF-8");
-                return PutInstruction(
-                    iindex,
-                    ref,
-                    value,
-                    FieldReference.findOrCreate(
-                        JavaScriptTypes.Root,
-                        Atom.findOrCreate(utf8, 0, utf8.length),
-                        JavaScriptTypes.Root));
-              } catch (UnsupportedEncodingException e) {
-                Assertions.UNREACHABLE();
-                return null;
-              }
+              byte[] utf8 = field.getBytes(StandardCharsets.UTF_8);
+              return PutInstruction(
+                  iindex,
+                  ref,
+                  value,
+                  FieldReference.findOrCreate(
+                      JavaScriptTypes.Root,
+                      Atom.findOrCreate(utf8, 0, utf8.length),
+                      JavaScriptTypes.Root));
             }
 
             @Override

--- a/core/src/main/java/com/ibm/wala/core/util/config/AnalysisScopeReader.java
+++ b/core/src/main/java/com/ibm/wala/core/util/config/AnalysisScopeReader.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.StringTokenizer;
 import java.util.jar.JarFile;
 import org.intellij.lang.annotations.Language;
@@ -95,7 +96,9 @@ public class AnalysisScopeReader {
       // assume the scope file is UTF-8 encoded; ASCII files will also be handled properly
       // TODO allow specifying encoding as a parameter?
       if (scopeFile.exists()) {
-        r = new BufferedReader(new InputStreamReader(new FileInputStream(scopeFile), "UTF-8"));
+        r =
+            new BufferedReader(
+                new InputStreamReader(new FileInputStream(scopeFile), StandardCharsets.UTF_8));
       } else {
         // try to read from jar
         InputStream inFromJar = javaLoader.getResourceAsStream(scopeFileName);
@@ -146,7 +149,7 @@ public class AnalysisScopeReader {
       if (inStream == null) {
         throw new IllegalArgumentException("Unable to retrieve URI " + scopeFileURI);
       }
-      r = new BufferedReader(new InputStreamReader(inStream, "UTF-8"));
+      r = new BufferedReader(new InputStreamReader(inStream, StandardCharsets.UTF_8));
 
       while ((line = r.readLine()) != null) {
         processScopeDefLine(scope, javaLoader, line);

--- a/core/src/main/java/com/ibm/wala/core/util/io/FileProvider.java
+++ b/core/src/main/java/com/ibm/wala/core/util/io/FileProvider.java
@@ -15,18 +15,17 @@ import com.ibm.wala.classLoader.JarStreamModule;
 import com.ibm.wala.classLoader.Module;
 import com.ibm.wala.classLoader.NestedJarFileModule;
 import com.ibm.wala.classLoader.ResourceJarFileModule;
-import com.ibm.wala.util.debug.Assertions;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.JarURLConnection;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.JarInputStream;
@@ -195,13 +194,7 @@ public class FileProvider {
     // This solution works. See discussion at
     // http://stackoverflow.com/questions/4494063/how-to-avoid-java-net-urisyntaxexception-in-url-touri
     // we assume url has been properly encoded, so we decode it
-    try {
-      URI uri = new File(URLDecoder.decode(url.getPath(), "UTF-8")).toURI();
-      return uri.getPath();
-    } catch (UnsupportedEncodingException e) {
-      // this really shouldn't happen
-      Assertions.UNREACHABLE();
-      return null;
-    }
+    URI uri = new File(URLDecoder.decode(url.getPath(), StandardCharsets.UTF_8)).toURI();
+    return uri.getPath();
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-com-uber-nullaway = "0.13.1"
+com-uber-nullaway = "0.13.2"
 #noinspection UnusedVersionCatalogEntry
 eclipse = "4.30.0"
 eclipse-wst-jsdt = "1.0.201.v2010012803"
@@ -19,7 +19,7 @@ eclipse-osgi = "org.eclipse.platform:org.eclipse.osgi:3.24.0"
 eclipse-wst-jsdt-core = { module = "org.eclipse.wst.jsdt:core", version.ref = "eclipse-wst-jsdt" }
 eclipse-wst-jsdt-ui = { module = "org.eclipse.wst.jsdt:ui", version.ref = "eclipse-wst-jsdt" }
 #noinspection UnusedVersionCatalogEntry
-errorprone-core = "com.google.errorprone:error_prone_core:2.46.0"
+errorprone-core = "com.google.errorprone:error_prone_core:2.49.0"
 gson = "com.google.code.gson:gson:2.13.2"
 guava = "com.google.guava:guava:33.5.0-jre"
 htmlparser = "nu.validator.htmlparser:htmlparser:1.4"

--- a/shrike/src/main/java/com/ibm/wala/shrike/cg/Runtime.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/cg/Runtime.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.zip.GZIPOutputStream;
 
@@ -75,7 +76,7 @@ public class Runtime {
       output =
           new PrintWriter(
               new OutputStreamWriter(
-                  new GZIPOutputStream(new FileOutputStream(fileName)), "UTF-8"));
+                  new GZIPOutputStream(new FileOutputStream(fileName)), StandardCharsets.UTF_8));
     } catch (IOException e) {
       output = new PrintWriter(System.err);
     }

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/SourceDebugExtensionWriter.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/SourceDebugExtensionWriter.java
@@ -10,7 +10,7 @@
  */
 package com.ibm.wala.shrike.shrikeCT;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 public class SourceDebugExtensionWriter extends ClassWriter.Element {
   private final int attrID;
@@ -59,11 +59,7 @@ public class SourceDebugExtensionWriter extends ClassWriter.Element {
     if (sourceDebug == null) {
       throw new IllegalArgumentException("sourceDebug is null");
     }
-    try {
-      byte[] bytes = sourceDebug.getBytes("UTF8");
-      setRawTable(bytes);
-    } catch (UnsupportedEncodingException e) {
-      System.err.println(e);
-    }
+    byte[] bytes = sourceDebug.getBytes(StandardCharsets.UTF_8);
+    setRawTable(bytes);
   }
 }


### PR DESCRIPTION
Fix a number of calls to use `StandardCharsets.UTF_8` to fix a new Error Prone warning