### PR TITLE
Use `JrtModule` consistently to handle standard library on modern JDKs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -56,7 +56,7 @@ jobs:
             21
             25
             26
-          distribution: 'zulu'
+          distribution: 'temurin'
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
         with:

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -31,7 +31,7 @@ java.toolchain {
   languageVersion = JavaLanguageVersion.of(property("com.ibm.wala.jdk-version") as String)
   // We prefer a toolchain that includes jmod files for the Java standard library, like Azul Zulu.
   // Temurin does not include jmod files as of their JDK 24 builds.
-  vendor = JvmVendorSpec.AZUL
+  //vendor = JvmVendorSpec.AZUL
 }
 
 base.archivesName = "com.ibm.wala${path.replace(':', '.')}"

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -3,7 +3,6 @@ package com.ibm.wala.gradle
 // Build configuration for subprojects that include Java source code.
 
 import net.ltgt.gradle.errorprone.errorprone
-import org.gradle.jvm.toolchain.JvmVendorSpec
 
 plugins {
   eclipse
@@ -31,7 +30,7 @@ java.toolchain {
   languageVersion = JavaLanguageVersion.of(property("com.ibm.wala.jdk-version") as String)
   // We prefer a toolchain that includes jmod files for the Java standard library, like Azul Zulu.
   // Temurin does not include jmod files as of their JDK 24 builds.
-  //vendor = JvmVendorSpec.AZUL
+  // vendor = JvmVendorSpec.AZUL
 }
 
 base.archivesName = "com.ibm.wala${path.replace(':', '.')}"

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -28,9 +28,6 @@ repositories {
 
 java.toolchain {
   languageVersion = JavaLanguageVersion.of(property("com.ibm.wala.jdk-version") as String)
-  // We prefer a toolchain that includes jmod files for the Java standard library, like Azul Zulu.
-  // Temurin does not include jmod files as of their JDK 24 builds.
-  // vendor = JvmVendorSpec.AZUL
 }
 
 base.archivesName = "com.ibm.wala${path.replace(':', '.')}"

--- a/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/ecj/util/SourceDirCallGraph.java
+++ b/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/ecj/util/SourceDirCallGraph.java
@@ -26,6 +26,7 @@ import com.ibm.wala.properties.WalaProperties;
 import com.ibm.wala.ssa.SymbolTable;
 import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.util.PlatformUtil;
+import com.ibm.wala.util.PlatformUtil.NoJDKModulesFoundException;
 import com.ibm.wala.util.io.CommandLine;
 import java.io.File;
 import java.io.IOException;
@@ -81,12 +82,12 @@ public class SourceDirCallGraph {
     String mainClass = p.getProperty("mainClass");
     AnalysisScope scope = new JavaSourceAnalysisScope();
     // add standard libraries to scope
-    String[] stdlibs = WalaProperties.getJ2SEJarFiles();
-    if (stdlibs.length > 0) {
+    try {
+      String[] stdlibs = WalaProperties.getJ2SEJarFiles();
       for (String stdlib : stdlibs) {
         scope.addToScope(ClassLoaderReference.Primordial, new JarFile(stdlib));
       }
-    } else {
+    } catch (NoJDKModulesFoundException e) {
       for (String moduleName : PlatformUtil.getJDKModuleNames(false)) {
         scope.addJDKModuleToScope(ClassLoaderReference.Primordial, moduleName);
       }

--- a/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/ecj/util/SourceDirCallGraph.java
+++ b/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/ecj/util/SourceDirCallGraph.java
@@ -22,16 +22,12 @@ import com.ibm.wala.ipa.callgraph.impl.Util;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.ipa.cha.ClassHierarchyFactory;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
-import com.ibm.wala.properties.WalaProperties;
 import com.ibm.wala.ssa.SymbolTable;
 import com.ibm.wala.types.ClassLoaderReference;
-import com.ibm.wala.util.PlatformUtil;
-import com.ibm.wala.util.PlatformUtil.NoJDKLibraryFilesFoundException;
 import com.ibm.wala.util.io.CommandLine;
 import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
-import java.util.jar.JarFile;
 
 /**
  * Driver that constructs a call graph for an application specified as a directory of source code.
@@ -82,16 +78,7 @@ public class SourceDirCallGraph {
     String mainClass = p.getProperty("mainClass");
     AnalysisScope scope = new JavaSourceAnalysisScope();
     // add standard libraries to scope
-    try {
-      String[] stdlibs = WalaProperties.getJ2SEJarFiles();
-      for (String stdlib : stdlibs) {
-        scope.addToScope(ClassLoaderReference.Primordial, new JarFile(stdlib));
-      }
-    } catch (NoJDKLibraryFilesFoundException e) {
-      for (String moduleName : PlatformUtil.getJDKModuleNames(false)) {
-        scope.addJDKModuleToScope(ClassLoaderReference.Primordial, moduleName);
-      }
-    }
+    scope.addStdLibs(false, ClassLoaderReference.Primordial);
     // add the source directory
     File root = new File(sourceDir);
     if (root.isDirectory()) {

--- a/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/ecj/util/SourceDirCallGraph.java
+++ b/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/ecj/util/SourceDirCallGraph.java
@@ -26,7 +26,7 @@ import com.ibm.wala.properties.WalaProperties;
 import com.ibm.wala.ssa.SymbolTable;
 import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.util.PlatformUtil;
-import com.ibm.wala.util.PlatformUtil.NoJDKModulesFoundException;
+import com.ibm.wala.util.PlatformUtil.NoJDKLibraryFilesFoundException;
 import com.ibm.wala.util.io.CommandLine;
 import java.io.File;
 import java.io.IOException;
@@ -87,7 +87,7 @@ public class SourceDirCallGraph {
       for (String stdlib : stdlibs) {
         scope.addToScope(ClassLoaderReference.Primordial, new JarFile(stdlib));
       }
-    } catch (NoJDKModulesFoundException e) {
+    } catch (NoJDKLibraryFilesFoundException e) {
       for (String moduleName : PlatformUtil.getJDKModuleNames(false)) {
         scope.addJDKModuleToScope(ClassLoaderReference.Primordial, moduleName);
       }

--- a/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/ecj/util/SourceDirCallGraph.java
+++ b/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/ecj/util/SourceDirCallGraph.java
@@ -25,6 +25,7 @@ import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.properties.WalaProperties;
 import com.ibm.wala.ssa.SymbolTable;
 import com.ibm.wala.types.ClassLoaderReference;
+import com.ibm.wala.util.PlatformUtil;
 import com.ibm.wala.util.io.CommandLine;
 import java.io.File;
 import java.io.IOException;
@@ -81,8 +82,14 @@ public class SourceDirCallGraph {
     AnalysisScope scope = new JavaSourceAnalysisScope();
     // add standard libraries to scope
     String[] stdlibs = WalaProperties.getJ2SEJarFiles();
-    for (String stdlib : stdlibs) {
-      scope.addToScope(ClassLoaderReference.Primordial, new JarFile(stdlib));
+    if (stdlibs.length > 0) {
+      for (String stdlib : stdlibs) {
+        scope.addToScope(ClassLoaderReference.Primordial, new JarFile(stdlib));
+      }
+    } else {
+      for (String moduleName : PlatformUtil.getJDKModuleNames(false)) {
+        scope.addJDKModuleToScope(ClassLoaderReference.Primordial, moduleName);
+      }
     }
     // add the source directory
     File root = new File(sourceDir);

--- a/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/ecj/ECJSourceModuleTranslator.java
+++ b/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/ecj/ECJSourceModuleTranslator.java
@@ -89,17 +89,8 @@ public class ECJSourceModuleTranslator implements SourceModuleTranslator {
    * while {@code includeRunningVMBootclasspath} is enabled when the scope is backed by {@link
    * JrtModule} entries instead of jar or jmod paths.
    */
-  private static final class ClassPath {
-    private final String[] sources;
-    private final String[] libs;
-    private final boolean includeRunningVMBootclasspath;
-
-    private ClassPath(String[] sources, String[] libs, boolean includeRunningVMBootclasspath) {
-      this.sources = sources;
-      this.libs = libs;
-      this.includeRunningVMBootclasspath = includeRunningVMBootclasspath;
-    }
-  }
+  private record ClassPath(
+      String[] sources, String[] libs, boolean includeRunningVMBootclasspath) {}
 
   protected static class ECJJavaToCAstTranslator extends JDTJava2CAstTranslator<Position> {
     public ECJJavaToCAstTranslator(
@@ -208,9 +199,9 @@ public class ECJSourceModuleTranslator implements SourceModuleTranslator {
     this.dump = dump;
 
     ClassPath paths = computeClassPath(scope);
-    sources = paths.sources;
-    libs = paths.libs;
-    includeRunningVMBootclasspath = paths.includeRunningVMBootclasspath;
+    sources = paths.sources();
+    libs = paths.libs();
+    includeRunningVMBootclasspath = paths.includeRunningVMBootclasspath();
 
     this.exclusions = scope.getExclusions();
   }

--- a/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/ecj/ECJSourceModuleTranslator.java
+++ b/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/ecj/ECJSourceModuleTranslator.java
@@ -94,8 +94,7 @@ public class ECJSourceModuleTranslator implements SourceModuleTranslator {
     private final String[] libs;
     private final boolean includeRunningVMBootclasspath;
 
-    private ClassPath(
-        String[] sources, String[] libs, boolean includeRunningVMBootclasspath) {
+    private ClassPath(String[] sources, String[] libs, boolean includeRunningVMBootclasspath) {
       this.sources = sources;
       this.libs = libs;
       this.includeRunningVMBootclasspath = includeRunningVMBootclasspath;
@@ -254,9 +253,7 @@ public class ECJSourceModuleTranslator implements SourceModuleTranslator {
     }
 
     return new ClassPath(
-        sources.toArray(new String[0]),
-        libs.toArray(new String[0]),
-        includeRunningVMBootclasspath);
+        sources.toArray(new String[0]), libs.toArray(new String[0]), includeRunningVMBootclasspath);
   }
 
   /*

--- a/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/ecj/ECJSourceModuleTranslator.java
+++ b/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/ecj/ECJSourceModuleTranslator.java
@@ -49,10 +49,10 @@ import com.ibm.wala.classLoader.JarStreamModule;
 import com.ibm.wala.classLoader.Module;
 import com.ibm.wala.classLoader.ModuleEntry;
 import com.ibm.wala.classLoader.SourceFileModule;
+import com.ibm.wala.core.java11.JrtModule;
 import com.ibm.wala.ipa.callgraph.AnalysisScope;
 import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.util.collections.HashMapFactory;
-import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.util.config.StringFilter;
 import com.ibm.wala.util.io.TemporaryFile;
 import java.io.File;
@@ -82,6 +82,26 @@ import org.eclipse.jdt.core.dom.FileASTRequestor;
  */
 // remove me comment: Jdt little-case = not OK, upper case = OK
 public class ECJSourceModuleTranslator implements SourceModuleTranslator {
+  /**
+   * Classpath inputs derived from an {@link AnalysisScope} for ECJ parser configuration.
+   *
+   * <p>{@code libs} and {@code sources} are passed directly to {@link ASTParser#setEnvironment},
+   * while {@code includeRunningVMBootclasspath} is enabled when the scope is backed by {@link
+   * JrtModule} entries instead of jar or jmod paths.
+   */
+  private static final class ClassPath {
+    private final String[] sources;
+    private final String[] libs;
+    private final boolean includeRunningVMBootclasspath;
+
+    private ClassPath(
+        String[] sources, String[] libs, boolean includeRunningVMBootclasspath) {
+      this.sources = sources;
+      this.libs = libs;
+      this.includeRunningVMBootclasspath = includeRunningVMBootclasspath;
+    }
+  }
+
   protected static class ECJJavaToCAstTranslator extends JDTJava2CAstTranslator<Position> {
     public ECJJavaToCAstTranslator(
         JavaSourceLoaderImpl sourceLoader,
@@ -176,6 +196,7 @@ public class ECJSourceModuleTranslator implements SourceModuleTranslator {
   protected ECJSourceLoaderImpl sourceLoader;
   private final String[] sources;
   private final String[] libs;
+  private final boolean includeRunningVMBootclasspath;
   private final StringFilter exclusions;
 
   public ECJSourceModuleTranslator(AnalysisScope scope, ECJSourceLoaderImpl sourceLoader) {
@@ -187,16 +208,18 @@ public class ECJSourceModuleTranslator implements SourceModuleTranslator {
     this.sourceLoader = sourceLoader;
     this.dump = dump;
 
-    Pair<String[], String[]> paths = computeClassPath(scope);
-    sources = paths.fst;
-    libs = paths.snd;
+    ClassPath paths = computeClassPath(scope);
+    sources = paths.sources;
+    libs = paths.libs;
+    includeRunningVMBootclasspath = paths.includeRunningVMBootclasspath;
 
     this.exclusions = scope.getExclusions();
   }
 
-  private static Pair<String[], String[]> computeClassPath(AnalysisScope scope) {
+  private static ClassPath computeClassPath(AnalysisScope scope) {
     List<String> sources = new ArrayList<>();
     List<String> libs = new ArrayList<>();
+    boolean includeRunningVMBootclasspath = false;
     for (ClassLoaderReference cl : scope.getLoaders()) {
 
       while (cl != null) {
@@ -220,6 +243,8 @@ public class ECJSourceModuleTranslator implements SourceModuleTranslator {
             DirectoryTreeModule directoryTreeModule = (DirectoryTreeModule) m;
 
             sources.add(directoryTreeModule.getPath());
+          } else if (m instanceof JrtModule) {
+            includeRunningVMBootclasspath = true;
           } else {
             // Assertions.UNREACHABLE("Module entry is neither jar file nor directory");
           }
@@ -228,7 +253,10 @@ public class ECJSourceModuleTranslator implements SourceModuleTranslator {
       }
     }
 
-    return Pair.make(sources.toArray(new String[0]), libs.toArray(new String[0]));
+    return new ClassPath(
+        sources.toArray(new String[0]),
+        libs.toArray(new String[0]),
+        includeRunningVMBootclasspath);
   }
 
   /*
@@ -251,7 +279,7 @@ public class ECJSourceModuleTranslator implements SourceModuleTranslator {
     @SuppressWarnings("deprecation")
     final ASTParser parser = ASTParser.newParser(AST.JLS8);
     parser.setResolveBindings(true);
-    parser.setEnvironment(libs, this.sources, null, false);
+    parser.setEnvironment(libs, this.sources, null, includeRunningVMBootclasspath);
     Hashtable<String, String> options = JavaCore.getOptions();
     options.put(JavaCore.COMPILER_SOURCE, "11");
     parser.setCompilerOptions(options);

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
@@ -48,6 +48,7 @@ import com.ibm.wala.types.TypeName;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.NullProgressMonitor;
+import com.ibm.wala.util.PlatformUtil.NoJDKModulesFoundException;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.collections.Iterator2Iterable;
 import com.ibm.wala.util.collections.Pair;
@@ -72,7 +73,18 @@ public abstract class IRTests {
 
   protected boolean dump = true;
 
-  public static final List<String> rtJar = Arrays.asList(WalaProperties.getJ2SEJarFiles());
+  public static final List<String> rtJar;
+
+  static {
+    List<String> jars;
+    try {
+      jars = Arrays.asList(WalaProperties.getJ2SEJarFiles());
+    } catch (NoJDKModulesFoundException e) {
+      // TODO better handle case when there are no stdlib jar / jmod files
+      jars = Collections.emptyList();
+    }
+    rtJar = jars;
+  }
 
   protected static List<IRAssertion> emptyList = Collections.emptyList();
 

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
@@ -50,7 +50,7 @@ import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.NullProgressMonitor;
 import com.ibm.wala.util.PlatformUtil;
-import com.ibm.wala.util.PlatformUtil.NoJDKLibraryFilesFoundException;
+import com.ibm.wala.util.WalaException;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.collections.Iterator2Iterable;
 import com.ibm.wala.util.collections.Pair;
@@ -84,7 +84,7 @@ public abstract class IRTests {
   private static List<String> getJavaRuntimeLibraries() {
     try {
       return Arrays.asList(WalaProperties.getJ2SEJarFiles());
-    } catch (NoJDKLibraryFilesFoundException e) {
+    } catch (WalaException e) {
       return Arrays.asList(PlatformUtil.getJDKModuleNames(false));
     }
   }

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
@@ -75,11 +75,7 @@ public abstract class IRTests {
 
   protected boolean dump = true;
 
-  public static final List<String> rtJar;
-
-  static {
-    rtJar = getJavaRuntimeLibraries();
-  }
+  public static final List<String> rtJar = getJavaRuntimeLibraries();
 
   private static List<String> getJavaRuntimeLibraries() {
     try {

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
@@ -48,7 +48,7 @@ import com.ibm.wala.types.TypeName;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.NullProgressMonitor;
-import com.ibm.wala.util.PlatformUtil.NoJDKModulesFoundException;
+import com.ibm.wala.util.PlatformUtil.NoJDKLibraryFilesFoundException;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.collections.Iterator2Iterable;
 import com.ibm.wala.util.collections.Pair;
@@ -79,7 +79,7 @@ public abstract class IRTests {
     List<String> jars;
     try {
       jars = Arrays.asList(WalaProperties.getJ2SEJarFiles());
-    } catch (NoJDKModulesFoundException e) {
+    } catch (NoJDKLibraryFilesFoundException e) {
       // TODO better handle case when there are no stdlib jar / jmod files
       jars = Collections.emptyList();
     }

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
@@ -30,6 +30,7 @@ import com.ibm.wala.classLoader.Language;
 import com.ibm.wala.classLoader.SourceDirectoryTreeModule;
 import com.ibm.wala.classLoader.SourceFileModule;
 import com.ibm.wala.client.AbstractAnalysisEngine;
+import com.ibm.wala.core.java11.JrtModule;
 import com.ibm.wala.core.util.strings.Atom;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.CallGraph;
@@ -48,6 +49,7 @@ import com.ibm.wala.types.TypeName;
 import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.NullProgressMonitor;
+import com.ibm.wala.util.PlatformUtil;
 import com.ibm.wala.util.PlatformUtil.NoJDKLibraryFilesFoundException;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.collections.Iterator2Iterable;
@@ -76,14 +78,15 @@ public abstract class IRTests {
   public static final List<String> rtJar;
 
   static {
-    List<String> jars;
+    rtJar = getJavaRuntimeLibraries();
+  }
+
+  private static List<String> getJavaRuntimeLibraries() {
     try {
-      jars = Arrays.asList(WalaProperties.getJ2SEJarFiles());
+      return Arrays.asList(WalaProperties.getJ2SEJarFiles());
     } catch (NoJDKLibraryFilesFoundException e) {
-      // TODO better handle case when there are no stdlib jar / jmod files
-      jars = Collections.emptyList();
+      return Arrays.asList(PlatformUtil.getJDKModuleNames(false));
     }
-    rtJar = jars;
   }
 
   protected static List<IRAssertion> emptyList = Collections.emptyList();
@@ -448,12 +451,19 @@ public abstract class IRTests {
 
   public static void populateScope(
       JavaSourceAnalysisEngine engine, Collection<Path> sources, List<String> libs) {
-    assertThat(libs)
-        .map(File::new)
-        .filteredOn(File::exists)
-        .isNotEmpty()
-        .allSatisfy(
-            libFile -> engine.addSystemModule(new JarFileModule(new JarFile(libFile, false))));
+    assertThat(libs).isNotEmpty();
+    for (String lib : libs) {
+      File libFile = new File(lib);
+      try {
+        if (libFile.exists()) {
+          engine.addSystemModule(new JarFileModule(new JarFile(libFile, false)));
+        } else {
+          engine.addSystemModule(new JrtModule(lib));
+        }
+      } catch (IOException e) {
+        throw new IllegalStateException("unable to add Java runtime library " + lib, e);
+      }
+    }
 
     for (Path srcFilePath : sources) {
       Path srcFileName = srcFilePath.getFileName();

--- a/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
+++ b/cast/java/src/testFixtures/java/com/ibm/wala/cast/java/test/IRTests.java
@@ -456,8 +456,13 @@ public abstract class IRTests {
       File libFile = new File(lib);
       try {
         if (libFile.exists()) {
+          // Traditional test setup passes jar/jmod filesystem paths, which we add directly.
           engine.addSystemModule(new JarFileModule(new JarFile(libFile, false)));
         } else {
+          // When the running JDK exposes standard libraries only via the jrt:/ image, the
+          // fallback runtime list contains module names such as "java.base" rather than paths.
+          // Convert those names into JrtModule instances so the source analysis scope can still
+          // resolve JDK classes without requiring jar or jmod files on disk.
           engine.addSystemModule(new JrtModule(lib));
         }
       } catch (IOException e) {

--- a/core/src/main/java/com/ibm/wala/core/java11/Java9AnalysisScopeReader.java
+++ b/core/src/main/java/com/ibm/wala/core/java11/Java9AnalysisScopeReader.java
@@ -1,34 +1,12 @@
 package com.ibm.wala.core.java11;
 
 import com.ibm.wala.core.util.config.AnalysisScopeReader;
-import com.ibm.wala.ipa.callgraph.AnalysisScope;
-import com.ibm.wala.types.ClassLoaderReference;
-import java.io.IOException;
 
+/**
+ * @deprecated Use {@link AnalysisScopeReader}; support for {@code jrt} entries is now built in.
+ */
+@Deprecated
 public class Java9AnalysisScopeReader extends AnalysisScopeReader {
 
   public static final Java9AnalysisScopeReader instance = new Java9AnalysisScopeReader();
-
-  static {
-    setScopeReader(instance);
-  }
-
-  @Override
-  protected boolean handleInSubclass(
-      AnalysisScope scope,
-      ClassLoaderReference walaLoader,
-      String language,
-      String entryType,
-      String entryPathname) {
-    if ("jrt".equals(entryType)) {
-      try {
-        scope.addToScope(walaLoader, new JrtModule(entryPathname));
-        return true;
-      } catch (IOException e) {
-        return false;
-      }
-    } else {
-      return false;
-    }
-  }
 }

--- a/core/src/main/java/com/ibm/wala/core/java11/JrtModule.java
+++ b/core/src/main/java/com/ibm/wala/core/java11/JrtModule.java
@@ -10,6 +10,10 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystemAlreadyExistsException;
+import java.nio.file.FileSystems;
+import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -19,12 +23,25 @@ import java.util.stream.Collectors;
 
 public class JrtModule implements Module {
   final Path root;
+  private static final java.net.URI JRT_URI = java.net.URI.create("jrt:/");
 
   public JrtModule(String module) throws IOException {
-    root =
-        java.nio.file.FileSystems.newFileSystem(
-                java.net.URI.create("jrt:/"), java.util.Collections.emptyMap())
-            .getPath("modules", module);
+    root = getJrtFileSystem().getPath("modules", module);
+    if (!Files.exists(root)) {
+      throw new IOException("cannot find jrt module " + module + ", tried " + root);
+    }
+  }
+
+  private static FileSystem getJrtFileSystem() throws IOException {
+    try {
+      return FileSystems.getFileSystem(JRT_URI);
+    } catch (FileSystemNotFoundException e) {
+      try {
+        return FileSystems.newFileSystem(JRT_URI, Collections.emptyMap());
+      } catch (FileSystemAlreadyExistsException ignored) {
+        return FileSystems.getFileSystem(JRT_URI);
+      }
+    }
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/core/java11/JrtModule.java
+++ b/core/src/main/java/com/ibm/wala/core/java11/JrtModule.java
@@ -12,8 +12,8 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystemAlreadyExistsException;
-import java.nio.file.FileSystems;
 import java.nio.file.FileSystemNotFoundException;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -26,7 +26,9 @@ public class JrtModule implements Module {
   private static final java.net.URI JRT_URI = java.net.URI.create("jrt:/");
 
   public JrtModule(String module) throws IOException {
+    // Reuse the shared jrt filesystem when it is already installed; creating it repeatedly fails.
     root = getJrtFileSystem().getPath("modules", module);
+    // Fail fast for an unknown module name.
     if (!Files.exists(root)) {
       throw new IOException("cannot find jrt module " + module + ", tried " + root);
     }
@@ -39,6 +41,7 @@ public class JrtModule implements Module {
       try {
         return FileSystems.newFileSystem(JRT_URI, Collections.emptyMap());
       } catch (FileSystemAlreadyExistsException ignored) {
+        // Another caller won the race to install the filesystem; reuse that instance.
         return FileSystems.getFileSystem(JRT_URI);
       }
     }

--- a/core/src/main/java/com/ibm/wala/core/java11/JrtModule.java
+++ b/core/src/main/java/com/ibm/wala/core/java11/JrtModule.java
@@ -5,15 +5,12 @@ import com.ibm.wala.classLoader.ModuleEntry;
 import com.ibm.wala.core.util.shrike.ShrikeClassReaderHandle;
 import com.ibm.wala.core.util.strings.ImmutableByteArray;
 import com.ibm.wala.shrike.shrikeCT.InvalidClassFileException;
+import com.ibm.wala.util.PlatformUtil;
 import com.ibm.wala.util.collections.ComposedIterator;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystemAlreadyExistsException;
-import java.nio.file.FileSystemNotFoundException;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -23,27 +20,13 @@ import java.util.stream.Collectors;
 
 public class JrtModule implements Module {
   final Path root;
-  private static final java.net.URI JRT_URI = java.net.URI.create("jrt:/");
 
   public JrtModule(String module) throws IOException {
     // Reuse the shared jrt filesystem when it is already installed; creating it repeatedly fails.
-    root = getJrtFileSystem().getPath("modules", module);
+    root = PlatformUtil.getJrtFileSystem().getPath("modules", module);
     // Fail fast for an unknown module name.
     if (!Files.exists(root)) {
       throw new IOException("cannot find jrt module " + module + ", tried " + root);
-    }
-  }
-
-  private static FileSystem getJrtFileSystem() throws IOException {
-    try {
-      return FileSystems.getFileSystem(JRT_URI);
-    } catch (FileSystemNotFoundException e) {
-      try {
-        return FileSystems.newFileSystem(JRT_URI, Collections.emptyMap());
-      } catch (FileSystemAlreadyExistsException ignored) {
-        // Another caller won the race to install the filesystem; reuse that instance.
-        return FileSystems.getFileSystem(JRT_URI);
-      }
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/core/java11/LibraryStuff.java
+++ b/core/src/main/java/com/ibm/wala/core/java11/LibraryStuff.java
@@ -25,7 +25,7 @@ public class LibraryStuff {
 
   public static void main(String[] args) throws Exception {
     try {
-      AnalysisScopeReader r = new Java9AnalysisScopeReader();
+      AnalysisScopeReader r = AnalysisScopeReader.instance;
       AnalysisScope scope =
           r.readJavaScope(
               (args.length > 0 ? args[0] : "wala.testdata.txt"),

--- a/core/src/main/java/com/ibm/wala/core/tests/callGraph/CallGraphTestUtil.java
+++ b/core/src/main/java/com/ibm/wala/core/tests/callGraph/CallGraphTestUtil.java
@@ -11,7 +11,7 @@
 package com.ibm.wala.core.tests.callGraph;
 
 import com.ibm.wala.classLoader.Language;
-import com.ibm.wala.core.java11.Java9AnalysisScopeReader;
+import com.ibm.wala.core.util.config.AnalysisScopeReader;
 import com.ibm.wala.core.util.io.FileProvider;
 import com.ibm.wala.ipa.callgraph.AnalysisOptions;
 import com.ibm.wala.ipa.callgraph.AnalysisScope;
@@ -53,7 +53,7 @@ public class CallGraphTestUtil {
 
   public static AnalysisScope makeJ2SEAnalysisScope(
       String scopeFile, String exclusionsFile, ClassLoader myClassLoader) throws IOException {
-    return Java9AnalysisScopeReader.instance.readJavaScope(
+    return AnalysisScopeReader.instance.readJavaScope(
         scopeFile, new FileProvider().getFile(exclusionsFile), myClassLoader);
   }
 

--- a/core/src/main/java/com/ibm/wala/core/util/config/AnalysisScopeReader.java
+++ b/core/src/main/java/com/ibm/wala/core/util/config/AnalysisScopeReader.java
@@ -21,7 +21,7 @@ import com.ibm.wala.properties.WalaProperties;
 import com.ibm.wala.shrike.shrikeCT.InvalidClassFileException;
 import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.util.PlatformUtil;
-import com.ibm.wala.util.PlatformUtil.NoJDKModulesFoundException;
+import com.ibm.wala.util.PlatformUtil.NoJDKLibraryFilesFoundException;
 import com.ibm.wala.util.config.PatternsFilter;
 import com.ibm.wala.util.debug.Assertions;
 import java.io.BufferedReader;
@@ -236,7 +236,7 @@ public class AnalysisScopeReader {
         for (String stdlib : stdlibs) {
           scope.addToScope(walaLoader, new JarFile(stdlib, false));
         }
-      } catch (NoJDKModulesFoundException e) {
+      } catch (NoJDKLibraryFilesFoundException e) {
         for (String moduleName : PlatformUtil.getJDKModuleNames(justBase)) {
           scope.addJDKModuleToScope(walaLoader, moduleName);
         }

--- a/core/src/main/java/com/ibm/wala/core/util/config/AnalysisScopeReader.java
+++ b/core/src/main/java/com/ibm/wala/core/util/config/AnalysisScopeReader.java
@@ -32,7 +32,6 @@ import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.StringTokenizer;
 import java.util.jar.JarFile;
 import org.intellij.lang.annotations.Language;

--- a/core/src/main/java/com/ibm/wala/core/util/config/AnalysisScopeReader.java
+++ b/core/src/main/java/com/ibm/wala/core/util/config/AnalysisScopeReader.java
@@ -233,8 +233,8 @@ public class AnalysisScopeReader {
       for (String stdlib : stdlibs) {
         scope.addToScope(walaLoader, new JarFile(stdlib, false));
       }
-    } else if ("jdkModule".equals(entryType)) {
-      scope.addJDKModuleToScope(entryPathname);
+    } else if ("jdkModule".equals(entryType) || "jrt".equals(entryType)) {
+      scope.addJDKModuleToScope(walaLoader, entryPathname);
     } else if (!handleInSubclass(scope, walaLoader, language, entryType, entryPathname)) {
       Assertions.UNREACHABLE();
     }
@@ -246,7 +246,7 @@ public class AnalysisScopeReader {
       @SuppressWarnings("unused") String language,
       @SuppressWarnings("unused") String entryType,
       @SuppressWarnings("unused") String entryPathname) {
-    // hook for e.g., Java 11
+    // hook for reader extensions that add custom scope entry types
     return false;
   }
 

--- a/core/src/main/java/com/ibm/wala/core/util/config/AnalysisScopeReader.java
+++ b/core/src/main/java/com/ibm/wala/core/util/config/AnalysisScopeReader.java
@@ -20,6 +20,7 @@ import com.ibm.wala.ipa.callgraph.AnalysisScope;
 import com.ibm.wala.properties.WalaProperties;
 import com.ibm.wala.shrike.shrikeCT.InvalidClassFileException;
 import com.ibm.wala.types.ClassLoaderReference;
+import com.ibm.wala.util.PlatformUtil;
 import com.ibm.wala.util.config.PatternsFilter;
 import com.ibm.wala.util.debug.Assertions;
 import java.io.BufferedReader;
@@ -230,8 +231,14 @@ public class AnalysisScopeReader {
     } else if ("stdlib".equals(entryType)) {
       boolean justBase = entryPathname.equals("base");
       String[] stdlibs = WalaProperties.getJDKLibraryFiles(justBase);
-      for (String stdlib : stdlibs) {
-        scope.addToScope(walaLoader, new JarFile(stdlib, false));
+      if (stdlibs != null) {
+        for (String stdlib : stdlibs) {
+          scope.addToScope(walaLoader, new JarFile(stdlib, false));
+        }
+      } else {
+        for (String moduleName : PlatformUtil.getJDKModuleNames(justBase)) {
+          scope.addJDKModuleToScope(walaLoader, moduleName);
+        }
       }
     } else if ("jdkModule".equals(entryType) || "jrt".equals(entryType)) {
       scope.addJDKModuleToScope(walaLoader, entryPathname);

--- a/core/src/main/java/com/ibm/wala/core/util/config/AnalysisScopeReader.java
+++ b/core/src/main/java/com/ibm/wala/core/util/config/AnalysisScopeReader.java
@@ -21,6 +21,7 @@ import com.ibm.wala.properties.WalaProperties;
 import com.ibm.wala.shrike.shrikeCT.InvalidClassFileException;
 import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.util.PlatformUtil;
+import com.ibm.wala.util.PlatformUtil.NoJDKModulesFoundException;
 import com.ibm.wala.util.config.PatternsFilter;
 import com.ibm.wala.util.debug.Assertions;
 import java.io.BufferedReader;
@@ -230,12 +231,12 @@ public class AnalysisScopeReader {
       scope.setLoaderImpl(walaLoader, entryPathname);
     } else if ("stdlib".equals(entryType)) {
       boolean justBase = entryPathname.equals("base");
-      String[] stdlibs = WalaProperties.getJDKLibraryFiles(justBase);
-      if (stdlibs.length > 0) {
+      try {
+        String[] stdlibs = WalaProperties.getJDKLibraryFiles(justBase);
         for (String stdlib : stdlibs) {
           scope.addToScope(walaLoader, new JarFile(stdlib, false));
         }
-      } else {
+      } catch (NoJDKModulesFoundException e) {
         for (String moduleName : PlatformUtil.getJDKModuleNames(justBase)) {
           scope.addJDKModuleToScope(walaLoader, moduleName);
         }

--- a/core/src/main/java/com/ibm/wala/core/util/config/AnalysisScopeReader.java
+++ b/core/src/main/java/com/ibm/wala/core/util/config/AnalysisScopeReader.java
@@ -17,11 +17,8 @@ import com.ibm.wala.classLoader.SourceDirectoryTreeModule;
 import com.ibm.wala.core.util.io.FileProvider;
 import com.ibm.wala.core.util.strings.Atom;
 import com.ibm.wala.ipa.callgraph.AnalysisScope;
-import com.ibm.wala.properties.WalaProperties;
 import com.ibm.wala.shrike.shrikeCT.InvalidClassFileException;
 import com.ibm.wala.types.ClassLoaderReference;
-import com.ibm.wala.util.PlatformUtil;
-import com.ibm.wala.util.PlatformUtil.NoJDKLibraryFilesFoundException;
 import com.ibm.wala.util.config.PatternsFilter;
 import com.ibm.wala.util.debug.Assertions;
 import java.io.BufferedReader;
@@ -231,16 +228,7 @@ public class AnalysisScopeReader {
       scope.setLoaderImpl(walaLoader, entryPathname);
     } else if ("stdlib".equals(entryType)) {
       boolean justBase = entryPathname.equals("base");
-      try {
-        String[] stdlibs = WalaProperties.getJDKLibraryFiles(justBase);
-        for (String stdlib : stdlibs) {
-          scope.addToScope(walaLoader, new JarFile(stdlib, false));
-        }
-      } catch (NoJDKLibraryFilesFoundException e) {
-        for (String moduleName : PlatformUtil.getJDKModuleNames(justBase)) {
-          scope.addJDKModuleToScope(walaLoader, moduleName);
-        }
-      }
+      scope.addStdLibs(justBase, walaLoader);
     } else if ("jdkModule".equals(entryType) || "jrt".equals(entryType)) {
       scope.addJDKModuleToScope(walaLoader, entryPathname);
     } else if (!handleInSubclass(scope, walaLoader, language, entryType, entryPathname)) {

--- a/core/src/main/java/com/ibm/wala/core/util/config/AnalysisScopeReader.java
+++ b/core/src/main/java/com/ibm/wala/core/util/config/AnalysisScopeReader.java
@@ -32,6 +32,7 @@ import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.StringTokenizer;
 import java.util.jar.JarFile;
 import org.intellij.lang.annotations.Language;
@@ -231,7 +232,7 @@ public class AnalysisScopeReader {
     } else if ("stdlib".equals(entryType)) {
       boolean justBase = entryPathname.equals("base");
       String[] stdlibs = WalaProperties.getJDKLibraryFiles(justBase);
-      if (stdlibs != null) {
+      if (stdlibs.length > 0) {
         for (String stdlib : stdlibs) {
           scope.addToScope(walaLoader, new JarFile(stdlib, false));
         }

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/AnalysisScope.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/AnalysisScope.java
@@ -24,12 +24,15 @@ import com.ibm.wala.classLoader.SourceFileModule;
 import com.ibm.wala.core.java11.JrtModule;
 import com.ibm.wala.core.util.strings.Atom;
 import com.ibm.wala.core.util.strings.ImmutableByteArray;
+import com.ibm.wala.properties.WalaProperties;
 import com.ibm.wala.shrike.shrikeCT.InvalidClassFileException;
 import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.Descriptor;
 import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.TypeName;
 import com.ibm.wala.types.TypeReference;
+import com.ibm.wala.util.PlatformUtil;
+import com.ibm.wala.util.WalaException;
 import com.ibm.wala.util.collections.FilterIterator;
 import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.collections.HashSetFactory;
@@ -217,6 +220,29 @@ public class AnalysisScope {
   public void addJDKModuleToScope(ClassLoaderReference loader, String moduleName)
       throws IOException {
     addToScope(loader, new JrtModule(moduleName));
+  }
+
+  /**
+   * Add modules for the Java standard library to the scope. First, try to add the standard
+   * libraries specified in the wala.properties file. If that fails, add the standard library
+   * modules from the running JDK.
+   *
+   * @param justBase if true, just include the base module; otherwise, include all discovered
+   *     modules
+   * @param loader the target loader for the standard library modules
+   * @throws IOException if creating a {@link JarFile} fails with an {@link IOException}
+   */
+  public void addStdLibs(boolean justBase, ClassLoaderReference loader) throws IOException {
+    try {
+      String[] stdlibs = WalaProperties.getJDKLibraryFiles(justBase);
+      for (String stdlib : stdlibs) {
+        addToScope(loader, new JarFile(stdlib, false));
+      }
+    } catch (WalaException e) {
+      for (String moduleName : PlatformUtil.getJDKModuleNames(justBase)) {
+        addJDKModuleToScope(loader, moduleName);
+      }
+    }
   }
 
   /**

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/AnalysisScope.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/AnalysisScope.java
@@ -21,6 +21,7 @@ import com.ibm.wala.classLoader.Language;
 import com.ibm.wala.classLoader.Module;
 import com.ibm.wala.classLoader.SourceDirectoryTreeModule;
 import com.ibm.wala.classLoader.SourceFileModule;
+import com.ibm.wala.core.java11.JrtModule;
 import com.ibm.wala.core.util.strings.Atom;
 import com.ibm.wala.core.util.strings.ImmutableByteArray;
 import com.ibm.wala.shrike.shrikeCT.InvalidClassFileException;
@@ -29,7 +30,6 @@ import com.ibm.wala.types.Descriptor;
 import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.TypeName;
 import com.ibm.wala.types.TypeReference;
-import com.ibm.wala.util.PlatformUtil;
 import com.ibm.wala.util.collections.FilterIterator;
 import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.collections.HashSetFactory;
@@ -42,8 +42,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.NotSerializableException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -206,11 +204,19 @@ public class AnalysisScope {
    * @throws IOException if a module by that name cannot successfully be loaded
    */
   public void addJDKModuleToScope(String moduleName) throws IOException {
-    Path path = PlatformUtil.getPathForJDKModule(moduleName);
-    if (!Files.exists(path)) {
-      throw new IOException("cannot find jmod file for module " + moduleName + ", tried " + path);
-    }
-    addToScope(ClassLoaderReference.Primordial, new JarFile(path.toString(), false));
+    addJDKModuleToScope(ClassLoaderReference.Primordial, moduleName);
+  }
+
+  /**
+   * Adds a module from the running JDK image to the analysis scope for a specific loader.
+   *
+   * @param loader the target loader
+   * @param moduleName the name of the module, e.g., {@code "java.sql"}
+   * @throws IOException if a module by that name cannot successfully be loaded
+   */
+  public void addJDKModuleToScope(ClassLoaderReference loader, String moduleName)
+      throws IOException {
+    addToScope(loader, new JrtModule(moduleName));
   }
 
   /**

--- a/core/src/main/java/com/ibm/wala/properties/WalaProperties.java
+++ b/core/src/main/java/com/ibm/wala/properties/WalaProperties.java
@@ -12,6 +12,7 @@ package com.ibm.wala.properties;
 
 import com.ibm.wala.core.util.io.FileProvider;
 import com.ibm.wala.util.PlatformUtil;
+import com.ibm.wala.util.PlatformUtil.NoJDKModulesFoundException;
 import com.ibm.wala.util.WalaException;
 import com.ibm.wala.util.debug.Assertions;
 import com.ibm.wala.util.io.FileUtil;
@@ -53,10 +54,10 @@ public final class WalaProperties {
    *
    * <p>If wala.properties cannot be loaded, returns library files in boot classpath.
    *
-   * @throws IllegalStateException if library files cannot be discovered
+   * @throws NoJDKModulesFoundException if library files cannot be discovered
    * @see PlatformUtil#getJDKModules(boolean)
    */
-  public static String[] getJ2SEJarFiles() {
+  public static String[] getJ2SEJarFiles() throws NoJDKModulesFoundException {
     return getJDKLibraryFiles(false);
   }
 
@@ -69,8 +70,10 @@ public final class WalaProperties {
    *     returns the {@code java.base} library from boot classpath. Otherwise, returns all library
    *     modules from boot classpath.
    * @see PlatformUtil#getJDKModules(boolean)
+   * @throws com.ibm.wala.util.PlatformUtil.NoJDKModulesFoundException if wala.properties cannot be
+   *     loaded and also jmod files from the running JDK cannot be found
    */
-  public static String[] getJDKLibraryFiles(boolean justBase) {
+  public static String[] getJDKLibraryFiles(boolean justBase) throws NoJDKModulesFoundException {
     final Properties p;
     try {
       p = WalaProperties.loadProperties();

--- a/core/src/main/java/com/ibm/wala/properties/WalaProperties.java
+++ b/core/src/main/java/com/ibm/wala/properties/WalaProperties.java
@@ -75,21 +75,26 @@ public final class WalaProperties {
     try {
       p = WalaProperties.loadProperties();
     } catch (WalaException e) {
-      return PlatformUtil.getJDKModules(justBase);
+      return resolveSystemJDKLibraryFiles(justBase);
     }
 
     String dir = p.getProperty(WalaProperties.J2SE_DIR);
     if (dir == null) {
-      return PlatformUtil.getJDKModules(justBase);
+      return resolveSystemJDKLibraryFiles(justBase);
     }
     if (!new File(dir).isDirectory()) {
       System.err.println(
           "WARNING: java_runtime_dir "
               + dir
               + " in wala.properties is invalid.  Using boot class path instead.");
-      return PlatformUtil.getJDKModules(justBase);
+      return resolveSystemJDKLibraryFiles(justBase);
     }
     return getJarsInDirectory(dir);
+  }
+
+  private static String[] resolveSystemJDKLibraryFiles(boolean justBase) {
+    String[] modules = PlatformUtil.getJDKModules(justBase);
+    return modules.length == 0 ? null : modules;
   }
 
   /**

--- a/core/src/main/java/com/ibm/wala/properties/WalaProperties.java
+++ b/core/src/main/java/com/ibm/wala/properties/WalaProperties.java
@@ -75,26 +75,21 @@ public final class WalaProperties {
     try {
       p = WalaProperties.loadProperties();
     } catch (WalaException e) {
-      return resolveSystemJDKLibraryFiles(justBase);
+      return PlatformUtil.getJDKModules(justBase);
     }
 
     String dir = p.getProperty(WalaProperties.J2SE_DIR);
     if (dir == null) {
-      return resolveSystemJDKLibraryFiles(justBase);
+      return PlatformUtil.getJDKModules(justBase);
     }
     if (!new File(dir).isDirectory()) {
       System.err.println(
           "WARNING: java_runtime_dir "
               + dir
               + " in wala.properties is invalid.  Using boot class path instead.");
-      return resolveSystemJDKLibraryFiles(justBase);
+      return PlatformUtil.getJDKModules(justBase);
     }
     return getJarsInDirectory(dir);
-  }
-
-  private static String[] resolveSystemJDKLibraryFiles(boolean justBase) {
-    String[] modules = PlatformUtil.getJDKModules(justBase);
-    return modules.length == 0 ? null : modules;
   }
 
   /**

--- a/core/src/main/java/com/ibm/wala/properties/WalaProperties.java
+++ b/core/src/main/java/com/ibm/wala/properties/WalaProperties.java
@@ -11,8 +11,6 @@
 package com.ibm.wala.properties;
 
 import com.ibm.wala.core.util.io.FileProvider;
-import com.ibm.wala.util.PlatformUtil;
-import com.ibm.wala.util.PlatformUtil.NoJDKLibraryFilesFoundException;
 import com.ibm.wala.util.WalaException;
 import com.ibm.wala.util.debug.Assertions;
 import com.ibm.wala.util.io.FileUtil;
@@ -54,10 +52,9 @@ public final class WalaProperties {
    *
    * <p>If wala.properties cannot be loaded, returns library files in boot classpath.
    *
-   * @throws NoJDKLibraryFilesFoundException if library files cannot be discovered
-   * @see PlatformUtil#getJDKModules(boolean)
+   * @throws WalaException if library files cannot be discovered
    */
-  public static String[] getJ2SEJarFiles() throws NoJDKLibraryFilesFoundException {
+  public static String[] getJ2SEJarFiles() throws WalaException {
     return getJDKLibraryFiles(false);
   }
 
@@ -69,29 +66,22 @@ public final class WalaProperties {
    * @param justBase Only relevant if wala.properties cannot be loaded. If {@code true}, only
    *     returns the {@code java.base} library from boot classpath. Otherwise, returns all library
    *     modules from boot classpath.
-   * @see PlatformUtil#getJDKModules(boolean)
-   * @throws NoJDKLibraryFilesFoundException if wala.properties cannot be loaded and also jmod files
-   *     from the running JDK cannot be found
+   * @throws WalaException if JDK library files cannot be loaded based on properties in
+   *     wala.properties
    */
-  public static String[] getJDKLibraryFiles(boolean justBase)
-      throws NoJDKLibraryFilesFoundException {
+  public static String[] getJDKLibraryFiles(boolean justBase) throws WalaException {
     final Properties p;
-    try {
-      p = WalaProperties.loadProperties();
-    } catch (WalaException e) {
-      return PlatformUtil.getJDKModules(justBase);
-    }
+    p = WalaProperties.loadProperties();
 
     String dir = p.getProperty(WalaProperties.J2SE_DIR);
     if (dir == null) {
-      return PlatformUtil.getJDKModules(justBase);
+      throw new WalaException("J2SE_DIR not set in WALA properties file");
     }
     if (!new File(dir).isDirectory()) {
-      System.err.println(
+      throw new WalaException(
           "WARNING: java_runtime_dir "
               + dir
               + " in wala.properties is invalid.  Using boot class path instead.");
-      return PlatformUtil.getJDKModules(justBase);
     }
     return getJarsInDirectory(dir);
   }

--- a/core/src/main/java/com/ibm/wala/properties/WalaProperties.java
+++ b/core/src/main/java/com/ibm/wala/properties/WalaProperties.java
@@ -70,10 +70,11 @@ public final class WalaProperties {
    *     returns the {@code java.base} library from boot classpath. Otherwise, returns all library
    *     modules from boot classpath.
    * @see PlatformUtil#getJDKModules(boolean)
-   * @throws NoJDKLibraryFilesFoundException if wala.properties cannot be
-   *     loaded and also jmod files from the running JDK cannot be found
+   * @throws NoJDKLibraryFilesFoundException if wala.properties cannot be loaded and also jmod files
+   *     from the running JDK cannot be found
    */
-  public static String[] getJDKLibraryFiles(boolean justBase) throws NoJDKLibraryFilesFoundException {
+  public static String[] getJDKLibraryFiles(boolean justBase)
+      throws NoJDKLibraryFilesFoundException {
     final Properties p;
     try {
       p = WalaProperties.loadProperties();

--- a/core/src/main/java/com/ibm/wala/properties/WalaProperties.java
+++ b/core/src/main/java/com/ibm/wala/properties/WalaProperties.java
@@ -12,7 +12,7 @@ package com.ibm.wala.properties;
 
 import com.ibm.wala.core.util.io.FileProvider;
 import com.ibm.wala.util.PlatformUtil;
-import com.ibm.wala.util.PlatformUtil.NoJDKModulesFoundException;
+import com.ibm.wala.util.PlatformUtil.NoJDKLibraryFilesFoundException;
 import com.ibm.wala.util.WalaException;
 import com.ibm.wala.util.debug.Assertions;
 import com.ibm.wala.util.io.FileUtil;
@@ -54,10 +54,10 @@ public final class WalaProperties {
    *
    * <p>If wala.properties cannot be loaded, returns library files in boot classpath.
    *
-   * @throws NoJDKModulesFoundException if library files cannot be discovered
+   * @throws NoJDKLibraryFilesFoundException if library files cannot be discovered
    * @see PlatformUtil#getJDKModules(boolean)
    */
-  public static String[] getJ2SEJarFiles() throws NoJDKModulesFoundException {
+  public static String[] getJ2SEJarFiles() throws NoJDKLibraryFilesFoundException {
     return getJDKLibraryFiles(false);
   }
 
@@ -70,10 +70,10 @@ public final class WalaProperties {
    *     returns the {@code java.base} library from boot classpath. Otherwise, returns all library
    *     modules from boot classpath.
    * @see PlatformUtil#getJDKModules(boolean)
-   * @throws com.ibm.wala.util.PlatformUtil.NoJDKModulesFoundException if wala.properties cannot be
+   * @throws NoJDKLibraryFilesFoundException if wala.properties cannot be
    *     loaded and also jmod files from the running JDK cannot be found
    */
-  public static String[] getJDKLibraryFiles(boolean justBase) throws NoJDKModulesFoundException {
+  public static String[] getJDKLibraryFiles(boolean justBase) throws NoJDKLibraryFilesFoundException {
     final Properties p;
     try {
       p = WalaProperties.loadProperties();

--- a/core/src/test/java/com/ibm/wala/core/tests/cha/AnalysisScopeTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/cha/AnalysisScopeTest.java
@@ -14,6 +14,7 @@ import com.ibm.wala.ipa.cha.ClassHierarchyFactory;
 import com.ibm.wala.properties.WalaProperties;
 import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.TypeReference;
+import com.ibm.wala.util.PlatformUtil.NoJDKModulesFoundException;
 import com.ibm.wala.util.config.StringFilter;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -102,11 +103,15 @@ public class AnalysisScopeTest {
   public void testToJsonCustom() throws IOException {
     AnalysisScope scope;
     scope = AnalysisScope.createJavaAnalysisScope();
-    String[] stdlibs = WalaProperties.getJ2SEJarFiles();
-    Arrays.sort(stdlibs);
-    for (String stdlib : stdlibs) {
-      scope.addToScope(ClassLoaderReference.Primordial, new JarFile(stdlib));
-      scope.addToScope(ClassLoaderReference.Application, new JarFile(stdlib));
+    try {
+      String[] stdlibs = WalaProperties.getJ2SEJarFiles();
+      Arrays.sort(stdlibs);
+      for (String stdlib : stdlibs) {
+        scope.addToScope(ClassLoaderReference.Primordial, new JarFile(stdlib));
+        scope.addToScope(ClassLoaderReference.Application, new JarFile(stdlib));
+      }
+    } catch (NoJDKModulesFoundException e) {
+      // TODO handle case where JDK has no jmod files
     }
     scope.setExclusions((StringFilter) null);
     Gson gson = new Gson();

--- a/core/src/test/java/com/ibm/wala/core/tests/cha/AnalysisScopeTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/cha/AnalysisScopeTest.java
@@ -103,15 +103,17 @@ public class AnalysisScopeTest {
   public void testToJsonCustom() throws IOException {
     AnalysisScope scope;
     scope = AnalysisScope.createJavaAnalysisScope();
+    String[] stdlibs;
     try {
-      String[] stdlibs = WalaProperties.getJ2SEJarFiles();
+      stdlibs = WalaProperties.getJ2SEJarFiles();
       Arrays.sort(stdlibs);
       for (String stdlib : stdlibs) {
         scope.addToScope(ClassLoaderReference.Primordial, new JarFile(stdlib));
         scope.addToScope(ClassLoaderReference.Application, new JarFile(stdlib));
       }
     } catch (NoJDKModulesFoundException e) {
-      // TODO handle case where JDK has no jmod files
+      // TODO properly handle case where JDK has no jmod files
+      stdlibs = new String[0];
     }
     scope.setExclusions((StringFilter) null);
     Gson gson = new Gson();

--- a/core/src/test/java/com/ibm/wala/core/tests/cha/AnalysisScopeTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/cha/AnalysisScopeTest.java
@@ -14,7 +14,7 @@ import com.ibm.wala.ipa.cha.ClassHierarchyFactory;
 import com.ibm.wala.properties.WalaProperties;
 import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.TypeReference;
-import com.ibm.wala.util.PlatformUtil.NoJDKModulesFoundException;
+import com.ibm.wala.util.PlatformUtil.NoJDKLibraryFilesFoundException;
 import com.ibm.wala.util.config.StringFilter;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -111,7 +111,7 @@ public class AnalysisScopeTest {
         scope.addToScope(ClassLoaderReference.Primordial, new JarFile(stdlib));
         scope.addToScope(ClassLoaderReference.Application, new JarFile(stdlib));
       }
-    } catch (NoJDKModulesFoundException e) {
+    } catch (NoJDKLibraryFilesFoundException e) {
       // TODO properly handle case where JDK has no jmod files
       stdlibs = new String[0];
     }

--- a/core/src/test/java/com/ibm/wala/core/tests/cha/AnalysisScopeTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/cha/AnalysisScopeTest.java
@@ -14,7 +14,7 @@ import com.ibm.wala.ipa.cha.ClassHierarchyFactory;
 import com.ibm.wala.properties.WalaProperties;
 import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.TypeReference;
-import com.ibm.wala.util.PlatformUtil.NoJDKLibraryFilesFoundException;
+import com.ibm.wala.util.WalaException;
 import com.ibm.wala.util.config.StringFilter;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -111,7 +111,7 @@ public class AnalysisScopeTest {
         scope.addToScope(ClassLoaderReference.Primordial, new JarFile(stdlib));
         scope.addToScope(ClassLoaderReference.Application, new JarFile(stdlib));
       }
-    } catch (NoJDKLibraryFilesFoundException e) {
+    } catch (WalaException e) {
       // TODO properly handle case where JDK has no jmod files
       stdlibs = new String[0];
     }

--- a/core/src/testFixtures/java/com/ibm/wala/core/tests/shrike/DynamicCallGraphTestBase.java
+++ b/core/src/testFixtures/java/com/ibm/wala/core/tests/shrike/DynamicCallGraphTestBase.java
@@ -24,7 +24,7 @@ import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.Selector;
 import com.ibm.wala.types.TypeReference;
-import com.ibm.wala.util.PlatformUtil.NoJDKLibraryFilesFoundException;
+import com.ibm.wala.util.WalaException;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.util.io.TemporaryFile;
@@ -79,7 +79,7 @@ public abstract class DynamicCallGraphTestBase extends WalaTestCase {
             rtJar = jar;
           }
         }
-      } catch (NoJDKLibraryFilesFoundException e) {
+      } catch (WalaException e) {
         // TODO handle case where JDK has no jmod files
       }
       List<String> args =

--- a/core/src/testFixtures/java/com/ibm/wala/core/tests/shrike/DynamicCallGraphTestBase.java
+++ b/core/src/testFixtures/java/com/ibm/wala/core/tests/shrike/DynamicCallGraphTestBase.java
@@ -24,6 +24,7 @@ import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.Selector;
 import com.ibm.wala.types.TypeReference;
+import com.ibm.wala.util.PlatformUtil.NoJDKModulesFoundException;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.util.io.TemporaryFile;
@@ -71,13 +72,16 @@ public abstract class DynamicCallGraphTestBase extends WalaTestCase {
       Files.deleteIfExists(instrumentedJarLocation);
 
       String rtJar = null;
-      for (String jar : WalaProperties.getJ2SEJarFiles()) {
-        if (jar.endsWith(File.separator + "rt.jar")
-            || jar.endsWith(File.separator + "classes.jar")) {
-          rtJar = jar;
+      try {
+        for (String jar : WalaProperties.getJ2SEJarFiles()) {
+          if (jar.endsWith(File.separator + "rt.jar")
+              || jar.endsWith(File.separator + "classes.jar")) {
+            rtJar = jar;
+          }
         }
+      } catch (NoJDKModulesFoundException e) {
+        // TODO handle case where JDK has no jmod files
       }
-
       List<String> args =
           new ArrayList<>(Arrays.asList(testJarLocation, "-o", instrumentedJarLocation.toString()));
       if (rtJar != null) {

--- a/core/src/testFixtures/java/com/ibm/wala/core/tests/shrike/DynamicCallGraphTestBase.java
+++ b/core/src/testFixtures/java/com/ibm/wala/core/tests/shrike/DynamicCallGraphTestBase.java
@@ -24,7 +24,7 @@ import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.Selector;
 import com.ibm.wala.types.TypeReference;
-import com.ibm.wala.util.PlatformUtil.NoJDKModulesFoundException;
+import com.ibm.wala.util.PlatformUtil.NoJDKLibraryFilesFoundException;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.util.io.TemporaryFile;
@@ -79,7 +79,7 @@ public abstract class DynamicCallGraphTestBase extends WalaTestCase {
             rtJar = jar;
           }
         }
-      } catch (NoJDKModulesFoundException e) {
+      } catch (NoJDKLibraryFilesFoundException e) {
         // TODO handle case where JDK has no jmod files
       }
       List<String> args =

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/Constants.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/Constants.java
@@ -503,6 +503,8 @@ public interface Constants {
 
   byte CONSTANT_MethodType = 16;
 
+  byte CONSTANT_Dynamic = 17;
+
   byte CONSTANT_InvokeDynamic = 18;
 
   byte T_BOOLEAN = 4;

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/ClassConstants.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/ClassConstants.java
@@ -43,6 +43,8 @@ public interface ClassConstants {
 
   byte CONSTANT_MethodType = 16;
 
+  byte CONSTANT_Dynamic = 17;
+
   byte CONSTANT_InvokeDynamic = 18;
 
   byte CONSTANT_Module = 19;

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/ConstantPoolParser.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/ConstantPoolParser.java
@@ -634,6 +634,7 @@ public final class ConstantPoolParser implements ClassConstants {
         case CONSTANT_InterfaceMethodRef:
         case CONSTANT_Integer:
         case CONSTANT_Float:
+        case CONSTANT_Dynamic:
         case CONSTANT_InvokeDynamic:
           itemLen = 4;
           break;

--- a/util/src/main/java/com/ibm/wala/util/PlatformUtil.java
+++ b/util/src/main/java/com/ibm/wala/util/PlatformUtil.java
@@ -59,13 +59,13 @@ public class PlatformUtil {
    *
    * @param justBase if {@code true}, only include the file corresponding to the {@code java.base}
    *     module
-   * @return array of {@code .jmod} module files
+   * @return array of {@code .jmod} module files, or an empty array if the files cannot be loaded
    * @throws IllegalStateException if modules cannot be found
    */
   public static String @Nullable [] getJDKModules(boolean justBase) {
     Path jmodsDir = Paths.get(System.getProperty("java.home"), "jmods");
     if (!Files.isDirectory(jmodsDir)) {
-      return null;
+      return new String[0];
     }
 
     List<String> jmods;

--- a/util/src/main/java/com/ibm/wala/util/PlatformUtil.java
+++ b/util/src/main/java/com/ibm/wala/util/PlatformUtil.java
@@ -53,18 +53,25 @@ public class PlatformUtil {
     return "IKVM.NET".equals(System.getProperty("java.runtime.name"));
   }
 
+  public static class NoJDKModulesFoundException extends Exception {
+
+    public NoJDKModulesFoundException(String msg) {
+      super(msg);
+    }
+  }
+
   /**
    * Gets the standard JDK modules shipped with the running JDK
    *
    * @param justBase if {@code true}, only include the file corresponding to the {@code java.base}
    *     module
    * @return array of {@code .jmod} module files, or an empty array if the files cannot be loaded
-   * @throws IllegalStateException if modules cannot be found
+   * @throws IllegalStateException if the running JDK does not include jmod files
    */
-  public static String[] getJDKModules(boolean justBase) {
+  public static String[] getJDKModules(boolean justBase) throws NoJDKModulesFoundException {
     Path jmodsDir = Paths.get(System.getProperty("java.home"), "jmods");
     if (!Files.isDirectory(jmodsDir)) {
-      return new String[0];
+      throw new NoJDKModulesFoundException("could not find jmods directory at " + jmodsDir);
     }
 
     List<String> jmods;

--- a/util/src/main/java/com/ibm/wala/util/PlatformUtil.java
+++ b/util/src/main/java/com/ibm/wala/util/PlatformUtil.java
@@ -28,6 +28,7 @@ import org.jspecify.annotations.Nullable;
 public class PlatformUtil {
 
   private static final java.net.URI JRT_URI = java.net.URI.create("jrt:/");
+  private static final FileSystem JRT_FILE_SYSTEM = initJrtFileSystem();
 
   /** are we running on Mac OS X? */
   public static boolean onMacOSX() {
@@ -100,7 +101,7 @@ public class PlatformUtil {
       if (justBase) {
         modules = List.of("java.base");
       } else {
-        try (Stream<Path> modulePaths = Files.list(getJrtFileSystem().getPath("modules"))) {
+        try (Stream<Path> modulePaths = Files.list(JRT_FILE_SYSTEM.getPath("modules"))) {
           modules =
               modulePaths.map(Path::getFileName).map(Path::toString).collect(Collectors.toList());
         }
@@ -127,7 +128,12 @@ public class PlatformUtil {
     return Integer.parseInt(version);
   }
 
-  public static FileSystem getJrtFileSystem() throws IOException {
+  /** Returns the shared {@code jrt:/} filesystem for this JVM. Callers should not close it. */
+  public static FileSystem getJrtFileSystem() {
+    return JRT_FILE_SYSTEM;
+  }
+
+  private static FileSystem initJrtFileSystem() {
     try {
       return FileSystems.getFileSystem(JRT_URI);
     } catch (FileSystemNotFoundException e) {
@@ -136,6 +142,8 @@ public class PlatformUtil {
       } catch (FileSystemAlreadyExistsException ignored) {
         // Another caller won the race to install the filesystem; reuse that instance.
         return FileSystems.getFileSystem(JRT_URI);
+      } catch (IOException ioException) {
+        throw new IllegalStateException("unable to initialize jrt filesystem", ioException);
       }
     }
   }

--- a/util/src/main/java/com/ibm/wala/util/PlatformUtil.java
+++ b/util/src/main/java/com/ibm/wala/util/PlatformUtil.java
@@ -17,7 +17,6 @@ import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -51,54 +50,6 @@ public class PlatformUtil {
   /** are we running on <a href="http://www.ikvm.net">IKVM</a>? */
   public static boolean onIKVM() {
     return "IKVM.NET".equals(System.getProperty("java.runtime.name"));
-  }
-
-  /** Exception thrown when WALA cannot locate the JDK library files for the running runtime. */
-  public static class NoJDKLibraryFilesFoundException extends Exception {
-
-    private static final long serialVersionUID = 1L;
-
-    /**
-     * @param msg description of the missing-library failure
-     */
-    public NoJDKLibraryFilesFoundException(String msg) {
-      super(msg);
-    }
-  }
-
-  /**
-   * Gets the standard JDK modules shipped with the running JDK
-   *
-   * @param justBase if {@code true}, only include the file corresponding to the {@code java.base}
-   *     module
-   * @return array of {@code .jmod} module files
-   * @throws NoJDKLibraryFilesFoundException if the running JDK does not include jmod files
-   */
-  public static String[] getJDKModules(boolean justBase) throws NoJDKLibraryFilesFoundException {
-    Path jmodsDir = Paths.get(System.getProperty("java.home"), "jmods");
-    if (!Files.isDirectory(jmodsDir)) {
-      throw new NoJDKLibraryFilesFoundException("could not find jmods directory at " + jmodsDir);
-    }
-
-    List<String> jmods;
-    if (justBase) {
-      Path basePath = jmodsDir.resolve("java.base.jmod");
-      if (!Files.exists(basePath)) {
-        throw new IllegalStateException("could not find java.base.jmod");
-      }
-      jmods = List.of(basePath.toString());
-    } else {
-      try (Stream<Path> stream = Files.list(jmodsDir)) {
-        jmods =
-            stream
-                .map(Path::toString)
-                .filter(p -> p.endsWith(".jmod"))
-                .collect(Collectors.toList());
-      } catch (IOException e) {
-        throw new IllegalStateException(e);
-      }
-    }
-    return jmods.toArray(new String[0]);
   }
 
   /**

--- a/util/src/main/java/com/ibm/wala/util/PlatformUtil.java
+++ b/util/src/main/java/com/ibm/wala/util/PlatformUtil.java
@@ -11,15 +11,22 @@
 package com.ibm.wala.util;
 
 import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystemAlreadyExistsException;
+import java.nio.file.FileSystemNotFoundException;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /** Platform-specific utility functions. */
 public class PlatformUtil {
+
+  private static final java.net.URI JRT_URI = java.net.URI.create("jrt:/");
 
   /** are we running on Mac OS X? */
   public static boolean onMacOSX() {
@@ -54,15 +61,20 @@ public class PlatformUtil {
    * @throws IllegalStateException if modules cannot be found
    */
   public static String[] getJDKModules(boolean justBase) {
+    Path jmodsDir = Paths.get(System.getProperty("java.home"), "jmods");
+    if (!Files.isDirectory(jmodsDir)) {
+      return new String[0];
+    }
+
     List<String> jmods;
     if (justBase) {
-      Path basePath = Paths.get(System.getProperty("java.home"), "jmods", "java.base.jmod");
+      Path basePath = jmodsDir.resolve("java.base.jmod");
       if (!Files.exists(basePath)) {
         throw new IllegalStateException("could not find java.base.jmod");
       }
       jmods = List.of(basePath.toString());
     } else {
-      try (Stream<Path> stream = Files.list(Paths.get(System.getProperty("java.home"), "jmods"))) {
+      try (Stream<Path> stream = Files.list(jmodsDir)) {
         jmods =
             stream
                 .map(Path::toString)
@@ -73,6 +85,32 @@ public class PlatformUtil {
       }
     }
     return jmods.toArray(new String[0]);
+  }
+
+  /**
+   * Gets the standard JDK module names exposed by the running JDK image.
+   *
+   * @param justBase if {@code true}, only include {@code java.base}
+   * @return array of module names from the {@code jrt:/modules} filesystem
+   */
+  public static String[] getJDKModuleNames(boolean justBase) {
+    List<String> modules;
+    try {
+      if (justBase) {
+        modules = List.of("java.base");
+      } else {
+        try (Stream<Path> modulePaths = Files.list(getJrtFileSystem().getPath("modules"))) {
+          modules =
+              modulePaths
+                  .map(Path::getFileName)
+                  .map(Path::toString)
+                  .collect(Collectors.toList());
+        }
+      }
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+    return modules.toArray(new String[0]);
   }
 
   /**
@@ -89,5 +127,18 @@ public class PlatformUtil {
       }
     }
     return Integer.parseInt(version);
+  }
+
+  public static FileSystem getJrtFileSystem() throws IOException {
+    try {
+      return FileSystems.getFileSystem(JRT_URI);
+    } catch (FileSystemNotFoundException e) {
+      try {
+        return FileSystems.newFileSystem(JRT_URI, Collections.emptyMap());
+      } catch (FileSystemAlreadyExistsException ignored) {
+        // Another caller won the race to install the filesystem; reuse that instance.
+        return FileSystems.getFileSystem(JRT_URI);
+      }
+    }
   }
 }

--- a/util/src/main/java/com/ibm/wala/util/PlatformUtil.java
+++ b/util/src/main/java/com/ibm/wala/util/PlatformUtil.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.jspecify.annotations.Nullable;
 
 /** Platform-specific utility functions. */
 public class PlatformUtil {

--- a/util/src/main/java/com/ibm/wala/util/PlatformUtil.java
+++ b/util/src/main/java/com/ibm/wala/util/PlatformUtil.java
@@ -53,9 +53,15 @@ public class PlatformUtil {
     return "IKVM.NET".equals(System.getProperty("java.runtime.name"));
   }
 
-  public static class NoJDKModulesFoundException extends Exception {
+  /** Exception thrown when WALA cannot locate the JDK library files for the running runtime. */
+  public static class NoJDKLibraryFilesFoundException extends Exception {
 
-    public NoJDKModulesFoundException(String msg) {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * @param msg description of the missing-library failure
+     */
+    public NoJDKLibraryFilesFoundException(String msg) {
       super(msg);
     }
   }
@@ -68,10 +74,10 @@ public class PlatformUtil {
    * @return array of {@code .jmod} module files, or an empty array if the files cannot be loaded
    * @throws IllegalStateException if the running JDK does not include jmod files
    */
-  public static String[] getJDKModules(boolean justBase) throws NoJDKModulesFoundException {
+  public static String[] getJDKModules(boolean justBase) throws NoJDKLibraryFilesFoundException {
     Path jmodsDir = Paths.get(System.getProperty("java.home"), "jmods");
     if (!Files.isDirectory(jmodsDir)) {
-      throw new NoJDKModulesFoundException("could not find jmods directory at " + jmodsDir);
+      throw new NoJDKLibraryFilesFoundException("could not find jmods directory at " + jmodsDir);
     }
 
     List<String> jmods;

--- a/util/src/main/java/com/ibm/wala/util/PlatformUtil.java
+++ b/util/src/main/java/com/ibm/wala/util/PlatformUtil.java
@@ -76,16 +76,6 @@ public class PlatformUtil {
   }
 
   /**
-   * Returns the filesystem path for a JDK module from the running JVM
-   *
-   * @param moduleName name of the module, e.g., {@code "java.sql"}
-   * @return path to the module
-   */
-  public static Path getPathForJDKModule(String moduleName) {
-    return Paths.get(System.getProperty("java.home"), "jmods", moduleName + ".jmod");
-  }
-
-  /**
    * @return the major version of the Java runtime we are running on.
    */
   public static int getJavaRuntimeVersion() {

--- a/util/src/main/java/com/ibm/wala/util/PlatformUtil.java
+++ b/util/src/main/java/com/ibm/wala/util/PlatformUtil.java
@@ -62,7 +62,7 @@ public class PlatformUtil {
    * @return array of {@code .jmod} module files, or an empty array if the files cannot be loaded
    * @throws IllegalStateException if modules cannot be found
    */
-  public static String @Nullable [] getJDKModules(boolean justBase) {
+  public static String[] getJDKModules(boolean justBase) {
     Path jmodsDir = Paths.get(System.getProperty("java.home"), "jmods");
     if (!Files.isDirectory(jmodsDir)) {
       return new String[0];

--- a/util/src/main/java/com/ibm/wala/util/PlatformUtil.java
+++ b/util/src/main/java/com/ibm/wala/util/PlatformUtil.java
@@ -71,8 +71,8 @@ public class PlatformUtil {
    *
    * @param justBase if {@code true}, only include the file corresponding to the {@code java.base}
    *     module
-   * @return array of {@code .jmod} module files, or an empty array if the files cannot be loaded
-   * @throws IllegalStateException if the running JDK does not include jmod files
+   * @return array of {@code .jmod} module files
+   * @throws NoJDKLibraryFilesFoundException if the running JDK does not include jmod files
    */
   public static String[] getJDKModules(boolean justBase) throws NoJDKLibraryFilesFoundException {
     Path jmodsDir = Paths.get(System.getProperty("java.home"), "jmods");

--- a/util/src/main/java/com/ibm/wala/util/PlatformUtil.java
+++ b/util/src/main/java/com/ibm/wala/util/PlatformUtil.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.jspecify.annotations.Nullable;
 
 /** Platform-specific utility functions. */
 public class PlatformUtil {
@@ -60,10 +61,10 @@ public class PlatformUtil {
    * @return array of {@code .jmod} module files
    * @throws IllegalStateException if modules cannot be found
    */
-  public static String[] getJDKModules(boolean justBase) {
+  public static String @Nullable [] getJDKModules(boolean justBase) {
     Path jmodsDir = Paths.get(System.getProperty("java.home"), "jmods");
     if (!Files.isDirectory(jmodsDir)) {
-      return new String[0];
+      return null;
     }
 
     List<String> jmods;
@@ -101,10 +102,7 @@ public class PlatformUtil {
       } else {
         try (Stream<Path> modulePaths = Files.list(getJrtFileSystem().getPath("modules"))) {
           modules =
-              modulePaths
-                  .map(Path::getFileName)
-                  .map(Path::toString)
-                  .collect(Collectors.toList());
+              modulePaths.map(Path::getFileName).map(Path::toString).collect(Collectors.toList());
         }
       }
     } catch (IOException e) {


### PR DESCRIPTION
Fixes #1876 

Before this change, we would load standard library `jmod` files for recent JDKs from a well-known place in the filesystem.  But, certain JDK distributions like Temurin no longer distribute such files directly.  This change allows WALA to run on such JDKs, by loading the standard library files via the pre-existing `JrtModule` support, which loads the files via a special virtual filesystem.  This will be a nice benefit for WALA users, since WALA will be able to load the running JVM's standard libraries out of the box on recent versions of JDKs like Temurin that don't package jmod files.  To ensure this support doesn't regress, we now install Temurin JDKs by default on CI, and we no longer specifically request Zulu JDKs (which include jmod files) in our Java toolchain configuration.

There are some API-incompatible changes in this PR.  In particular, `WalaProperties.getJ2SEJarFiles` now can throw a `NoJDKLibraryFilesFoundException` if there are no standard library files distributed with the JDK, in which case client code should fall back on calling `PlatformUtil.getJDKModuleNames` and then loading the modules via `JrtModule`.  It would be nice to have a single clean code path for handling all these cases, but it's not straightforward, given we still want to support loading standard libraries specified in scope files.

There are a couple of cases where tests passed without even loading the standard library; so for now, I just left TODO comments on those to do more detailed handling in the future.

Other related changes:

* Moved the functionality from `Java9AnalysisScopeReader` into `AnalysisScopeReader`, and deprecated the former.
* This PR exposed another bug which is that Shrike did not yet support `CONSTANT_Dynamic` constant pool entries (exposed since these changes caused all library modules to be loaded on modern JDKs for the first time); add basic support for those.