### PR TITLE
Don't block ECJ from compiling JLex on Java 17+

### DIFF
--- a/cast/java/test/data/build.gradle.kts
+++ b/cast/java/test/data/build.gradle.kts
@@ -70,9 +70,3 @@ testSubjects { java.srcDir(downloadJLex.map { it.destinationDir }) }
 //
 
 tasks.register("prepareMavenBuild") { dependsOn("eclipseClasspath", "eclipseProject") }
-
-// On JDK 17, deprecation errors in ECJ cannot be disabled when compiling JLex code.  So, we disable
-// the ECJ task on JDK 17+.
-if (JavaVersion.current() >= JavaVersion.VERSION_17) {
-  tasks.named("compileTestJavaUsingEcj") { enabled = false }
-}


### PR DESCRIPTION
We had to disable that at some point because it failed with non-suppressable errors.  But now I find that it works just fine.  Not sure what changed, but in general we prefer to pass as much WALA code as possible through ECJ.  So let's let this ECJ task run too.