### PR TITLE
Upgrade Eclipse ECJ

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ assertj-core = "org.assertj:assertj-core:3.27.7"
 commons-cli = "commons-cli:commons-cli:1.11.0"
 commons-io = "commons-io:commons-io:2.22.0"
 dexlib2 = "org.smali:dexlib2:2.5.2"
-eclipse-ecj = "org.eclipse.jdt:ecj:3.44.0"
+eclipse-ecj = "org.eclipse.jdt:ecj:3.45.0"
 eclipse-osgi = "org.eclipse.platform:org.eclipse.osgi:3.24.100"
 eclipse-wst-jsdt-core = { module = "org.eclipse.wst.jsdt:core", version.ref = "eclipse-wst-jsdt" }
 eclipse-wst-jsdt-ui = { module = "org.eclipse.wst.jsdt:ui", version.ref = "eclipse-wst-jsdt" }

--- a/util/src/main/java/com/ibm/wala/util/intset/SemiSparseMutableIntSet.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/SemiSparseMutableIntSet.java
@@ -69,8 +69,7 @@ public class SemiSparseMutableIntSet implements MutableIntSet {
 
   private void fixAfterSparseInsert() {
     if (sparsePart.size() % FIX_SPARSE_MOD == FIX_SPARSE_MOD - 1
-        && (densePart == null
-            || (densePart != null && sparsePart.size() > FIX_SPARSE_RATIO * densePart.getSize()))) {
+        && (densePart == null || sparsePart.size() > FIX_SPARSE_RATIO * densePart.getSize())) {
       assert assertDisjoint() : this.toString();
 
       if (densePart == null) {


### PR DESCRIPTION
In `SemiSparseMutableIntSet.java`, the newer ECJ correctly reports that a Boolean condition must always be true. OK, good catch! Let's simplify the code accordingly.