### PR TITLE
Tidy up `SyntheticMethod.getStatements` APIs

### DIFF
--- a/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/examples/hybrid/Driver.java
+++ b/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/examples/hybrid/Driver.java
@@ -91,7 +91,7 @@ public class Driver {
     JavaJavaScriptHybridCallGraphBuilder b =
         new JavaJavaScriptHybridCallGraphBuilder(
             new FakeRootMethod(
-                new FakeRootClass(CrossLanguageCallGraph.crossCoreLoader, cha), options, cache),
+                new FakeRootClass(CrossLanguageCallGraph.crossCoreLoader, cha), cache),
             options,
             cache);
 

--- a/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/AstCallGraph.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/AstCallGraph.java
@@ -43,21 +43,43 @@ public class AstCallGraph extends ExplicitCallGraph {
 
   public static class AstFakeRoot extends AbstractRootMethod {
 
+    /**
+     * @deprecated to remove unused {@code options} parameter
+     * @see #AstFakeRoot(MethodReference, IClass, IClassHierarchy, IAnalysisCacheView)
+     */
+    @Deprecated(forRemoval = true, since = "1.7.2")
     public AstFakeRoot(
         MethodReference rootMethod,
         IClass declaringClass,
         IClassHierarchy cha,
-        AnalysisOptions options,
+        @SuppressWarnings("unused") AnalysisOptions options,
         IAnalysisCacheView cache) {
-      super(rootMethod, declaringClass, cha, options, cache);
+      this(rootMethod, declaringClass, cha, cache);
     }
 
     public AstFakeRoot(
         MethodReference rootMethod,
+        IClass declaringClass,
         IClassHierarchy cha,
-        AnalysisOptions options,
         IAnalysisCacheView cache) {
-      super(rootMethod, cha, options, cache);
+      super(rootMethod, declaringClass, cha, cache);
+    }
+
+    /**
+     * @deprecated to remove unused {@code options} parameter
+     * @see #AstFakeRoot(MethodReference, IClassHierarchy, IAnalysisCacheView)
+     */
+    @Deprecated(forRemoval = true, since = "1.7.2")
+    public AstFakeRoot(
+        MethodReference rootMethod,
+        IClassHierarchy cha,
+        @SuppressWarnings("unused") AnalysisOptions options,
+        IAnalysisCacheView cache) {
+      this(rootMethod, cha, cache);
+    }
+
+    public AstFakeRoot(MethodReference rootMethod, IClassHierarchy cha, IAnalysisCacheView cache) {
+      super(rootMethod, cha, cache);
     }
 
     @Override
@@ -78,17 +100,27 @@ public class AstCallGraph extends ExplicitCallGraph {
         MethodReference rootMethod,
         IClass declaringClass,
         IClassHierarchy cha,
-        AnalysisOptions options,
+        @SuppressWarnings("unused") AnalysisOptions options,
         IAnalysisCacheView cache) {
-      super(rootMethod, declaringClass, cha, options, cache);
+      super(rootMethod, declaringClass, cha, cache);
     }
 
+    /**
+     * @deprecated to remove unused {@code options} parameter
+     * @see #ScriptFakeRoot(MethodReference, IClassHierarchy, IAnalysisCacheView)
+     */
+    @Deprecated(forRemoval = true, since = "1.7.2")
     public ScriptFakeRoot(
         MethodReference rootMethod,
         IClassHierarchy cha,
-        AnalysisOptions options,
+        @SuppressWarnings("unused") AnalysisOptions options,
         IAnalysisCacheView cache) {
-      super(rootMethod, cha, options, cache);
+      this(rootMethod, cha, cache);
+    }
+
+    public ScriptFakeRoot(
+        MethodReference rootMethod, IClassHierarchy cha, IAnalysisCacheView cache) {
+      super(rootMethod, cha, cache);
     }
 
     public abstract SSAAbstractInvokeInstruction addDirectCall(

--- a/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/CrossLanguageCallGraph.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/CrossLanguageCallGraph.java
@@ -114,9 +114,20 @@ public class CrossLanguageCallGraph extends AstCallGraph {
       super(rootMethod, declaringClass, cha, options, cache);
     }
 
+    /**
+     * @deprecated to remove unused {@code options} parameter
+     * @see #CrossLanguageFakeRoot(IClassHierarchy, IAnalysisCacheView)
+     */
+    @Deprecated(forRemoval = true, since = "1.7.2")
     public CrossLanguageFakeRoot(
-        IClassHierarchy cha, AnalysisOptions options, IAnalysisCacheView cache) {
-      super(rootMethod, cha, options, cache);
+        IClassHierarchy cha,
+        @SuppressWarnings("unused") AnalysisOptions options,
+        IAnalysisCacheView cache) {
+      this(cha, cache);
+    }
+
+    public CrossLanguageFakeRoot(IClassHierarchy cha, IAnalysisCacheView cache) {
+      super(rootMethod, cha, cache);
     }
 
     public int addPhi(TypeReference type, int[] values) {
@@ -192,6 +203,6 @@ public class CrossLanguageCallGraph extends AstCallGraph {
   @Override
   protected CGNode makeFakeRootNode() throws CancelException {
     return findOrCreateNode(
-        new CrossLanguageFakeRoot(cha, options, getAnalysisCache()), Everywhere.EVERYWHERE);
+        new CrossLanguageFakeRoot(cha, getAnalysisCache()), Everywhere.EVERYWHERE);
   }
 }

--- a/core/src/main/java/com/ibm/wala/analysis/reflection/FactoryBypassInterpreter.java
+++ b/core/src/main/java/com/ibm/wala/analysis/reflection/FactoryBypassInterpreter.java
@@ -490,7 +490,7 @@ public class FactoryBypassInterpreter extends AbstractReflectionInterpreter {
     }
 
     private int addOriginalStatements(SummarizedMethod m) {
-      SSAInstruction[] original = m.getStatements(options.getSSAOptions());
+      SSAInstruction[] original = m.getStatements();
       // local value number 1 is "this", so the next free value number is 2
       int nextLocal = 2;
       for (SSAInstruction s : original) {

--- a/core/src/main/java/com/ibm/wala/classLoader/JavaLanguage.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/JavaLanguage.java
@@ -839,8 +839,7 @@ public class JavaLanguage extends LanguageImpl implements BytecodeLanguage, Cons
   @Override
   public AbstractRootMethod getFakeRootMethod(
       IClassHierarchy cha, AnalysisOptions options, IAnalysisCacheView cache) {
-    return new FakeRootMethod(
-        new FakeRootClass(ClassLoaderReference.Primordial, cha), options, cache);
+    return new FakeRootMethod(new FakeRootClass(ClassLoaderReference.Primordial, cha), cache);
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/classLoader/SyntheticMethod.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/SyntheticMethod.java
@@ -251,16 +251,6 @@ public class SyntheticMethod implements IMethod {
     return -1;
   }
 
-  /*
-   * TODO: why isn't this abstract?
-   *
-   * @param options options governing SSA construction
-   */
-  @Deprecated
-  public SSAInstruction[] getStatements(@SuppressWarnings("unused") SSAOptions options) {
-    return NO_STATEMENTS;
-  }
-
   /**
    * Most subclasses should override this.
    *
@@ -355,7 +345,7 @@ public class SyntheticMethod implements IMethod {
   }
 
   public SSAInstruction[] getStatements() {
-    return getStatements(SSAOptions.defaultOptions());
+    return NO_STATEMENTS;
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/cha/CHACallGraph.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/cha/CHACallGraph.java
@@ -307,9 +307,7 @@ public class CHACallGraph extends BasicCallGraph<CHAContextInterpreter> {
   protected CGNode makeFakeWorldClinitNode() throws CancelException {
     return new CHARootNode(
         new FakeWorldClinitMethod(
-            Language.JAVA.getFakeRootMethod(cha, options, cache).getDeclaringClass(),
-            options,
-            cache),
+            Language.JAVA.getFakeRootMethod(cha, options, cache).getDeclaringClass(), cache),
         Everywhere.EVERYWHERE);
   }
 

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/AbstractRootMethod.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/AbstractRootMethod.java
@@ -105,12 +105,8 @@ public abstract class AbstractRootMethod extends SyntheticMethod {
         cache);
   }
 
-  /**
-   * @see SyntheticMethod#getStatements()
-   */
-  @SuppressWarnings("deprecation")
   @Override
-  public SSAInstruction[] getStatements(SSAOptions options) {
+  public SSAInstruction[] getStatements() {
     SSAInstruction[] result = new SSAInstruction[statements.size()];
     int i = 0;
     for (SSAInstruction ssaInstruction : statements) {
@@ -122,7 +118,7 @@ public abstract class AbstractRootMethod extends SyntheticMethod {
 
   @Override
   public IR makeIR(Context context, SSAOptions options) {
-    SSAInstruction[] instrs = getStatements(options);
+    SSAInstruction[] instrs = getStatements();
     Map<Integer, ConstantValue> constants = null;
     if (!constant2ValueNumber.isEmpty()) {
       constants = HashMapFactory.make(constant2ValueNumber.size());
@@ -406,7 +402,7 @@ public abstract class AbstractRootMethod extends SyntheticMethod {
       @Override
       public Iterator<NewSiteReference> iterateNewSites(CGNode node) {
         ArrayList<NewSiteReference> result = new ArrayList<>();
-        SSAInstruction[] statements = getStatements(options.getSSAOptions());
+        SSAInstruction[] statements = getStatements();
         for (SSAInstruction statement : statements) {
           if (statement instanceof SSANewInstruction) {
             SSANewInstruction s = (SSANewInstruction) statement;
@@ -418,7 +414,7 @@ public abstract class AbstractRootMethod extends SyntheticMethod {
 
       public Iterator<SSAInstruction> getInvokeStatements() {
         ArrayList<SSAInstruction> result = new ArrayList<>();
-        SSAInstruction[] statements = getStatements(options.getSSAOptions());
+        SSAInstruction[] statements = getStatements();
         for (SSAInstruction statement : statements) {
           if (statement instanceof SSAInvokeInstruction) {
             result.add(statement);

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/AbstractRootMethod.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/AbstractRootMethod.java
@@ -64,21 +64,31 @@ public abstract class AbstractRootMethod extends SyntheticMethod {
 
   public final IClassHierarchy cha;
 
-  private final AnalysisOptions options;
-
   protected final IAnalysisCacheView cache;
 
   protected final SSAInstructionFactory insts;
+
+  /**
+   * @deprecated to remove unused {@code options} parameter
+   * @see #AbstractRootMethod(MethodReference, IClass, IClassHierarchy, IAnalysisCacheView)
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
+  public AbstractRootMethod(
+      MethodReference method,
+      IClass declaringClass,
+      final IClassHierarchy cha,
+      @SuppressWarnings("unused") AnalysisOptions options,
+      IAnalysisCacheView cache) {
+    this(method, declaringClass, cha, cache);
+  }
 
   public AbstractRootMethod(
       MethodReference method,
       IClass declaringClass,
       final IClassHierarchy cha,
-      AnalysisOptions options,
       IAnalysisCacheView cache) {
     super(method, declaringClass, true, false);
     this.cha = cha;
-    this.options = options;
     this.cache = cache;
     this.insts = declaringClass.getClassLoader().getInstructionFactory();
     if (cache == null) {
@@ -92,17 +102,22 @@ public abstract class AbstractRootMethod extends SyntheticMethod {
     }
   }
 
+  /**
+   * @deprecated to remove unused {@code options} parameter
+   * @see #AbstractRootMethod(MethodReference, IClassHierarchy, IAnalysisCacheView)
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public AbstractRootMethod(
       MethodReference method,
       final IClassHierarchy cha,
-      AnalysisOptions options,
+      @SuppressWarnings("unused") AnalysisOptions options,
       IAnalysisCacheView cache) {
-    this(
-        method,
-        new FakeRootClass(method.getDeclaringClass().getClassLoader(), cha),
-        cha,
-        options,
-        cache);
+    this(method, cha, cache);
+  }
+
+  public AbstractRootMethod(
+      MethodReference method, final IClassHierarchy cha, IAnalysisCacheView cache) {
+    this(method, new FakeRootClass(method.getDeclaringClass().getClassLoader(), cha), cha, cache);
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/ExplicitCallGraph.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/ExplicitCallGraph.java
@@ -90,7 +90,7 @@ public class ExplicitCallGraph extends BasicCallGraph<SSAContextInterpreter>
   @Override
   protected CGNode makeFakeWorldClinitNode() throws CancelException {
     return findOrCreateNode(
-        new FakeWorldClinitMethod(fakeRootMethod.getDeclaringClass(), options, cache),
+        new FakeWorldClinitMethod(fakeRootMethod.getDeclaringClass(), cache),
         Everywhere.EVERYWHERE);
   }
 

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/FakeRootMethod.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/FakeRootMethod.java
@@ -30,12 +30,22 @@ public class FakeRootMethod extends AbstractRootMethod {
   public static final Descriptor descr =
       Descriptor.findOrCreate(new TypeName[0], TypeReference.VoidName);
 
+  /**
+   * @deprecated to remove unused {@code options} parameter
+   * @see #FakeRootMethod(IClass, IAnalysisCacheView)
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public FakeRootMethod(
-      final IClass fakeRootClass, AnalysisOptions options, IAnalysisCacheView cache) {
+      final IClass fakeRootClass,
+      @SuppressWarnings("unused") AnalysisOptions options,
+      IAnalysisCacheView cache) {
+    this(fakeRootClass, cache);
+  }
+
+  public FakeRootMethod(final IClass fakeRootClass, IAnalysisCacheView cache) {
     super(
         MethodReference.findOrCreate(fakeRootClass.getReference(), name, descr),
         fakeRootClass.getClassHierarchy(),
-        options,
         cache);
   }
 

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/FakeWorldClinitMethod.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/FakeWorldClinitMethod.java
@@ -27,12 +27,22 @@ public class FakeWorldClinitMethod extends AbstractRootMethod {
   private static final Descriptor descr =
       Descriptor.findOrCreate(new TypeName[0], TypeReference.VoidName);
 
+  /**
+   * @deprecated to remove unused {@code options} parameter
+   * @see #FakeWorldClinitMethod(IClass, IAnalysisCacheView)
+   */
+  @Deprecated(forRemoval = true, since = "1.7.2")
   public FakeWorldClinitMethod(
-      final IClass fakeRootClass, AnalysisOptions options, IAnalysisCacheView cache) {
+      final IClass fakeRootClass,
+      @SuppressWarnings("unused") AnalysisOptions options,
+      IAnalysisCacheView cache) {
+    this(fakeRootClass, cache);
+  }
+
+  public FakeWorldClinitMethod(final IClass fakeRootClass, IAnalysisCacheView cache) {
     super(
         MethodReference.findOrCreate(fakeRootClass.getReference(), name, descr),
         fakeRootClass.getClassHierarchy(),
-        options,
         cache);
   }
 }

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/SummarizedMethod.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/SummarizedMethod.java
@@ -67,9 +67,8 @@ public class SummarizedMethod extends SyntheticMethod {
     return summary.hasPoison();
   }
 
-  @SuppressWarnings("deprecation")
   @Override
-  public SSAInstruction[] getStatements(SSAOptions options) {
+  public SSAInstruction[] getStatements() {
     if (DEBUG) {
       System.err.println(("getStatements: " + this));
     }
@@ -78,7 +77,7 @@ public class SummarizedMethod extends SyntheticMethod {
 
   @Override
   public IR makeIR(Context context, SSAOptions options) {
-    SSAInstruction[] instrs = getStatements(options);
+    SSAInstruction[] instrs = getStatements();
     return new SyntheticIR(
         this,
         Everywhere.EVERYWHERE,

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/SummarizedMethodWithNames.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/SummarizedMethodWithNames.java
@@ -180,7 +180,7 @@ public class SummarizedMethodWithNames extends SummarizedMethod {
 
   @Override
   public IR makeIR(Context context, SSAOptions options) {
-    final SSAInstruction[] instrs = getStatements(options);
+    final SSAInstruction[] instrs = getStatements();
 
     return new SyntheticIRWithNames(
         this,


### PR DESCRIPTION
## Tidy up `SyntheticMethod.getStatements` APIs

Previously we had two overloads of `SyntheticMethod.getStatements`:

* a deprecated overload taking an `SSAOptions` parameter, with a default implementation that returned a special "no statements" value; and

* a non-deprecated overload taking no parameters, with a default implementation that called the deprecated overload with default SSA options.

In practice, no implementation of the unary overload ever actually used the SSA options. So we can simplify things by removing that overload and changing the default implementation of the nullary overload to return the special "no statements" value.

## Deprecate many unused options parameters

The unary `SyntheticMethod.getStatements(SSAOptions)` method has been deprecated in favor of the nullary `SyntheticMethod.getStatements()` method. Anything passing in an `SSAOptions` argument no longer needs to do that. This turns out to transitively make quite a few constructor parameters unnecessary, as well as a few fields. Let's migrate toward alternate constructors that no longer pass these unnecessary parameters. We won't remove the original constructors right away, though. Instead we will just mark them as deprecated and intended for future removal.