### PR TITLE
Target JDK 17

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,8 +23,6 @@ jobs:
           - os: windows-latest
             java: 17
           - os: ubuntu-latest
-            java: 11
-          - os: ubuntu-latest
             java: 17
           - os: ubuntu-latest
             java: 21

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -52,10 +52,10 @@ dependencies {
 tasks.withType<JavaCompile>().configureEach {
   // Always compile with a recent JDK version, to get the latest bug fixes in the compiler toolchain
   javaCompiler = javaToolchains.compilerFor { languageVersion = JavaLanguageVersion.of(26) }
-  // Generate JDK 11 bytecodes; that is the minimum version supported by WALA
+  // Generate JDK 17 bytecodes; that is the minimum version supported by WALA
   options.run {
     isDeprecation = true
-    release = 11
+    release = 17
     errorprone {
       // don't run warning-level checks by default as they add too much noise to build output
       disableAllWarnings = true

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -31,7 +31,10 @@ eclipse {
 val compileTestSubjectsJava = tasks.named("compileTestSubjectsJava")
 
 tasks {
-  named<JavaCompile>("compileTestSubjectsJava") { options.isDeprecation = false }
+  named<JavaCompile>("compileTestSubjectsJava") {
+    options.isDeprecation = false
+    options.compilerArgs.add("-Xlint:-removal")
+  }
 
   named<JavaCompileUsingEcj>("compileTestSubjectsJavaUsingEcj") {
     options.compilerArgumentProviders.add {

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@ org.gradle.configureondemand=true
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
 org.gradle.parallel=true
 
-VERSION_NAME=1.7.2-SNAPSHOT
+VERSION_NAME=1.8.0-SNAPSHOT

--- a/util/src/main/java/com/ibm/wala/util/collections/Util.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/Util.java
@@ -214,6 +214,7 @@ public class Util {
    *
    * @throws IllegalArgumentException if obj == null
    */
+  @SuppressWarnings("removal")
   public static String objectFieldsToString(Object obj) throws IllegalArgumentException {
     if (obj == null) {
       throw new IllegalArgumentException("obj == null");


### PR DESCRIPTION
Fixes #1830 

After this lands, WALA will require a JDK 17+ JVM to run.  It will still be able to analyze programs with pre-JDK-17 bytecodes.