### PR TITLE
perf(dominators): empty bucket while iterating in step 2

### DIFF
--- a/util/src/main/java/com/ibm/wala/util/graph/dominators/Dominators.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/dominators/Dominators.java
@@ -299,6 +299,7 @@ public abstract class Dominators<T> {
       Iterator<T> bucketEnum = iterateBucket(getParent(node));
       while (bucketEnum.hasNext()) {
         T node2 = bucketEnum.next();
+        bucketEnum.remove();
 
         // u = EVAL(node2)
         T u = EVAL(node2);

--- a/util/src/main/java/com/ibm/wala/util/graph/dominators/Dominators.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/dominators/Dominators.java
@@ -299,6 +299,8 @@ public abstract class Dominators<T> {
       Iterator<T> bucketEnum = iterateBucket(getParent(node));
       while (bucketEnum.hasNext()) {
         T node2 = bucketEnum.next();
+        // LT paper step 3: "delete v from bucket(parent(w))".
+        // Otherwise siblings with the same parent reprocess old bucket entries.
         bucketEnum.remove();
 
         // u = EVAL(node2)

--- a/util/src/test/java/com/ibm/wala/util/graph/dominators/DominatorsTest.java
+++ b/util/src/test/java/com/ibm/wala/util/graph/dominators/DominatorsTest.java
@@ -1,0 +1,31 @@
+package com.ibm.wala.util.graph.dominators;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.wala.util.graph.impl.SlowSparseNumberedGraph;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+public class DominatorsTest {
+
+  @Test
+  @Timeout(value = 5, unit = TimeUnit.SECONDS)
+  public void wideStarGraphRunsInLinearTime() {
+    int n = 20_000;
+    SlowSparseNumberedGraph<Integer> g = SlowSparseNumberedGraph.make();
+    Integer root = Integer.valueOf(0);
+    g.addNode(root);
+    for (int i = 1; i < n; i++) {
+      Integer v = Integer.valueOf(i);
+      g.addNode(v);
+      g.addEdge(root, v);
+    }
+
+    Dominators<Integer> d = Dominators.make(g, root);
+
+    for (int i = 1; i < n; i++) {
+      assertThat(d.getIdom(Integer.valueOf(i))).isEqualTo(root);
+    }
+  }
+}


### PR DESCRIPTION
bucket(parent(w)) wasn't getting cleared, so DFS siblings sharing a semidominator kept reprocessing each other's entries. paper has "delete v from bucket(parent(w))" inside the loop. fixes O(n^2) regression on wide flowgraphs.