### PR TITLE
Download Java CUP 11a from Maven Central

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -173,11 +173,12 @@ val extractBcel =
 
 ////////////////////////////////////////////////////////////////////////
 //
-//  download "java-cup-11a.jar"
+//  download "java-cup-11a-RELEASE290.jar"
 //
 
-val downloadJavaCup =
-    adHocDownload(uri("https://www2.cs.tum.edu/projects/cup"), "java-cup", "jar", "11a")
+val downloadJavaCup = configurations.create("downloadJavaCup") { isCanBeConsumed = false }
+
+dependencies { downloadJavaCup(libs.netbeans.java.cup) }
 
 val copyJavaCup =
     tasks.register<Sync>("copyJavaCup") {

--- a/core/src/testFixtures/resources/java_cup.txt
+++ b/core/src/testFixtures/resources/java_cup.txt
@@ -1,3 +1,3 @@
 Primordial,Java,stdlib,base
 Primordial,Java,jarFile,primordial.jar.model
-Application,Java,jarFile,java-cup-11a.jar
+Application,Java,jarFile,java-cup-11a-RELEASE290.jar

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ junit-platform-engine = { module = "org.junit.platform:junit-platform-engine" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 #noinspection UnusedVersionCatalogEntry
 junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine" }
+netbeans-java-cup = "org.netbeans.external:java-cup-11a:RELEASE290"
 #noinspection UnusedVersionCatalogEntry
 nullaway = { module = "com.uber.nullaway:nullaway", version.ref = "com-uber-nullaway" }
 #noinspection UnusedVersionCatalogEntry


### PR DESCRIPTION
Checksums confirm that this JAR is byte-for-byte identical to the one that we were previously downloading using an _ad hoc_ URL.

Fixes #1898.