### PR TITLE
Deprecate redundant `DexConstants`

### DIFF
--- a/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexConstants.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexConstants.java
@@ -48,6 +48,7 @@
 package com.ibm.wala.dalvik.classLoader;
 
 import org.jf.dexlib2.AccessFlags;
+import org.jf.dexlib2.ValueType;
 
 public interface DexConstants {
   int ACC_PUBLIC = AccessFlags.PUBLIC.getValue();
@@ -78,20 +79,20 @@ public interface DexConstants {
   @Deprecated(forRemoval = true, since = "1.7.1")
   int ACC_private = ACC_PUBLIC;
 
-  int VALUE_BYTE = 0x00;
-  int VALUE_SHORT = 0x02;
-  int VALUE_CHAR = 0x03;
-  int VALUE_INT = 0x04;
-  int VALUE_LONG = 0x06;
-  int VALUE_FLOAT = 0x10;
-  int VALUE_DOUBLE = 0x11;
-  int VALUE_STRING = 0x17;
-  int VALUE_TYPE = 0x18;
-  int VALUE_FIELD = 0x19;
-  int VALUE_METHOD = 0x1a;
-  int VALUE_ENUM = 0x1b;
-  int VALUE_ARRAY = 0x1c;
-  int VALUE_ANNOTATION = 0x1d;
-  int VALUE_NULL = 0x1e;
-  int VALUE_BOOLEAN = 0x1f;
+  int VALUE_BYTE = ValueType.BYTE;
+  int VALUE_SHORT = ValueType.SHORT;
+  int VALUE_CHAR = ValueType.CHAR;
+  int VALUE_INT = ValueType.INT;
+  int VALUE_LONG = ValueType.LONG;
+  int VALUE_FLOAT = ValueType.FLOAT;
+  int VALUE_DOUBLE = ValueType.DOUBLE;
+  int VALUE_STRING = ValueType.STRING;
+  int VALUE_TYPE = ValueType.TYPE;
+  int VALUE_FIELD = ValueType.FIELD;
+  int VALUE_METHOD = ValueType.METHOD;
+  int VALUE_ENUM = ValueType.ENUM;
+  int VALUE_ARRAY = ValueType.ARRAY;
+  int VALUE_ANNOTATION = ValueType.ANNOTATION;
+  int VALUE_NULL = ValueType.NULL;
+  int VALUE_BOOLEAN = ValueType.BOOLEAN;
 }

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexConstants.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexConstants.java
@@ -47,27 +47,29 @@
 
 package com.ibm.wala.dalvik.classLoader;
 
+import org.jf.dexlib2.AccessFlags;
+
 public interface DexConstants {
-  int ACC_PUBLIC = 0x1;
-  int ACC_PRIVATE = 0x2;
-  int ACC_PROTECTED = 0x4;
-  int ACC_STATIC = 0x8;
-  int ACC_FINAL = 0x10;
-  int ACC_SYNCHRONIZED = 0x20;
-  int ACC_VOLATILE = 0x40;
-  int ACC_BRIDGE = 0x40;
-  int ACC_TRANSIENT = 0x80;
-  int ACC_VARARGS = 0x80;
-  int ACC_NATIVE = 0x100;
-  int ACC_INTERFACE = 0x200;
-  int ACC_ABSTRACT = 0x400;
-  int ACC_STRICT = 0x800;
-  int ACC_SYNTHETIC = 0x1000;
-  int ACC_ANNOTATION = 0x2000;
-  int ACC_ENUM = 0x4000;
+  int ACC_PUBLIC = AccessFlags.PUBLIC.getValue();
+  int ACC_PRIVATE = AccessFlags.PRIVATE.getValue();
+  int ACC_PROTECTED = AccessFlags.PROTECTED.getValue();
+  int ACC_STATIC = AccessFlags.STATIC.getValue();
+  int ACC_FINAL = AccessFlags.FINAL.getValue();
+  int ACC_SYNCHRONIZED = AccessFlags.SYNCHRONIZED.getValue();
+  int ACC_VOLATILE = AccessFlags.VOLATILE.getValue();
+  int ACC_BRIDGE = AccessFlags.BRIDGE.getValue();
+  int ACC_TRANSIENT = AccessFlags.TRANSIENT.getValue();
+  int ACC_VARARGS = AccessFlags.VARARGS.getValue();
+  int ACC_NATIVE = AccessFlags.NATIVE.getValue();
+  int ACC_INTERFACE = AccessFlags.INTERFACE.getValue();
+  int ACC_ABSTRACT = AccessFlags.ABSTRACT.getValue();
+  int ACC_STRICT = AccessFlags.STRICTFP.getValue();
+  int ACC_SYNTHETIC = AccessFlags.SYNTHETIC.getValue();
+  int ACC_ANNOTATION = AccessFlags.ANNOTATION.getValue();
+  int ACC_ENUM = AccessFlags.ENUM.getValue();
   int ACC_UNUSED = 0x8000;
-  int ACC_CONSTRUCTOR = 0x10000;
-  int ACC_DECLARED_SYNCHRONIZED = 0x2000;
+  int ACC_CONSTRUCTOR = AccessFlags.CONSTRUCTOR.getValue();
+  int ACC_DECLARED_SYNCHRONIZED = AccessFlags.DECLARED_SYNCHRONIZED.getValue();
 
   /**
    * @deprecated

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexConstants.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexConstants.java
@@ -50,49 +50,264 @@ package com.ibm.wala.dalvik.classLoader;
 import org.jf.dexlib2.AccessFlags;
 import org.jf.dexlib2.ValueType;
 
+/**
+ * @deprecated replace {@code ACC_XXX} with {@link AccessFlags}{@code .XXX.getValue()} and replace
+ *     {@code VALUE_XXX} with {@link ValueType}{@code .XXX}
+ */
+@Deprecated(forRemoval = true, since = "1.7.2")
 public interface DexConstants {
+
+  /**
+   * @deprecated
+   * @see AccessFlags#PUBLIC
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int ACC_PUBLIC = AccessFlags.PUBLIC.getValue();
+
+  /**
+   * @deprecated
+   * @see AccessFlags#PRIVATE
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int ACC_PRIVATE = AccessFlags.PRIVATE.getValue();
+
+  /**
+   * @deprecated
+   * @see AccessFlags#PROTECTED
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int ACC_PROTECTED = AccessFlags.PROTECTED.getValue();
+
+  /**
+   * @deprecated
+   * @see AccessFlags#STATIC
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int ACC_STATIC = AccessFlags.STATIC.getValue();
+
+  /**
+   * @deprecated
+   * @see AccessFlags#FINAL
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int ACC_FINAL = AccessFlags.FINAL.getValue();
+
+  /**
+   * @deprecated
+   * @see AccessFlags#SYNCHRONIZED
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int ACC_SYNCHRONIZED = AccessFlags.SYNCHRONIZED.getValue();
+
+  /**
+   * @deprecated
+   * @see AccessFlags#VOLATILE
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int ACC_VOLATILE = AccessFlags.VOLATILE.getValue();
+
+  /**
+   * @deprecated
+   * @see AccessFlags#BRIDGE
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int ACC_BRIDGE = AccessFlags.BRIDGE.getValue();
+
+  /**
+   * @deprecated
+   * @see AccessFlags#TRANSIENT
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int ACC_TRANSIENT = AccessFlags.TRANSIENT.getValue();
+
+  /**
+   * @deprecated
+   * @see AccessFlags#VARARGS
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int ACC_VARARGS = AccessFlags.VARARGS.getValue();
+
+  /**
+   * @deprecated
+   * @see AccessFlags#NATIVE
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int ACC_NATIVE = AccessFlags.NATIVE.getValue();
+
+  /**
+   * @deprecated
+   * @see AccessFlags#INTERFACE
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int ACC_INTERFACE = AccessFlags.INTERFACE.getValue();
+
+  /**
+   * @deprecated
+   * @see AccessFlags#ABSTRACT
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int ACC_ABSTRACT = AccessFlags.ABSTRACT.getValue();
+
+  /**
+   * @deprecated
+   * @see AccessFlags#STRICTFP
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int ACC_STRICT = AccessFlags.STRICTFP.getValue();
+
+  /**
+   * @deprecated
+   * @see AccessFlags#SYNTHETIC
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int ACC_SYNTHETIC = AccessFlags.SYNTHETIC.getValue();
+
+  /**
+   * @deprecated
+   * @see AccessFlags#ANNOTATION
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int ACC_ANNOTATION = AccessFlags.ANNOTATION.getValue();
+
+  /**
+   * @deprecated
+   * @see AccessFlags#ENUM
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int ACC_ENUM = AccessFlags.ENUM.getValue();
+
   int ACC_UNUSED = 0x8000;
+
+  /**
+   * @deprecated
+   * @see AccessFlags#CONSTRUCTOR
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int ACC_CONSTRUCTOR = AccessFlags.CONSTRUCTOR.getValue();
+
+  /**
+   * @deprecated
+   * @see AccessFlags#DECLARED_SYNCHRONIZED
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int ACC_DECLARED_SYNCHRONIZED = AccessFlags.DECLARED_SYNCHRONIZED.getValue();
 
   /**
    * @deprecated
    * @see #ACC_PUBLIC
    */
-  @Deprecated(forRemoval = true, since = "1.7.1")
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int ACC_private = ACC_PUBLIC;
 
+  /**
+   * @deprecated
+   * @see ValueType#BYTE
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int VALUE_BYTE = ValueType.BYTE;
+
+  /**
+   * @deprecated
+   * @see ValueType#SHORT
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int VALUE_SHORT = ValueType.SHORT;
+
+  /**
+   * @deprecated
+   * @see ValueType#CHAR
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int VALUE_CHAR = ValueType.CHAR;
+
+  /**
+   * @deprecated
+   * @see ValueType#INT
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int VALUE_INT = ValueType.INT;
+
+  /**
+   * @deprecated
+   * @see ValueType#LONG
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int VALUE_LONG = ValueType.LONG;
+
+  /**
+   * @deprecated
+   * @see ValueType#FLOAT
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int VALUE_FLOAT = ValueType.FLOAT;
+
+  /**
+   * @deprecated
+   * @see ValueType#DOUBLE
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int VALUE_DOUBLE = ValueType.DOUBLE;
+
+  /**
+   * @deprecated
+   * @see ValueType#STRING
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int VALUE_STRING = ValueType.STRING;
+
+  /**
+   * @deprecated
+   * @see ValueType#TYPE
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int VALUE_TYPE = ValueType.TYPE;
+
+  /**
+   * @deprecated
+   * @see ValueType#FIELD
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int VALUE_FIELD = ValueType.FIELD;
+
+  /**
+   * @deprecated
+   * @see ValueType#METHOD
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int VALUE_METHOD = ValueType.METHOD;
+
+  /**
+   * @deprecated
+   * @see ValueType#ENUM
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int VALUE_ENUM = ValueType.ENUM;
+
+  /**
+   * @deprecated
+   * @see ValueType#ARRAY
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int VALUE_ARRAY = ValueType.ARRAY;
+
+  /**
+   * @deprecated
+   * @see ValueType#ANNOTATION
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int VALUE_ANNOTATION = ValueType.ANNOTATION;
+
+  /**
+   * @deprecated
+   * @see ValueType#NULL
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int VALUE_NULL = ValueType.NULL;
+
+  /**
+   * @deprecated
+   * @see ValueType#BOOLEAN
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   int VALUE_BOOLEAN = ValueType.BOOLEAN;
 }

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexConstants.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexConstants.java
@@ -48,7 +48,7 @@
 package com.ibm.wala.dalvik.classLoader;
 
 public interface DexConstants {
-  int ACC_private = 0x1;
+  int ACC_PUBLIC = 0x1;
   int ACC_PRIVATE = 0x2;
   int ACC_PROTECTED = 0x4;
   int ACC_STATIC = 0x8;
@@ -68,6 +68,13 @@ public interface DexConstants {
   int ACC_UNUSED = 0x8000;
   int ACC_CONSTRUCTOR = 0x10000;
   int ACC_DECLARED_SYNCHRONIZED = 0x2000;
+
+  /**
+   * @deprecated
+   * @see #ACC_PUBLIC
+   */
+  @Deprecated(forRemoval = true, since = "1.7.1")
+  int ACC_private = ACC_PUBLIC;
 
   int VALUE_BYTE = 0x00;
   int VALUE_SHORT = 0x02;

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ssa/AbstractIntRegisterMachine.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ssa/AbstractIntRegisterMachine.java
@@ -14,7 +14,6 @@ package com.ibm.wala.dalvik.ssa;
 import com.ibm.wala.core.util.CancelRuntimeException;
 import com.ibm.wala.dalvik.classLoader.DexCFG;
 import com.ibm.wala.dalvik.classLoader.DexCFG.BasicBlock;
-import com.ibm.wala.dalvik.classLoader.DexConstants;
 import com.ibm.wala.dalvik.dex.instructions.ArrayGet;
 import com.ibm.wala.dalvik.dex.instructions.ArrayLength;
 import com.ibm.wala.dalvik.dex.instructions.ArrayPut;
@@ -751,7 +750,7 @@ public abstract class AbstractIntRegisterMachine implements FixedPointConstants 
    * This gives some basic facilities for shoving things around on the stack. Client analyses should
    * subclass this as needed.
    */
-  protected abstract static class BasicRegisterFlowProvider implements FlowProvider, DexConstants {
+  protected abstract static class BasicRegisterFlowProvider implements FlowProvider {
     private final DexCFG cfg;
 
     protected MachineState workingState;


### PR DESCRIPTION
This collection of constants is almost completely redundant with respect to values defined by `org.jf.dexlib2.AccessFlags` and `org.jf.dexlib2.ValueType`, with the one exception of `ACC_UNUSED`. Furthermore, no existing WALA code uses any of these constants.  I see
no reason to keep this code around.

Let's deprecate `DexConstants` for now, just in case some third-party WALA-dependent code uses any of these constants.  We can remove it entirely in some future release.