### PR TITLE
Mark some deprecated symbols for future removal

### DIFF
--- a/core/src/main/java/com/ibm/wala/analysis/exceptionanalysis/IntraproceduralExceptionAnalysis.java
+++ b/core/src/main/java/com/ibm/wala/analysis/exceptionanalysis/IntraproceduralExceptionAnalysis.java
@@ -62,7 +62,7 @@ public class IntraproceduralExceptionAnalysis {
    * You can use this method, if you don't have a call graph, but want some exception analysis. But
    * as no pointer analysis is given, we can not consider throw instructions.
    */
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public IntraproceduralExceptionAnalysis(
       IR ir, ExceptionFilter<SSAInstruction> filter, ClassHierarchy cha) {
     this(ir, filter, cha, null, null);

--- a/core/src/main/java/com/ibm/wala/core/java11/Java9AnalysisScopeReader.java
+++ b/core/src/main/java/com/ibm/wala/core/java11/Java9AnalysisScopeReader.java
@@ -5,7 +5,7 @@ import com.ibm.wala.core.util.config.AnalysisScopeReader;
 /**
  * @deprecated Use {@link AnalysisScopeReader}; support for {@code jrt} entries is now built in.
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "1.7.2")
 public class Java9AnalysisScopeReader extends AnalysisScopeReader {
 
   public static final Java9AnalysisScopeReader instance = new Java9AnalysisScopeReader();

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/Util.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/Util.java
@@ -95,7 +95,7 @@ public class Util {
    *     <p>Use {@link Util#addBypassLogic(AnalysisOptions, ClassLoader, String, IClassHierarchy)}
    *     instead
    */
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public static void addBypassLogic(
       AnalysisOptions options,
       @SuppressWarnings("unused") AnalysisScope scope,
@@ -141,7 +141,7 @@ public class Util {
    *     <p>Use {@link Util#addBypassLogic(AnalysisOptions, ClassLoader, XMLMethodSummaryReader,
    *     IClassHierarchy)} instead
    */
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public static void addBypassLogic(
       AnalysisOptions options,
       @SuppressWarnings("unused") AnalysisScope scope,
@@ -188,7 +188,7 @@ public class Util {
    * @deprecated
    *     <p>Use {@link Util#makeMainEntrypoints(IClassHierarchy)} instead
    */
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public static Iterable<Entrypoint> makeMainEntrypoints(
       @SuppressWarnings("unused") AnalysisScope scope, IClassHierarchy cha) {
 
@@ -230,7 +230,7 @@ public class Util {
    * @deprecated
    *     <p>Use {@link Util#makeMainEntrypoints(IClassHierarchy, String)}
    */
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public static Iterable<Entrypoint> makeMainEntrypoints(
       @SuppressWarnings("unused") AnalysisScope scope,
       final IClassHierarchy cha,
@@ -250,7 +250,7 @@ public class Util {
    * @deprecated Please
    *     <p>Use {@link Util#makeMainEntrypoints(IClassHierarchy, String[])}
    */
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public static Iterable<Entrypoint> makeMainEntrypoints(
       @SuppressWarnings("unused") final AnalysisScope scope,
       final IClassHierarchy cha,
@@ -397,7 +397,7 @@ public class Util {
    * @deprecated
    *     <p>Use {@link Util#makeRTABuilder(AnalysisOptions, IAnalysisCacheView, IClassHierarchy)}
    */
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public static CallGraphBuilder<InstanceKey> makeRTABuilder(
       AnalysisOptions options,
       IAnalysisCacheView cache,
@@ -430,7 +430,7 @@ public class Util {
    *     <p>Use {@link Util#makeZeroCFABuilder(Language, AnalysisOptions, IAnalysisCacheView,
    *     IClassHierarchy)}
    */
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public static SSAPropagationCallGraphBuilder makeZeroCFABuilder(
       Language l,
       AnalysisOptions options,
@@ -462,7 +462,7 @@ public class Util {
    *     <p>Use {@link Util#makeZeroCFABuilder(Language, AnalysisOptions, IAnalysisCacheView,
    *     IClassHierarchy, ContextSelector, SSAContextInterpreter)}
    */
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public static SSAPropagationCallGraphBuilder makeZeroCFABuilder(
       Language l,
       AnalysisOptions options,
@@ -510,7 +510,7 @@ public class Util {
    *     <p>Use {@link Util#makeZeroOneCFABuilder(Language, AnalysisOptions, IAnalysisCacheView,
    *     IClassHierarchy)}
    */
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public static SSAPropagationCallGraphBuilder makeZeroOneCFABuilder(
       Language l,
       AnalysisOptions options,
@@ -542,7 +542,7 @@ public class Util {
    *     <p>Use {@link Util#makeVanillaZeroOneCFABuilder(Language, AnalysisOptions,
    *     IAnalysisCacheView, IClassHierarchy, ContextSelector, SSAContextInterpreter)}
    */
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public static SSAPropagationCallGraphBuilder makeVanillaZeroOneCFABuilder(
       Language l,
       AnalysisOptions options,
@@ -597,7 +597,7 @@ public class Util {
    *     <p>use {@link Util#makeVanillaZeroOneCFABuilder(Language, AnalysisOptions,
    *     IAnalysisCacheView, IClassHierarchy)}
    */
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public static SSAPropagationCallGraphBuilder makeVanillaZeroOneCFABuilder(
       Language l,
       AnalysisOptions options,
@@ -629,7 +629,7 @@ public class Util {
    *     <p>Use {@link Util#makeZeroOneCFABuilder(Language, AnalysisOptions, IAnalysisCacheView,
    *     IClassHierarchy, ContextSelector, SSAContextInterpreter)}
    */
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public static SSAPropagationCallGraphBuilder makeZeroOneCFABuilder(
       Language l,
       AnalysisOptions options,
@@ -687,7 +687,7 @@ public class Util {
    *     <p>Use {@link Util#makeZeroContainerCFABuilder(AnalysisOptions, IAnalysisCacheView,
    *     IClassHierarchy)}
    */
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public static SSAPropagationCallGraphBuilder makeZeroContainerCFABuilder(
       AnalysisOptions options,
       IAnalysisCacheView cache,
@@ -727,7 +727,7 @@ public class Util {
    *     <p>Use {@link Util#makeZeroOneCFABuilder(Language, AnalysisOptions, IAnalysisCacheView,
    *     IClassHierarchy)}
    */
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public static SSAPropagationCallGraphBuilder makeZeroOneContainerCFABuilder(
       AnalysisOptions options,
       IAnalysisCacheView cache,
@@ -741,7 +741,7 @@ public class Util {
    *     <p>Use {@link Util#makeZeroOneContainerCFABuilder(AnalysisOptions, IAnalysisCacheView,
    *     IClassHierarchy, ContextSelector, SSAContextInterpreter)}
    */
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public static SSAPropagationCallGraphBuilder makeZeroOneContainerCFABuilder(
       AnalysisOptions options,
       IAnalysisCacheView cache,
@@ -798,7 +798,7 @@ public class Util {
    *     <p>Use {@link Util#makeNCFABuilder(int, Language, AnalysisOptions,
    *     IAnalysisCacheView,IClassHierarchy)}
    */
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public static SSAPropagationCallGraphBuilder makeNCFABuilder(
       int n,
       AnalysisOptions options,
@@ -851,7 +851,7 @@ public class Util {
    *     <p>Use {@link Util#makeNObjBuilder(int, AnalysisOptions, IAnalysisCacheView,
    *     IClassHierarchy)}
    */
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public static SSAPropagationCallGraphBuilder makeNObjBuilder(
       int n,
       AnalysisOptions options,
@@ -896,7 +896,7 @@ public class Util {
    *     <p>Use {@link Util#makeVanillaNObjBuilder(int, AnalysisOptions, IAnalysisCacheView,
    *     IClassHierarchy)}
    */
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public static SSAPropagationCallGraphBuilder makeVanillaNObjBuilder(
       int n,
       AnalysisOptions options,
@@ -928,7 +928,7 @@ public class Util {
    *     <p>Use {@link Util#makeVanillaNCFABuilder(int, AnalysisOptions, IAnalysisCacheView,
    *     IClassHierarchy)}
    */
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public static SSAPropagationCallGraphBuilder makeVanillaNCFABuilder(
       int n,
       AnalysisOptions options,
@@ -975,7 +975,7 @@ public class Util {
    *     <p>Use {@link Util#makeVanillaZeroOneContainerCFABuilder(AnalysisOptions,
    *     IAnalysisCacheView, IClassHierarchy)}
    */
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public static SSAPropagationCallGraphBuilder makeVanillaZeroOneContainerCFABuilder(
       AnalysisOptions options,
       IAnalysisCacheView cache,
@@ -1011,7 +1011,7 @@ public class Util {
    * @deprecated
    *     <p>Use {@link Util#addDefaultBypassLogic(AnalysisOptions, ClassLoader, IClassHierarchy)}
    */
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public static void addDefaultBypassLogic(
       AnalysisOptions options,
       @SuppressWarnings("unused") AnalysisScope scope,

--- a/core/src/main/java/com/ibm/wala/ssa/SSACheckCastInstruction.java
+++ b/core/src/main/java/com/ibm/wala/ssa/SSACheckCastInstruction.java
@@ -129,7 +129,7 @@ public abstract class SSACheckCastInstruction extends SSAInstruction {
    * @deprecated the system now supports multiple types, so this accessor will not work for all
    *     languages.
    */
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public TypeReference getDeclaredResultType() {
     assert declaredResultTypes.length == 1;
     return declaredResultTypes[0];

--- a/dalvik/models/src/ActivityModelActivity.java
+++ b/dalvik/models/src/ActivityModelActivity.java
@@ -49,7 +49,7 @@ package activity.model;
 import android.app.Activity;
 
 /** @deprecated building the Android-Livecycle is done in the class AndroidModel now */
-@Deprecated
+@Deprecated(forRemoval = true, since="1.7.2")
 public class ActivityModelActivity extends Activity {
   /*   |, /, \ flow down
    *   ^ flow up , <= flow left, => flow right

--- a/ide/jdt/src/main/java/com/ibm/wala/ide/util/JdtUtil.java
+++ b/ide/jdt/src/main/java/com/ibm/wala/ide/util/JdtUtil.java
@@ -119,7 +119,7 @@ public class JdtUtil {
     return javaElt.getHandleIdentifier();
   }
 
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public static IJavaElement createJavaElementFromJdtHandle(String jdtHandle) {
     return JavaCore.create(jdtHandle);
   }
@@ -475,7 +475,7 @@ public class JdtUtil {
    *
    * @return null if not found
    */
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public static IMethod findJavaMethodInWorkspaceBrokenForInnerClasses(String methodSig) {
     // dammit ... this doesn't work for inner classes.
 

--- a/scandroid/src/main/java/org/scandroid/flow/functions/IFDSTaintFlowFunctionProvider.java
+++ b/scandroid/src/main/java/org/scandroid/flow/functions/IFDSTaintFlowFunctionProvider.java
@@ -100,7 +100,7 @@ import org.scandroid.flow.types.FlowType;
 /**
  * @deprecated Replaced by TaintTransferFunctions.
  */
-@Deprecated
+@Deprecated(forRemoval = true, since = "1.7.2")
 public class IFDSTaintFlowFunctionProvider<E extends ISSABasicBlock>
     implements IFlowFunctionMap<BasicBlockInContext<E>> {
 
@@ -108,7 +108,7 @@ public class IFDSTaintFlowFunctionProvider<E extends ISSABasicBlock>
   private final ISupergraph<BasicBlockInContext<E>, CGNode> graph;
   private final PointerAnalysis<InstanceKey> pa;
 
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public IFDSTaintFlowFunctionProvider(
       IFDSTaintDomain<E> domain,
       ISupergraph<BasicBlockInContext<E>, CGNode> graph,
@@ -395,7 +395,7 @@ public class IFDSTaintFlowFunctionProvider<E extends ISSABasicBlock>
     }
   }
 
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   @Override
   public IUnaryFlowFunction getCallFlowFunction(
       BasicBlockInContext<E> src, BasicBlockInContext<E> dest, BasicBlockInContext<E> ret) {
@@ -446,7 +446,7 @@ public class IFDSTaintFlowFunctionProvider<E extends ISSABasicBlock>
     };
   }
 
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   @Override
   public IUnaryFlowFunction getCallNoneToReturnFlowFunction(
       BasicBlockInContext<E> src, BasicBlockInContext<E> dest) {
@@ -466,7 +466,7 @@ public class IFDSTaintFlowFunctionProvider<E extends ISSABasicBlock>
     return new DefUse(dest);
   }
 
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   @Override
   public IUnaryFlowFunction getCallToReturnFlowFunction(
       BasicBlockInContext<E> src, BasicBlockInContext<E> dest) {
@@ -488,7 +488,7 @@ public class IFDSTaintFlowFunctionProvider<E extends ISSABasicBlock>
     return new DefUse(dest);
   }
 
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public class ReturnDefUse extends DefUse {
     CodeElement callSet;
     Set<CodeElement> receivers = new HashSet<>();
@@ -562,7 +562,7 @@ public class IFDSTaintFlowFunctionProvider<E extends ISSABasicBlock>
     }
   }
 
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   @Override
   public IFlowFunction getReturnFlowFunction(
       BasicBlockInContext<E> call, BasicBlockInContext<E> src, BasicBlockInContext<E> dest) {

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/tools/MethodOptimizer.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/tools/MethodOptimizer.java
@@ -24,7 +24,7 @@ import com.ibm.wala.shrike.shrikeBT.info.LocalAllocator;
 import java.util.Arrays;
 import java.util.BitSet;
 
-@Deprecated
+@Deprecated(forRemoval = true, since = "1.7.2")
 public final class MethodOptimizer {
   private final MethodData data;
 
@@ -58,9 +58,10 @@ public final class MethodOptimizer {
   // instruction
   // or -1 if there is more than one such instruction.
 
-  @Deprecated static final int[] noEdges = new int[0];
+  @Deprecated(forRemoval = true, since = "1.7.2")
+  static final int[] noEdges = new int[0];
 
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public MethodOptimizer(MethodData d, MethodEditor e) {
     if (d == null) {
       throw new IllegalArgumentException("null d");

--- a/util/src/main/java/com/ibm/wala/util/processes/JavaLauncher.java
+++ b/util/src/main/java/com/ibm/wala/util/processes/JavaLauncher.java
@@ -266,7 +266,7 @@ public class JavaLauncher extends Launcher {
    * to make a Mac happy with quotes. Trailing separators are unsafe, so we have to escape the last
    * backslash (if present and unescaped), so it doesn't escape the closing quote.
    */
-  @Deprecated
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public static String quoteStringIfNeeded(String s) {
     s = s.trim();
     // s = s.replaceAll(" ", "\\\\ ");


### PR DESCRIPTION
Each of these symbols was already annotated as deprecated and is already unused elsewhere in the WALA code base.  Now we're going further by flagging them as intended for removal in some future version.

We're also noting version 1.7.2 as the version since which these symbols have been so flagged.  Some of these deprecations are *much* older than that.  But we recently released 1.7.1, so it's fair to say that we warned about future removal _at least_ since 1.7.2.