### PR TITLE
Upgrade code formatters

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -177,4 +177,13 @@ if (gradle.parent != null) {
   }
 }
 
-spotless { java { googleJavaFormat(catalogVersion("google-java-format")) } }
+spotless {
+  java {
+    googleJavaFormat(
+        catalogVersion(
+            if (JavaVersion.current() >= JavaVersion.VERSION_21) "google-java-format-jdk21"
+            else "google-java-format"
+        )
+    )
+  }
+}

--- a/cast/java/test/data/build.gradle.kts
+++ b/cast/java/test/data/build.gradle.kts
@@ -37,10 +37,10 @@ artifacts {
   add(testJavaSourceDirectory.name, testSubjects.map { it.java.srcDirs.first() })
 }
 
-// exclude since various tests make assertions based on
-// source positions in the test inputs.  to auto-format
+// Exclude since various tests make assertions based on
+// source positions in the test inputs.  To auto-format
 // we also need to update the test assertions
-spotless { java { targetExclude("**/*") } }
+spotless { java { target(files()) } }
 
 ////////////////////////////////////////////////////////////////////////
 //

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,37 @@ org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.parallel=true
 org.gradle.configureondemand=true
-org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
+# google-java-format needs deep access to javac internals; these module-system flags
+# are required for it to function within the Gradle daemon process regardless of the
+# JDK version.
+#
+#   --add-exports (all six):  google-java-format directly imports classes from many
+#     internal javac packages (api, code, file, parser, tree, util).  Exporting each
+#     package makes those classes accessible to code in the unnamed module (the Gradle
+#     daemon and its plugins).
+#
+#   --add-opens jdk.compiler/com.sun.tools.javac.tree:  Even when the field
+#     `JCCompilationUnit.endPositions` is declared `public` and the enclosing package
+#     is exported, google-java-format accesses it via bytecode `getfield` rather than
+#     reflection.  Within the Gradle daemon's classloading infrastructure the JVM
+#     module-accessibility check at the `getfield` resolution point requires the
+#     declaring package to be *opened* (not merely exported) before it permits the
+#     access.  Without this flag the JVM throws `NoSuchFieldError` at runtime.
+#
+# Different JDK versions need different google-java-format releases:
+#
+#   JDK 17:  google-java-format 1.28.0.  Versions 1.29.0+ reference `JCTree$JCAnyPattern`,
+#     an inner class added in JDK 21 (JEP 441).  1.28.0 avoids that dependency but still
+#     accesses `endPositions` via `getfield`, so `--add-opens` is required.
+#
+#   JDK 21+: google-java-format 1.35.0.  `JCAnyPattern` exists here, and 1.35.0 was
+#     refactored to avoid the `getfield endPositions` bytecode pattern entirely (the field
+#     was removed from `JCCompilationUnit` in JDK 21).  The `--add-opens` flag is
+#     unnecessary but harmless.
+#
+# The google-java-format version is selected automatically at build time by the
+# Spotless configuration in `build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts`.
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
 org.gradle.parallel=true
 
 VERSION_NAME=1.8.0-SNAPSHOT

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,8 @@ eclipse = "4.30.0"
 eclipse-wst-jsdt = "1.0.201.v2010012803"
 #noinspection UnusedVersionCatalogEntry
 google-java-format = "1.28.0"
+#noinspection UnusedVersionCatalogEntry
+google-java-format-jdk21 = "1.35.0"
 ktfmt = "0.59"
 
 [libraries]
@@ -56,7 +58,7 @@ file-lister = "all.shared.gradle.file-lister:1.0.2"
 maven-publish = "com.vanniktech.maven.publish:0.36.0"
 node = "com.github.node-gradle.node:7.1.0"
 shellcheck = "com.felipefzdz.gradle.shellcheck:1.5.1"
-spotless = "com.diffplug.spotless:8.0.0"
+spotless = "com.diffplug.spotless:8.5.1"
 task-tree = "com.dorongold.task-tree:4.0.1"
 version-catalog-update = "nl.littlerobots.version-catalog-update:1.1.0"
 versions = "com.github.ben-manes.versions:0.54.0"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,7 +6,7 @@ pluginManagement {
       settings.rootDir.resolve("foojay-resolver-convention-version.txt").readText().trim()
 }
 
-buildscript { dependencies.classpath("com.diffplug.spotless:spotless-lib-extra:4.0.0") }
+buildscript { dependencies.classpath("com.diffplug.spotless:spotless-lib-extra:4.6.1") }
 
 plugins {
   id("com.diffplug.configuration-cache-for-platform-specific-build") version "4.4.0"


### PR DESCRIPTION
- Spotless 8.0.0 → 8.5.1
- spotless-lib-extra 4.0.0 → 4.6.1

google-java-format is selected at build time based on the Gradle JVM:

  JDK 17  → 1.28.0
  JDK 21+ → 1.35.0

No single version of google-java-format works on both.  Versions 1.29.0+ reference `JCTree$JCAnyPattern`, an inner class added in JDK 21 (JEP 441) that does not exist in JDK 17.  Furthermore, the field `JCCompilationUnit.endPositions` was removed from javac in JDK 21, so versions that access it via bytecode `getfield` (including 1.28.0) fail there too.  Version 1.35.0 was refactored to avoid the `getfield` pattern entirely.

Six `--add-exports` flags and one `--add-opens` flag in `gradle.properties` are needed for the javac internals that google-java-format accesses directly.  These are safe to apply unconditionally on all supported JDK versions.

Also replace `targetExclude("**/*")` with `target(files())` in `cast/java/test/data/build.gradle.kts`.  Both patterns exclude all files from formatting (test assertions depend on source positions), but `target(files())` is the idiomatic form for newer Spotless versions.