### PR TITLE
Upgrade code formatters and require Gradle Java 21

### DIFF
--- a/README-Gradle.md
+++ b/README-Gradle.md
@@ -26,7 +26,7 @@ if they are not already
 or
 [custom-configured](https://docs.gradle.org/current/userguide/toolchains.html#sec:custom_loc).
 
-Gradle itself requires a Java 17 JVM or newer when building and testing WALA.
+Gradle itself requires a Java 21 JVM or newer when building and testing WALA.
 For advice on changing Gradle’s JVM, visit Gradle’s [Configuring the Build
 Environment](https://docs.gradle.org/current/userguide/build_environment.html)
 documentation and look for discussion of the `org.gradle.java.home` Gradle

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,8 @@
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import com.github.gradle.node.npm.task.NpxTask
 import com.ibm.wala.gradle.forEachJavaProject
-import org.gradle.api.JavaVersion.VERSION_17
+import org.gradle.api.GradleException
+import org.gradle.api.JavaVersion.VERSION_21
 
 buildscript { dependencies.classpath(libs.commons.io) }
 
@@ -31,9 +32,10 @@ plugins {
 repositories.mavenCentral()
 
 JavaVersion.current().let {
-  if (!it.isCompatibleWith(VERSION_17)) {
-    logger.error(
-        "Gradle is running on a Java $it JVM, which is not compatible with Java 17. Build failures are likely. For advice on changing JVMs, visit <https://docs.gradle.org/current/userguide/build_environment.html> and look for discussion of the `org.gradle.java.home` Gradle property or the `JAVA_HOME` environment variable."
+  val minimumRequired = VERSION_21
+  if (!it.isCompatibleWith(minimumRequired)) {
+    throw GradleException(
+        "Gradle is running on a Java $it JVM, which is not compatible with Java $minimumRequired. Build failures are likely. For advice on changing JVMs, visit <https://docs.gradle.org/current/userguide/build_environment.html> and look for discussion of the `org.gradle.java.home` Gradle property or the `JAVA_HOME` environment variable."
     )
   }
 }

--- a/cast/java/test/data/build.gradle.kts
+++ b/cast/java/test/data/build.gradle.kts
@@ -37,10 +37,10 @@ artifacts {
   add(testJavaSourceDirectory.name, testSubjects.map { it.java.srcDirs.first() })
 }
 
-// exclude since various tests make assertions based on
-// source positions in the test inputs.  to auto-format
+// Exclude since various tests make assertions based on
+// source positions in the test inputs.  To auto-format
 // we also need to update the test assertions
-spotless { java { targetExclude("**/*") } }
+spotless { java { target(files()) } }
 
 ////////////////////////////////////////////////////////////////////////
 //

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ com-uber-nullaway = "0.13.4"
 eclipse = "4.30.0"
 eclipse-wst-jsdt = "1.0.201.v2010012803"
 #noinspection UnusedVersionCatalogEntry
-google-java-format = "1.28.0"
+google-java-format = "1.35.0"
 ktfmt = "0.59"
 
 [libraries]
@@ -56,7 +56,7 @@ file-lister = "all.shared.gradle.file-lister:1.0.2"
 maven-publish = "com.vanniktech.maven.publish:0.36.0"
 node = "com.github.node-gradle.node:7.1.0"
 shellcheck = "com.felipefzdz.gradle.shellcheck:1.5.1"
-spotless = "com.diffplug.spotless:8.0.0"
+spotless = "com.diffplug.spotless:8.5.1"
 task-tree = "com.dorongold.task-tree:4.0.1"
 version-catalog-update = "nl.littlerobots.version-catalog-update:1.1.0"
 versions = "com.github.ben-manes.versions:0.54.0"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,7 +6,7 @@ pluginManagement {
       settings.rootDir.resolve("foojay-resolver-convention-version.txt").readText().trim()
 }
 
-buildscript { dependencies.classpath("com.diffplug.spotless:spotless-lib-extra:4.0.0") }
+buildscript { dependencies.classpath("com.diffplug.spotless:spotless-lib-extra:4.6.1") }
 
 plugins {
   id("com.diffplug.configuration-cache-for-platform-specific-build") version "4.4.0"


### PR DESCRIPTION
* [Require that Gradle use Java 21+](https://github.com/wala/WALA/commit/41dd93fba9cde1f77c80a44880dce8e516cf105e)

  Gradle's JVM must now be Java 21 or newer.  We are raising the Gradle bar here to simplify a planned upgrade to the google-java-format build-time dependency.

  The project artifact target remains Java 17.

* [Upgrade code formatters](https://github.com/wala/WALA/commit/e45c7b3a85402e538903320da2e679e48164a754) 

  Upgrade google-java-format to version 1.35.0, Spotless to version 8.5.1, and spotless-lib-extra to version 4.6.1.