### PR TITLE
Upgrade Rhino from 1.8.1 to 1.9.1

### DIFF
--- a/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
+++ b/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
@@ -61,6 +61,7 @@ import org.mozilla.javascript.Kit;
 import org.mozilla.javascript.Node;
 import org.mozilla.javascript.Parser;
 import org.mozilla.javascript.Token;
+import org.mozilla.javascript.ast.AbstractObjectProperty;
 import org.mozilla.javascript.ast.ArrayComprehension;
 import org.mozilla.javascript.ast.ArrayComprehensionLoop;
 import org.mozilla.javascript.ast.ArrayLiteral;
@@ -1218,9 +1219,9 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
       for (int i = 5; fn != null && i > 0; i--, fn = fn.getParent()) {
         if (fn instanceof ObjectProperty) {
           ObjectProperty prop = (ObjectProperty) fn;
-          AstNode label = prop.getLeft();
-          if (label instanceof Name) {
-            return label.getString();
+          AstNode key = prop.getKey();
+          if (key instanceof Name) {
+            return key.getString();
           }
         }
       }
@@ -1390,6 +1391,10 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
           {
             return Ast.makeConstant(null);
           }
+        case Token.UNDEFINED:
+          {
+            return readName(arg, node, "undefined");
+          }
         default:
           throw new RuntimeException(
               "unexpected keyword literal " + node + " (" + node.getType() + ')');
@@ -1461,18 +1466,19 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
 
     @Override
     public CAstNode visitObjectLiteral(ObjectLiteral n, WalkContext context) {
-      List<ObjectProperty> props = n.getElements();
+      List<AbstractObjectProperty> props = n.getElements();
       List<CAstNode> args = new ArrayList<>(props.size() * 2 + 1);
       args.add(
           (isPrologueScript(context)
               ? makeBuiltinNew("Object")
               : handleNew(context, "Object", null)));
-      for (ObjectProperty prop : props) {
-        AstNode label = prop.getLeft();
-        args.add(
-            (label instanceof Name)
-                ? Ast.makeConstant(prop.getLeft().getString())
-                : visit(label, context));
+      for (AbstractObjectProperty abstractProp : props) {
+        if (!(abstractProp instanceof ObjectProperty)) {
+          continue;
+        }
+        final ObjectProperty prop = (ObjectProperty) abstractProp;
+        final AstNode key = prop.getKey();
+        args.add((key instanceof Name) ? Ast.makeConstant(key.getString()) : visit(key, context));
         args.add(visit(prop, context));
       }
 
@@ -1483,7 +1489,7 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
 
     @Override
     public CAstNode visitObjectProperty(ObjectProperty node, WalkContext context) {
-      return visit(node.getRight(), context);
+      return visit(node.getValue(), context);
     }
 
     @Override
@@ -2465,13 +2471,17 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
       case Token.OBJECTLIT: {
       	CAstNode[] args;
       	if (n instanceof ObjectLiteral) {
-      		List<ObjectProperty> props = ((ObjectLiteral)n).getElements();
-      		args = new CAstNode[props.size() * 2 + 1];
-      		int i = 0;
-      		args[i++] = ((isPrologueScript(context)) ? makeBuiltinNew("Object") : handleNew(context, "Object", null));
-      		for(ObjectProperty prop : props) {
-      			args[i++] = walkNodes(prop.getLeft(), context);
-      			args[i++] = walkNodes(prop.getRight(), context);
+       		List<AbstractObjectProperty> props = ((ObjectLiteral)n).getElements();
+       		args = new CAstNode[props.size() * 2 + 1];
+       		int i = 0;
+       		args[i++] = ((isPrologueScript(context)) ? makeBuiltinNew("Object") : handleNew(context, "Object", null));
+       		for(AbstractObjectProperty abstractProp : props) {
+       			if (!(abstractProp instanceof ObjectProperty)) {
+       			  continue;
+       			}
+       			final ObjectProperty prop = (ObjectProperty) abstractProp;
+       			args[i++] = walkNodes(prop.getKey(), context);
+       			args[i++] = walkNodes(prop.getValue(), context);
       		}
       	} else {
       		Object[] propertyList = (Object[]) n.getProp(Node.OBJECT_IDS_PROP);

--- a/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/translator/TypedNodeVisitor.java
+++ b/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/translator/TypedNodeVisitor.java
@@ -149,6 +149,7 @@ public abstract class TypedNodeVisitor<R, A> {
     } else if (node instanceof ReturnStatement) {
       return visitReturnStatement((ReturnStatement) node, arg);
     } else if (node instanceof SwitchStatement) {
+      // `SwitchStatement` extends `Scope`, so we must check for the former _before_ the latter.
       return visitSwitchStatement((SwitchStatement) node, arg);
     } else if (node instanceof Scope) {
       return visitScope((Scope) node, arg);

--- a/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/translator/TypedNodeVisitor.java
+++ b/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/translator/TypedNodeVisitor.java
@@ -148,6 +148,8 @@ public abstract class TypedNodeVisitor<R, A> {
       return visitRegExpLiteral((RegExpLiteral) node, arg);
     } else if (node instanceof ReturnStatement) {
       return visitReturnStatement((ReturnStatement) node, arg);
+    } else if (node instanceof SwitchStatement) {
+      return visitSwitchStatement((SwitchStatement) node, arg);
     } else if (node instanceof Scope) {
       return visitScope((Scope) node, arg);
     } else if (node instanceof ScriptNode) {
@@ -156,8 +158,6 @@ public abstract class TypedNodeVisitor<R, A> {
       return visitStringLiteral((StringLiteral) node, arg);
     } else if (node instanceof SwitchCase) {
       return visitSwitchCase((SwitchCase) node, arg);
-    } else if (node instanceof SwitchStatement) {
-      return visitSwitchStatement((SwitchStatement) node, arg);
     } else if (node instanceof ThrowStatement) {
       return visitThrowStatement((ThrowStatement) node, arg);
     } else if (node instanceof TryStatement) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,7 @@ nullaway = { module = "com.uber.nullaway:nullaway", version.ref = "com-uber-null
 #noinspection UnusedVersionCatalogEntry
 nullaway-annotations = { module = "com.uber.nullaway:nullaway-annotations", version.ref = "com-uber-nullaway" }
 osgi-framework = "org.osgi:org.osgi.framework:1.10.0"
-rhino = "org.mozilla:rhino:1.8.1"
+rhino = "org.mozilla:rhino:1.9.1"
 slf4j-api = "org.slf4j:slf4j-api:2.0.18"
 
 [plugins]


### PR DESCRIPTION
- Update library version in `gradle/libs.versions.toml`.

In `RhinoToAstTranslator.java`:

- Replace deprecated `ObjectProperty.getLeft()`/`getRight()` with `getKey()`/`getValue()`. `ObjectProperty.getLeft()`/`getRight()` were removed in Rhino 1.9.1.

- Iterate using `AbstractObjectProperty` (new base class in 1.9.1) and skip non-`ObjectProperty` entries since object literals may now contain other element types.

- Handle `Token.UNDEFINED` as a new `KeywordLiteral` type.  `undefined` was previously parsed as a `Name`, but Rhino 1.9.1 introduced a dedicated token for it.

In `TypedNodeVisitor.java`:

- Reorder `instanceof` checks.  `SwitchStatement` must be tested before `Scope` because Rhino 1.9.1 changed `SwitchStatement` from extending `Jump` to extending `Scope`, making every `SwitchStatement` an instance of `Scope`.