### PR TITLE
Require Java 17+ across all of WALA

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,8 +23,6 @@ jobs:
           - os: windows-latest
             java: 17
           - os: ubuntu-latest
-            java: 11
-          - os: ubuntu-latest
             java: 17
           - os: ubuntu-latest
             java: 21
@@ -43,7 +41,6 @@ jobs:
           # Install all the JDK versions we use in the matrix.  We do JDK 26 last to use that
           # to run Gradle.
           java-version: |
-            11
             17
             21
             25

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -62,7 +62,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="zulu-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="zulu-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
   <component name="TaskProjectConfiguration">

--- a/README.md
+++ b/README.md
@@ -83,10 +83,8 @@ issue](https://github.com/wala/WALA/issues).
 
 ## Required Java Versions
 
-Most components of each [official WALA
-release](https://github.com/wala/WALA/releases) are built for use with
-Java 11 or newer.  However, components that use Eclipse require at
-least Java 17.
+Each [official WALA release](https://github.com/wala/WALA/releases) is
+built for use with Java 17 or newer.
 
 ## Building from Source
 

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -52,10 +52,10 @@ dependencies {
 tasks.withType<JavaCompile>().configureEach {
   // Always compile with a recent JDK version, to get the latest bug fixes in the compiler toolchain
   javaCompiler = javaToolchains.compilerFor { languageVersion = JavaLanguageVersion.of(26) }
-  // Generate JDK 11 bytecodes; that is the minimum version supported by WALA
+  // Generate JDK 17 bytecodes; that is the minimum version supported by WALA
   options.run {
     isDeprecation = true
-    release = 11
+    release = 17
     errorprone {
       // don't run warning-level checks by default as they add too much noise to build output
       disableAllWarnings = true

--- a/core/src/testSubjects/java/demandpa/A.java
+++ b/core/src/testSubjects/java/demandpa/A.java
@@ -41,6 +41,7 @@ class A {
 
   Object f;
 
+  @SuppressWarnings("removal")
   Object foo() {
     return new Integer(3);
   }

--- a/core/src/testSubjects/java/demandpa/B.java
+++ b/core/src/testSubjects/java/demandpa/B.java
@@ -39,6 +39,7 @@ package demandpa;
 
 class B extends A {
   @Override
+  @SuppressWarnings("removal")
   Object foo() {
     return new Float(4);
   }

--- a/core/src/testSubjects/java/slice/A.java
+++ b/core/src/testSubjects/java/slice/A.java
@@ -15,6 +15,7 @@ class A {
   Object f;
   Object g;
 
+  @SuppressWarnings("removal")
   Object foo() {
     return new Integer(3);
   }

--- a/core/src/testSubjects/java/slice/B.java
+++ b/core/src/testSubjects/java/slice/B.java
@@ -12,6 +12,7 @@ package slice;
 
 class B extends A {
   @Override
+  @SuppressWarnings("removal")
   Object foo() {
     return new Float(4);
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Preferred JDK version to use for compiling WALA and running WALA tests. WALA's Eclipse-dependent
 # components may override this with something newer; see `MINIMUM_ECLIPSE_COMPATIBLE_JAVA_VERSION`
 # in `build-logic/src/main/kotlin/com/ibm/wala/gradle/EclipseCompatibleJavaExtension.kt`.
-com.ibm.wala.jdk-version=11
+com.ibm.wala.jdk-version=17
 
 # <https://github.com/littlerobots/version-catalog-update-plugin/pull/125#issue-2024490739>
 nl.littlerobots.vcu.resolver=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@ org.gradle.configureondemand=true
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
 org.gradle.parallel=true
 
-VERSION_NAME=1.8.0=SNAPSHOT
+VERSION_NAME=1.8.0-SNAPSHOT

--- a/util/src/main/java/com/ibm/wala/util/collections/Util.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/Util.java
@@ -214,6 +214,7 @@ public class Util {
    *
    * @throws IllegalArgumentException if obj == null
    */
+  @SuppressWarnings("removal")
   public static String objectFieldsToString(Object obj) throws IllegalArgumentException {
     if (obj == null) {
       throw new IllegalArgumentException("obj == null");


### PR DESCRIPTION
Java 17 brings many improvements over Java 11 that WALA could potentially use.  However, those can come in future revisions.  This commit only makes the _minimal_ changes needed to require (and be compatible with) Java 17+.

Resolves #1830.