### PR TITLE
Improve type safety of analysis results

### DIFF
--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/AnalysisResult.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/AnalysisResult.java
@@ -1,0 +1,8 @@
+package com.ibm.wala.shrike.shrikeBT;
+
+/** Analyses use these constants to report results. */
+public enum AnalysisResult {
+  NO,
+  YES,
+  MAYBE,
+}

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/Constants.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/Constants.java
@@ -603,9 +603,25 @@ public interface Constants {
   byte[] indexedTypes_T = {T_INT, T_LONG, T_FLOAT, T_DOUBLE, 0, T_BYTE, T_CHAR, T_SHORT, T_BOOLEAN};
 
   // analyses use these constants to report results
-  int NO = 1;
 
-  int YES = 2;
+  /**
+   * @deprecated use {@code AnalysisResult.NO.ordinal() + 1}
+   * @see AnalysisResult#NO
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
+  int NO = AnalysisResult.NO.ordinal() + 1;
 
-  int MAYBE = 3;
+  /**
+   * @deprecated use {@code AnalysisResult.YES.ordinal() + 1}
+   * @see AnalysisResult#YES
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
+  int YES = AnalysisResult.YES.ordinal() + 1;
+
+  /**
+   * @deprecated use {@code AnalysisResult.MAYBE.ordinal() + 1}
+   * @see AnalysisResult#MAYBE
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
+  int MAYBE = AnalysisResult.MAYBE.ordinal() + 1;
 }

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/analysis/ClassHierarchy.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/analysis/ClassHierarchy.java
@@ -10,6 +10,7 @@
  */
 package com.ibm.wala.shrike.shrikeBT.analysis;
 
+import com.ibm.wala.shrike.shrikeBT.AnalysisResult;
 import com.ibm.wala.shrike.shrikeBT.Constants;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -25,33 +26,35 @@ public final class ClassHierarchy {
   private ClassHierarchy() {}
 
   /** Equals Constants.NO */
-  public static final int NO = Constants.NO;
+  public static final AnalysisResult NO = AnalysisResult.NO;
 
   /** Equals Constants.YES */
-  public static final int YES = Constants.YES;
+  public static final AnalysisResult YES = AnalysisResult.YES;
 
   /** Equals Constants.MAYBE */
-  public static final int MAYBE = Constants.MAYBE;
+  public static final AnalysisResult MAYBE = AnalysisResult.MAYBE;
 
-  private static int checkSuperinterfacesContain(
+  private static AnalysisResult checkSuperinterfacesContain(
       ClassHierarchyProvider hierarchy, String t1, String t2, HashSet<String> visited) {
     String[] interfaces = hierarchy.getSuperInterfaces(t1);
     if (interfaces == null) {
       return MAYBE;
     }
 
-    int r = NO;
+    AnalysisResult r = NO;
     for (String iface : interfaces) {
       if (visited.add(iface)) {
         if (iface.equals(t2)) {
           return YES;
         } else {
-          int v = checkSuperinterfacesContain(hierarchy, iface, t2, visited);
+          AnalysisResult v = checkSuperinterfacesContain(hierarchy, iface, t2, visited);
           switch (v) {
             case YES:
               return YES;
             case MAYBE:
               r = MAYBE;
+              break;
+            case NO:
               break;
           }
         }
@@ -60,9 +63,9 @@ public final class ClassHierarchy {
     return r;
   }
 
-  private static int checkSupertypesContain(
+  private static AnalysisResult checkSupertypesContain(
       ClassHierarchyProvider hierarchy, String t1, String t2) {
-    int r = NO;
+    AnalysisResult r = NO;
 
     String c = t1;
     while (true) {
@@ -85,12 +88,14 @@ public final class ClassHierarchy {
       HashSet<String> visited = new HashSet<>();
 
       for (c = t1; c != null; c = hierarchy.getSuperClass(c)) {
-        int v = checkSuperinterfacesContain(hierarchy, c, t2, visited);
+        AnalysisResult v = checkSuperinterfacesContain(hierarchy, c, t2, visited);
         switch (v) {
           case YES:
             return YES;
           case MAYBE:
             r = MAYBE;
+            break;
+          case NO:
             break;
         }
       }
@@ -99,7 +104,7 @@ public final class ClassHierarchy {
     return r;
   }
 
-  private static int checkSubtypesContain(
+  private static AnalysisResult checkSubtypesContain(
       ClassHierarchyProvider hierarchy, String t1, String t2, HashSet<String> visited) {
     // No interface is a subclass of a real class
     if (hierarchy.isInterface(t1) == NO && hierarchy.isInterface(t2) == YES) {
@@ -111,18 +116,20 @@ public final class ClassHierarchy {
       return MAYBE;
     }
 
-    int r = NO;
+    AnalysisResult r = NO;
     for (String subtype : subtypes) {
       if (visited.add(subtype)) {
         if (subtype.equals(t2)) {
           return YES;
         } else {
-          int v = checkSubtypesContain(hierarchy, subtype, t2, visited);
+          AnalysisResult v = checkSubtypesContain(hierarchy, subtype, t2, visited);
           switch (v) {
             case YES:
               return YES;
             case MAYBE:
               r = MAYBE;
+              break;
+            case NO:
               break;
           }
         }
@@ -131,12 +138,12 @@ public final class ClassHierarchy {
     return r;
   }
 
-  private static int checkSubtypeOfHierarchy(
+  private static AnalysisResult checkSubtypeOfHierarchy(
       ClassHierarchyProvider hierarchy, String t1, String t2) {
     if (t2.equals(Constants.TYPE_Object)) {
       return YES;
     } else {
-      int v = checkSupertypesContain(hierarchy, t1, t2);
+      AnalysisResult v = checkSupertypesContain(hierarchy, t1, t2);
       if (v == MAYBE) {
         v = checkSubtypesContain(hierarchy, t2, t1, new HashSet<>());
       }
@@ -152,7 +159,7 @@ public final class ClassHierarchy {
    * @param t2 a type in JVM format
    * @return whether t1 is a subtype of t2 (YES, NO, MAYBE)
    */
-  public static int isSubtypeOf(ClassHierarchyProvider hierarchy, String t1, String t2) {
+  public static AnalysisResult isSubtypeOf(ClassHierarchyProvider hierarchy, String t1, String t2) {
     if (t1 == null || t2 == null) {
       return NO;
     } else if (t1.equals(t2)) {

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/analysis/ClassHierarchyProvider.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/analysis/ClassHierarchyProvider.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.shrike.shrikeBT.analysis;
 
+import com.ibm.wala.shrike.shrikeBT.AnalysisResult;
+
 /**
  * This interface provides information about the class hierarchy to some consumer, such as a
  * bytecode verifier.
@@ -35,7 +37,7 @@ public interface ClassHierarchyProvider {
   String[] getSubClasses(String cl);
 
   /**
-   * @return whether or not cl is an interface, or Constants.MAYBE if not known
+   * @return whether or not cl is an interface, or {@link AnalysisResult#MAYBE} if not known
    */
-  int isInterface(String cl);
+  AnalysisResult isInterface(String cl);
 }

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/analysis/ClassHierarchyStore.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/analysis/ClassHierarchyStore.java
@@ -10,7 +10,7 @@
  */
 package com.ibm.wala.shrike.shrikeBT.analysis;
 
-import com.ibm.wala.shrike.shrikeBT.Constants;
+import com.ibm.wala.shrike.shrikeBT.AnalysisResult;
 import java.util.HashMap;
 import java.util.Iterator;
 
@@ -91,8 +91,10 @@ public final class ClassHierarchyStore implements ClassHierarchyProvider {
   }
 
   @Override
-  public int isInterface(String cl) {
+  public AnalysisResult isInterface(String cl) {
     ClassInfo info = contents.get(cl);
-    return info == null ? Constants.MAYBE : (info.isInterface ? Constants.YES : Constants.NO);
+    return info == null
+        ? AnalysisResult.MAYBE
+        : (info.isInterface ? AnalysisResult.YES : AnalysisResult.NO);
   }
 }


### PR DESCRIPTION
Previously we used three `int` constants to report various yes/no/maybe analysis results.  Now we extract these constants into their own `enum`. This change improves static type checking and also enables diagnostics about non-exhaustive `switch` statements.