### PR TITLE
Mechanically migrate to enhanced `switch`

### DIFF
--- a/.idea/inspectionProfiles/No_Back_Sliding.xml
+++ b/.idea/inspectionProfiles/No_Back_Sliding.xml
@@ -124,6 +124,10 @@
       <option name="m_reportEmptyBlocks" value="false" />
     </inspection_tool>
     <inspection_tool class="EmptyTryBlock" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="EnhancedSwitchBackwardMigration" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="EnhancedSwitchMigration" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="myWarnOnlyOnExpressionConversion" value="false" />
+    </inspection_tool>
     <inspection_tool class="EnumerationCanBeIteration" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Java Sources as Test Subjects" level="WARNING" enabled="false" />
     </inspection_tool>

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -66,6 +66,13 @@ tasks.withType<JavaCompile>().configureEach {
       error("AnnotationPosition")
       error("AssertEqualsArgumentOrderChecker")
       error("ArgumentSelectionDefectChecker")
+      error("FallThrough")
+      error("IfChainToSwitch")
+      error("RefactorSwitch")
+      error("StatementSwitchToExpressionSwitch")
+      error("TraditionalSwitchExpression")
+      error("UnnecessaryBreakInSwitch")
+      error("UseEnumSwitch")
       // checks we do not intend to try to fix in the near-term:
       disable("LabelledBreakTarget")
       // Just too many of these; proper Javadoc would be a great long-term goal

--- a/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/FakeExceptionTypeBinding.java
+++ b/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/FakeExceptionTypeBinding.java
@@ -368,23 +368,17 @@ public class FakeExceptionTypeBinding implements ITypeBinding {
   public boolean isSubTypeCompatible(ITypeBinding type) {
     String name = type.getBinaryName();
     if (exceptionBinaryName.endsWith("Error;")) {
-      switch (name) {
-        case "Ljava/lang/Error;":
-        case "Ljava/lang/Throwable;":
-          return true;
-        default:
-          return name.equals(exceptionBinaryName);
-      }
+      return switch (name) {
+        case "Ljava/lang/Error;", "Ljava/lang/Throwable;" -> true;
+        default -> name.equals(exceptionBinaryName);
+      };
 
     } else {
-      switch (name) {
-        case "Ljava/lang/Exception;":
-        case "Ljava/lang/RuntimeException;":
-        case "Ljava/lang/Throwable;":
-          return true;
-        default:
-          return name.equals(exceptionBinaryName);
-      }
+      return switch (name) {
+        case "Ljava/lang/Exception;", "Ljava/lang/RuntimeException;", "Ljava/lang/Throwable;" ->
+            true;
+        default -> name.equals(exceptionBinaryName);
+      };
     }
   }
 

--- a/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
+++ b/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
@@ -2939,31 +2939,17 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
       CAstNode zero;
       ITypeBinding type = n.getOperand().resolveTypeBinding();
       switch (type.getBinaryName()) {
-        case "C":
-          zero = fFactory.makeConstant((char) 0);
-          break;
-        case "B":
-          zero = fFactory.makeConstant((byte) 0);
-          break;
-        case "S":
-          zero = fFactory.makeConstant((short) 0);
-          break;
-        case "I":
-          zero = fFactory.makeConstant(0);
-          break;
-        case "J":
-          zero = fFactory.makeConstant(0L);
-          break;
-        case "F":
-          zero = fFactory.makeConstant(0.0);
-          break;
-        case "D":
-          zero = fFactory.makeConstant(0.0D);
-          break;
-        default:
+        case "C" -> zero = fFactory.makeConstant((char) 0);
+        case "B" -> zero = fFactory.makeConstant((byte) 0);
+        case "S" -> zero = fFactory.makeConstant((short) 0);
+        case "I" -> zero = fFactory.makeConstant(0);
+        case "J" -> zero = fFactory.makeConstant(0L);
+        case "F" -> zero = fFactory.makeConstant(0.0);
+        case "D" -> zero = fFactory.makeConstant(0.0D);
+        default -> {
           zero = null;
           assert false : "unexpected type " + type.getBinaryName();
-          break;
+        }
       }
       return makeNode(
           context,
@@ -4816,15 +4802,10 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
 
       // the type
       switch (i) {
-        case 1:
-          paramTypes.add(fTypeDict.getCAstTypeFor(ast.resolveWellKnownType("java.lang.String")));
-          break;
-        case 2:
-          paramTypes.add(fTypeDict.getCAstTypeFor(ast.resolveWellKnownType("int")));
-          break;
-        default:
-          paramTypes.add(fTypeDict.getCAstTypeFor(ctor.getParameterTypes()[i - 3]));
-          break;
+        case 1 ->
+            paramTypes.add(fTypeDict.getCAstTypeFor(ast.resolveWellKnownType("java.lang.String")));
+        case 2 -> paramTypes.add(fTypeDict.getCAstTypeFor(ast.resolveWellKnownType("int")));
+        default -> paramTypes.add(fTypeDict.getCAstTypeFor(ctor.getParameterTypes()[i - 3]));
       }
     }
 

--- a/cast/java/src/main/java/com/ibm/wala/cast/java/translator/JavaCAst2IRTranslator.java
+++ b/cast/java/src/main/java/com/ibm/wala/cast/java/translator/JavaCAst2IRTranslator.java
@@ -389,22 +389,15 @@ public class JavaCAst2IRTranslator extends AstTranslator {
 
   @Override
   protected String composeEntityName(WalkContext parent, CAstEntity f) {
-    switch (f.getKind()) {
-      case CAstEntity.TYPE_ENTITY:
-        {
-          return parent.getName().isEmpty() ? f.getName() : parent.getName() + '/' + f.getName();
-        }
-      case CAstEntity.FUNCTION_ENTITY:
-        {
+    return switch (f.getKind()) {
+      case CAstEntity.TYPE_ENTITY ->
+          parent.getName().isEmpty() ? f.getName() : parent.getName() + '/' + f.getName();
+      case CAstEntity.FUNCTION_ENTITY ->
           // TODO properly handle types with clashing names/signatures within a
           // given method
-          return parent.getName() + '/' + f.getSignature();
-        }
-      default:
-        {
-          return parent.getName();
-        }
-    }
+          parent.getName() + '/' + f.getSignature();
+      default -> parent.getName();
+    };
   }
 
   private CAstEntity getEnclosingType(CAstEntity entity) {
@@ -414,23 +407,19 @@ public class JavaCAst2IRTranslator extends AstTranslator {
 
   private CAstEntity getEnclosingTypeInternal(CAstEntity entity) {
     switch (entity.getKind()) {
-      case CAstEntity.TYPE_ENTITY:
-        {
-          return entity;
-        }
-      case CAstEntity.FUNCTION_ENTITY:
-        {
-          if (entity.getQualifiers().contains(CAstQualifier.STATIC)) return null;
-          else return getEnclosingTypeInternal(getParent(entity));
-        }
-      case CAstEntity.FILE_ENTITY:
-        {
-          return null;
-        }
-      default:
-        {
-          return getEnclosingTypeInternal(getParent(entity));
-        }
+      case CAstEntity.TYPE_ENTITY -> {
+        return entity;
+      }
+      case CAstEntity.FUNCTION_ENTITY -> {
+        if (entity.getQualifiers().contains(CAstQualifier.STATIC)) return null;
+        else return getEnclosingTypeInternal(getParent(entity));
+      }
+      case CAstEntity.FILE_ENTITY -> {
+        return null;
+      }
+      default -> {
+        return getEnclosingTypeInternal(getParent(entity));
+      }
     }
   }
 

--- a/cast/js/nodejs/src/main/java/com/ibm/wala/cast/js/nodejs/NodejsRequiredSourceModule.java
+++ b/cast/js/nodejs/src/main/java/com/ibm/wala/cast/js/nodejs/NodejsRequiredSourceModule.java
@@ -71,22 +71,23 @@ public class NodejsRequiredSourceModule extends SourceFileModule {
 
     final String wrapperSource;
     String ext = FilenameUtils.getExtension(getFile().toString()).toLowerCase();
-    switch (ext) {
-      case "js":
-        // JS file -> use module wrapper
-        wrapperSource = MODULE_WRAPPER_SOURCE;
-        break;
-      case "json":
-        // JSON file -> use JSON wrapper
-        wrapperSource = JSON_WRAPPER_SOURCE;
-        break;
-      default:
-        // No clue -> try module wrapper
-        System.err.println(
-            "NodejsRequiredSourceModule: Unsupported file type (" + ext + "), continue anyway.");
-        wrapperSource = MODULE_WRAPPER_SOURCE;
-        break;
-    }
+    wrapperSource =
+        switch (ext) {
+          case "js" ->
+              // JS file -> use module wrapper
+              MODULE_WRAPPER_SOURCE;
+          case "json" ->
+              // JSON file -> use JSON wrapper
+              JSON_WRAPPER_SOURCE;
+          default -> {
+            // No clue -> try module wrapper
+            System.err.println(
+                "NodejsRequiredSourceModule: Unsupported file type ("
+                    + ext
+                    + "), continue anyway.");
+            yield MODULE_WRAPPER_SOURCE;
+          }
+        };
 
     String wrappedModuleSource =
         wrapperSource

--- a/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
+++ b/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
@@ -236,71 +236,33 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
   }
 
   private static CAstNode translateOpcode(int nodeType) {
-    switch (nodeType) {
-      case Token.POS:
-      case Token.ADD:
-      case Token.ASSIGN_ADD:
-        return CAstOperator.OP_ADD;
-      case Token.DIV:
-      case Token.ASSIGN_DIV:
-        return CAstOperator.OP_DIV;
-      case Token.ASSIGN_LSH:
-      case Token.LSH:
-        return CAstOperator.OP_LSH;
-      case Token.MOD:
-      case Token.ASSIGN_MOD:
-        return CAstOperator.OP_MOD;
-      case Token.MUL:
-      case Token.ASSIGN_MUL:
-        return CAstOperator.OP_MUL;
-      case Token.RSH:
-      case Token.ASSIGN_RSH:
-        return CAstOperator.OP_RSH;
-      case Token.SUB:
-      case Token.NEG:
-      case Token.ASSIGN_SUB:
-        return CAstOperator.OP_SUB;
-      case Token.URSH:
-      case Token.ASSIGN_URSH:
-        return CAstOperator.OP_URSH;
-      case Token.BITAND:
-      case Token.ASSIGN_BITAND:
-        return CAstOperator.OP_BIT_AND;
-      case Token.BITOR:
-      case Token.ASSIGN_BITOR:
-        return CAstOperator.OP_BIT_OR;
-      case Token.BITXOR:
-      case Token.ASSIGN_BITXOR:
-        return CAstOperator.OP_BIT_XOR;
-
-      case Token.EQ:
-      case Token.IFEQ:
-        return CAstOperator.OP_EQ;
-      case Token.SHEQ:
-        return CAstOperator.OP_STRICT_EQ;
-      case Token.GE:
-        return CAstOperator.OP_GE;
-      case Token.GT:
-        return CAstOperator.OP_GT;
-      case Token.LE:
-        return CAstOperator.OP_LE;
-      case Token.LT:
-        return CAstOperator.OP_LT;
-      case Token.NE:
-      case Token.IFNE:
-        return CAstOperator.OP_NE;
-      case Token.SHNE:
-        return CAstOperator.OP_STRICT_NE;
-
-      case Token.BITNOT:
-        return CAstOperator.OP_BITNOT;
-      case Token.NOT:
-        return CAstOperator.OP_NOT;
-
-      default:
+    return switch (nodeType) {
+      case Token.POS, Token.ADD, Token.ASSIGN_ADD -> CAstOperator.OP_ADD;
+      case Token.DIV, Token.ASSIGN_DIV -> CAstOperator.OP_DIV;
+      case Token.ASSIGN_LSH, Token.LSH -> CAstOperator.OP_LSH;
+      case Token.MOD, Token.ASSIGN_MOD -> CAstOperator.OP_MOD;
+      case Token.MUL, Token.ASSIGN_MUL -> CAstOperator.OP_MUL;
+      case Token.RSH, Token.ASSIGN_RSH -> CAstOperator.OP_RSH;
+      case Token.SUB, Token.NEG, Token.ASSIGN_SUB -> CAstOperator.OP_SUB;
+      case Token.URSH, Token.ASSIGN_URSH -> CAstOperator.OP_URSH;
+      case Token.BITAND, Token.ASSIGN_BITAND -> CAstOperator.OP_BIT_AND;
+      case Token.BITOR, Token.ASSIGN_BITOR -> CAstOperator.OP_BIT_OR;
+      case Token.BITXOR, Token.ASSIGN_BITXOR -> CAstOperator.OP_BIT_XOR;
+      case Token.EQ, Token.IFEQ -> CAstOperator.OP_EQ;
+      case Token.SHEQ -> CAstOperator.OP_STRICT_EQ;
+      case Token.GE -> CAstOperator.OP_GE;
+      case Token.GT -> CAstOperator.OP_GT;
+      case Token.LE -> CAstOperator.OP_LE;
+      case Token.LT -> CAstOperator.OP_LT;
+      case Token.NE, Token.IFNE -> CAstOperator.OP_NE;
+      case Token.SHNE -> CAstOperator.OP_STRICT_NE;
+      case Token.BITNOT -> CAstOperator.OP_BITNOT;
+      case Token.NOT -> CAstOperator.OP_NOT;
+      default -> {
         Assertions.UNREACHABLE();
-        return null;
-    }
+        yield null;
+      }
+    };
   }
 
   private CAstNode makeBuiltinNew(String typeName) {
@@ -1368,36 +1330,30 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
     @Override
     public CAstNode visitKeywordLiteral(KeywordLiteral node, WalkContext arg) {
       switch (node.getType()) {
-        case Token.THIS:
-          {
-            if (arg.top() instanceof ScriptNode && !(arg.top() instanceof FunctionNode)) {
-              CAstNode globalRef = makeVarRef(JSSSAPropagationCallGraphBuilder.GLOBAL_OBJ_VAR_NAME);
-              arg.cfg().map(globalRef, globalRef);
-              return globalRef;
-            } else {
-              return Ast.makeNode(CAstNode.VAR, Ast.makeConstant("this"));
-            }
+        case Token.THIS -> {
+          if (arg.top() instanceof ScriptNode && !(arg.top() instanceof FunctionNode)) {
+            CAstNode globalRef = makeVarRef(JSSSAPropagationCallGraphBuilder.GLOBAL_OBJ_VAR_NAME);
+            arg.cfg().map(globalRef, globalRef);
+            return globalRef;
+          } else {
+            return Ast.makeNode(CAstNode.VAR, Ast.makeConstant("this"));
           }
-        case Token.TRUE:
-          {
-            return Ast.makeConstant(true);
-          }
-        case Token.FALSE:
-          {
-            return Ast.makeConstant(false);
-          }
-        case Token.NULL:
-        case Token.DEBUGGER:
-          {
-            return Ast.makeConstant(null);
-          }
-        case Token.UNDEFINED:
-          {
-            return readName(arg, node, "undefined");
-          }
-        default:
-          throw new RuntimeException(
-              "unexpected keyword literal " + node + " (" + node.getType() + ')');
+        }
+        case Token.TRUE -> {
+          return Ast.makeConstant(true);
+        }
+        case Token.FALSE -> {
+          return Ast.makeConstant(false);
+        }
+        case Token.NULL, Token.DEBUGGER -> {
+          return Ast.makeConstant(null);
+        }
+        case Token.UNDEFINED -> {
+          return readName(arg, node, "undefined");
+        }
+        default ->
+            throw new RuntimeException(
+                "unexpected keyword literal " + node + " (" + node.getType() + ')');
       }
     }
 

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/html/DefaultSourceExtractor.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/html/DefaultSourceExtractor.java
@@ -199,18 +199,18 @@ public class DefaultSourceExtractor extends DomLessSourceExtractor {
     protected void writePortletAttribute(ITag tag, String attr, String value, String varName) {
       if (attr.equals("portletid")) {
         switch (value.substring(value.length() - 4)) {
-          case "vice":
+          case "vice" -> {
             newLine();
             newLine();
             printlnIndented(
                 "function cVice() { var contextVice = " + varName + "; }\ncVice();\n", tag);
-            break;
-          case "root":
+          }
+          case "root" -> {
             newLine();
             newLine();
             printlnIndented(
                 "function cRoot() { var contextRoot = " + varName + "; }\ncRoot();\n", tag);
-            break;
+          }
         }
       }
     }

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/ClosureExtractor.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/ClosureExtractor.java
@@ -215,22 +215,15 @@ public class ClosureExtractor extends CAstRewriterExt {
       CAstControlFlowMap cfg,
       NodePos context,
       Map<Pair<CAstNode, NoKey>, CAstNode> nodeMap) {
-    switch (root.getKind()) {
-      case OPERATOR:
-        return root;
-      case CONSTANT:
-        return copyConstant(root, context, nodeMap);
-      case BLOCK_STMT:
-        return copyBlock(root, cfg, context, nodeMap);
-      case RETURN:
-        return copyReturn(root, cfg, context, nodeMap);
-      case VAR:
-        return copyVar(root, cfg, context, nodeMap);
-      case GOTO:
-        return copyGoto(root, cfg, context, nodeMap);
-      default:
-        return copyNode(root, cfg, context, nodeMap);
-    }
+    return switch (root.getKind()) {
+      case OPERATOR -> root;
+      case CONSTANT -> copyConstant(root, context, nodeMap);
+      case BLOCK_STMT -> copyBlock(root, cfg, context, nodeMap);
+      case RETURN -> copyReturn(root, cfg, context, nodeMap);
+      case VAR -> copyVar(root, cfg, context, nodeMap);
+      case GOTO -> copyGoto(root, cfg, context, nodeMap);
+      default -> copyNode(root, cfg, context, nodeMap);
+    };
   }
 
   /* Constants are not affected by the rewriting, they are just copied. */
@@ -936,15 +929,17 @@ public class ClosureExtractor extends CAstRewriterExt {
   // determine whether the given subtree contains no unstructured control flow and calls
   private boolean noJumpsAndNoCalls(CAstNode node) {
     switch (node.getKind()) {
-      case CAstNode.BREAK:
-      case CAstNode.CONTINUE:
-      case CAstNode.GOTO:
-      case CAstNode.RETURN:
-      case CAstNode.CALL:
-      case CAstNode.NEW:
+      case CAstNode.BREAK,
+          CAstNode.CONTINUE,
+          CAstNode.GOTO,
+          CAstNode.RETURN,
+          CAstNode.CALL,
+          CAstNode.NEW -> {
         return false;
-      default:
+      }
+      default -> {
         // fall through to generic handlers below
+      }
     }
     for (CAstNode child : node.getChildren()) if (!noJumpsAndNoCalls(child)) return false;
     return true;

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/summaries/JavaScriptConstructorFunctions.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/summaries/JavaScriptConstructorFunctions.java
@@ -455,9 +455,10 @@ public class JavaScriptConstructorFunctions {
     SymbolTable ST = callerIR.getSymbolTable();
 
     switch (nargs) {
-      case 0:
+      case 0 -> {
         return makeFunctionConstructor(cls, cls);
-      case 1:
+      }
+      case 1 -> {
         if (ST.isStringConstant(callStmt.getUse(1))
             && !ST.getStringValue(callStmt.getUse(1)).isEmpty()) {
           TypeReference ref =
@@ -472,7 +473,8 @@ public class JavaScriptConstructorFunctions {
         }
 
         return makeFunctionConstructor(cls, cls);
-      default:
+      }
+      default -> {
         assert nargs > 1;
         JavaScriptLoader cl = (JavaScriptLoader) cha.getLoader(JavaScriptTypes.jsLoader);
 
@@ -588,6 +590,7 @@ public class JavaScriptConstructorFunctions {
         }
 
         return makeFunctionConstructor(cls, cls);
+      }
     }
   }
 

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ssa/JavaScriptInstanceOf.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ssa/JavaScriptInstanceOf.java
@@ -93,14 +93,13 @@ public class JavaScriptInstanceOf extends SSAInstruction {
 
   @Override
   public int getUse(int i) {
-    switch (i) {
-      case 0:
-        return objVal;
-      case 1:
-        return typeVal;
-      default:
+    return switch (i) {
+      case 0 -> objVal;
+      case 1 -> typeVal;
+      default -> {
         Assertions.UNREACHABLE();
-        return -1;
-    }
+        yield -1;
+      }
+    };
   }
 }

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/translator/JSAstTranslator.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/translator/JSAstTranslator.java
@@ -427,117 +427,94 @@ public class JSAstTranslator extends AstTranslator {
     try {
       String name = (String) primitiveCall.getChild(0).getValue();
       switch (name) {
-        case "GlobalNaN":
-          context
-              .cfg()
-              .addInstruction(
-                  ((JSInstructionFactory) insts)
-                      .AssignInstruction(
-                          context.cfg().getCurrentInstruction(),
-                          resultVal,
-                          context.currentScope().getConstantValue(Float.NaN)));
-          break;
-        case "GlobalInfinity":
-          context
-              .cfg()
-              .addInstruction(
-                  ((JSInstructionFactory) insts)
-                      .AssignInstruction(
-                          context.cfg().getCurrentInstruction(),
-                          resultVal,
-                          context.currentScope().getConstantValue(Float.POSITIVE_INFINITY)));
-          break;
-        case "MathE":
-          context
-              .cfg()
-              .addInstruction(
-                  ((JSInstructionFactory) insts)
-                      .AssignInstruction(
-                          context.cfg().getCurrentInstruction(),
-                          resultVal,
-                          context.currentScope().getConstantValue(Math.E)));
-          break;
-        case "MathPI":
-          context
-              .cfg()
-              .addInstruction(
-                  ((JSInstructionFactory) insts)
-                      .AssignInstruction(
-                          context.cfg().getCurrentInstruction(),
-                          resultVal,
-                          context.currentScope().getConstantValue(Math.PI)));
-          break;
-        case "MathSQRT1_2":
-          context
-              .cfg()
-              .addInstruction(
-                  ((JSInstructionFactory) insts)
-                      .AssignInstruction(
-                          context.cfg().getCurrentInstruction(),
-                          resultVal,
-                          context.currentScope().getConstantValue(Math.sqrt(.5))));
-          break;
-        case "MathSQRT2":
-          context
-              .cfg()
-              .addInstruction(
-                  ((JSInstructionFactory) insts)
-                      .AssignInstruction(
-                          context.cfg().getCurrentInstruction(),
-                          resultVal,
-                          context.currentScope().getConstantValue(Math.sqrt(2))));
-          break;
-        case "MathLN2":
-          context
-              .cfg()
-              .addInstruction(
-                  ((JSInstructionFactory) insts)
-                      .AssignInstruction(
-                          context.cfg().getCurrentInstruction(),
-                          resultVal,
-                          context.currentScope().getConstantValue(Math.log(2))));
-          break;
-        case "MathLN10":
-          context
-              .cfg()
-              .addInstruction(
-                  ((JSInstructionFactory) insts)
-                      .AssignInstruction(
-                          context.cfg().getCurrentInstruction(),
-                          resultVal,
-                          context.currentScope().getConstantValue(Math.log(10))));
-          break;
-        case "NewObject":
-          doNewObject(context, null, resultVal, "Object", null);
-          break;
-        case "NewArray":
-          doNewObject(context, null, resultVal, "Array", null);
-          break;
-        case "NewString":
-          doPrimitiveNew(context, resultVal, "String");
-          break;
-        case "NewNumber":
-          doPrimitiveNew(context, resultVal, "Number");
-          break;
-        case "NewRegExp":
-          doPrimitiveNew(context, resultVal, "RegExp");
-          break;
-        case "NewFunction":
-          doNewObject(context, null, resultVal, "Function", null);
-          break;
-        case "NewUndefined":
-          doNewObject(context, null, resultVal, "Undefined", null);
-          break;
-        default:
-          context
-              .cfg()
-              .addInstruction(
-                  ((JSInstructionFactory) insts)
-                      .AssignInstruction(
-                          context.cfg().getCurrentInstruction(),
-                          resultVal,
-                          context.currentScope().getConstantValue(null)));
-          break;
+        case "GlobalNaN" ->
+            context
+                .cfg()
+                .addInstruction(
+                    ((JSInstructionFactory) insts)
+                        .AssignInstruction(
+                            context.cfg().getCurrentInstruction(),
+                            resultVal,
+                            context.currentScope().getConstantValue(Float.NaN)));
+        case "GlobalInfinity" ->
+            context
+                .cfg()
+                .addInstruction(
+                    ((JSInstructionFactory) insts)
+                        .AssignInstruction(
+                            context.cfg().getCurrentInstruction(),
+                            resultVal,
+                            context.currentScope().getConstantValue(Float.POSITIVE_INFINITY)));
+        case "MathE" ->
+            context
+                .cfg()
+                .addInstruction(
+                    ((JSInstructionFactory) insts)
+                        .AssignInstruction(
+                            context.cfg().getCurrentInstruction(),
+                            resultVal,
+                            context.currentScope().getConstantValue(Math.E)));
+        case "MathPI" ->
+            context
+                .cfg()
+                .addInstruction(
+                    ((JSInstructionFactory) insts)
+                        .AssignInstruction(
+                            context.cfg().getCurrentInstruction(),
+                            resultVal,
+                            context.currentScope().getConstantValue(Math.PI)));
+        case "MathSQRT1_2" ->
+            context
+                .cfg()
+                .addInstruction(
+                    ((JSInstructionFactory) insts)
+                        .AssignInstruction(
+                            context.cfg().getCurrentInstruction(),
+                            resultVal,
+                            context.currentScope().getConstantValue(Math.sqrt(.5))));
+        case "MathSQRT2" ->
+            context
+                .cfg()
+                .addInstruction(
+                    ((JSInstructionFactory) insts)
+                        .AssignInstruction(
+                            context.cfg().getCurrentInstruction(),
+                            resultVal,
+                            context.currentScope().getConstantValue(Math.sqrt(2))));
+        case "MathLN2" ->
+            context
+                .cfg()
+                .addInstruction(
+                    ((JSInstructionFactory) insts)
+                        .AssignInstruction(
+                            context.cfg().getCurrentInstruction(),
+                            resultVal,
+                            context.currentScope().getConstantValue(Math.log(2))));
+        case "MathLN10" ->
+            context
+                .cfg()
+                .addInstruction(
+                    ((JSInstructionFactory) insts)
+                        .AssignInstruction(
+                            context.cfg().getCurrentInstruction(),
+                            resultVal,
+                            context.currentScope().getConstantValue(Math.log(10))));
+        case "NewObject" -> doNewObject(context, null, resultVal, "Object", null);
+        case "NewArray" -> doNewObject(context, null, resultVal, "Array", null);
+        case "NewString" -> doPrimitiveNew(context, resultVal, "String");
+        case "NewNumber" -> doPrimitiveNew(context, resultVal, "Number");
+        case "NewRegExp" -> doPrimitiveNew(context, resultVal, "RegExp");
+        case "NewFunction" -> doNewObject(context, null, resultVal, "Function", null);
+        case "NewUndefined" -> doNewObject(context, null, resultVal, "Undefined", null);
+        default ->
+            context
+                .cfg()
+                .addInstruction(
+                    ((JSInstructionFactory) insts)
+                        .AssignInstruction(
+                            context.cfg().getCurrentInstruction(),
+                            resultVal,
+                            context.currentScope().getConstantValue(null)));
       }
     } catch (ClassCastException e) {
       throw new RuntimeException(
@@ -584,44 +561,39 @@ public class JSAstTranslator extends AstTranslator {
   @Override
   protected boolean doVisit(CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
     switch (n.getKind()) {
-      case CAstNode.TYPE_OF:
-        {
-          int result = context.currentScope().allocateTempValue();
+      case CAstNode.TYPE_OF -> {
+        int result = context.currentScope().allocateTempValue();
 
-          this.visit(n.getChild(0), context, this);
-          int ref = context.getValue(n.getChild(0));
+        this.visit(n.getChild(0), context, this);
+        int ref = context.getValue(n.getChild(0));
 
-          context
-              .cfg()
-              .addInstruction(
-                  ((JSInstructionFactory) insts)
-                      .TypeOfInstruction(context.cfg().getCurrentInstruction(), result, ref));
+        context
+            .cfg()
+            .addInstruction(
+                ((JSInstructionFactory) insts)
+                    .TypeOfInstruction(context.cfg().getCurrentInstruction(), result, ref));
 
-          context.setValue(n, result);
-          return true;
-        }
+        context.setValue(n, result);
+        return true;
+      }
+      case JavaScriptCAstNode.ENTER_WITH, JavaScriptCAstNode.EXIT_WITH -> {
+        this.visit(n.getChild(0), context, this);
+        int ref = context.getValue(n.getChild(0));
 
-      case JavaScriptCAstNode.ENTER_WITH:
-      case JavaScriptCAstNode.EXIT_WITH:
-        {
-          this.visit(n.getChild(0), context, this);
-          int ref = context.getValue(n.getChild(0));
+        context
+            .cfg()
+            .addInstruction(
+                ((JSInstructionFactory) insts)
+                    .WithRegion(
+                        context.cfg().getCurrentInstruction(),
+                        ref,
+                        n.getKind() == JavaScriptCAstNode.ENTER_WITH));
 
-          context
-              .cfg()
-              .addInstruction(
-                  ((JSInstructionFactory) insts)
-                      .WithRegion(
-                          context.cfg().getCurrentInstruction(),
-                          ref,
-                          n.getKind() == JavaScriptCAstNode.ENTER_WITH));
-
-          return true;
-        }
-      default:
-        {
-          return false;
-        }
+        return true;
+      }
+      default -> {
+        return false;
+      }
     }
   }
 

--- a/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/CAstDumper.java
+++ b/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/CAstDumper.java
@@ -106,17 +106,12 @@ public class CAstDumper {
   }
 
   private boolean isTrivial(CAstNode node) {
-    switch (node.getKind()) {
-      case ASSIGN:
-        return node.getChild(0).getKind() == CAstNode.VAR && isTrivial(node.getChild(1));
-      case EMPTY:
-        return true;
-      case BLOCK_EXPR:
-      case BLOCK_STMT:
-        return getNonTrivialChildCount(node) == 0;
-      default:
-        return false;
-    }
+    return switch (node.getKind()) {
+      case ASSIGN -> node.getChild(0).getKind() == CAstNode.VAR && isTrivial(node.getChild(1));
+      case EMPTY -> true;
+      case BLOCK_EXPR, BLOCK_STMT -> getNonTrivialChildCount(node) == 0;
+      default -> false;
+    };
   }
 
   private int getNonTrivialChildCount(CAstNode node) {

--- a/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/MiscellaneousHacksContextSelector.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/MiscellaneousHacksContextSelector.java
@@ -48,75 +48,61 @@ public class MiscellaneousHacksContextSelector implements ContextSelector {
       switch (descr.length) {
 
         // loader name, loader language, classname, method name, method descr
-        case 5:
-          {
-            ClassLoaderReference clr =
-                cha.getScope().getLoader(Atom.findOrCreateUnicodeAtom(descr[0]));
-            IClassLoader loader = cha.getLoader(clr);
-            MethodReference ref =
-                MethodReference.findOrCreate(
-                    TypeReference.findOrCreate(clr, TypeName.string2TypeName(descr[2])),
-                    Atom.findOrCreateUnicodeAtom(descr[3]),
-                    Descriptor.findOrCreateUTF8(loader.getLanguage(), descr[4]));
+        case 5 -> {
+          ClassLoaderReference clr =
+              cha.getScope().getLoader(Atom.findOrCreateUnicodeAtom(descr[0]));
+          IClassLoader loader = cha.getLoader(clr);
+          MethodReference ref =
+              MethodReference.findOrCreate(
+                  TypeReference.findOrCreate(clr, TypeName.string2TypeName(descr[2])),
+                  Atom.findOrCreateUnicodeAtom(descr[3]),
+                  Descriptor.findOrCreateUTF8(loader.getLanguage(), descr[4]));
 
-            if (cha.resolveMethod(ref) != null) {
-              methodsToSpecialize.add(cha.resolveMethod(ref).getReference());
-            } else {
-              methodsToSpecialize.add(ref);
-            }
-            break;
+          if (cha.resolveMethod(ref) != null) {
+            methodsToSpecialize.add(cha.resolveMethod(ref).getReference());
+          } else {
+            methodsToSpecialize.add(ref);
           }
+        }
 
         // classname, method name, method descr
-        case 3:
-          {
-            MethodReference ref =
-                MethodReference.findOrCreate(
-                    TypeReference.findOrCreate(
-                        ClassLoaderReference.Application, TypeName.string2TypeName(descr[0])),
-                    Atom.findOrCreateUnicodeAtom(descr[1]),
-                    Descriptor.findOrCreateUTF8(Language.JAVA, descr[2]));
+        case 3 -> {
+          MethodReference ref =
+              MethodReference.findOrCreate(
+                  TypeReference.findOrCreate(
+                      ClassLoaderReference.Application, TypeName.string2TypeName(descr[0])),
+                  Atom.findOrCreateUnicodeAtom(descr[1]),
+                  Descriptor.findOrCreateUTF8(Language.JAVA, descr[2]));
 
-            methodsToSpecialize.add(cha.resolveMethod(ref).getReference());
-            break;
-          }
+          methodsToSpecialize.add(cha.resolveMethod(ref).getReference());
+        }
 
         // loader name, classname, meaning all methods of that class
-        case 2:
-          {
-            IClass klass =
-                cha.lookupClass(
-                    TypeReference.findOrCreate(
-                        new ClassLoaderReference(
-                            Atom.findOrCreateUnicodeAtom(descr[0]),
-                            ClassLoaderReference.Java,
-                            null),
-                        TypeName.string2TypeName(descr[1])));
+        case 2 -> {
+          IClass klass =
+              cha.lookupClass(
+                  TypeReference.findOrCreate(
+                      new ClassLoaderReference(
+                          Atom.findOrCreateUnicodeAtom(descr[0]), ClassLoaderReference.Java, null),
+                      TypeName.string2TypeName(descr[1])));
 
-            for (IMethod M : klass.getDeclaredMethods()) {
-              methodsToSpecialize.add(M.getReference());
-            }
-
-            break;
+          for (IMethod M : klass.getDeclaredMethods()) {
+            methodsToSpecialize.add(M.getReference());
           }
+        }
 
         // classname, meaning all methods of that class
-        case 1:
-          {
-            IClass klass =
-                cha.lookupClass(
-                    TypeReference.findOrCreate(
-                        ClassLoaderReference.Application, TypeName.string2TypeName(descr[0])));
+        case 1 -> {
+          IClass klass =
+              cha.lookupClass(
+                  TypeReference.findOrCreate(
+                      ClassLoaderReference.Application, TypeName.string2TypeName(descr[0])));
 
-            for (IMethod M : klass.getDeclaredMethods()) {
-              methodsToSpecialize.add(M.getReference());
-            }
-
-            break;
+          for (IMethod M : klass.getDeclaredMethods()) {
+            methodsToSpecialize.add(M.getReference());
           }
-
-        default:
-          Assertions.UNREACHABLE();
+        }
+        default -> Assertions.UNREACHABLE();
       }
     }
 

--- a/cast/src/main/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
@@ -4186,7 +4186,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
   protected void leaveIfgoto(CAstNode n, WalkContext context, CAstVisitor<WalkContext> visitor) {
     int currentInstruction = context.cfg().currentInstruction;
     switch (n.getChildCount()) {
-      case 1:
+      case 1 -> {
         CAstNode arg = n.getChild(0);
         context
             .cfg()
@@ -4199,8 +4199,8 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
                     context.currentScope().getConstantValue(0),
                     -1));
         context.cfg().noteOperands(currentInstruction, context.getSourceMap().getPosition(arg));
-        break;
-      case 3:
+      }
+      case 3 -> {
         CAstNode op = n.getChild(0);
         CAstNode leftExpr = n.getChild(1);
         CAstNode rightExpr = n.getChild(2);
@@ -4220,9 +4220,8 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
                 currentInstruction,
                 context.getSourceMap().getPosition(leftExpr),
                 context.getSourceMap().getPosition(rightExpr));
-        break;
-      default:
-        Assertions.UNREACHABLE();
+      }
+      default -> Assertions.UNREACHABLE();
     }
 
     context.cfg().addPreNode(n, context.getUnwindState());

--- a/cast/src/main/java/com/ibm/wala/cast/tree/visit/CAstVisitor.java
+++ b/cast/src/main/java/com/ibm/wala/cast/tree/visit/CAstVisitor.java
@@ -180,82 +180,67 @@ public abstract class CAstVisitor<C extends CAstVisitor.Context> {
 
     if (visitor.enterEntity(n, context, visitor)) return;
     switch (n.getKind()) {
-      case CAstEntity.FILE_ENTITY:
-        {
-          C fileContext = visitor.makeFileContext(context, n);
-          if (visitor.visitFileEntity(n, context, fileContext, visitor)) break;
-          visitor.visitScopedEntities(n, n.getAllScopedEntities(), fileContext, visitor);
-          visitor.leaveFileEntity(n, context, fileContext, visitor);
-          break;
+      case CAstEntity.FILE_ENTITY -> {
+        C fileContext = visitor.makeFileContext(context, n);
+        if (visitor.visitFileEntity(n, context, fileContext, visitor)) break;
+        visitor.visitScopedEntities(n, n.getAllScopedEntities(), fileContext, visitor);
+        visitor.leaveFileEntity(n, context, fileContext, visitor);
+      }
+      case CAstEntity.FIELD_ENTITY -> {
+        if (visitor.visitFieldEntity(n, context, visitor)) break;
+        visitor.leaveFieldEntity(n, context, visitor);
+      }
+      case CAstEntity.GLOBAL_ENTITY -> {
+        if (visitor.visitGlobalEntity(n, context, visitor)) break;
+        visitor.leaveGlobalEntity(n, context, visitor);
+      }
+      case CAstEntity.TYPE_ENTITY -> {
+        C typeContext = visitor.makeTypeContext(context, n);
+        if (visitor.visitTypeEntity(n, context, typeContext, visitor)) break;
+        visitor.visitScopedEntities(n, n.getAllScopedEntities(), typeContext, visitor);
+        visitor.leaveTypeEntity(n, context, typeContext, visitor);
+      }
+      case CAstEntity.FUNCTION_ENTITY -> {
+        for (CAstNode dflt : n.getArgumentDefaults()) {
+          visitor.visit(dflt, getCodeContext(context), visitor);
+          visitor.visitScopedEntities(
+              context.top(), context.top().getScopedEntities(dflt), context, visitor);
         }
-      case CAstEntity.FIELD_ENTITY:
-        {
-          if (visitor.visitFieldEntity(n, context, visitor)) break;
-          visitor.leaveFieldEntity(n, context, visitor);
-          break;
+        C codeContext = visitor.makeCodeContext(context, n);
+        if (visitor.visitFunctionEntity(n, context, codeContext, visitor)) break;
+        // visit the AST if any
+        if (n.getAST() != null) visitor.visit(n.getAST(), codeContext, visitor);
+        // XXX: there may be code that needs to go in here
+        // process any remaining scoped children
+        visitor.visitScopedEntities(n, n.getScopedEntities(null), codeContext, visitor);
+        visitor.leaveFunctionEntity(n, context, codeContext, visitor);
+      }
+      case CAstEntity.MACRO_ENTITY -> {
+        C codeContext = visitor.makeCodeContext(context, n);
+        if (visitor.visitMacroEntity(n, context, codeContext, visitor)) break;
+        // visit the AST if any
+        if (n.getAST() != null) visitor.visit(n.getAST(), codeContext, visitor);
+        // XXX: there may be code that needs to go in here
+        // process any remaining scoped children
+        visitor.visitScopedEntities(n, n.getScopedEntities(null), codeContext, visitor);
+        visitor.leaveMacroEntity(n, context, codeContext, visitor);
+      }
+      case CAstEntity.SCRIPT_ENTITY -> {
+        C codeContext = visitor.makeCodeContext(context, n);
+        if (visitor.visitScriptEntity(n, context, codeContext, visitor)) break;
+        // visit the AST if any
+        if (n.getAST() != null) visitor.visit(n.getAST(), codeContext, visitor);
+        // XXX: there may be code that needs to go in here
+        // process any remaining scoped children
+        visitor.visitScopedEntities(n, n.getScopedEntities(null), codeContext, visitor);
+        visitor.leaveScriptEntity(n, context, codeContext, visitor);
+      }
+      default -> {
+        if (!visitor.doVisitEntity(n, context, visitor)) {
+          System.err.println(("No handler for entity " + n.getName()));
+          Assertions.UNREACHABLE("cannot handle entity of kind" + n.getKind());
         }
-      case CAstEntity.GLOBAL_ENTITY:
-        {
-          if (visitor.visitGlobalEntity(n, context, visitor)) break;
-          visitor.leaveGlobalEntity(n, context, visitor);
-          break;
-        }
-      case CAstEntity.TYPE_ENTITY:
-        {
-          C typeContext = visitor.makeTypeContext(context, n);
-          if (visitor.visitTypeEntity(n, context, typeContext, visitor)) break;
-          visitor.visitScopedEntities(n, n.getAllScopedEntities(), typeContext, visitor);
-          visitor.leaveTypeEntity(n, context, typeContext, visitor);
-          break;
-        }
-      case CAstEntity.FUNCTION_ENTITY:
-        {
-          for (CAstNode dflt : n.getArgumentDefaults()) {
-            visitor.visit(dflt, getCodeContext(context), visitor);
-            visitor.visitScopedEntities(
-                context.top(), context.top().getScopedEntities(dflt), context, visitor);
-          }
-          C codeContext = visitor.makeCodeContext(context, n);
-          if (visitor.visitFunctionEntity(n, context, codeContext, visitor)) break;
-          // visit the AST if any
-          if (n.getAST() != null) visitor.visit(n.getAST(), codeContext, visitor);
-          // XXX: there may be code that needs to go in here
-          // process any remaining scoped children
-          visitor.visitScopedEntities(n, n.getScopedEntities(null), codeContext, visitor);
-          visitor.leaveFunctionEntity(n, context, codeContext, visitor);
-          break;
-        }
-      case CAstEntity.MACRO_ENTITY:
-        {
-          C codeContext = visitor.makeCodeContext(context, n);
-          if (visitor.visitMacroEntity(n, context, codeContext, visitor)) break;
-          // visit the AST if any
-          if (n.getAST() != null) visitor.visit(n.getAST(), codeContext, visitor);
-          // XXX: there may be code that needs to go in here
-          // process any remaining scoped children
-          visitor.visitScopedEntities(n, n.getScopedEntities(null), codeContext, visitor);
-          visitor.leaveMacroEntity(n, context, codeContext, visitor);
-          break;
-        }
-      case CAstEntity.SCRIPT_ENTITY:
-        {
-          C codeContext = visitor.makeCodeContext(context, n);
-          if (visitor.visitScriptEntity(n, context, codeContext, visitor)) break;
-          // visit the AST if any
-          if (n.getAST() != null) visitor.visit(n.getAST(), codeContext, visitor);
-          // XXX: there may be code that needs to go in here
-          // process any remaining scoped children
-          visitor.visitScopedEntities(n, n.getScopedEntities(null), codeContext, visitor);
-          visitor.leaveScriptEntity(n, context, codeContext, visitor);
-          break;
-        }
-      default:
-        {
-          if (!visitor.doVisitEntity(n, context, visitor)) {
-            System.err.println(("No handler for entity " + n.getName()));
-            Assertions.UNREACHABLE("cannot handle entity of kind" + n.getKind());
-          }
-        }
+      }
     }
     visitor.postProcessEntity(n, context, visitor);
 
@@ -533,477 +518,320 @@ public abstract class CAstVisitor<C extends CAstVisitor.Context> {
 
     int NT = n.getKind();
     switch (NT) {
-      case CAstNode.FUNCTION_EXPR:
-        {
-          if (visitor.visitFunctionExpr(n, context, visitor)) break;
-          visitor.leaveFunctionExpr(n, context, visitor);
+      case CAstNode.FUNCTION_EXPR -> {
+        if (visitor.visitFunctionExpr(n, context, visitor)) break;
+        visitor.leaveFunctionExpr(n, context, visitor);
+      }
+      case CAstNode.FUNCTION_STMT -> {
+        if (visitor.visitFunctionStmt(n, context, visitor)) break;
+        visitor.leaveFunctionStmt(n, context, visitor);
+      }
+      case CAstNode.CLASS_STMT -> {
+        if (visitor.visitClassStmt(n, context, visitor)) break;
+        visitor.leaveClassStmt(n, context, visitor);
+      }
+      case CAstNode.LOCAL_SCOPE -> {
+        if (visitor.visitLocalScope(n, context, visitor)) break;
+        C localContext = visitor.makeLocalContext(context, n);
+        visitor.visit(n.getChild(0), localContext, visitor);
+        visitor.leaveLocalScope(n, context, visitor);
+      }
+      case CAstNode.SPECIAL_PARENT_SCOPE -> {
+        if (visitor.visitSpecialParentScope(n, context, visitor)) break;
+        C localContext = visitor.makeSpecialParentContext(context, n);
+        visitor.visit(n.getChild(1), localContext, visitor);
+        visitor.leaveSpecialParentScope(n, context, visitor);
+      }
+      case CAstNode.BLOCK_EXPR -> {
+        if (visitor.visitBlockExpr(n, context, visitor)) break;
+        visitor.visitAllChildren(n, context, visitor);
+        visitor.leaveBlockExpr(n, context, visitor);
+      }
+      case CAstNode.BLOCK_STMT -> {
+        if (visitor.visitBlockStmt(n, context, visitor)) break;
+        visitor.visitAllChildren(n, context, visitor);
+        visitor.leaveBlockStmt(n, context, visitor);
+      }
+      case CAstNode.LOOP -> {
+        if (visitor.visitLoop(n, context, visitor)) break;
+        visitor.visit(n.getChild(0), context, visitor);
+        visitor.leaveLoopHeader(n, context, visitor);
+        visitor.visit(n.getChild(1), context, visitor);
+        visitor.leaveLoop(n, context, visitor);
+      }
+      case CAstNode.FORIN_LOOP -> {
+        if (visitor.visitForIn(n, context, visitor)) {
           break;
         }
-
-      case CAstNode.FUNCTION_STMT:
-        {
-          if (visitor.visitFunctionStmt(n, context, visitor)) break;
-          visitor.leaveFunctionStmt(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.CLASS_STMT:
-        {
-          if (visitor.visitClassStmt(n, context, visitor)) break;
-          visitor.leaveClassStmt(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.LOCAL_SCOPE:
-        {
-          if (visitor.visitLocalScope(n, context, visitor)) break;
-          C localContext = visitor.makeLocalContext(context, n);
-          visitor.visit(n.getChild(0), localContext, visitor);
-          visitor.leaveLocalScope(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.SPECIAL_PARENT_SCOPE:
-        {
-          if (visitor.visitSpecialParentScope(n, context, visitor)) break;
-          C localContext = visitor.makeSpecialParentContext(context, n);
-          visitor.visit(n.getChild(1), localContext, visitor);
-          visitor.leaveSpecialParentScope(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.BLOCK_EXPR:
-        {
-          if (visitor.visitBlockExpr(n, context, visitor)) break;
-          visitor.visitAllChildren(n, context, visitor);
-          visitor.leaveBlockExpr(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.BLOCK_STMT:
-        {
-          if (visitor.visitBlockStmt(n, context, visitor)) break;
-          visitor.visitAllChildren(n, context, visitor);
-          visitor.leaveBlockStmt(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.LOOP:
-        {
-          if (visitor.visitLoop(n, context, visitor)) break;
+        visitor.leaveForIn(n, context, visitor);
+      }
+      case CAstNode.GET_CAUGHT_EXCEPTION -> {
+        if (visitor.visitGetCaughtException(n, context, visitor)) break;
+        visitor.leaveGetCaughtException(n, context, visitor);
+      }
+      case CAstNode.THIS -> {
+        if (visitor.visitThis(n, context, visitor)) break;
+        visitor.leaveThis(n, context, visitor);
+      }
+      case CAstNode.SUPER -> {
+        if (visitor.visitSuper(n, context, visitor)) break;
+        visitor.leaveSuper(n, context, visitor);
+      }
+      case CAstNode.CALL -> {
+        if (visitor.visitCall(n, context, visitor)) break;
+        visitor.visit(n.getChild(0), context, visitor);
+        visitor.visitChildren(n, 2, context, visitor);
+        visitor.leaveCall(n, context, visitor);
+      }
+      case CAstNode.VAR -> {
+        if (visitor.visitVar(n, context, visitor)) break;
+        visitor.leaveVar(n, context, visitor);
+      }
+      case CAstNode.CONSTANT -> {
+        if (visitor.visitConstant(n, context, visitor)) break;
+        visitor.leaveConstant(n, context, visitor);
+      }
+      case CAstNode.BINARY_EXPR -> {
+        if (visitor.visitBinaryExpr(n, context, visitor)) break;
+        visitor.visit(n.getChild(1), context, visitor);
+        visitor.visit(n.getChild(2), context, visitor);
+        visitor.leaveBinaryExpr(n, context, visitor);
+      }
+      case CAstNode.UNARY_EXPR -> {
+        if (visitor.visitUnaryExpr(n, context, visitor)) break;
+        visitor.visit(n.getChild(1), context, visitor);
+        visitor.leaveUnaryExpr(n, context, visitor);
+      }
+      case CAstNode.ARRAY_LENGTH -> {
+        if (visitor.visitArrayLength(n, context, visitor)) break;
+        visitor.visit(n.getChild(0), context, visitor);
+        visitor.leaveArrayLength(n, context, visitor);
+      }
+      case CAstNode.ARRAY_REF -> {
+        if (visitor.visitArrayRef(n, context, visitor)) break;
+        visitor.visit(n.getChild(0), context, visitor);
+        visitor.visitChildren(n, 2, context, visitor);
+        visitor.leaveArrayRef(n, context, visitor);
+      }
+      case CAstNode.DECL_STMT -> {
+        if (visitor.visitDeclStmt(n, context, visitor)) break;
+        if (n.getChildCount() == 2) visitor.visit(n.getChild(1), context, visitor);
+        visitor.leaveDeclStmt(n, context, visitor);
+      }
+      case CAstNode.RETURN -> {
+        if (visitor.visitReturn(n, context, visitor)) break;
+        if (n.getChildCount() > 0) visitor.visit(n.getChild(0), context, visitor);
+        visitor.leaveReturn(n, context, visitor);
+      }
+      case CAstNode.IFGOTO -> {
+        if (visitor.visitIfgoto(n, context, visitor)) break;
+        if (n.getChildCount() == 1) {
           visitor.visit(n.getChild(0), context, visitor);
-          visitor.leaveLoopHeader(n, context, visitor);
-          visitor.visit(n.getChild(1), context, visitor);
-          visitor.leaveLoop(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.FORIN_LOOP:
-        {
-          if (visitor.visitForIn(n, context, visitor)) {
-            break;
-          }
-          visitor.leaveForIn(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.GET_CAUGHT_EXCEPTION:
-        {
-          if (visitor.visitGetCaughtException(n, context, visitor)) break;
-          visitor.leaveGetCaughtException(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.THIS:
-        {
-          if (visitor.visitThis(n, context, visitor)) break;
-          visitor.leaveThis(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.SUPER:
-        {
-          if (visitor.visitSuper(n, context, visitor)) break;
-          visitor.leaveSuper(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.CALL:
-        {
-          if (visitor.visitCall(n, context, visitor)) break;
-          visitor.visit(n.getChild(0), context, visitor);
-          visitor.visitChildren(n, 2, context, visitor);
-          visitor.leaveCall(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.VAR:
-        {
-          if (visitor.visitVar(n, context, visitor)) break;
-          visitor.leaveVar(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.CONSTANT:
-        {
-          if (visitor.visitConstant(n, context, visitor)) break;
-          visitor.leaveConstant(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.BINARY_EXPR:
-        {
-          if (visitor.visitBinaryExpr(n, context, visitor)) break;
+        } else if (n.getChildCount() == 3) {
           visitor.visit(n.getChild(1), context, visitor);
           visitor.visit(n.getChild(2), context, visitor);
-          visitor.leaveBinaryExpr(n, context, visitor);
-          break;
+        } else {
+          Assertions.UNREACHABLE();
         }
 
-      case CAstNode.UNARY_EXPR:
-        {
-          if (visitor.visitUnaryExpr(n, context, visitor)) break;
+        visitor.leaveIfgoto(n, context, visitor);
+      }
+      case CAstNode.GOTO -> {
+        if (visitor.visitGoto(n, context, visitor)) break;
+        visitor.leaveGoto(n, context, visitor);
+      }
+      case CAstNode.LABEL_STMT -> {
+        if (visitor.visitLabelStmt(n, context, visitor)) break;
+        visitor.visit(n.getChild(0), context, visitor);
+        if (n.getChildCount() == 2) visitor.visit(n.getChild(1), context, visitor);
+        else assert n.getChildCount() < 2;
+        visitor.leaveLabelStmt(n, context, visitor);
+      }
+      case CAstNode.IF_STMT -> {
+        if (visitor.visitIfStmt(n, context, visitor)) break;
+        visitor.visit(n.getChild(0), context, visitor);
+        visitor.leaveIfStmtCondition(n, context, visitor);
+        visitor.visit(n.getChild(1), context, visitor);
+        visitor.leaveIfStmtTrueClause(n, context, visitor);
+        if (n.getChildCount() == 3) visitor.visit(n.getChild(2), context, visitor);
+        visitor.leaveIfStmt(n, context, visitor);
+      }
+      case CAstNode.IF_EXPR -> {
+        if (visitor.visitIfExpr(n, context, visitor)) break;
+        visitor.visit(n.getChild(0), context, visitor);
+        visitor.leaveIfExprCondition(n, context, visitor);
+        visitor.visit(n.getChild(1), context, visitor);
+        visitor.leaveIfExprTrueClause(n, context, visitor);
+        if (n.getChildCount() == 3) visitor.visit(n.getChild(2), context, visitor);
+        visitor.leaveIfExpr(n, context, visitor);
+      }
+      case CAstNode.NEW_ENCLOSING, CAstNode.NEW -> {
+        if (visitor.visitNew(n, context, visitor)) break;
+
+        visitChildren(n, 1, context, visitor);
+
+        visitor.leaveNew(n, context, visitor);
+      }
+      case CAstNode.OBJECT_LITERAL -> {
+        if (visitor.visitObjectLiteral(n, context, visitor)) break;
+        visitor.visit(n.getChild(0), context, visitor);
+        for (int i = 1; i < n.getChildCount(); i += 2) {
+          visitor.visit(n.getChild(i), context, visitor);
+          visitor.visit(n.getChild(i + 1), context, visitor);
+          visitor.leaveObjectLiteralFieldInit(n, i, context, visitor);
+        }
+        visitor.leaveObjectLiteral(n, context, visitor);
+      }
+      case CAstNode.ARRAY_LITERAL -> {
+        if (visitor.visitArrayLiteral(n, context, visitor)) break;
+        visitor.visit(n.getChild(0), context, visitor);
+        visitor.leaveArrayLiteralObject(n, context, visitor);
+        for (int i = 1; i < n.getChildCount(); i++) {
+          visitor.visit(n.getChild(i), context, visitor);
+          visitor.leaveArrayLiteralInitElement(n, i, context, visitor);
+        }
+        visitor.leaveArrayLiteral(n, context, visitor);
+      }
+      case CAstNode.OBJECT_REF -> {
+        if (visitor.visitObjectRef(n, context, visitor)) break;
+        visitor.visit(n.getChild(0), context, visitor);
+        visitor.leaveObjectRef(n, context, visitor);
+      }
+      case CAstNode.ASSIGN, CAstNode.ASSIGN_PRE_OP, CAstNode.ASSIGN_POST_OP -> {
+        if (visitor.visitAssign(n, context, visitor)) break;
+        visitor.visit(n.getChild(1), context, visitor);
+        // TODO: is this correct?
+        if (visitor.visitAssignNodes(n.getChild(0), context, n.getChild(1), n, visitor)) break;
+        visitor.leaveAssign(n, context, visitor);
+      }
+      case CAstNode.SWITCH -> {
+        if (visitor.visitSwitch(n, context, visitor)) break;
+        visitor.visit(n.getChild(0), context, visitor);
+        visitor.leaveSwitchValue(n, context, visitor);
+        visitor.visit(n.getChild(1), context, visitor);
+        visitor.leaveSwitch(n, context, visitor);
+      }
+      case CAstNode.THROW -> {
+        if (visitor.visitThrow(n, context, visitor)) break;
+        visitor.visit(n.getChild(0), context, visitor);
+        visitor.leaveThrow(n, context, visitor);
+      }
+      case CAstNode.CATCH -> {
+        if (visitor.visitCatch(n, context, visitor)) break;
+        visitor.visitChildren(n, 1, context, visitor);
+        visitor.leaveCatch(n, context, visitor);
+      }
+      case CAstNode.UNWIND -> {
+        if (visitor.visitUnwind(n, context, visitor)) break;
+        C unwindContext = visitor.makeUnwindContext(context, n.getChild(1), visitor);
+        visitor.visit(n.getChild(0), unwindContext, visitor);
+        visitor.visit(n.getChild(1), context, visitor);
+        visitor.leaveUnwind(n, context, visitor);
+      }
+      case CAstNode.TRY -> {
+        if (visitor.visitTry(n, context, visitor)) break;
+        visitor.visit(n.getChild(0), context, visitor);
+        visitor.leaveTryBlock(n, context, visitor);
+        visitor.visit(n.getChild(1), context, visitor);
+        visitor.leaveTry(n, context, visitor);
+      }
+      case CAstNode.EMPTY -> {
+        if (visitor.visitEmpty(n, context, visitor)) break;
+        visitor.leaveEmpty(n, context, visitor);
+      }
+      case CAstNode.PRIMITIVE -> {
+        if (visitor.visitPrimitive(n, context, visitor)) break;
+        visitor.visitAllChildren(n, context, visitor);
+        visitor.leavePrimitive(n, context, visitor);
+      }
+      case CAstNode.VOID -> {
+        if (visitor.visitVoid(n, context, visitor)) break;
+        visitor.leaveVoid(n, context, visitor);
+      }
+      case CAstNode.CAST -> {
+        if (visitor.visitCast(n, context, visitor)) break;
+        visitor.visit(n.getChild(1), context, visitor);
+        visitor.leaveCast(n, context, visitor);
+      }
+      case CAstNode.INSTANCEOF -> {
+        if (visitor.visitInstanceOf(n, context, visitor)) break;
+        visitor.visit(n.getChild(1), context, visitor);
+        visitor.leaveInstanceOf(n, context, visitor);
+      }
+      case CAstNode.ASSERT -> {
+        if (visitor.visitAssert(n, context, visitor)) break;
+        visitor.visit(n.getChild(0), context, visitor);
+        visitor.leaveAssert(n, context, visitor);
+      }
+      case CAstNode.EACH_ELEMENT_GET -> {
+        if (visitor.visitEachElementGet(n, context, visitor)) break;
+        visitor.visit(n.getChild(0), context, visitor);
+        visitor.visit(n.getChild(1), context, visitor);
+        visitor.leaveEachElementGet(n, context, visitor);
+      }
+      case CAstNode.EACH_ELEMENT_HAS_NEXT -> {
+        if (visitor.visitEachElementHasNext(n, context, visitor)) break;
+        visitor.visit(n.getChild(0), context, visitor);
+        visitor.visit(n.getChild(1), context, visitor);
+        visitor.leaveEachElementHasNext(n, context, visitor);
+      }
+      case CAstNode.TYPE_LITERAL_EXPR -> {
+        if (visitor.visitTypeLiteralExpr(n, context, visitor)) {
+          break;
+        }
+        visitor.visit(n.getChild(0), context, visitor);
+        visitor.leaveTypeLiteralExpr(n, context, visitor);
+      }
+      case CAstNode.IS_DEFINED_EXPR -> {
+        if (visitor.visitIsDefinedExpr(n, context, visitor)) {
+          break;
+        }
+        visitor.visit(n.getChild(0), context, visitor);
+        if (n.getChildCount() == 2) {
           visitor.visit(n.getChild(1), context, visitor);
-          visitor.leaveUnaryExpr(n, context, visitor);
+        }
+        visitor.leaveIsDefinedExpr(n, context, visitor);
+      }
+      case CAstNode.INCLUDE -> {
+        if (visitor.visitInclude(n, context, visitor)) {
           break;
         }
-
-      case CAstNode.ARRAY_LENGTH:
-        {
-          if (visitor.visitArrayLength(n, context, visitor)) break;
-          visitor.visit(n.getChild(0), context, visitor);
-          visitor.leaveArrayLength(n, context, visitor);
+        visitor.leaveInclude(n, context, visitor);
+      }
+      case CAstNode.MACRO_VAR -> {
+        if (visitor.visitMacroVar(n, context, visitor)) {
           break;
         }
-
-      case CAstNode.ARRAY_REF:
-        {
-          if (visitor.visitArrayRef(n, context, visitor)) break;
-          visitor.visit(n.getChild(0), context, visitor);
-          visitor.visitChildren(n, 2, context, visitor);
-          visitor.leaveArrayRef(n, context, visitor);
+        visitor.leaveMacroVar(n, context, visitor);
+      }
+      case CAstNode.ECHO -> {
+        if (visitor.visitEcho(n, context, visitor)) {
           break;
         }
-
-      case CAstNode.DECL_STMT:
-        {
-          if (visitor.visitDeclStmt(n, context, visitor)) break;
-          if (n.getChildCount() == 2) visitor.visit(n.getChild(1), context, visitor);
-          visitor.leaveDeclStmt(n, context, visitor);
+        visitAllChildren(n, context, visitor);
+        visitor.leaveEcho(n, context, visitor);
+      }
+      case CAstNode.RETURN_WITHOUT_BRANCH -> {
+        if (visitor.visitYield(n, context, visitor)) {
           break;
         }
-
-      case CAstNode.RETURN:
-        {
-          if (visitor.visitReturn(n, context, visitor)) break;
-          if (n.getChildCount() > 0) visitor.visit(n.getChild(0), context, visitor);
-          visitor.leaveReturn(n, context, visitor);
+        visitAllChildren(n, context, visitor);
+        visitor.leaveYield(n, context, visitor);
+      }
+      case CAstNode.EXPR_STMT -> {
+        if (visitor.visitExprStmt(n, context, visitor)) {
           break;
         }
-
-      case CAstNode.IFGOTO:
-        {
-          if (visitor.visitIfgoto(n, context, visitor)) break;
-          if (n.getChildCount() == 1) {
-            visitor.visit(n.getChild(0), context, visitor);
-          } else if (n.getChildCount() == 3) {
-            visitor.visit(n.getChild(1), context, visitor);
-            visitor.visit(n.getChild(2), context, visitor);
-          } else {
-            Assertions.UNREACHABLE();
-          }
-
-          visitor.leaveIfgoto(n, context, visitor);
-          break;
+        visitAllChildren(n, context, visitor);
+        visitor.leaveExprStmt(n, context, visitor);
+      }
+      default -> {
+        if (!visitor.doVisit(n, context, visitor)) {
+          System.err.println(
+              ("looking at unhandled " + n + '(' + NT + ')' + " of " + n.getClass()));
+          Assertions.UNREACHABLE("cannot handle node of kind " + NT);
         }
-
-      case CAstNode.GOTO:
-        {
-          if (visitor.visitGoto(n, context, visitor)) break;
-          visitor.leaveGoto(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.LABEL_STMT:
-        {
-          if (visitor.visitLabelStmt(n, context, visitor)) break;
-          visitor.visit(n.getChild(0), context, visitor);
-          if (n.getChildCount() == 2) visitor.visit(n.getChild(1), context, visitor);
-          else assert n.getChildCount() < 2;
-          visitor.leaveLabelStmt(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.IF_STMT:
-        {
-          if (visitor.visitIfStmt(n, context, visitor)) break;
-          visitor.visit(n.getChild(0), context, visitor);
-          visitor.leaveIfStmtCondition(n, context, visitor);
-          visitor.visit(n.getChild(1), context, visitor);
-          visitor.leaveIfStmtTrueClause(n, context, visitor);
-          if (n.getChildCount() == 3) visitor.visit(n.getChild(2), context, visitor);
-          visitor.leaveIfStmt(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.IF_EXPR:
-        {
-          if (visitor.visitIfExpr(n, context, visitor)) break;
-          visitor.visit(n.getChild(0), context, visitor);
-          visitor.leaveIfExprCondition(n, context, visitor);
-          visitor.visit(n.getChild(1), context, visitor);
-          visitor.leaveIfExprTrueClause(n, context, visitor);
-          if (n.getChildCount() == 3) visitor.visit(n.getChild(2), context, visitor);
-          visitor.leaveIfExpr(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.NEW_ENCLOSING:
-      case CAstNode.NEW:
-        {
-          if (visitor.visitNew(n, context, visitor)) break;
-
-          visitChildren(n, 1, context, visitor);
-
-          visitor.leaveNew(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.OBJECT_LITERAL:
-        {
-          if (visitor.visitObjectLiteral(n, context, visitor)) break;
-          visitor.visit(n.getChild(0), context, visitor);
-          for (int i = 1; i < n.getChildCount(); i += 2) {
-            visitor.visit(n.getChild(i), context, visitor);
-            visitor.visit(n.getChild(i + 1), context, visitor);
-            visitor.leaveObjectLiteralFieldInit(n, i, context, visitor);
-          }
-          visitor.leaveObjectLiteral(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.ARRAY_LITERAL:
-        {
-          if (visitor.visitArrayLiteral(n, context, visitor)) break;
-          visitor.visit(n.getChild(0), context, visitor);
-          visitor.leaveArrayLiteralObject(n, context, visitor);
-          for (int i = 1; i < n.getChildCount(); i++) {
-            visitor.visit(n.getChild(i), context, visitor);
-            visitor.leaveArrayLiteralInitElement(n, i, context, visitor);
-          }
-          visitor.leaveArrayLiteral(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.OBJECT_REF:
-        {
-          if (visitor.visitObjectRef(n, context, visitor)) break;
-          visitor.visit(n.getChild(0), context, visitor);
-          visitor.leaveObjectRef(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.ASSIGN:
-      case CAstNode.ASSIGN_PRE_OP:
-      case CAstNode.ASSIGN_POST_OP:
-        {
-          if (visitor.visitAssign(n, context, visitor)) break;
-          visitor.visit(n.getChild(1), context, visitor);
-          // TODO: is this correct?
-          if (visitor.visitAssignNodes(n.getChild(0), context, n.getChild(1), n, visitor)) break;
-          visitor.leaveAssign(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.SWITCH:
-        {
-          if (visitor.visitSwitch(n, context, visitor)) break;
-          visitor.visit(n.getChild(0), context, visitor);
-          visitor.leaveSwitchValue(n, context, visitor);
-          visitor.visit(n.getChild(1), context, visitor);
-          visitor.leaveSwitch(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.THROW:
-        {
-          if (visitor.visitThrow(n, context, visitor)) break;
-          visitor.visit(n.getChild(0), context, visitor);
-          visitor.leaveThrow(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.CATCH:
-        {
-          if (visitor.visitCatch(n, context, visitor)) break;
-          visitor.visitChildren(n, 1, context, visitor);
-          visitor.leaveCatch(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.UNWIND:
-        {
-          if (visitor.visitUnwind(n, context, visitor)) break;
-          C unwindContext = visitor.makeUnwindContext(context, n.getChild(1), visitor);
-          visitor.visit(n.getChild(0), unwindContext, visitor);
-          visitor.visit(n.getChild(1), context, visitor);
-          visitor.leaveUnwind(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.TRY:
-        {
-          if (visitor.visitTry(n, context, visitor)) break;
-          visitor.visit(n.getChild(0), context, visitor);
-          visitor.leaveTryBlock(n, context, visitor);
-          visitor.visit(n.getChild(1), context, visitor);
-          visitor.leaveTry(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.EMPTY:
-        {
-          if (visitor.visitEmpty(n, context, visitor)) break;
-          visitor.leaveEmpty(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.PRIMITIVE:
-        {
-          if (visitor.visitPrimitive(n, context, visitor)) break;
-          visitor.visitAllChildren(n, context, visitor);
-          visitor.leavePrimitive(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.VOID:
-        {
-          if (visitor.visitVoid(n, context, visitor)) break;
-          visitor.leaveVoid(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.CAST:
-        {
-          if (visitor.visitCast(n, context, visitor)) break;
-          visitor.visit(n.getChild(1), context, visitor);
-          visitor.leaveCast(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.INSTANCEOF:
-        {
-          if (visitor.visitInstanceOf(n, context, visitor)) break;
-          visitor.visit(n.getChild(1), context, visitor);
-          visitor.leaveInstanceOf(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.ASSERT:
-        {
-          if (visitor.visitAssert(n, context, visitor)) break;
-          visitor.visit(n.getChild(0), context, visitor);
-          visitor.leaveAssert(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.EACH_ELEMENT_GET:
-        {
-          if (visitor.visitEachElementGet(n, context, visitor)) break;
-          visitor.visit(n.getChild(0), context, visitor);
-          visitor.visit(n.getChild(1), context, visitor);
-          visitor.leaveEachElementGet(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.EACH_ELEMENT_HAS_NEXT:
-        {
-          if (visitor.visitEachElementHasNext(n, context, visitor)) break;
-          visitor.visit(n.getChild(0), context, visitor);
-          visitor.visit(n.getChild(1), context, visitor);
-          visitor.leaveEachElementHasNext(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.TYPE_LITERAL_EXPR:
-        {
-          if (visitor.visitTypeLiteralExpr(n, context, visitor)) {
-            break;
-          }
-          visitor.visit(n.getChild(0), context, visitor);
-          visitor.leaveTypeLiteralExpr(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.IS_DEFINED_EXPR:
-        {
-          if (visitor.visitIsDefinedExpr(n, context, visitor)) {
-            break;
-          }
-          visitor.visit(n.getChild(0), context, visitor);
-          if (n.getChildCount() == 2) {
-            visitor.visit(n.getChild(1), context, visitor);
-          }
-          visitor.leaveIsDefinedExpr(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.INCLUDE:
-        {
-          if (visitor.visitInclude(n, context, visitor)) {
-            break;
-          }
-          visitor.leaveInclude(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.MACRO_VAR:
-        {
-          if (visitor.visitMacroVar(n, context, visitor)) {
-            break;
-          }
-          visitor.leaveMacroVar(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.ECHO:
-        {
-          if (visitor.visitEcho(n, context, visitor)) {
-            break;
-          }
-          visitAllChildren(n, context, visitor);
-          visitor.leaveEcho(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.RETURN_WITHOUT_BRANCH:
-        {
-          if (visitor.visitYield(n, context, visitor)) {
-            break;
-          }
-          visitAllChildren(n, context, visitor);
-          visitor.leaveYield(n, context, visitor);
-          break;
-        }
-
-      case CAstNode.EXPR_STMT:
-        {
-          if (visitor.visitExprStmt(n, context, visitor)) {
-            break;
-          }
-          visitAllChildren(n, context, visitor);
-          visitor.leaveExprStmt(n, context, visitor);
-          break;
-        }
-
-      default:
-        {
-          if (!visitor.doVisit(n, context, visitor)) {
-            System.err.println(
-                ("looking at unhandled " + n + '(' + NT + ')' + " of " + n.getClass()));
-            Assertions.UNREACHABLE("cannot handle node of kind " + NT);
-          }
-        }
+      }
     }
 
     if (context != null) {
@@ -1059,78 +887,58 @@ public abstract class CAstVisitor<C extends CAstVisitor.Context> {
     boolean assign = NT == CAstNode.ASSIGN;
     boolean preOp = NT == CAstNode.ASSIGN_PRE_OP;
     switch (n.getKind()) {
-      case CAstNode.ARRAY_REF:
-        {
-          if (doVisitArrayRefNode(n, v, a, assign, preOp, context, visitor)) {
-            return true;
+      case CAstNode.ARRAY_REF -> {
+        if (doVisitArrayRefNode(n, v, a, assign, preOp, context, visitor)) {
+          return true;
+        }
+      }
+      case CAstNode.OBJECT_REF -> {
+        if (assign
+            ? visitor.visitObjectRefAssign(n, v, a, context, visitor)
+            : visitor.visitObjectRefAssignOp(n, v, a, preOp, context, visitor)) return true;
+        visitor.visit(n.getChild(0), context, visitor);
+        if (assign) visitor.leaveObjectRefAssign(n, v, a, context, visitor);
+        else visitor.leaveObjectRefAssignOp(n, v, a, preOp, context, visitor);
+      }
+      case CAstNode.BLOCK_EXPR -> {
+        if (assign
+            ? visitor.visitBlockExprAssign(n, v, a, context, visitor)
+            : visitor.visitBlockExprAssignOp(n, v, a, preOp, context, visitor)) return true;
+        // FIXME: is it correct to ignore all the other children?
+        if (visitor.visitAssignNodes(n.getChild(n.getChildCount() - 1), context, v, a, visitor))
+          return true;
+        if (assign) visitor.leaveBlockExprAssign(n, v, a, context, visitor);
+        else visitor.leaveBlockExprAssignOp(n, v, a, preOp, context, visitor);
+      }
+      case CAstNode.VAR -> {
+        if (assign
+            ? visitor.visitVarAssign(n, v, a, context, visitor)
+            : visitor.visitVarAssignOp(n, v, a, preOp, context, visitor)) return true;
+        if (assign) visitor.leaveVarAssign(n, v, a, context, visitor);
+        else visitor.leaveVarAssignOp(n, v, a, preOp, context, visitor);
+      }
+      case CAstNode.ARRAY_LITERAL -> {
+        assert assign;
+        if (visitor.visitArrayLiteralAssign(n, v, a, context, visitor)) return true;
+        visitor.leaveArrayLiteralAssign(n, v, a, context, visitor);
+      }
+      case CAstNode.OBJECT_LITERAL -> {
+        assert assign;
+        for (int i = 1; i < n.getChildCount(); i += 2) {
+          visitor.visit(n.getChild(i), context, visitor);
+        }
+        if (visitor.visitObjectLiteralAssign(n, v, a, context, visitor)) return true;
+        visitor.leaveObjectLiteralAssign(n, v, a, context, visitor);
+      }
+      default -> {
+        if (!visitor.doVisitAssignNodes(n, context, a, v, visitor)) {
+          if (DEBUG) {
+            System.err.println(("cannot handle assign to kind " + n.getKind()));
           }
-
-          break;
+          throw new UnsupportedOperationException(
+              "cannot handle assignment: " + CAstPrinter.print(a, context.getSourceMap()));
         }
-
-      case CAstNode.OBJECT_REF:
-        {
-          if (assign
-              ? visitor.visitObjectRefAssign(n, v, a, context, visitor)
-              : visitor.visitObjectRefAssignOp(n, v, a, preOp, context, visitor)) return true;
-          visitor.visit(n.getChild(0), context, visitor);
-          if (assign) visitor.leaveObjectRefAssign(n, v, a, context, visitor);
-          else visitor.leaveObjectRefAssignOp(n, v, a, preOp, context, visitor);
-          break;
-        }
-
-      case CAstNode.BLOCK_EXPR:
-        {
-          if (assign
-              ? visitor.visitBlockExprAssign(n, v, a, context, visitor)
-              : visitor.visitBlockExprAssignOp(n, v, a, preOp, context, visitor)) return true;
-          // FIXME: is it correct to ignore all the other children?
-          if (visitor.visitAssignNodes(n.getChild(n.getChildCount() - 1), context, v, a, visitor))
-            return true;
-          if (assign) visitor.leaveBlockExprAssign(n, v, a, context, visitor);
-          else visitor.leaveBlockExprAssignOp(n, v, a, preOp, context, visitor);
-          break;
-        }
-
-      case CAstNode.VAR:
-        {
-          if (assign
-              ? visitor.visitVarAssign(n, v, a, context, visitor)
-              : visitor.visitVarAssignOp(n, v, a, preOp, context, visitor)) return true;
-          if (assign) visitor.leaveVarAssign(n, v, a, context, visitor);
-          else visitor.leaveVarAssignOp(n, v, a, preOp, context, visitor);
-          break;
-        }
-
-      case CAstNode.ARRAY_LITERAL:
-        {
-          assert assign;
-          if (visitor.visitArrayLiteralAssign(n, v, a, context, visitor)) return true;
-          visitor.leaveArrayLiteralAssign(n, v, a, context, visitor);
-          break;
-        }
-
-      case CAstNode.OBJECT_LITERAL:
-        {
-          assert assign;
-          for (int i = 1; i < n.getChildCount(); i += 2) {
-            visitor.visit(n.getChild(i), context, visitor);
-          }
-          if (visitor.visitObjectLiteralAssign(n, v, a, context, visitor)) return true;
-          visitor.leaveObjectLiteralAssign(n, v, a, context, visitor);
-          break;
-        }
-
-      default:
-        {
-          if (!visitor.doVisitAssignNodes(n, context, a, v, visitor)) {
-            if (DEBUG) {
-              System.err.println(("cannot handle assign to kind " + n.getKind()));
-            }
-            throw new UnsupportedOperationException(
-                "cannot handle assignment: " + CAstPrinter.print(a, context.getSourceMap()));
-          }
-        }
+      }
     }
     return false;
   }

--- a/cast/src/main/java/com/ibm/wala/cast/util/CAstPattern.java
+++ b/cast/src/main/java/com/ibm/wala/cast/util/CAstPattern.java
@@ -188,18 +188,14 @@ public class CAstPattern {
     } else if (i < tree.getChildCount() && j >= cs.length) {
       return false;
     } else if (i >= tree.getChildCount() && j < cs.length) {
-      switch (cs[j].kind) {
-        case CHILDREN_KIND:
-        case OPTIONAL_PATTERN_KIND:
-        case REPEATED_PATTERN_KIND:
-          return matchChildren(tree, i, cs, j + 1, s);
-
-        default:
-          return false;
-      }
+      return switch (cs[j].kind) {
+        case CHILDREN_KIND, OPTIONAL_PATTERN_KIND, REPEATED_PATTERN_KIND ->
+            matchChildren(tree, i, cs, j + 1, s);
+        default -> false;
+      };
     } else {
       switch (cs[j].kind) {
-        case CHILD_KIND:
+        case CHILD_KIND -> {
           if (DEBUG_MATCH) {
             System.err.println(("* matches " + CAstPrinter.print(tree.getChild(i))));
           }
@@ -208,8 +204,8 @@ public class CAstPattern {
             s.add(cs[j].name, tree.getChild(i));
           }
           return matchChildren(tree, i + 1, cs, j + 1, s);
-
-        case CHILDREN_KIND:
+        }
+        case CHILDREN_KIND -> {
           if (tryMatchChildren(tree, i, cs, j + 1, s)) {
 
             if (DEBUG_MATCH) {
@@ -230,8 +226,8 @@ public class CAstPattern {
 
             return matchChildren(tree, i + 1, cs, j, s);
           }
-
-        case REPEATED_PATTERN_KIND:
+        }
+        case REPEATED_PATTERN_KIND -> {
           CAstPattern repeatedPattern = cs[j].children[0];
           if (repeatedPattern.tryMatch(tree.getChild(i), s)) {
             if (s != null && cs[j].name != null) {
@@ -252,8 +248,8 @@ public class CAstPattern {
 
             return matchChildren(tree, i, cs, j + 1, s);
           }
-
-        case OPTIONAL_PATTERN_KIND:
+        }
+        case OPTIONAL_PATTERN_KIND -> {
           if (tryMatchChildren(tree, i, cs, j + 1, s)) {
 
             if (DEBUG_MATCH) {
@@ -274,9 +270,10 @@ public class CAstPattern {
               return false;
             }
           }
-
-        default:
+        }
+        default -> {
           return cs[j].match(tree.getChild(i), s) && matchChildren(tree, i + 1, cs, j + 1, s);
+        }
       }
     }
   }
@@ -287,10 +284,10 @@ public class CAstPattern {
     }
 
     switch (kind) {
-      case REFERENCE_PATTERN_KIND:
+      case REFERENCE_PATTERN_KIND -> {
         return references.get(value).match(tree, s);
-
-      case ALTERNATIVE_PATTERN_KIND:
+      }
+      case ALTERNATIVE_PATTERN_KIND -> {
         for (CAstPattern element : children) {
           if (element.tryMatch(tree, s)) {
 
@@ -304,8 +301,8 @@ public class CAstPattern {
           System.err.println("match failed (a)");
         }
         return false;
-
-      default:
+      }
+      default -> {
         if ((value == null)
             ? tree.getKind() != kind
             : (tree.getKind() != CAstNode.CONSTANT
@@ -331,6 +328,7 @@ public class CAstPattern {
         } else {
           return matchChildren(tree, 0, children, 0, s);
         }
+      }
     }
   }
 

--- a/cast/src/main/java/com/ibm/wala/cast/util/CAstPrinter.java
+++ b/cast/src/main/java/com/ibm/wala/cast/util/CAstPrinter.java
@@ -53,150 +53,83 @@ public class CAstPrinter {
   }
 
   public String getKindAsString(int kind) {
-    switch (kind) {
+    return switch (kind) {
       // statements
-      case CAstNode.SWITCH:
-        return "SWITCH";
-      case CAstNode.LOOP:
-        return "LOOP";
-      case CAstNode.BLOCK_STMT:
-        return "BLOCK";
-      case CAstNode.TRY:
-        return "TRY";
-      case CAstNode.EXPR_STMT:
-        return "EXPR_STMT";
-      case CAstNode.DECL_STMT:
-        return "DECL_STMT";
-      case CAstNode.RETURN:
-        return "RETURN";
-      case CAstNode.GOTO:
-        return "GOTO";
-      case CAstNode.BREAK:
-        return "BREAK";
-      case CAstNode.CONTINUE:
-        return "CONTINUE";
-      case CAstNode.IF_STMT:
-        return "IF_STMT";
-      case CAstNode.THROW:
-        return "THROW";
-      case CAstNode.FUNCTION_STMT:
-        return "FUNCTION_STMT";
-      case CAstNode.ASSIGN:
-        return "ASSIGN";
-      case CAstNode.ASSIGN_PRE_OP:
-        return "ASSIGN_PRE_OP";
-      case CAstNode.ASSIGN_POST_OP:
-        return "ASSIGN_POST_OP";
-      case CAstNode.LABEL_STMT:
-        return "LABEL_STMT";
-      case CAstNode.IFGOTO:
-        return "IFGOTO";
-      case CAstNode.EMPTY:
-        return "EMPTY";
-      case CAstNode.YIELD_STMT:
-        return "YIELD";
-      case CAstNode.CATCH:
-        return "CATCH";
-      case CAstNode.UNWIND:
-        return "UNWIND";
-      case CAstNode.MONITOR_ENTER:
-        return "MONITOR_ENTER";
-      case CAstNode.MONITOR_EXIT:
-        return "MONITOR_EXIT";
-      case CAstNode.ECHO:
-        return "ECHO";
-      case CAstNode.FORIN_LOOP:
-        return "FOR..IN";
+      case CAstNode.SWITCH -> "SWITCH";
+      case CAstNode.LOOP -> "LOOP";
+      case CAstNode.BLOCK_STMT -> "BLOCK";
+      case CAstNode.TRY -> "TRY";
+      case CAstNode.EXPR_STMT -> "EXPR_STMT";
+      case CAstNode.DECL_STMT -> "DECL_STMT";
+      case CAstNode.RETURN -> "RETURN";
+      case CAstNode.GOTO -> "GOTO";
+      case CAstNode.BREAK -> "BREAK";
+      case CAstNode.CONTINUE -> "CONTINUE";
+      case CAstNode.IF_STMT -> "IF_STMT";
+      case CAstNode.THROW -> "THROW";
+      case CAstNode.FUNCTION_STMT -> "FUNCTION_STMT";
+      case CAstNode.ASSIGN -> "ASSIGN";
+      case CAstNode.ASSIGN_PRE_OP -> "ASSIGN_PRE_OP";
+      case CAstNode.ASSIGN_POST_OP -> "ASSIGN_POST_OP";
+      case CAstNode.LABEL_STMT -> "LABEL_STMT";
+      case CAstNode.IFGOTO -> "IFGOTO";
+      case CAstNode.EMPTY -> "EMPTY";
+      case CAstNode.YIELD_STMT -> "YIELD";
+      case CAstNode.CATCH -> "CATCH";
+      case CAstNode.UNWIND -> "UNWIND";
+      case CAstNode.MONITOR_ENTER -> "MONITOR_ENTER";
+      case CAstNode.MONITOR_EXIT -> "MONITOR_EXIT";
+      case CAstNode.ECHO -> "ECHO";
+      case CAstNode.FORIN_LOOP -> "FOR..IN";
 
       // expression kinds
-      case CAstNode.FUNCTION_EXPR:
-        return "FUNCTION_EXPR";
-      case CAstNode.EXPR_LIST:
-        return "EXPR_LIST";
-      case CAstNode.CALL:
-        return "CALL";
-      case CAstNode.GET_CAUGHT_EXCEPTION:
-        return "EXCEPTION";
-      case CAstNode.BLOCK_EXPR:
-        return "BLOCK_EXPR";
-      case CAstNode.BINARY_EXPR:
-        return "BINARY_EXPR";
-      case CAstNode.UNARY_EXPR:
-        return "UNARY_EXPR";
-      case CAstNode.IF_EXPR:
-        return "IF_EXPR";
-      case CAstNode.ANDOR_EXPR:
-        return "ANDOR_EXPR";
-      case CAstNode.NEW:
-        return "NEW";
-      case CAstNode.NEW_ENCLOSING:
-        return "NEW_ENCLOSING";
-      case CAstNode.OBJECT_LITERAL:
-        return "OBJECT_LITERAL";
-      case CAstNode.VAR:
-        return "VAR";
-      case CAstNode.OBJECT_REF:
-        return "OBJECT_REF";
-      case CAstNode.CHOICE_EXPR:
-        return "CHOICE_EXPR";
-      case CAstNode.CHOICE_CASE:
-        return "CHOICE_CASE";
-      case CAstNode.SUPER:
-        return "SUPER";
-      case CAstNode.THIS:
-        return "THIS";
-      case CAstNode.ARRAY_LITERAL:
-        return "ARRAY_LITERAL";
-      case CAstNode.CAST:
-        return "CAST";
-      case CAstNode.INSTANCEOF:
-        return "INSTANCEOF";
-      case CAstNode.ARRAY_REF:
-        return "ARRAY_REF";
-      case CAstNode.ARRAY_LENGTH:
-        return "ARRAY_LENGTH";
-      case CAstNode.TYPE_OF:
-        return "TYPE_OF";
-      case CAstNode.EACH_ELEMENT_HAS_NEXT:
-        return "EACH_ELEMENT_HAS_NEXT";
-      case CAstNode.EACH_ELEMENT_GET:
-        return "EACH_ELEMENT_GET";
-      case CAstNode.LIST_EXPR:
-        return "LIST_EXPR";
-      case CAstNode.EMPTY_LIST_EXPR:
-        return "EMPTY_LIST_EXPR";
-      case CAstNode.IS_DEFINED_EXPR:
-        return "IS_DEFINED_EXPR";
-      case CAstNode.NARY_EXPR:
-        return "NARY_EXPR";
-      case CAstNode.TYPE_LITERAL_EXPR:
-        return "TYPE_LITERAL_EXPR";
+      case CAstNode.FUNCTION_EXPR -> "FUNCTION_EXPR";
+      case CAstNode.EXPR_LIST -> "EXPR_LIST";
+      case CAstNode.CALL -> "CALL";
+      case CAstNode.GET_CAUGHT_EXCEPTION -> "EXCEPTION";
+      case CAstNode.BLOCK_EXPR -> "BLOCK_EXPR";
+      case CAstNode.BINARY_EXPR -> "BINARY_EXPR";
+      case CAstNode.UNARY_EXPR -> "UNARY_EXPR";
+      case CAstNode.IF_EXPR -> "IF_EXPR";
+      case CAstNode.ANDOR_EXPR -> "ANDOR_EXPR";
+      case CAstNode.NEW -> "NEW";
+      case CAstNode.NEW_ENCLOSING -> "NEW_ENCLOSING";
+      case CAstNode.OBJECT_LITERAL -> "OBJECT_LITERAL";
+      case CAstNode.VAR -> "VAR";
+      case CAstNode.OBJECT_REF -> "OBJECT_REF";
+      case CAstNode.CHOICE_EXPR -> "CHOICE_EXPR";
+      case CAstNode.CHOICE_CASE -> "CHOICE_CASE";
+      case CAstNode.SUPER -> "SUPER";
+      case CAstNode.THIS -> "THIS";
+      case CAstNode.ARRAY_LITERAL -> "ARRAY_LITERAL";
+      case CAstNode.CAST -> "CAST";
+      case CAstNode.INSTANCEOF -> "INSTANCEOF";
+      case CAstNode.ARRAY_REF -> "ARRAY_REF";
+      case CAstNode.ARRAY_LENGTH -> "ARRAY_LENGTH";
+      case CAstNode.TYPE_OF -> "TYPE_OF";
+      case CAstNode.EACH_ELEMENT_HAS_NEXT -> "EACH_ELEMENT_HAS_NEXT";
+      case CAstNode.EACH_ELEMENT_GET -> "EACH_ELEMENT_GET";
+      case CAstNode.LIST_EXPR -> "LIST_EXPR";
+      case CAstNode.EMPTY_LIST_EXPR -> "EMPTY_LIST_EXPR";
+      case CAstNode.IS_DEFINED_EXPR -> "IS_DEFINED_EXPR";
+      case CAstNode.NARY_EXPR -> "NARY_EXPR";
+      case CAstNode.TYPE_LITERAL_EXPR -> "TYPE_LITERAL_EXPR";
 
       // explicit lexical scopes
-      case CAstNode.LOCAL_SCOPE:
-        return "SCOPE";
-      case CAstNode.SPECIAL_PARENT_SCOPE:
-        return "SPECIAL PARENT SCOPE";
+      case CAstNode.LOCAL_SCOPE -> "SCOPE";
+      case CAstNode.SPECIAL_PARENT_SCOPE -> "SPECIAL PARENT SCOPE";
 
       // literal expression kinds
-      case CAstNode.CONSTANT:
-        return "CONSTANT";
-      case CAstNode.OPERATOR:
-        return "OPERATOR";
+      case CAstNode.CONSTANT -> "CONSTANT";
+      case CAstNode.OPERATOR -> "OPERATOR";
 
       // special stuff
-      case CAstNode.PRIMITIVE:
-        return "PRIMITIVE";
-      case CAstNode.VOID:
-        return "VOID";
-      case CAstNode.ERROR:
-        return "ERROR";
-      case CAstNode.ASSERT:
-        return "ASSERT";
-
-      default:
-        return "UNKNOWN(" + kind + ')';
-    }
+      case CAstNode.PRIMITIVE -> "PRIMITIVE";
+      case CAstNode.VOID -> "VOID";
+      case CAstNode.ERROR -> "ERROR";
+      case CAstNode.ASSERT -> "ASSERT";
+      default -> "UNKNOWN(" + kind + ')';
+    };
   }
 
   public static String print(CAstNode top) {
@@ -330,22 +263,15 @@ public class CAstPrinter {
   }
 
   public String getEntityKindAsString(int kind) {
-    switch (kind) {
-      case CAstEntity.FUNCTION_ENTITY:
-        return "function";
-      case CAstEntity.FIELD_ENTITY:
-        return "field";
-      case CAstEntity.FILE_ENTITY:
-        return "unit";
-      case CAstEntity.TYPE_ENTITY:
-        return "type";
-      case CAstEntity.SCRIPT_ENTITY:
-        return "script";
-      case CAstEntity.RULE_ENTITY:
-        return "rule";
-      default:
-        return "<unknown entity kind>";
-    }
+    return switch (kind) {
+      case CAstEntity.FUNCTION_ENTITY -> "function";
+      case CAstEntity.FIELD_ENTITY -> "field";
+      case CAstEntity.FILE_ENTITY -> "unit";
+      case CAstEntity.TYPE_ENTITY -> "type";
+      case CAstEntity.SCRIPT_ENTITY -> "script";
+      case CAstEntity.RULE_ENTITY -> "rule";
+      default -> "<unknown entity kind>";
+    };
   }
 
   public static void printTo(CAstEntity e, Writer w) {

--- a/core/src/main/java/com/ibm/wala/analysis/arraybounds/ArrayBoundsGraphBuilder.java
+++ b/core/src/main/java/com/ibm/wala/analysis/arraybounds/ArrayBoundsGraphBuilder.java
@@ -124,40 +124,40 @@ public class ArrayBoundsGraphBuilder {
 
     Integer helper;
     switch (op) {
-      case EQ:
+      case EQ -> {
         this.upperBoundGraph.addPi(piVar, piParent, piRestrictor);
         this.lowerBoundGraph.addPi(piVar, piParent, piRestrictor);
-        break;
-      case NE:
+      }
+      case NE -> {
         this.upperBoundGraph.addEdge(piParent, piVar);
         this.lowerBoundGraph.addEdge(piParent, piVar);
-        break;
-      case LE: // piVar <= piRestrictor
+      }
+      case LE -> {
         this.upperBoundGraph.addPi(piVar, piParent, piRestrictor);
 
         this.lowerBoundGraph.addEdge(piParent, piVar);
-        break;
-      case GE: // piVar >= piRestrictor
+      }
+      case GE -> {
         this.lowerBoundGraph.addPi(piVar, piParent, piRestrictor);
 
         this.upperBoundGraph.addEdge(piParent, piVar);
-        break;
-      case LT: // piVar < piRestrictor
+      }
+      case LT -> {
         helper = this.upperBoundGraph.generateNewVar();
         this.upperBoundGraph.addAdditionEdge(piRestrictor, helper, -1);
         this.upperBoundGraph.addPi(piVar, piParent, helper);
 
         this.lowerBoundGraph.addEdge(piParent, piVar);
-        break;
-      case GT: // piVar > piRestrictor
+      }
+      case GT -> {
         helper = this.lowerBoundGraph.generateNewVar();
         this.lowerBoundGraph.addAdditionEdge(piRestrictor, helper, 1);
         this.lowerBoundGraph.addPi(piVar, piParent, helper);
 
         this.upperBoundGraph.addEdge(piParent, piVar);
-        break;
-      default:
-        throw new UnsupportedOperationException(String.format("unexpected operator %s", op));
+      }
+      default ->
+          throw new UnsupportedOperationException(String.format("unexpected operator %s", op));
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/analysis/arraybounds/ArrayOutOfBoundsAnalysis.java
+++ b/core/src/main/java/com/ibm/wala/analysis/arraybounds/ArrayOutOfBoundsAnalysis.java
@@ -36,15 +36,13 @@ public class ArrayOutOfBoundsAnalysis {
       if (set.contains(BOTH) || (set.contains(UPPER) && set.contains(LOWER))) {
         return BOTH;
       } else {
-        switch (set.size()) {
-          case 0:
-            return NONE;
-          case 1:
-            return set.iterator().next();
-          default:
-            throw new RuntimeException(
-                "Case that should not happen, this method is implemented wrong.");
-        }
+        return switch (set.size()) {
+          case 0 -> NONE;
+          case 1 -> set.iterator().next();
+          default ->
+              throw new RuntimeException(
+                  "Case that should not happen, this method is implemented wrong.");
+        };
       }
     }
   }

--- a/core/src/main/java/com/ibm/wala/analysis/arraybounds/ConditionNormalizer.java
+++ b/core/src/main/java/com/ibm/wala/analysis/arraybounds/ConditionNormalizer.java
@@ -65,39 +65,23 @@ public class ConditionNormalizer {
   }
 
   private static Operator negateOperator(Operator op) {
-    switch (op) {
-      case EQ:
-        return Operator.NE;
-      case NE:
-        return Operator.EQ;
-      case LT:
-        return Operator.GE;
-      case GE:
-        return Operator.LT;
-      case GT:
-        return Operator.LE;
-      case LE:
-        return Operator.GT;
-      default:
-        throw new RuntimeException("Programming Error: Got unknown operator.");
-    }
+    return switch (op) {
+      case EQ -> Operator.NE;
+      case NE -> Operator.EQ;
+      case LT -> Operator.GE;
+      case GE -> Operator.LT;
+      case GT -> Operator.LE;
+      case LE -> Operator.GT;
+    };
   }
 
   private static Operator swapOperator(Operator op) {
-    switch (op) {
-      case EQ:
-      case NE:
-        return op;
-      case LT:
-        return Operator.GT;
-      case GE:
-        return Operator.LE;
-      case GT:
-        return Operator.LT;
-      case LE:
-        return Operator.GE;
-      default:
-        throw new RuntimeException("Programming Error: Got unknown operator.");
-    }
+    return switch (op) {
+      case EQ, NE -> op;
+      case LT -> Operator.GT;
+      case GE -> Operator.LE;
+      case GT -> Operator.LT;
+      case LE -> Operator.GE;
+    };
   }
 }

--- a/core/src/main/java/com/ibm/wala/analysis/reflection/java7/MethodHandles.java
+++ b/core/src/main/java/com/ibm/wala/analysis/reflection/java7/MethodHandles.java
@@ -482,68 +482,64 @@ public class MethodHandles {
                 if (isInvoke(key)) {
                   String name = key.getMethod().getName().toString();
                   switch (name) {
-                    case "invokeWithArguments":
-                      {
-                        int nargs = ref.getNumberOfParameters();
-                        int[] params = new int[nargs];
+                    case "invokeWithArguments" -> {
+                      int nargs = ref.getNumberOfParameters();
+                      int[] params = new int[nargs];
+                      for (int i = 0; i < nargs; i++) {
+                        code.addConstant(i + nargs + 3, new ConstantValue(i));
+                        code.addStatement(
+                            insts.ArrayLoadInstruction(
+                                code.getNumberOfStatements(),
+                                i + 3,
+                                1,
+                                i + nargs + 3,
+                                TypeReference.JavaLangObject));
+                        params[i] = i + 3;
+                      }
+                      CallSiteReference site =
+                          CallSiteReference.make(
+                              nargs + 1, ref, isStatic ? Dispatch.STATIC : Dispatch.SPECIAL);
+                      code.addStatement(
+                          insts.InvokeInstruction(
+                              code.getNumberOfStatements(),
+                              2 * nargs + 3,
+                              params,
+                              2 * nargs + 4,
+                              site,
+                              null));
+                      code.addStatement(
+                          insts.ReturnInstruction(
+                              code.getNumberOfStatements(), 2 * nargs + 3, false));
+                    }
+                    case "invokeExact" -> {
+                      int nargs = key.getMethod().getReference().getNumberOfParameters();
+                      int[] params = new int[nargs];
+                      if (nargs == ref.getNumberOfParameters() + (isStatic ? 0 : 1)) {
                         for (int i = 0; i < nargs; i++) {
-                          code.addConstant(i + nargs + 3, new ConstantValue(i));
-                          code.addStatement(
-                              insts.ArrayLoadInstruction(
-                                  code.getNumberOfStatements(),
-                                  i + 3,
-                                  1,
-                                  i + nargs + 3,
-                                  TypeReference.JavaLangObject));
-                          params[i] = i + 3;
+                          params[i] = i + 2;
                         }
                         CallSiteReference site =
                             CallSiteReference.make(
-                                nargs + 1, ref, isStatic ? Dispatch.STATIC : Dispatch.SPECIAL);
-                        code.addStatement(
-                            insts.InvokeInstruction(
-                                code.getNumberOfStatements(),
-                                2 * nargs + 3,
-                                params,
-                                2 * nargs + 4,
-                                site,
-                                null));
-                        code.addStatement(
-                            insts.ReturnInstruction(
-                                code.getNumberOfStatements(), 2 * nargs + 3, false));
-                        break;
-                      }
-                    case "invokeExact":
-                      {
-                        int nargs = key.getMethod().getReference().getNumberOfParameters();
-                        int[] params = new int[nargs];
-                        if (nargs == ref.getNumberOfParameters() + (isStatic ? 0 : 1)) {
-                          for (int i = 0; i < nargs; i++) {
-                            params[i] = i + 2;
-                          }
-                          CallSiteReference site =
-                              CallSiteReference.make(
-                                  0, ref, isStatic ? Dispatch.STATIC : Dispatch.SPECIAL);
-                          if (isVoid) {
-                            code.addStatement(
-                                insts.InvokeInstruction(
-                                    code.getNumberOfStatements(), params, nargs + 2, site, null));
-                          } else {
-                            code.addStatement(
-                                insts.InvokeInstruction(
-                                    code.getNumberOfStatements(),
-                                    nargs + 2,
-                                    params,
-                                    nargs + 3,
-                                    site,
-                                    null));
-                            code.addStatement(
-                                insts.ReturnInstruction(
-                                    code.getNumberOfStatements(), nargs + 2, false));
-                          }
+                                0, ref, isStatic ? Dispatch.STATIC : Dispatch.SPECIAL);
+                        if (isVoid) {
+                          code.addStatement(
+                              insts.InvokeInstruction(
+                                  code.getNumberOfStatements(), params, nargs + 2, site, null));
+                        } else {
+                          code.addStatement(
+                              insts.InvokeInstruction(
+                                  code.getNumberOfStatements(),
+                                  nargs + 2,
+                                  params,
+                                  nargs + 3,
+                                  site,
+                                  null));
+                          code.addStatement(
+                              insts.ReturnInstruction(
+                                  code.getNumberOfStatements(), nargs + 2, false));
                         }
-                        break;
                       }
+                    }
                   }
                 } else {
                   assert isType(key);

--- a/core/src/main/java/com/ibm/wala/cfg/Util.java
+++ b/core/src/main/java/com/ibm/wala/cfg/Util.java
@@ -160,26 +160,33 @@ public class Util {
     final ConditionalBranchInstruction.Operator operator =
         (ConditionalBranchInstruction.Operator) c.getOperator();
     switch (operator) {
-      case EQ:
+      case EQ -> {
         if (c1 == c2) return getTakenSuccessor(G, bb);
         else return getNotTakenSuccessor(G, bb);
-      case NE:
+      }
+      case NE -> {
         if (c1 != c2) return getTakenSuccessor(G, bb);
         else return getNotTakenSuccessor(G, bb);
-      case LT:
+      }
+      case LT -> {
         if (c1 < c2) return getTakenSuccessor(G, bb);
         else return getNotTakenSuccessor(G, bb);
-      case GE:
+      }
+      case GE -> {
         if (c1 >= c2) return getTakenSuccessor(G, bb);
         else return getNotTakenSuccessor(G, bb);
-      case GT:
+      }
+      case GT -> {
         if (c1 > c2) return getTakenSuccessor(G, bb);
         else return getNotTakenSuccessor(G, bb);
-      case LE:
+      }
+      case LE -> {
         if (c1 <= c2) return getTakenSuccessor(G, bb);
         else return getNotTakenSuccessor(G, bb);
-      default:
-        throw new UnsupportedOperationException(String.format("unexpected operator %s", operator));
+      }
+      default ->
+          throw new UnsupportedOperationException(
+              String.format("unexpected operator %s", operator));
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/cfg/exc/intra/NullPointerState.java
+++ b/core/src/main/java/com/ibm/wala/cfg/exc/intra/NullPointerState.java
@@ -226,20 +226,11 @@ public class NullPointerState extends AbstractVariable<NullPointerState> {
     StringBuilder buf = new StringBuilder("<");
     for (State var : vars) {
       switch (var) {
-        case BOTH:
-          buf.append('*');
-          break;
-        case NOT_NULL:
-          buf.append('1');
-          break;
-        case NULL:
-          buf.append('0');
-          break;
-        case UNKNOWN:
-          buf.append('?');
-          break;
-        default:
-          throw new IllegalStateException();
+        case BOTH -> buf.append('*');
+        case NOT_NULL -> buf.append('1');
+        case NULL -> buf.append('0');
+        case UNKNOWN -> buf.append('?');
+        default -> throw new IllegalStateException();
       }
     }
     buf.append('>');

--- a/core/src/main/java/com/ibm/wala/cfg/exc/intra/NullPointerTransferFunctionProvider.java
+++ b/core/src/main/java/com/ibm/wala/cfg/exc/intra/NullPointerTransferFunctionProvider.java
@@ -261,33 +261,31 @@ class NullPointerTransferFunctionProvider<T extends ISSABasicBlock>
 
       if (sym.isNullConstant(arg1)) {
         switch (op) {
-          case EQ:
+          case EQ -> {
             noIdentity = true;
             transfer1 = NullPointerState.nullifyFunction(arg2);
             transfer2 = NullPointerState.denullifyFunction(arg2);
-            break;
-          case NE:
+          }
+          case NE -> {
             noIdentity = true;
             transfer1 = NullPointerState.denullifyFunction(arg2);
             transfer2 = NullPointerState.nullifyFunction(arg2);
-            break;
-          default:
-            throw new IllegalStateException("Comparision to a null constant using " + op);
+          }
+          default -> throw new IllegalStateException("Comparision to a null constant using " + op);
         }
       } else if (sym.isNullConstant(arg2)) {
         switch (op) {
-          case EQ:
+          case EQ -> {
             noIdentity = true;
             transfer1 = NullPointerState.nullifyFunction(arg1);
             transfer2 = NullPointerState.denullifyFunction(arg1);
-            break;
-          case NE:
+          }
+          case NE -> {
             noIdentity = true;
             transfer1 = NullPointerState.denullifyFunction(arg1);
             transfer2 = NullPointerState.nullifyFunction(arg1);
-            break;
-          default:
-            throw new IllegalStateException("Comparision to a null constant using " + op);
+          }
+          default -> throw new IllegalStateException("Comparision to a null constant using " + op);
         }
       } else {
         noIdentity = false;

--- a/core/src/main/java/com/ibm/wala/cfg/exc/intra/ParameterState.java
+++ b/core/src/main/java/com/ibm/wala/cfg/exc/intra/ParameterState.java
@@ -67,24 +67,24 @@ public class ParameterState extends AbstractVariable<ParameterState> {
     State prev = params.get(varNum);
     if (prev != null) {
       switch (prev) {
-        case UNKNOWN:
+        case UNKNOWN -> {
           if (state != State.UNKNOWN) {
             throw new IllegalArgumentException("Try to set " + prev + " to " + state);
           }
-          break;
-        case NULL:
+        }
+        case NULL -> {
           if (!(state == State.BOTH || state == State.NULL)) {
             throw new IllegalArgumentException("Try to set " + prev + " to " + state);
           }
-          break;
-        case NOT_NULL:
+        }
+        case NOT_NULL -> {
           if (!(state == State.BOTH || state == State.NOT_NULL)) {
             throw new IllegalArgumentException("Try to set " + prev + " to " + state);
           }
-          break;
-        default:
-          throw new UnsupportedOperationException(
-              String.format("unexpected previous state %s", prev));
+        }
+        default ->
+            throw new UnsupportedOperationException(
+                String.format("unexpected previous state %s", prev));
       }
     }
     params.put(varNum, state);
@@ -121,20 +121,11 @@ public class ParameterState extends AbstractVariable<ParameterState> {
 
     for (Entry<Integer, State> param : paramsSet) {
       switch (param.getValue()) {
-        case BOTH:
-          buf.append('*');
-          break;
-        case NOT_NULL:
-          buf.append('1');
-          break;
-        case NULL:
-          buf.append('0');
-          break;
-        case UNKNOWN:
-          buf.append('?');
-          break;
-        default:
-          throw new IllegalStateException();
+        case BOTH -> buf.append('*');
+        case NOT_NULL -> buf.append('1');
+        case NULL -> buf.append('0');
+        case UNKNOWN -> buf.append('?');
+        default -> throw new IllegalStateException();
       }
     }
     buf.append('>');

--- a/core/src/main/java/com/ibm/wala/classLoader/JavaLanguage.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/JavaLanguage.java
@@ -667,60 +667,64 @@ public class JavaLanguage extends LanguageImpl implements BytecodeLanguage, Cons
       throw new IllegalArgumentException("pei is null");
     }
     switch (((Instruction) pei).getOpcode()) {
-      case OP_iaload:
-      case OP_laload:
-      case OP_faload:
-      case OP_daload:
-      case OP_aaload:
-      case OP_baload:
-      case OP_caload:
-      case OP_saload:
-      case OP_iastore:
-      case OP_lastore:
-      case OP_fastore:
-      case OP_dastore:
-      case OP_bastore:
-      case OP_castore:
-      case OP_sastore:
+      case OP_iaload,
+          OP_laload,
+          OP_faload,
+          OP_daload,
+          OP_aaload,
+          OP_baload,
+          OP_caload,
+          OP_saload,
+          OP_iastore,
+          OP_lastore,
+          OP_fastore,
+          OP_dastore,
+          OP_bastore,
+          OP_castore,
+          OP_sastore -> {
         return getArrayAccessExceptions();
-      case OP_aastore:
+      }
+      case OP_aastore -> {
         return getAaStoreExceptions();
-      case OP_getfield:
-      case OP_putfield:
-      case OP_invokevirtual:
-      case OP_invokespecial:
-      case OP_invokeinterface:
-      case OP_monitorenter:
-      case OP_monitorexit:
+      }
       // we're currently ignoring MonitorStateExceptions, since J2EE stuff
       // should be
       // logically single-threaded
-      case OP_athrow:
       // N.B: the caller must handle the explicitly-thrown exception
-      case OP_arraylength:
+      case OP_getfield,
+          OP_putfield,
+          OP_invokevirtual,
+          OP_invokespecial,
+          OP_invokeinterface,
+          OP_monitorenter,
+          OP_monitorexit,
+          OP_athrow,
+          OP_arraylength -> {
         return getNullPointerException();
-      case OP_idiv:
-      case OP_irem:
-      case OP_ldiv:
-      case OP_lrem:
+      }
+      case OP_idiv, OP_irem, OP_ldiv, OP_lrem -> {
         return getArithmeticException();
-      case OP_new:
+      }
+      case OP_new -> {
         return newScalarExceptions;
-      case OP_newarray:
-      case OP_anewarray:
-      case OP_multianewarray:
+      }
+      case OP_newarray, OP_anewarray, OP_multianewarray -> {
         return newArrayExceptions;
-      case OP_checkcast:
+      }
+      case OP_checkcast -> {
         return getClassCastException();
-      case OP_ldc_w:
+      }
+      case OP_ldc_w -> {
         if (((ConstantInstruction) pei).getType().equals(TYPE_Class))
           return getClassNotFoundException();
         else return null;
-      case OP_getstatic:
-      case OP_putstatic:
+      }
+      case OP_getstatic, OP_putstatic -> {
         return getExceptionInInitializerError();
-      default:
+      }
+      default -> {
         return Collections.emptySet();
+      }
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/core/util/bytecode/BytecodeStream.java
+++ b/core/src/main/java/com/ibm/wala/core/util/bytecode/BytecodeStream.java
@@ -444,32 +444,25 @@ public class BytecodeStream implements BytecodeConstants {
   // Skip a tableswitch or a lookupswitch instruction
   private void skipSpecialInstruction(int opcode) {
     switch (opcode) {
-      case JBC_tableswitch:
-        {
-          alignSwitch();
-          getDefaultSwitchOffset();
-          int l = getLowSwitchValue();
-          int h = getHighSwitchValue();
-          skipTableSwitchOffsets(h - l + 1); // jump offsets
-        }
-        break;
-      case JBC_lookupswitch:
-        {
-          alignSwitch();
-          getDefaultSwitchOffset();
-          int n = getSwitchLength();
-          skipLookupSwitchPairs(n); // match-offset pairs
-        }
-        break;
-      case JBC_wide:
-        {
-          int oc = getWideOpcode();
-          int len = JBC_length[oc] - 1;
-          bcIndex += len + len;
-        }
-        break;
-      default:
-        throw new NullPointerException();
+      case JBC_tableswitch -> {
+        alignSwitch();
+        getDefaultSwitchOffset();
+        int l = getLowSwitchValue();
+        int h = getHighSwitchValue();
+        skipTableSwitchOffsets(h - l + 1); // jump offsets
+      }
+      case JBC_lookupswitch -> {
+        alignSwitch();
+        getDefaultSwitchOffset();
+        int n = getSwitchLength();
+        skipLookupSwitchPairs(n); // match-offset pairs
+      }
+      case JBC_wide -> {
+        int oc = getWideOpcode();
+        int len = JBC_length[oc] - 1;
+        bcIndex += len + len;
+      }
+      default -> throw new NullPointerException();
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/core/util/io/FileProvider.java
+++ b/core/src/main/java/com/ibm/wala/core/util/io/FileProvider.java
@@ -155,21 +155,25 @@ public class FileProvider {
       }
     }
     switch (url.getProtocol()) {
-      case "jar":
+      case "jar" -> {
         JarURLConnection jc = (JarURLConnection) url.openConnection();
         JarFile f = jc.getJarFile();
         JarEntry entry = jc.getJarEntry();
         JarFileModule parent = new JarFileModule(f);
         return new NestedJarFileModule(parent, entry);
-      case "rsrc":
+      }
+      case "rsrc" -> {
         return new ResourceJarFileModule(url);
-      case "file":
+      }
+      case "file" -> {
         String filePath = filePathFromURL(url);
         return new JarFileModule(new JarFile(filePath, false));
-      default:
+      }
+      default -> {
         final URLConnection in = url.openConnection();
         final JarInputStream jarIn = new JarInputStream(in.getInputStream(), false);
         return new JarStreamModule(jarIn);
+      }
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/core/util/ref/CacheReference.java
+++ b/core/src/main/java/com/ibm/wala/core/util/ref/CacheReference.java
@@ -28,17 +28,15 @@ public final class CacheReference {
 
   public static Object make(final Object referent) {
 
-    switch (choice) {
-      case SOFT:
-        return new SoftReference<>(referent);
-      case WEAK:
-        return new WeakReference<>(referent);
-      case HARD:
-        return referent;
-      default:
+    return switch (choice) {
+      case SOFT -> new SoftReference<>(referent);
+      case WEAK -> new WeakReference<>(referent);
+      case HARD -> referent;
+      default -> {
         Assertions.UNREACHABLE();
-        return null;
-    }
+        yield null;
+      }
+    };
   }
 
   public static Object get(final Object reference) throws IllegalArgumentException {
@@ -46,20 +44,20 @@ public final class CacheReference {
     if (reference == null) {
       return null;
     }
-    switch (choice) {
-      case SOFT:
-        if (!(reference instanceof java.lang.ref.SoftReference)) {
+    return switch (choice) {
+      case SOFT -> {
+        if (!(reference instanceof SoftReference)) {
           throw new IllegalArgumentException(
               "not ( reference instanceof java.lang.ref.SoftReference ) ");
         }
-        return ((SoftReference<?>) reference).get();
-      case WEAK:
-        return ((WeakReference<?>) reference).get();
-      case HARD:
-        return reference;
-      default:
+        yield ((SoftReference<?>) reference).get();
+      }
+      case WEAK -> ((WeakReference<?>) reference).get();
+      case HARD -> reference;
+      default -> {
         Assertions.UNREACHABLE();
-        return null;
-    }
+        yield null;
+      }
+    };
   }
 }

--- a/core/src/main/java/com/ibm/wala/core/util/ssa/ParameterAccessor.java
+++ b/core/src/main/java/com/ibm/wala/core/util/ssa/ParameterAccessor.java
@@ -278,7 +278,7 @@ public class ParameterAccessor {
     @Override
     public String toString() {
       switch (this.disp) {
-        case THIS:
+        case THIS -> {
           return "Implicit this-parameter of "
               + this.mRef.getName()
               + " as "
@@ -286,7 +286,8 @@ public class ParameterAccessor {
               + " accessible using "
               + "SSA-Value "
               + this.number;
-        case PARAM:
+        }
+        case PARAM -> {
           if (this.key instanceof NamedKey) {
             return "Parameter "
                 + getNumberInDescriptor()
@@ -308,21 +309,24 @@ public class ParameterAccessor {
                 + " accessible using SSA-Value "
                 + this.number;
           }
-        case RETURN:
+        }
+        case RETURN -> {
           return "Return Value of "
               + this.mRef.getName()
               + " as "
               + this.type
               + " accessible using SSA-Value "
               + this.number;
-        case NEW:
+        }
+        case NEW -> {
           return "New instance of "
               + this.type
               + " accessible in "
               + this.mRef.getName()
               + " using number "
               + this.number;
-        default:
+        }
+        default -> {
           return "Parameter "
               + getNumberInDescriptor()
               + " - "
@@ -333,6 +337,7 @@ public class ParameterAccessor {
               + this.type
               + " accessible using SSA-Value "
               + this.number;
+        }
       }
     }
   }
@@ -541,29 +546,26 @@ public class ParameterAccessor {
     // no is checked by getParameterNo(int)
     final int newNo = getParameterNo(no);
 
-    switch (this.base) {
-      case IMETHOD: // TODO: Try reading parameter name
-        return new Parameter(
-            newNo,
-            null,
-            this.method.getParameterType(no),
-            ParameterDisposition.PARAM,
-            this.base,
-            this.method.getReference(),
-            this.descriptorOffset);
-      case METHOD_REFERENCE:
-        return new Parameter(
-            newNo,
-            null,
-            this.mRef.getParameterType(no - 1),
-            ParameterDisposition.PARAM,
-            this.base,
-            this.mRef,
-            this.descriptorOffset);
-      default:
-        throw new UnsupportedOperationException(
-            "No implementation of getParameter() for base " + this.base);
-    }
+    return switch (this.base) {
+      case IMETHOD -> // TODO: Try reading parameter name
+          new Parameter(
+              newNo,
+              null,
+              this.method.getParameterType(no),
+              ParameterDisposition.PARAM,
+              this.base,
+              this.method.getReference(),
+              this.descriptorOffset);
+      case METHOD_REFERENCE ->
+          new Parameter(
+              newNo,
+              null,
+              this.mRef.getParameterType(no - 1),
+              ParameterDisposition.PARAM,
+              this.base,
+              this.mRef,
+              this.descriptorOffset);
+    };
   }
 
   /**
@@ -596,17 +598,19 @@ public class ParameterAccessor {
     }
 
     switch (this.base) {
-      case IMETHOD:
+      case IMETHOD -> {
         return no + this.implicitThis; // + this.implicitThis; // TODO: Verify
-      case METHOD_REFERENCE:
+      }
+      case METHOD_REFERENCE -> {
         if (this.implicitThis > 0) {
           return no + this.implicitThis; //
         } else {
           return no;
         }
-      default:
-        throw new UnsupportedOperationException(
-            "No implementation of getParameter() for base " + this.base);
+      }
+      default ->
+          throw new UnsupportedOperationException(
+              "No implementation of getParameter() for base " + this.base);
     }
   }
 
@@ -638,50 +642,44 @@ public class ParameterAccessor {
       return all;
     } else {
       switch (this.base) {
-        case IMETHOD:
-          {
-            // final int firstInSelector = firstInSelector();
-            for (int i = (hasImplicitThis() ? 1 : 0);
-                i < this.method.getNumberOfParameters();
-                ++i) {
-              debug(
-                  "all() adding: Parameter({}, {}, {}, {}, {})",
-                  (i + 1),
-                  this.method.getParameterType(i),
-                  this.base,
-                  this.method,
-                  this.descriptorOffset);
-              all.add(
-                  new Parameter(
-                      i + 1,
-                      null,
-                      this.method.getParameterType(i),
-                      ParameterDisposition.PARAM,
-                      this.base,
-                      this.method.getReference(),
-                      this.descriptorOffset));
-            }
+        case IMETHOD -> {
+          // final int firstInSelector = firstInSelector();
+          for (int i = (hasImplicitThis() ? 1 : 0); i < this.method.getNumberOfParameters(); ++i) {
+            debug(
+                "all() adding: Parameter({}, {}, {}, {}, {})",
+                (i + 1),
+                this.method.getParameterType(i),
+                this.base,
+                this.method,
+                this.descriptorOffset);
+            all.add(
+                new Parameter(
+                    i + 1,
+                    null,
+                    this.method.getParameterType(i),
+                    ParameterDisposition.PARAM,
+                    this.base,
+                    this.method.getReference(),
+                    this.descriptorOffset));
           }
-          break;
-        case METHOD_REFERENCE:
-          {
-            final int firstInSelector = firstInSelector();
-            for (int i = 0 /*firstInSelector()*/; i < this.numberOfParameters; ++i) { // TODO:
-              all.add(
-                  new Parameter(
-                      i + firstInSelector,
-                      null,
-                      this.mRef.getParameterType(i),
-                      ParameterDisposition.PARAM,
-                      this.base,
-                      this.mRef,
-                      this.descriptorOffset));
-            }
+        }
+        case METHOD_REFERENCE -> {
+          final int firstInSelector = firstInSelector();
+          for (int i = 0 /*firstInSelector()*/; i < this.numberOfParameters; ++i) { // TODO:
+            all.add(
+                new Parameter(
+                    i + firstInSelector,
+                    null,
+                    this.mRef.getParameterType(i),
+                    ParameterDisposition.PARAM,
+                    this.base,
+                    this.mRef,
+                    this.descriptorOffset));
           }
-          break;
-        default:
-          throw new UnsupportedOperationException(
-              "No implementation of all() for base " + this.base);
+        }
+        default ->
+            throw new UnsupportedOperationException(
+                "No implementation of all() for base " + this.base);
       }
     }
 
@@ -701,18 +699,11 @@ public class ParameterAccessor {
    */
   public Parameter getThis() {
     final int self = getThisNo();
-    final TypeReference selfType;
-    switch (this.base) {
-      case IMETHOD:
-        selfType = this.method.getParameterType(self);
-        break;
-      case METHOD_REFERENCE:
-        selfType = this.mRef.getDeclaringClass();
-        break;
-      default:
-        throw new UnsupportedOperationException(
-            "No implementation of getThis() for base " + this.base);
-    }
+    final TypeReference selfType =
+        switch (this.base) {
+          case IMETHOD -> this.method.getParameterType(self);
+          case METHOD_REFERENCE -> this.mRef.getDeclaringClass();
+        };
     return getThisAs(selfType);
   }
 
@@ -725,7 +716,7 @@ public class ParameterAccessor {
     final int self = getThisNo();
 
     switch (this.base) {
-      case IMETHOD:
+      case IMETHOD -> {
         final IClassHierarchy cha = this.method.getClassHierarchy();
         try {
           if (!isSubclassOf(this.method.getParameterType(self), asType, cha)) {
@@ -747,7 +738,8 @@ public class ParameterAccessor {
             this.base,
             this.method.getReference(),
             this.descriptorOffset);
-      case METHOD_REFERENCE:
+      }
+      case METHOD_REFERENCE -> {
         // TODO assert asType is a subtype of self.type - we need cha to do that :(
         return new Parameter(
             self,
@@ -757,9 +749,11 @@ public class ParameterAccessor {
             this.base,
             this.mRef,
             this.descriptorOffset);
-      default:
-        throw new UnsupportedOperationException(
-            "No implementation of getThis() for base " + this.base);
+        // TODO assert asType is a subtype of self.type - we need cha to do that :(
+      }
+      default ->
+          throw new UnsupportedOperationException(
+              "No implementation of getThis() for base " + this.base);
     }
   }
 
@@ -797,29 +791,26 @@ public class ParameterAccessor {
       throw new IllegalStateException("Can't generate a return-value for a void-function.");
     }
 
-    switch (this.base) {
-      case IMETHOD:
-        return new Parameter(
-            ssa,
-            "retVal",
-            getReturnType(),
-            ParameterDisposition.RETURN,
-            this.base,
-            this.method.getReference(),
-            this.descriptorOffset);
-      case METHOD_REFERENCE:
-        return new Parameter(
-            ssa,
-            "retVal",
-            getReturnType(),
-            ParameterDisposition.RETURN,
-            this.base,
-            this.mRef,
-            this.descriptorOffset);
-      default:
-        throw new UnsupportedOperationException(
-            "No implementation of getReturn() for base " + this.base);
-    }
+    return switch (this.base) {
+      case IMETHOD ->
+          new Parameter(
+              ssa,
+              "retVal",
+              getReturnType(),
+              ParameterDisposition.RETURN,
+              this.base,
+              this.method.getReference(),
+              this.descriptorOffset);
+      case METHOD_REFERENCE ->
+          new Parameter(
+              ssa,
+              "retVal",
+              getReturnType(),
+              ParameterDisposition.RETURN,
+              this.base,
+              this.mRef,
+              this.descriptorOffset);
+    };
   }
 
   /**
@@ -869,7 +860,7 @@ public class ParameterAccessor {
     }
 
     switch (this.base) {
-      case IMETHOD:
+      case IMETHOD -> {
         if (this.hasImplicitThis()) { // XXX TODO BUG!
           debug(
               "This IMethod {} has an implicit this pointer at {}, so firstInSelector is accessible using SSA-Value {}",
@@ -883,7 +874,8 @@ public class ParameterAccessor {
               this.method);
           return 1;
         }
-      case METHOD_REFERENCE:
+      }
+      case METHOD_REFERENCE -> {
         if (this.hasImplicitThis()) {
           debug(
               "This IMethod {} has an implicit this pointer at {}, so firstInSelector is accessible using SSA-Value {}",
@@ -897,9 +889,10 @@ public class ParameterAccessor {
               this.mRef);
           return 1;
         }
-      default:
-        throw new UnsupportedOperationException(
-            "No implementation of firstInSelector() for base " + this.base);
+      }
+      default ->
+          throw new UnsupportedOperationException(
+              "No implementation of firstInSelector() for base " + this.base);
     }
   }
 
@@ -917,14 +910,9 @@ public class ParameterAccessor {
    * @return the type of the parameter
    */
   public TypeReference getParameterType(final int no) { // XXX Remove?
-    switch (this.base) {
-      case IMETHOD:
-      case METHOD_REFERENCE:
-        return this.method.getParameterType(getParameterNo(no));
-      default:
-        throw new UnsupportedOperationException(
-            "No implementation of getParameterType() for base " + this.base);
-    }
+    return switch (this.base) {
+      case IMETHOD, METHOD_REFERENCE -> this.method.getParameterType(getParameterNo(no));
+    };
   }
 
   /**
@@ -1908,15 +1896,10 @@ public class ParameterAccessor {
 
   /** Handed through to the IMethod / MethodReference */
   public TypeReference getReturnType() {
-    switch (this.base) {
-      case IMETHOD:
-        return this.method.getReturnType();
-      case METHOD_REFERENCE:
-        return this.mRef.getReturnType();
-      default:
-        throw new UnsupportedOperationException(
-            "No implementation of getReturnType() for base " + this.base);
-    }
+    return switch (this.base) {
+      case IMETHOD -> this.method.getReturnType();
+      case METHOD_REFERENCE -> this.mRef.getReturnType();
+    };
   }
 
   /** Number of parameters _excluding_ implicit this */

--- a/core/src/main/java/com/ibm/wala/core/util/strings/StringStuff.java
+++ b/core/src/main/java/com/ibm/wala/core/util/strings/StringStuff.java
@@ -149,39 +149,48 @@ public class StringStuff {
       throw new IllegalArgumentException("invalid descriptor: " + b);
     }
     switch (b.get(i)) {
-      case TypeReference.VoidTypeCode:
+      case TypeReference.VoidTypeCode -> {
         return TypeReference.Void.getName();
-      case TypeReference.BooleanTypeCode:
+      }
+      case TypeReference.BooleanTypeCode -> {
         return TypeReference.Boolean.getName();
-      case TypeReference.ByteTypeCode:
+      }
+      case TypeReference.ByteTypeCode -> {
         return TypeReference.Byte.getName();
-      case TypeReference.ShortTypeCode:
+      }
+      case TypeReference.ShortTypeCode -> {
         return TypeReference.Short.getName();
-      case TypeReference.IntTypeCode:
+      }
+      case TypeReference.IntTypeCode -> {
         return TypeReference.Int.getName();
-      case TypeReference.LongTypeCode:
+      }
+      case TypeReference.LongTypeCode -> {
         return TypeReference.Long.getName();
-      case TypeReference.FloatTypeCode:
+      }
+      case TypeReference.FloatTypeCode -> {
         return TypeReference.Float.getName();
-      case TypeReference.DoubleTypeCode:
+      }
+      case TypeReference.DoubleTypeCode -> {
         return TypeReference.Double.getName();
-      case TypeReference.CharTypeCode:
+      }
+      case TypeReference.CharTypeCode -> {
         return TypeReference.Char.getName();
-      case TypeReference.OtherPrimitiveTypeCode:
+      }
+      case TypeReference.OtherPrimitiveTypeCode -> {
         if (b.get(b.length() - 1) == ';') {
           return l.lookupPrimitiveType(new String(b.substring(i + 1, b.length() - i - 2)));
         } else {
           return l.lookupPrimitiveType(new String(b.substring(i + 1, b.length() - i - 1)));
         }
-      case TypeReference.ClassTypeCode: // fall through
-      case TypeReference.ArrayTypeCode:
+      }
+      case TypeReference.ClassTypeCode, TypeReference.ArrayTypeCode -> {
         if (b.get(b.length() - 1) == ';') {
           return TypeName.findOrCreate(b, i, b.length() - i - 1);
         } else {
           return TypeName.findOrCreate(b, i, b.length() - i);
         }
-      default:
-        throw new IllegalArgumentException("unexpected type in descriptor " + b);
+      }
+      default -> throw new IllegalArgumentException("unexpected type in descriptor " + b);
     }
   }
 
@@ -219,73 +228,46 @@ public class StringStuff {
     int i = 1;
     while (true) {
       switch (b.get(i++)) {
-        case TypeReference.VoidTypeCode:
-          sigs.add(TypeReference.VoidName);
-          continue;
-        case TypeReference.BooleanTypeCode:
-          sigs.add(TypeReference.BooleanName);
-          continue;
-        case TypeReference.ByteTypeCode:
-          sigs.add(TypeReference.ByteName);
-          continue;
-        case TypeReference.ShortTypeCode:
-          sigs.add(TypeReference.ShortName);
-          continue;
-        case TypeReference.IntTypeCode:
-          sigs.add(TypeReference.IntName);
-          continue;
-        case TypeReference.LongTypeCode:
-          sigs.add(TypeReference.LongName);
-          continue;
-        case TypeReference.FloatTypeCode:
-          sigs.add(TypeReference.FloatName);
-          continue;
-        case TypeReference.DoubleTypeCode:
-          sigs.add(TypeReference.DoubleName);
-          continue;
-        case TypeReference.CharTypeCode:
-          sigs.add(TypeReference.CharName);
-          continue;
-        case TypeReference.OtherPrimitiveTypeCode:
-          {
-            int off = i - 1;
+        case TypeReference.VoidTypeCode -> sigs.add(TypeReference.VoidName);
+        case TypeReference.BooleanTypeCode -> sigs.add(TypeReference.BooleanName);
+        case TypeReference.ByteTypeCode -> sigs.add(TypeReference.ByteName);
+        case TypeReference.ShortTypeCode -> sigs.add(TypeReference.ShortName);
+        case TypeReference.IntTypeCode -> sigs.add(TypeReference.IntName);
+        case TypeReference.LongTypeCode -> sigs.add(TypeReference.LongName);
+        case TypeReference.FloatTypeCode -> sigs.add(TypeReference.FloatName);
+        case TypeReference.DoubleTypeCode -> sigs.add(TypeReference.DoubleName);
+        case TypeReference.CharTypeCode -> sigs.add(TypeReference.CharName);
+        case TypeReference.OtherPrimitiveTypeCode -> {
+          int off = i - 1;
+          while (b.get(i++) != ';')
+            ;
+          sigs.add(l.lookupPrimitiveType(new String(b.substring(off + 1, i - off - 2))));
+        }
+        case TypeReference.ClassTypeCode -> {
+          int off = i - 1;
+          while (b.get(i++) != ';')
+            ;
+          sigs.add(TypeName.findOrCreate(b, off, i - off - 1));
+        }
+        case TypeReference.ArrayTypeCode,
+            TypeReference.PointerTypeCode,
+            TypeReference.ReferenceTypeCode -> {
+          int off = i - 1;
+          while (StringStuff.isTypeCodeChar(b, i)) {
+            ++i;
+          }
+          final TypeName T;
+          byte c = b.get(i++);
+          if (c == TypeReference.ClassTypeCode || c == TypeReference.OtherPrimitiveTypeCode) {
             while (b.get(i++) != ';')
               ;
-            sigs.add(l.lookupPrimitiveType(new String(b.substring(off + 1, i - off - 2))));
-
-            continue;
+            T = TypeName.findOrCreate(b, off, i - off - 1);
+          } else {
+            T = TypeName.findOrCreate(b, off, i - off);
           }
-        case TypeReference.ClassTypeCode:
-          {
-            int off = i - 1;
-            while (b.get(i++) != ';')
-              ;
-            sigs.add(TypeName.findOrCreate(b, off, i - off - 1));
-
-            continue;
-          }
-        case TypeReference.ArrayTypeCode:
-        case TypeReference.PointerTypeCode:
-        case TypeReference.ReferenceTypeCode:
-          {
-            int off = i - 1;
-            while (StringStuff.isTypeCodeChar(b, i)) {
-              ++i;
-            }
-            final TypeName T;
-            byte c = b.get(i++);
-            if (c == TypeReference.ClassTypeCode || c == TypeReference.OtherPrimitiveTypeCode) {
-              while (b.get(i++) != ';')
-                ;
-              T = TypeName.findOrCreate(b, off, i - off - 1);
-            } else {
-              T = TypeName.findOrCreate(b, off, i - off);
-            }
-            sigs.add(T);
-
-            continue;
-          }
-        case (byte) ')': // end of parameter list
+          sigs.add(T);
+        }
+        case (byte) ')' -> {
           int size = sigs.size();
           if (size == 0) {
             return null;
@@ -296,21 +278,19 @@ public class StringStuff {
             result[j] = it.next();
           }
           return result;
-        default:
+        }
+        default -> {
           assert false : "bad descriptor " + b;
+        }
       }
     }
   }
 
   public static boolean isTypeCodeChar(ImmutableByteArray name, int i) {
-    switch (name.b[i]) {
-      case ArrayTypeCode:
-      case PointerTypeCode:
-      case ReferenceTypeCode:
-        return true;
-      default:
-        return false;
-    }
+    return switch (name.b[i]) {
+      case ArrayTypeCode, PointerTypeCode, ReferenceTypeCode -> true;
+      default -> false;
+    };
   }
 
   /**
@@ -435,17 +415,10 @@ public class StringStuff {
         if (isTypeCodeChar(b, i)) {
           code <<= ElementBits;
           switch (b.b[i]) {
-            case ArrayTypeCode:
-              code |= ArrayMask;
-              break;
-            case PointerTypeCode:
-              code |= PointerMask;
-              break;
-            case ReferenceTypeCode:
-              code |= ReferenceMask;
-              break;
-            default:
-              throw new IllegalArgumentException("ill-formed array descriptor " + b);
+            case ArrayTypeCode -> code |= ArrayMask;
+            case PointerTypeCode -> code |= PointerMask;
+            case ReferenceTypeCode -> code |= ReferenceMask;
+            default -> throw new IllegalArgumentException("ill-formed array descriptor " + b);
           }
         } else {
           // type codes must be at the start of the descriptor; if we see something else, stop
@@ -576,34 +549,16 @@ public class StringStuff {
       prefix = jvmType.charAt(numberOfDimensions);
     }
     switch (prefix) {
-      case 'V':
-        readable.append("void");
-        break;
-      case 'B':
-        readable.append("byte");
-        break;
-      case 'C':
-        readable.append("char");
-        break;
-      case 'D':
-        readable.append("double");
-        break;
-      case 'F':
-        readable.append("float");
-        break;
-      case 'I':
-        readable.append("int");
-        break;
-      case 'J':
-        readable.append("long");
-        break;
-      case 'S':
-        readable.append("short");
-        break;
-      case 'Z':
-        readable.append("boolean");
-        break;
-      case 'L':
+      case 'V' -> readable.append("void");
+      case 'B' -> readable.append("byte");
+      case 'C' -> readable.append("char");
+      case 'D' -> readable.append("double");
+      case 'F' -> readable.append("float");
+      case 'I' -> readable.append("int");
+      case 'J' -> readable.append("long");
+      case 'S' -> readable.append("short");
+      case 'Z' -> readable.append("boolean");
+      case 'L' -> {
         readable.append(
             jvmType,
             numberOfDimensions + 1, // strip all leading '[' & 'L'
@@ -612,7 +567,7 @@ public class StringStuff {
         // Convert to standard Java dot-notation
         readable = new StringBuilder(slashToDot(readable.toString()));
         readable = new StringBuilder(dollarToDot(readable.toString()));
-        break;
+      }
     }
     // append trailing "[]" for each array dimension
     readable.append("[]".repeat(numberOfDimensions));
@@ -644,34 +599,16 @@ public class StringStuff {
       prefix = jvmType.charAt(numberOfDimensions);
     }
     switch (prefix) {
-      case 'V':
-        readable.append("void");
-        break;
-      case 'B':
-        readable.append("byte");
-        break;
-      case 'C':
-        readable.append("char");
-        break;
-      case 'D':
-        readable.append("double");
-        break;
-      case 'F':
-        readable.append("float");
-        break;
-      case 'I':
-        readable.append("int");
-        break;
-      case 'J':
-        readable.append("long");
-        break;
-      case 'S':
-        readable.append("short");
-        break;
-      case 'Z':
-        readable.append("boolean");
-        break;
-      case 'L':
+      case 'V' -> readable.append("void");
+      case 'B' -> readable.append("byte");
+      case 'C' -> readable.append("char");
+      case 'D' -> readable.append("double");
+      case 'F' -> readable.append("float");
+      case 'I' -> readable.append("int");
+      case 'J' -> readable.append("long");
+      case 'S' -> readable.append("short");
+      case 'Z' -> readable.append("boolean");
+      case 'L' -> {
         readable.append(
             jvmType,
             numberOfDimensions + 1, // strip all leading '[' & 'L'
@@ -679,7 +616,7 @@ public class StringStuff {
             );
         // Convert to standard Java dot-notation
         readable = new StringBuilder(slashToDot(readable.toString()));
-        break;
+      }
     }
     // append trailing "[]" for each array dimension
     readable.append("[]".repeat(numberOfDimensions));

--- a/core/src/main/java/com/ibm/wala/core/util/warnings/Warning.java
+++ b/core/src/main/java/com/ibm/wala/core/util/warnings/Warning.java
@@ -74,23 +74,18 @@ public abstract class Warning implements Comparable<Warning> {
   }
 
   protected String severityString() {
-    switch (level) {
-      case MILD:
-        return "mild";
-      case MODERATE:
-        return "Moderate";
-      case SEVERE:
-        return "SEVERE";
-      case CLIENT_MILD:
-        return "Client mild";
-      case CLIENT_MODERATE:
-        return "Client moderate";
-      case CLIENT_SEVERE:
-        return "Client severe";
-      default:
+    return switch (level) {
+      case MILD -> "mild";
+      case MODERATE -> "Moderate";
+      case SEVERE -> "SEVERE";
+      case CLIENT_MILD -> "Client mild";
+      case CLIENT_MODERATE -> "Client moderate";
+      case CLIENT_SEVERE -> "Client severe";
+      default -> {
         Assertions.UNREACHABLE();
-        return null;
-    }
+        yield null;
+      }
+    };
   }
 
   public byte getLevel() {

--- a/core/src/main/java/com/ibm/wala/dataflow/IFDS/BackwardsSupergraph.java
+++ b/core/src/main/java/com/ibm/wala/dataflow/IFDS/BackwardsSupergraph.java
@@ -260,19 +260,16 @@ public class BackwardsSupergraph<T, P> implements ISupergraph<T, P> {
   @Override
   public byte classifyEdge(T src, T dest) {
     byte d = delegate.classifyEdge(dest, src);
-    switch (d) {
-      case CALL_EDGE:
-        return RETURN_EDGE;
-      case RETURN_EDGE:
-        return CALL_EDGE;
-      case OTHER:
-        return OTHER;
-      case CALL_TO_RETURN_EDGE:
-        return CALL_TO_RETURN_EDGE;
-      default:
+    return switch (d) {
+      case CALL_EDGE -> RETURN_EDGE;
+      case RETURN_EDGE -> CALL_EDGE;
+      case OTHER -> OTHER;
+      case CALL_TO_RETURN_EDGE -> CALL_TO_RETURN_EDGE;
+      default -> {
         Assertions.UNREACHABLE();
-        return -1;
-    }
+        yield -1;
+      }
+    };
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/demandpa/util/PABasedMemoryAccessMap.java
+++ b/core/src/main/java/com/ibm/wala/demandpa/util/PABasedMemoryAccessMap.java
@@ -149,12 +149,11 @@ public class PABasedMemoryAccessMap implements MemoryAccessMap {
     }
     for (Statement s : stmts) {
       switch (s.getKind()) {
-        case NORMAL:
+        case NORMAL -> {
           NormalStatement normStmt = (NormalStatement) s;
           result.add(new MemoryAccess(normStmt.getInstructionIndex(), normStmt.getNode()));
-          break;
-        default:
-          Assertions.UNREACHABLE();
+        }
+        default -> Assertions.UNREACHABLE();
       }
     }
   }

--- a/core/src/main/java/com/ibm/wala/examples/drivers/DemandCastChecker.java
+++ b/core/src/main/java/com/ibm/wala/examples/drivers/DemandCastChecker.java
@@ -254,7 +254,7 @@ public class DemandCastChecker {
           final FieldRefinePolicy fieldRefinePolicy =
               dmp.getRefinementPolicy().getFieldRefinePolicy();
           switch (queryResult.fst) {
-            case SUCCESS:
+            case SUCCESS -> {
               System.err.println("SAFE: " + castInstr + " in " + node.getMethod());
               if (fieldRefinePolicy instanceof ManualFieldPolicy) {
                 ManualFieldPolicy hackedFieldPolicy = (ManualFieldPolicy) fieldRefinePolicy;
@@ -262,8 +262,8 @@ public class DemandCastChecker {
               }
               System.err.println("TRAVERSED " + dmp.getNumNodesTraversed() + " nodes");
               numSafe++;
-              break;
-            case NO_MORE_REFINE:
+            }
+            case NO_MORE_REFINE -> {
               if (queryResult.snd != null) {
                 System.err.println(
                     "MIGHT FAIL: no more refinement possible for "
@@ -276,15 +276,13 @@ public class DemandCastChecker {
               }
               failing.add(Pair.make(node, castInstr));
               numMightFail++;
-              break;
-            case BUDGET_EXCEEDED:
+            }
+            case BUDGET_EXCEEDED -> {
               System.err.println(
                   "MIGHT FAIL: exceeded budget for " + castInstr + " in " + node.getMethod());
               failing.add(Pair.make(node, castInstr));
               numMightFail++;
-              break;
-            default:
-              Assertions.UNREACHABLE();
+            }
           }
         }
       }

--- a/core/src/main/java/com/ibm/wala/examples/drivers/PDFSDG.java
+++ b/core/src/main/java/com/ibm/wala/examples/drivers/PDFSDG.java
@@ -177,24 +177,13 @@ public class PDFSDG {
 
   private static NodeDecorator<Statement> makeNodeDecorator() {
     return s -> {
-      switch (s.getKind()) {
-        case HEAP_PARAM_CALLEE:
-        case HEAP_PARAM_CALLER:
-        case HEAP_RET_CALLEE:
-        case HEAP_RET_CALLER:
+      return switch (s.getKind()) {
+        case HEAP_PARAM_CALLEE, HEAP_PARAM_CALLER, HEAP_RET_CALLEE, HEAP_RET_CALLER -> {
           HeapStatement h = (HeapStatement) s;
-          return s.getKind() + "\\n" + h.getNode() + "\\n" + h.getLocation();
-        case EXC_RET_CALLEE:
-        case EXC_RET_CALLER:
-        case NORMAL:
-        case NORMAL_RET_CALLEE:
-        case NORMAL_RET_CALLER:
-        case PARAM_CALLEE:
-        case PARAM_CALLER:
-        case PHI:
-        default:
-          return s.toString();
-      }
+          yield s.getKind() + "\\n" + h.getNode() + "\\n" + h.getLocation();
+        }
+        default -> s.toString();
+      };
     };
   }
 

--- a/core/src/main/java/com/ibm/wala/examples/drivers/PDFSlice.java
+++ b/core/src/main/java/com/ibm/wala/examples/drivers/PDFSlice.java
@@ -261,40 +261,35 @@ public class PDFSlice {
    */
   public static NodeDecorator<Statement> makeNodeDecorator() {
     return s -> {
-      switch (s.getKind()) {
-        case HEAP_PARAM_CALLEE:
-        case HEAP_PARAM_CALLER:
-        case HEAP_RET_CALLEE:
-        case HEAP_RET_CALLER:
+      return switch (s.getKind()) {
+        case HEAP_PARAM_CALLEE, HEAP_PARAM_CALLER, HEAP_RET_CALLEE, HEAP_RET_CALLER -> {
           HeapStatement h = (HeapStatement) s;
-          return s.getKind() + "\\n" + h.getNode() + "\\n" + h.getLocation();
-        case NORMAL:
+          yield s.getKind() + "\\n" + h.getNode() + "\\n" + h.getLocation();
+        }
+        case NORMAL -> {
           NormalStatement n = (NormalStatement) s;
-          return n.getInstruction() + "\\n" + n.getNode().getMethod().getSignature();
-        case PARAM_CALLEE:
+          yield n.getInstruction() + "\\n" + n.getNode().getMethod().getSignature();
+        }
+        case PARAM_CALLEE -> {
           ParamCallee paramCallee = (ParamCallee) s;
-          return s.getKind()
+          yield s.getKind()
               + " "
               + paramCallee.getValueNumber()
               + "\\n"
               + s.getNode().getMethod().getName();
-        case PARAM_CALLER:
+        }
+        case PARAM_CALLER -> {
           ParamCaller paramCaller = (ParamCaller) s;
-          return s.getKind()
+          yield s.getKind()
               + " "
               + paramCaller.getValueNumber()
               + "\\n"
               + s.getNode().getMethod().getName()
               + "\\n"
               + paramCaller.getInstruction().getCallSite().getDeclaredTarget().getName();
-        case EXC_RET_CALLEE:
-        case EXC_RET_CALLER:
-        case NORMAL_RET_CALLEE:
-        case NORMAL_RET_CALLER:
-        case PHI:
-        default:
-          return s.toString();
-      }
+        }
+        default -> s.toString();
+      };
     };
   }
 

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/Entrypoint.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/Entrypoint.java
@@ -100,16 +100,18 @@ public abstract class Entrypoint implements BytecodeConstants {
   protected int makeArgument(AbstractRootMethod m, int i) {
     TypeReference[] p = getParameterTypes(i);
     switch (p.length) {
-      case 0:
+      case 0 -> {
         return -1;
-      case 1:
+      }
+      case 1 -> {
         if (p[0].isPrimitiveType()) {
           return m.addLocal();
         } else {
           SSANewInstruction n = addNewStatement(m, p[0]);
           return (n == null) ? -1 : n.getDef();
         }
-      default:
+      }
+      default -> {
         int[] values = new int[p.length];
         int countErrors = 0;
         for (int j = 0; j < p.length; j++) {
@@ -144,6 +146,7 @@ public abstract class Entrypoint implements BytecodeConstants {
         }
 
         return m.addPhi(values);
+      }
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/ipa/slicer/HeapReachingDefs.java
+++ b/core/src/main/java/com/ibm/wala/ipa/slicer/HeapReachingDefs.java
@@ -216,23 +216,18 @@ public class HeapReachingDefs<T extends InstanceKey> {
       Map<PointerKey, MutableIntSet> pointerKeyMod = HashMapFactory.make();
       for (Statement s : domain) {
         switch (s.getKind()) {
-          case HEAP_PARAM_CALLEE:
-          case HEAP_RET_CALLER:
-            {
-              HeapStatement hs = (HeapStatement) s;
-              MutableIntSet set = findOrCreateIntSet(pointerKeyMod, hs.getLocation());
+          case HEAP_PARAM_CALLEE, HEAP_RET_CALLER -> {
+            HeapStatement hs = (HeapStatement) s;
+            MutableIntSet set = findOrCreateIntSet(pointerKeyMod, hs.getLocation());
+            set.add(domain.getMappedIndex(s));
+          }
+          default -> {
+            Collection<PointerKey> m = getMod(s, node, h, pa, exclusions);
+            for (PointerKey p : m) {
+              MutableIntSet set = findOrCreateIntSet(pointerKeyMod, p);
               set.add(domain.getMappedIndex(s));
-              break;
             }
-          default:
-            {
-              Collection<PointerKey> m = getMod(s, node, h, pa, exclusions);
-              for (PointerKey p : m) {
-                MutableIntSet set = findOrCreateIntSet(pointerKeyMod, p);
-                set.add(domain.getMappedIndex(s));
-              }
-              break;
-            }
+          }
         }
       }
       return pointerKeyMod;
@@ -346,7 +341,7 @@ public class HeapReachingDefs<T extends InstanceKey> {
         ExplodedControlFlowGraph cfg,
         Map<Integer, NormalStatement> ssaInstructionIndex2Statement) {
       switch (s.getKind()) {
-        case NORMAL:
+        case NORMAL -> {
           NormalStatement n = (NormalStatement) s;
           Collection<PointerKey> ref = modRef.getRef(node, h, pa, n.getInstruction(), exclusions);
           if (!ref.isEmpty()) {
@@ -364,75 +359,75 @@ public class HeapReachingDefs<T extends InstanceKey> {
           } else {
             return OrdinalSet.empty();
           }
-        case HEAP_RET_CALLEE:
-          {
-            HeapStatement.HeapReturnCallee r = (HeapStatement.HeapReturnCallee) s;
-            PointerKey p = r.getLocation();
-            BitVectorVariable v = solver.getIn(cfg.exit());
-            if (DEBUG) {
-              System.err.println(
-                  "computeResult " + cfg.exit() + ' ' + s + ' ' + pointerKeyMod.get(p) + ' ' + v);
-            }
-            if (pointerKeyMod.get(p) == null) {
-              return OrdinalSet.empty();
-            }
-            return new OrdinalSet<>(pointerKeyMod.get(p).intersection(v.getValue()), domain);
+        }
+        case HEAP_RET_CALLEE -> {
+          HeapStatement.HeapReturnCallee r = (HeapStatement.HeapReturnCallee) s;
+          PointerKey p = r.getLocation();
+          BitVectorVariable v = solver.getIn(cfg.exit());
+          if (DEBUG) {
+            System.err.println(
+                "computeResult " + cfg.exit() + ' ' + s + ' ' + pointerKeyMod.get(p) + ' ' + v);
           }
-        case HEAP_RET_CALLER:
-          {
-            HeapStatement.HeapReturnCaller r = (HeapStatement.HeapReturnCaller) s;
-            ISSABasicBlock bb = cfg.getBlockForInstruction(r.getCallIndex());
-            BitVectorVariable v = solver.getIn(bb);
-            if (allCalleesMod(cg, r, mod)
-                || pointerKeyMod.get(r.getLocation()) == null
-                || v.getValue() == null) {
-              // do nothing ... force flow into and out of the callees
-              return OrdinalSet.empty();
-            } else {
-              // the defs that flow to the call may flow to this return, since
-              // the callees may have no relevant effect.
-              return new OrdinalSet<>(
-                  pointerKeyMod.get(r.getLocation()).intersection(v.getValue()), domain);
-            }
+          if (pointerKeyMod.get(p) == null) {
+            return OrdinalSet.empty();
           }
-        case HEAP_PARAM_CALLER:
-          {
-            HeapStatement.HeapParamCaller r = (HeapStatement.HeapParamCaller) s;
-            NormalStatement call = ssaInstructionIndex2Statement.get(r.getCallIndex());
-            ISSABasicBlock callBlock = cfg.getBlockForInstruction(call.getInstructionIndex());
-            if (callBlock.isEntryBlock()) {
-              int x =
-                  domain.getMappedIndex(new HeapStatement.HeapParamCallee(node, r.getLocation()));
-              assert x >= 0;
-              IntSet xset = SparseIntSet.singleton(x);
-              return new OrdinalSet<>(xset, domain);
-            }
-            BitVectorVariable v = solver.getIn(callBlock);
-            if (pointerKeyMod.get(r.getLocation()) == null || v.getValue() == null) {
-              // do nothing ... force flow into and out of the callees
-              return OrdinalSet.empty();
-            } else {
-              return new OrdinalSet<>(
-                  pointerKeyMod.get(r.getLocation()).intersection(v.getValue()), domain);
-            }
+          return new OrdinalSet<>(pointerKeyMod.get(p).intersection(v.getValue()), domain);
+        }
+        case HEAP_RET_CALLER -> {
+          HeapReturnCaller r = (HeapReturnCaller) s;
+          ISSABasicBlock bb = cfg.getBlockForInstruction(r.getCallIndex());
+          BitVectorVariable v = solver.getIn(bb);
+          if (allCalleesMod(cg, r, mod)
+              || pointerKeyMod.get(r.getLocation()) == null
+              || v.getValue() == null) {
+            // do nothing ... force flow into and out of the callees
+            return OrdinalSet.empty();
+          } else {
+            // the defs that flow to the call may flow to this return, since
+            // the callees may have no relevant effect.
+            return new OrdinalSet<>(
+                pointerKeyMod.get(r.getLocation()).intersection(v.getValue()), domain);
           }
-        case HEAP_PARAM_CALLEE:
+        }
+        case HEAP_PARAM_CALLER -> {
+          HeapStatement.HeapParamCaller r = (HeapStatement.HeapParamCaller) s;
+          NormalStatement call = ssaInstructionIndex2Statement.get(r.getCallIndex());
+          ISSABasicBlock callBlock = cfg.getBlockForInstruction(call.getInstructionIndex());
+          if (callBlock.isEntryBlock()) {
+            int x = domain.getMappedIndex(new HeapStatement.HeapParamCallee(node, r.getLocation()));
+            assert x >= 0;
+            IntSet xset = SparseIntSet.singleton(x);
+            return new OrdinalSet<>(xset, domain);
+          }
+          BitVectorVariable v = solver.getIn(callBlock);
+          if (pointerKeyMod.get(r.getLocation()) == null || v.getValue() == null) {
+            // do nothing ... force flow into and out of the callees
+            return OrdinalSet.empty();
+          } else {
+            return new OrdinalSet<>(
+                pointerKeyMod.get(r.getLocation()).intersection(v.getValue()), domain);
+          }
+        }
+
         // no statements in this method will def the heap being passed in
-        case NORMAL_RET_CALLEE:
-        case NORMAL_RET_CALLER:
-        case PARAM_CALLEE:
-        case PARAM_CALLER:
-        case EXC_RET_CALLEE:
-        case EXC_RET_CALLER:
-        case PHI:
-        case PI:
-        case CATCH:
-        case METHOD_ENTRY:
-        case METHOD_EXIT:
+        case HEAP_PARAM_CALLEE,
+            NORMAL_RET_CALLEE,
+            NORMAL_RET_CALLER,
+            PARAM_CALLEE,
+            PARAM_CALLER,
+            EXC_RET_CALLEE,
+            EXC_RET_CALLER,
+            PHI,
+            PI,
+            CATCH,
+            METHOD_ENTRY,
+            METHOD_EXIT -> {
           return OrdinalSet.empty();
-        default:
+        }
+        default -> {
           Assertions.UNREACHABLE(s.getKind().toString());
           return null;
+        }
       }
     }
   }
@@ -475,33 +470,31 @@ public class HeapReachingDefs<T extends InstanceKey> {
       ExtendedHeapModel h,
       PointerAnalysis<T> pa,
       HeapExclusions exclusions) {
-    switch (s.getKind()) {
-      case NORMAL:
+    return switch (s.getKind()) {
+      case NORMAL -> {
         NormalStatement ns = (NormalStatement) s;
-        return modRef.getMod(n, h, pa, ns.getInstruction(), exclusions);
-      case HEAP_PARAM_CALLEE:
-      case HEAP_RET_CALLER:
+        yield modRef.getMod(n, h, pa, ns.getInstruction(), exclusions);
+      }
+      case HEAP_PARAM_CALLEE, HEAP_RET_CALLER -> {
         HeapStatement hs = (HeapStatement) s;
-        return Collections.singleton(hs.getLocation());
-      case HEAP_RET_CALLEE:
-      case HEAP_PARAM_CALLER:
-      case EXC_RET_CALLEE:
-      case EXC_RET_CALLER:
-      case NORMAL_RET_CALLEE:
-      case NORMAL_RET_CALLER:
-      case PARAM_CALLEE:
-      case PARAM_CALLER:
-      case PHI:
-      case PI:
-      case METHOD_ENTRY:
-      case METHOD_EXIT:
-      case CATCH:
-        // doesn't mod anything in the heap.
-        return Collections.emptySet();
-      default:
-        Assertions.UNREACHABLE(s.getKind() + " " + s);
-        return null;
-    }
+        yield Collections.singleton(hs.getLocation());
+      }
+      case HEAP_RET_CALLEE,
+          HEAP_PARAM_CALLER,
+          EXC_RET_CALLEE,
+          EXC_RET_CALLER,
+          NORMAL_RET_CALLEE,
+          NORMAL_RET_CALLER,
+          PARAM_CALLEE,
+          PARAM_CALLER,
+          PHI,
+          PI,
+          METHOD_ENTRY,
+          METHOD_EXIT,
+          CATCH ->
+          // doesn't mod anything in the heap.
+          Collections.emptySet();
+    };
   }
 
   /** map each SSAInstruction index to the NormalStatement which represents it. */

--- a/core/src/main/java/com/ibm/wala/ipa/slicer/PDG.java
+++ b/core/src/main/java/com/ibm/wala/ipa/slicer/PDG.java
@@ -445,92 +445,83 @@ public class PDG<T extends InstanceKey> implements NumberedLabeledGraph<Statemen
 
     for (Statement s : this) {
       switch (s.getKind()) {
-        case NORMAL:
-        case CATCH:
-        case PI:
-        case PHI:
-          {
-            SSAInstruction statement = statement2SSAInstruction(instructions, s);
-            // note that data dependencies from invoke instructions will pass
-            // interprocedurally
-            if (!(statement instanceof SSAAbstractInvokeInstruction)) {
-              if (dOptions.isTerminateAtCast() && (statement instanceof SSACheckCastInstruction)) {
-                break;
-              }
-              if (dOptions.isTerminateAtCast() && (statement instanceof SSAInstanceofInstruction)) {
-                break;
-              }
-              // add edges from this statement to every use of the def of this
-              // statement
-              for (int i = 0; i < statement.getNumberOfDefs(); i++) {
-                int def = statement.getDef(i);
-                for (SSAInstruction use : Iterator2Iterable.make(DU.getUses(def))) {
-                  if (dOptions.isIgnoreBasePtrs()) {
-                    if (use instanceof SSANewInstruction) {
-                      // cut out array length parameters
-                      continue;
-                    }
-                    if (hasBasePointer(use)) {
-                      int base = getBasePointer(use);
-                      if (def == base) {
-                        // skip the edge to the base pointer
-                        continue;
-                      }
-                      if (use instanceof SSAArrayReferenceInstruction) {
-                        SSAArrayReferenceInstruction arr = (SSAArrayReferenceInstruction) use;
-                        if (def == arr.getIndex()) {
-                          // skip the edge to the array index
-                          continue;
-                        }
-                      }
-                    }
-                  }
-                  Statement u = ssaInstruction2Statement(use, ir, instructionIndices);
-                  delegate.addEdge(s, u, Dependency.DATA_DEP);
-                }
-              }
+        case NORMAL, CATCH, PI, PHI -> {
+          SSAInstruction statement = statement2SSAInstruction(instructions, s);
+          // note that data dependencies from invoke instructions will pass
+          // interprocedurally
+          if (!(statement instanceof SSAAbstractInvokeInstruction)) {
+            if (dOptions.isTerminateAtCast() && (statement instanceof SSACheckCastInstruction)) {
+              break;
             }
-            break;
-          }
-        case EXC_RET_CALLER:
-        case NORMAL_RET_CALLER:
-        case PARAM_CALLEE:
-          {
-            assert !dOptions.isIgnoreExceptions() || !s.getKind().equals(Kind.EXC_RET_CALLER);
-
-            ValueNumberCarrier a = (ValueNumberCarrier) s;
-            for (SSAInstruction use : Iterator2Iterable.make(DU.getUses(a.getValueNumber()))) {
-              if (dOptions.isIgnoreBasePtrs()) {
-                if (use instanceof SSANewInstruction) {
-                  // cut out array length parameters
-                  continue;
-                }
-                if (hasBasePointer(use)) {
-                  int base = getBasePointer(use);
-                  if (a.getValueNumber() == base) {
-                    // skip the edge to the base pointer
+            if (dOptions.isTerminateAtCast() && (statement instanceof SSAInstanceofInstruction)) {
+              break;
+            }
+            // add edges from this statement to every use of the def of this
+            // statement
+            for (int i = 0; i < statement.getNumberOfDefs(); i++) {
+              int def = statement.getDef(i);
+              for (SSAInstruction use : Iterator2Iterable.make(DU.getUses(def))) {
+                if (dOptions.isIgnoreBasePtrs()) {
+                  if (use instanceof SSANewInstruction) {
+                    // cut out array length parameters
                     continue;
                   }
-                  if (use instanceof SSAArrayReferenceInstruction) {
-                    SSAArrayReferenceInstruction arr = (SSAArrayReferenceInstruction) use;
-                    if (a.getValueNumber() == arr.getIndex()) {
-                      // skip the edge to the array index
+                  if (hasBasePointer(use)) {
+                    int base = getBasePointer(use);
+                    if (def == base) {
+                      // skip the edge to the base pointer
                       continue;
+                    }
+                    if (use instanceof SSAArrayReferenceInstruction) {
+                      SSAArrayReferenceInstruction arr = (SSAArrayReferenceInstruction) use;
+                      if (def == arr.getIndex()) {
+                        // skip the edge to the array index
+                        continue;
+                      }
                     }
                   }
                 }
+                Statement u = ssaInstruction2Statement(use, ir, instructionIndices);
+                delegate.addEdge(s, u, Dependency.DATA_DEP);
               }
-              Statement u = ssaInstruction2Statement(use, ir, instructionIndices);
-              delegate.addEdge(s, u, Dependency.DATA_DEP);
             }
-            break;
           }
-        case NORMAL_RET_CALLEE:
+        }
+        case EXC_RET_CALLER, NORMAL_RET_CALLER, PARAM_CALLEE -> {
+          assert !dOptions.isIgnoreExceptions() || !s.getKind().equals(Kind.EXC_RET_CALLER);
+
+          ValueNumberCarrier a = (ValueNumberCarrier) s;
+          for (SSAInstruction use : Iterator2Iterable.make(DU.getUses(a.getValueNumber()))) {
+            if (dOptions.isIgnoreBasePtrs()) {
+              if (use instanceof SSANewInstruction) {
+                // cut out array length parameters
+                continue;
+              }
+              if (hasBasePointer(use)) {
+                int base = getBasePointer(use);
+                if (a.getValueNumber() == base) {
+                  // skip the edge to the base pointer
+                  continue;
+                }
+                if (use instanceof SSAArrayReferenceInstruction) {
+                  SSAArrayReferenceInstruction arr = (SSAArrayReferenceInstruction) use;
+                  if (a.getValueNumber() == arr.getIndex()) {
+                    // skip the edge to the array index
+                    continue;
+                  }
+                }
+              }
+            }
+            Statement u = ssaInstruction2Statement(use, ir, instructionIndices);
+            delegate.addEdge(s, u, Dependency.DATA_DEP);
+          }
+        }
+        case NORMAL_RET_CALLEE -> {
           for (NormalStatement ret : computeReturnStatements(ir)) {
             delegate.addEdge(ret, s, Dependency.DATA_DEP);
           }
-          break;
-        case EXC_RET_CALLEE:
+        }
+        case EXC_RET_CALLEE -> {
           if (dOptions.isIgnoreExceptions()) {
             Assertions.UNREACHABLE();
           }
@@ -550,56 +541,50 @@ public class PDG<T extends InstanceKey> implements NumberedLabeledGraph<Statemen
               delegate.addEdge(new NormalStatement(node, index), s, Dependency.DATA_DEP);
             }
           }
-          break;
-        case PARAM_CALLER:
-          {
-            ParamCaller pac = (ParamCaller) s;
-            int vn = pac.getValueNumber();
-            // note that if the caller is the fake root method and the parameter
-            // type is primitive,
-            // it's possible to have a value number of -1. If so, just ignore it.
-            if (vn > -1) {
-              if (ir.getSymbolTable().isParameter(vn)) {
-                Statement a = new ParamCallee(node, vn);
-                delegate.addEdge(a, pac, Dependency.DATA_DEP);
-              } else {
-                SSAInstruction d = DU.getDef(vn);
-                if (dOptions.isTerminateAtCast() && (d instanceof SSACheckCastInstruction)) {
-                  break;
-                }
-                if (d != null) {
-                  if (d instanceof SSAAbstractInvokeInstruction) {
-                    SSAAbstractInvokeInstruction call = (SSAAbstractInvokeInstruction) d;
-                    if (vn == call.getException()) {
-                      if (!dOptions.isIgnoreExceptions()) {
-                        Statement st = new ExceptionalReturnCaller(node, instructionIndices.get(d));
-                        delegate.addEdge(st, pac, Dependency.DATA_DEP);
-                      }
-                    } else {
-                      Statement st = new NormalReturnCaller(node, instructionIndices.get(d));
+        }
+        case PARAM_CALLER -> {
+          ParamCaller pac = (ParamCaller) s;
+          int vn = pac.getValueNumber();
+          // note that if the caller is the fake root method and the parameter
+          // type is primitive,
+          // it's possible to have a value number of -1. If so, just ignore it.
+          if (vn > -1) {
+            if (ir.getSymbolTable().isParameter(vn)) {
+              Statement a = new ParamCallee(node, vn);
+              delegate.addEdge(a, pac, Dependency.DATA_DEP);
+            } else {
+              SSAInstruction d = DU.getDef(vn);
+              if (dOptions.isTerminateAtCast() && (d instanceof SSACheckCastInstruction)) {
+                break;
+              }
+              if (d != null) {
+                if (d instanceof SSAAbstractInvokeInstruction) {
+                  SSAAbstractInvokeInstruction call = (SSAAbstractInvokeInstruction) d;
+                  if (vn == call.getException()) {
+                    if (!dOptions.isIgnoreExceptions()) {
+                      Statement st = new ExceptionalReturnCaller(node, instructionIndices.get(d));
                       delegate.addEdge(st, pac, Dependency.DATA_DEP);
                     }
                   } else {
-                    Statement ds = ssaInstruction2Statement(d, ir, instructionIndices);
-                    delegate.addEdge(ds, pac, Dependency.DATA_DEP);
+                    Statement st = new NormalReturnCaller(node, instructionIndices.get(d));
+                    delegate.addEdge(st, pac, Dependency.DATA_DEP);
                   }
+                } else {
+                  Statement ds = ssaInstruction2Statement(d, ir, instructionIndices);
+                  delegate.addEdge(ds, pac, Dependency.DATA_DEP);
                 }
               }
             }
           }
-          break;
-
-        case HEAP_RET_CALLEE:
-        case HEAP_RET_CALLER:
-        case HEAP_PARAM_CALLER:
-        case HEAP_PARAM_CALLEE:
-        case METHOD_ENTRY:
-        case METHOD_EXIT:
+        }
+        case HEAP_RET_CALLEE,
+            HEAP_RET_CALLER,
+            HEAP_PARAM_CALLER,
+            HEAP_PARAM_CALLEE,
+            METHOD_ENTRY,
+            METHOD_EXIT -> {
           // do nothing
-          break;
-        default:
-          Assertions.UNREACHABLE(s.toString());
-          break;
+        }
       }
     }
   }
@@ -706,46 +691,31 @@ public class PDG<T extends InstanceKey> implements NumberedLabeledGraph<Statemen
 
     for (Map.Entry<Statement, OrdinalSet<Statement>> entry : heapReachingDefs.entrySet()) {
       switch (entry.getKey().getKind()) {
-        case NORMAL:
-        case CATCH:
-        case PHI:
-        case PI:
-          {
-            OrdinalSet<Statement> defs = entry.getValue();
-            if (defs != null) {
-              for (Statement def : defs) {
-                delegate.addEdge(def, entry.getKey(), Dependency.HEAP_DATA_DEP);
-              }
+        case NORMAL, CATCH, PHI, PI -> {
+          OrdinalSet<Statement> defs = entry.getValue();
+          if (defs != null) {
+            for (Statement def : defs) {
+              delegate.addEdge(def, entry.getKey(), Dependency.HEAP_DATA_DEP);
             }
           }
-          break;
-        case EXC_RET_CALLER:
-        case NORMAL_RET_CALLER:
-        case PARAM_CALLEE:
-        case NORMAL_RET_CALLEE:
-        case PARAM_CALLER:
-        case EXC_RET_CALLEE:
-          break;
-        case HEAP_RET_CALLEE:
-        case HEAP_RET_CALLER:
-        case HEAP_PARAM_CALLER:
-          {
-            OrdinalSet<Statement> defs = entry.getValue();
-            if (defs != null) {
-              for (Statement def : defs) {
-                delegate.addEdge(def, entry.getKey(), Dependency.DATA_DEP);
-              }
+        }
+        case EXC_RET_CALLER,
+            NORMAL_RET_CALLER,
+            PARAM_CALLEE,
+            NORMAL_RET_CALLEE,
+            PARAM_CALLER,
+            EXC_RET_CALLEE -> {}
+        case HEAP_RET_CALLEE, HEAP_RET_CALLER, HEAP_PARAM_CALLER -> {
+          OrdinalSet<Statement> defs = entry.getValue();
+          if (defs != null) {
+            for (Statement def : defs) {
+              delegate.addEdge(def, entry.getKey(), Dependency.DATA_DEP);
             }
-            break;
           }
-        case HEAP_PARAM_CALLEE:
-        case METHOD_ENTRY:
-        case METHOD_EXIT:
+        }
+        case HEAP_PARAM_CALLEE, METHOD_ENTRY, METHOD_EXIT -> {
           // do nothing .. there are no incoming edges
-          break;
-        default:
-          Assertions.UNREACHABLE(entry.getKey().toString());
-          break;
+        }
       }
     }
   }
@@ -868,24 +838,23 @@ public class PDG<T extends InstanceKey> implements NumberedLabeledGraph<Statemen
       SSAInstruction[] instructions, Statement s) {
     SSAInstruction statement = null;
     switch (s.getKind()) {
-      case NORMAL:
+      case NORMAL -> {
         NormalStatement n = (NormalStatement) s;
         statement = instructions[n.getInstructionIndex()];
-        break;
-      case PHI:
+      }
+      case PHI -> {
         PhiStatement p = (PhiStatement) s;
         statement = p.getPhi();
-        break;
-      case PI:
+      }
+      case PI -> {
         PiStatement ps = (PiStatement) s;
         statement = ps.getPi();
-        break;
-      case CATCH:
+      }
+      case CATCH -> {
         GetCaughtExceptionStatement g = (GetCaughtExceptionStatement) s;
         statement = g.getInstruction();
-        break;
-      default:
-        Assertions.UNREACHABLE(s.toString());
+      }
+      default -> Assertions.UNREACHABLE(s.toString());
     }
     return statement;
   }
@@ -1115,7 +1084,7 @@ public class PDG<T extends InstanceKey> implements NumberedLabeledGraph<Statemen
 
   private void computeIncomingHeapDependencies(Statement N) {
     switch (N.getKind()) {
-      case NORMAL:
+      case NORMAL -> {
         NormalStatement st = (NormalStatement) N;
         if (!(ignoreAllocHeapDefs && st.getInstruction() instanceof SSANewInstruction)) {
           Collection<PointerKey> ref =
@@ -1124,22 +1093,20 @@ public class PDG<T extends InstanceKey> implements NumberedLabeledGraph<Statemen
             createHeapDataDependenceEdges(pk);
           }
         }
-        break;
-      case HEAP_PARAM_CALLEE:
-      case HEAP_PARAM_CALLER:
-      case HEAP_RET_CALLEE:
-      case HEAP_RET_CALLER:
+      }
+      case HEAP_PARAM_CALLEE, HEAP_PARAM_CALLER, HEAP_RET_CALLEE, HEAP_RET_CALLER -> {
         HeapStatement h = (HeapStatement) N;
         createHeapDataDependenceEdges(h.getLocation());
-        break;
-      default:
+      }
+      default -> {
         // do nothing
+      }
     }
   }
 
   private void computeOutgoingHeapDependencies(Statement N) {
     switch (N.getKind()) {
-      case NORMAL:
+      case NORMAL -> {
         NormalStatement st = (NormalStatement) N;
         if (!(ignoreAllocHeapDefs && st.getInstruction() instanceof SSANewInstruction)) {
           Collection<PointerKey> mod =
@@ -1148,16 +1115,14 @@ public class PDG<T extends InstanceKey> implements NumberedLabeledGraph<Statemen
             createHeapDataDependenceEdges(pk);
           }
         }
-        break;
-      case HEAP_PARAM_CALLEE:
-      case HEAP_PARAM_CALLER:
-      case HEAP_RET_CALLEE:
-      case HEAP_RET_CALLER:
+      }
+      case HEAP_PARAM_CALLEE, HEAP_PARAM_CALLER, HEAP_RET_CALLEE, HEAP_RET_CALLER -> {
         HeapStatement h = (HeapStatement) N;
         createHeapDataDependenceEdges(h.getLocation());
-        break;
-      default:
+      }
+      default -> {
         // do nothing
+      }
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/ipa/slicer/SDG.java
+++ b/core/src/main/java/com/ibm/wala/ipa/slicer/SDG.java
@@ -288,140 +288,136 @@ public class SDG<T extends InstanceKey> extends AbstractNumberedGraph<Statement>
       }
       addPDGStatementNodes(N.getNode());
       switch (N.getKind()) {
-        case NORMAL:
-        case PHI:
-        case PI:
-        case EXC_RET_CALLEE:
-        case NORMAL_RET_CALLEE:
-        case PARAM_CALLER:
-        case HEAP_PARAM_CALLER:
-        case HEAP_RET_CALLEE:
-        case CATCH:
-        case METHOD_EXIT:
+        case NORMAL,
+            PHI,
+            PI,
+            EXC_RET_CALLEE,
+            NORMAL_RET_CALLEE,
+            PARAM_CALLER,
+            HEAP_PARAM_CALLER,
+            HEAP_RET_CALLEE,
+            CATCH,
+            METHOD_EXIT -> {
           return getPDG(N.getNode()).getPredNodes(N);
-        case EXC_RET_CALLER:
-          {
-            ExceptionalReturnCaller nrc = (ExceptionalReturnCaller) N;
-            SSAAbstractInvokeInstruction call = nrc.getInstruction();
-            Collection<Statement> result =
-                Iterator2Collection.toSet(getPDG(N.getNode()).getPredNodes(N));
-            if (!dOptions.equals(DataDependenceOptions.NONE)) {
-              // data dependence predecessors
-              for (CGNode t : cg.getPossibleTargets(N.getNode(), call.getCallSite())) {
-                Statement s = new ExceptionalReturnCallee(t);
+        }
+        case EXC_RET_CALLER -> {
+          ExceptionalReturnCaller nrc = (ExceptionalReturnCaller) N;
+          SSAAbstractInvokeInstruction call = nrc.getInstruction();
+          Collection<Statement> result =
+              Iterator2Collection.toSet(getPDG(N.getNode()).getPredNodes(N));
+          if (!dOptions.equals(DataDependenceOptions.NONE)) {
+            // data dependence predecessors
+            for (CGNode t : cg.getPossibleTargets(N.getNode(), call.getCallSite())) {
+              Statement s = new ExceptionalReturnCallee(t);
+              addNode(s);
+              result.add(s);
+            }
+          }
+          return result.iterator();
+        }
+        case NORMAL_RET_CALLER -> {
+          NormalReturnCaller nrc = (NormalReturnCaller) N;
+          SSAAbstractInvokeInstruction call = nrc.getInstruction();
+          Collection<Statement> result =
+              Iterator2Collection.toSet(getPDG(N.getNode()).getPredNodes(N));
+          if (!dOptions.equals(DataDependenceOptions.NONE)) {
+            // data dependence predecessors
+            for (CGNode t : cg.getPossibleTargets(N.getNode(), call.getCallSite())) {
+              Statement s = new NormalReturnCallee(t);
+              addNode(s);
+              result.add(s);
+            }
+          }
+          return result.iterator();
+        }
+        case HEAP_RET_CALLER -> {
+          HeapStatement.HeapReturnCaller r = (HeapStatement.HeapReturnCaller) N;
+          SSAAbstractInvokeInstruction call = r.getCall();
+          Collection<Statement> result =
+              Iterator2Collection.toSet(getPDG(N.getNode()).getPredNodes(N));
+          if (!dOptions.equals(DataDependenceOptions.NONE)) {
+            // data dependence predecessors
+            for (CGNode t : cg.getPossibleTargets(N.getNode(), call.getCallSite())) {
+              if (mod.get(t).contains(r.getLocation())) {
+                Statement s = new HeapStatement.HeapReturnCallee(t, r.getLocation());
                 addNode(s);
                 result.add(s);
               }
             }
-            return result.iterator();
           }
-        case NORMAL_RET_CALLER:
-          {
-            NormalReturnCaller nrc = (NormalReturnCaller) N;
-            SSAAbstractInvokeInstruction call = nrc.getInstruction();
-            Collection<Statement> result =
-                Iterator2Collection.toSet(getPDG(N.getNode()).getPredNodes(N));
-            if (!dOptions.equals(DataDependenceOptions.NONE)) {
-              // data dependence predecessors
-              for (CGNode t : cg.getPossibleTargets(N.getNode(), call.getCallSite())) {
-                Statement s = new NormalReturnCallee(t);
-                addNode(s);
-                result.add(s);
-              }
-            }
-            return result.iterator();
-          }
-        case HEAP_RET_CALLER:
-          {
-            HeapStatement.HeapReturnCaller r = (HeapStatement.HeapReturnCaller) N;
-            SSAAbstractInvokeInstruction call = r.getCall();
-            Collection<Statement> result =
-                Iterator2Collection.toSet(getPDG(N.getNode()).getPredNodes(N));
-            if (!dOptions.equals(DataDependenceOptions.NONE)) {
-              // data dependence predecessors
-              for (CGNode t : cg.getPossibleTargets(N.getNode(), call.getCallSite())) {
-                if (mod.get(t).contains(r.getLocation())) {
-                  Statement s = new HeapStatement.HeapReturnCallee(t, r.getLocation());
-                  addNode(s);
-                  result.add(s);
-                }
-              }
-            }
-            return result.iterator();
-          }
-        case PARAM_CALLEE:
-          {
-            ParamCallee pac = (ParamCallee) N;
-            int parameterIndex = pac.getValueNumber() - 1;
-            Collection<Statement> result = HashSetFactory.make(5);
-            if (!dOptions.equals(DataDependenceOptions.NONE)) {
+          return result.iterator();
+        }
+        case PARAM_CALLEE -> {
+          ParamCallee pac = (ParamCallee) N;
+          int parameterIndex = pac.getValueNumber() - 1;
+          Collection<Statement> result = HashSetFactory.make(5);
+          if (!dOptions.equals(DataDependenceOptions.NONE)) {
 
-              if (dOptions.isTerminateAtCast()
-                  && !pac.getNode().getMethod().isStatic()
-                  && pac.getValueNumber() == 1) {
-                // a virtual dispatch is just like a cast. No flow.
-                return EmptyIterator.instance();
-              }
-              if (dOptions.isTerminateAtCast() && isUninformativeForReflection(pac.getNode())) {
-                // don't track flow for reflection
-                return EmptyIterator.instance();
-              }
-
-              // data dependence predecessors
-              for (CGNode caller : Iterator2Iterable.make(cg.getPredNodes(N.getNode()))) {
-                for (CallSiteReference site :
-                    Iterator2Iterable.make(cg.getPossibleSites(caller, N.getNode()))) {
-                  IR ir = caller.getIR();
-                  IntSet indices = ir.getCallInstructionIndices(site);
-                  for (IntIterator ii = indices.intIterator(); ii.hasNext(); ) {
-                    int i = ii.next();
-                    SSAAbstractInvokeInstruction call =
-                        (SSAAbstractInvokeInstruction) ir.getInstructions()[i];
-                    if (call.getNumberOfUses() > parameterIndex) {
-                      int p = call.getUse(parameterIndex);
-                      Statement s = new ParamCaller(caller, i, p);
-                      addNode(s);
-                      result.add(s);
-                    }
-                  }
-                }
-              }
+            if (dOptions.isTerminateAtCast()
+                && !pac.getNode().getMethod().isStatic()
+                && pac.getValueNumber() == 1) {
+              // a virtual dispatch is just like a cast. No flow.
+              return EmptyIterator.instance();
             }
-            // if (!cOptions.equals(ControlDependenceOptions.NONE)) {
-            // Statement s = new MethodEntryStatement(N.getNode());
-            // addNode(s);
-            // result.add(s);
-            // }
-            return result.iterator();
-          }
-        case HEAP_PARAM_CALLEE:
-          {
-            HeapStatement.HeapParamCallee hpc = (HeapStatement.HeapParamCallee) N;
-            Collection<Statement> result = HashSetFactory.make(5);
-            if (!dOptions.equals(DataDependenceOptions.NONE)) {
-              // data dependence predecessors
-              for (CGNode caller : Iterator2Iterable.make(cg.getPredNodes(N.getNode()))) {
-                for (CallSiteReference site :
-                    Iterator2Iterable.make(cg.getPossibleSites(caller, N.getNode()))) {
-                  IR ir = caller.getIR();
-                  IntSet indices = ir.getCallInstructionIndices(site);
-                  for (IntIterator ii = indices.intIterator(); ii.hasNext(); ) {
-                    int i = ii.next();
-                    Statement s = new HeapStatement.HeapParamCaller(caller, i, hpc.getLocation());
+            if (dOptions.isTerminateAtCast() && isUninformativeForReflection(pac.getNode())) {
+              // don't track flow for reflection
+              return EmptyIterator.instance();
+            }
+
+            // data dependence predecessors
+            for (CGNode caller : Iterator2Iterable.make(cg.getPredNodes(N.getNode()))) {
+              for (CallSiteReference site :
+                  Iterator2Iterable.make(cg.getPossibleSites(caller, N.getNode()))) {
+                IR ir = caller.getIR();
+                IntSet indices = ir.getCallInstructionIndices(site);
+                for (IntIterator ii = indices.intIterator(); ii.hasNext(); ) {
+                  int i = ii.next();
+                  SSAAbstractInvokeInstruction call =
+                      (SSAAbstractInvokeInstruction) ir.getInstructions()[i];
+                  if (call.getNumberOfUses() > parameterIndex) {
+                    int p = call.getUse(parameterIndex);
+                    Statement s = new ParamCaller(caller, i, p);
                     addNode(s);
                     result.add(s);
                   }
                 }
               }
             }
-            // if (!cOptions.equals(ControlDependenceOptions.NONE)) {
-            // Statement s = new MethodEntryStatement(N.getNode());
-            // addNode(s);
-            // result.add(s);
-            // }
-            return result.iterator();
           }
-        case METHOD_ENTRY:
+          // if (!cOptions.equals(ControlDependenceOptions.NONE)) {
+          // Statement s = new MethodEntryStatement(N.getNode());
+          // addNode(s);
+          // result.add(s);
+          // }
+          return result.iterator();
+        }
+        case HEAP_PARAM_CALLEE -> {
+          HeapStatement.HeapParamCallee hpc = (HeapStatement.HeapParamCallee) N;
+          Collection<Statement> result = HashSetFactory.make(5);
+          if (!dOptions.equals(DataDependenceOptions.NONE)) {
+            // data dependence predecessors
+            for (CGNode caller : Iterator2Iterable.make(cg.getPredNodes(N.getNode()))) {
+              for (CallSiteReference site :
+                  Iterator2Iterable.make(cg.getPossibleSites(caller, N.getNode()))) {
+                IR ir = caller.getIR();
+                IntSet indices = ir.getCallInstructionIndices(site);
+                for (IntIterator ii = indices.intIterator(); ii.hasNext(); ) {
+                  int i = ii.next();
+                  Statement s = new HeapStatement.HeapParamCaller(caller, i, hpc.getLocation());
+                  addNode(s);
+                  result.add(s);
+                }
+              }
+            }
+          }
+          // if (!cOptions.equals(ControlDependenceOptions.NONE)) {
+          // Statement s = new MethodEntryStatement(N.getNode());
+          // addNode(s);
+          // result.add(s);
+          // }
+          return result.iterator();
+        }
+        case METHOD_ENTRY -> {
           Collection<Statement> result = HashSetFactory.make(5);
           if (!cOptions.isIgnoreInterproc()) {
             for (CGNode caller : Iterator2Iterable.make(cg.getPredNodes(N.getNode()))) {
@@ -439,9 +435,11 @@ public class SDG<T extends InstanceKey> extends AbstractNumberedGraph<Statement>
             }
           }
           return result.iterator();
-        default:
+        }
+        default -> {
           Assertions.UNREACHABLE(N.getKind().toString());
           return null;
+        }
       }
     }
 
@@ -457,7 +455,7 @@ public class SDG<T extends InstanceKey> extends AbstractNumberedGraph<Statement>
       }
       addPDGStatementNodes(N.getNode());
       switch (N.getKind()) {
-        case NORMAL:
+        case NORMAL -> {
           if (cOptions.isIgnoreInterproc()) {
             return getPDG(N.getNode()).getSuccNodes(N);
           } else {
@@ -476,117 +474,115 @@ public class SDG<T extends InstanceKey> extends AbstractNumberedGraph<Statement>
               return getPDG(N.getNode()).getSuccNodes(N);
             }
           }
-        case PHI:
-        case PI:
-        case CATCH:
-        case EXC_RET_CALLER:
-        case NORMAL_RET_CALLER:
-        case PARAM_CALLEE:
-        case HEAP_PARAM_CALLEE:
-        case HEAP_RET_CALLER:
-        case METHOD_ENTRY:
-        case METHOD_EXIT:
+        }
+        case PHI,
+            PI,
+            CATCH,
+            EXC_RET_CALLER,
+            NORMAL_RET_CALLER,
+            PARAM_CALLEE,
+            HEAP_PARAM_CALLEE,
+            HEAP_RET_CALLER,
+            METHOD_ENTRY,
+            METHOD_EXIT -> {
           return getPDG(N.getNode()).getSuccNodes(N);
-        case EXC_RET_CALLEE:
-          {
-            Collection<Statement> result = HashSetFactory.make(5);
-            if (!dOptions.equals(DataDependenceOptions.NONE)) {
-              // data dependence predecessors
-              for (CGNode caller : Iterator2Iterable.make(cg.getPredNodes(N.getNode()))) {
-                for (CallSiteReference site :
-                    Iterator2Iterable.make(cg.getPossibleSites(caller, N.getNode()))) {
-                  IR ir = caller.getIR();
-                  IntSet indices = ir.getCallInstructionIndices(site);
-                  for (IntIterator ii = indices.intIterator(); ii.hasNext(); ) {
-                    int i = ii.next();
-                    Statement s = new ExceptionalReturnCaller(caller, i);
-                    addNode(s);
-                    result.add(s);
-                  }
+        }
+        case EXC_RET_CALLEE -> {
+          Collection<Statement> result = HashSetFactory.make(5);
+          if (!dOptions.equals(DataDependenceOptions.NONE)) {
+            // data dependence predecessors
+            for (CGNode caller : Iterator2Iterable.make(cg.getPredNodes(N.getNode()))) {
+              for (CallSiteReference site :
+                  Iterator2Iterable.make(cg.getPossibleSites(caller, N.getNode()))) {
+                IR ir = caller.getIR();
+                IntSet indices = ir.getCallInstructionIndices(site);
+                for (IntIterator ii = indices.intIterator(); ii.hasNext(); ) {
+                  int i = ii.next();
+                  Statement s = new ExceptionalReturnCaller(caller, i);
+                  addNode(s);
+                  result.add(s);
                 }
               }
             }
-            return result.iterator();
           }
-        case NORMAL_RET_CALLEE:
-          {
-            Collection<Statement> result = HashSetFactory.make(5);
-            if (!dOptions.equals(DataDependenceOptions.NONE)) {
-              // data dependence predecessors
-              for (CGNode caller : Iterator2Iterable.make(cg.getPredNodes(N.getNode()))) {
-                for (CallSiteReference site :
-                    Iterator2Iterable.make(cg.getPossibleSites(caller, N.getNode()))) {
-                  IR ir = caller.getIR();
-                  IntSet indices = ir.getCallInstructionIndices(site);
-                  for (IntIterator ii = indices.intIterator(); ii.hasNext(); ) {
-                    int i = ii.next();
-                    Statement s = new NormalReturnCaller(caller, i);
-                    addNode(s);
-                    result.add(s);
-                  }
+          return result.iterator();
+        }
+        case NORMAL_RET_CALLEE -> {
+          Collection<Statement> result = HashSetFactory.make(5);
+          if (!dOptions.equals(DataDependenceOptions.NONE)) {
+            // data dependence predecessors
+            for (CGNode caller : Iterator2Iterable.make(cg.getPredNodes(N.getNode()))) {
+              for (CallSiteReference site :
+                  Iterator2Iterable.make(cg.getPossibleSites(caller, N.getNode()))) {
+                IR ir = caller.getIR();
+                IntSet indices = ir.getCallInstructionIndices(site);
+                for (IntIterator ii = indices.intIterator(); ii.hasNext(); ) {
+                  int i = ii.next();
+                  Statement s = new NormalReturnCaller(caller, i);
+                  addNode(s);
+                  result.add(s);
                 }
               }
             }
-            return result.iterator();
           }
-        case HEAP_RET_CALLEE:
-          {
-            HeapStatement.HeapReturnCallee r = (HeapStatement.HeapReturnCallee) N;
-            Collection<Statement> result = HashSetFactory.make(5);
-            if (!dOptions.equals(DataDependenceOptions.NONE)) {
-              // data dependence predecessors
-              for (CGNode caller : Iterator2Iterable.make(cg.getPredNodes(N.getNode()))) {
-                for (CallSiteReference site :
-                    Iterator2Iterable.make(cg.getPossibleSites(caller, N.getNode()))) {
-                  IR ir = caller.getIR();
-                  IntSet indices = ir.getCallInstructionIndices(site);
-                  for (IntIterator ii = indices.intIterator(); ii.hasNext(); ) {
-                    int i = ii.next();
-                    Statement s = new HeapStatement.HeapReturnCaller(caller, i, r.getLocation());
-                    addNode(s);
-                    result.add(s);
-                  }
+          return result.iterator();
+        }
+        case HEAP_RET_CALLEE -> {
+          HeapStatement.HeapReturnCallee r = (HeapStatement.HeapReturnCallee) N;
+          Collection<Statement> result = HashSetFactory.make(5);
+          if (!dOptions.equals(DataDependenceOptions.NONE)) {
+            // data dependence predecessors
+            for (CGNode caller : Iterator2Iterable.make(cg.getPredNodes(N.getNode()))) {
+              for (CallSiteReference site :
+                  Iterator2Iterable.make(cg.getPossibleSites(caller, N.getNode()))) {
+                IR ir = caller.getIR();
+                IntSet indices = ir.getCallInstructionIndices(site);
+                for (IntIterator ii = indices.intIterator(); ii.hasNext(); ) {
+                  int i = ii.next();
+                  Statement s = new HeapStatement.HeapReturnCaller(caller, i, r.getLocation());
+                  addNode(s);
+                  result.add(s);
                 }
               }
             }
-            return result.iterator();
           }
-        case PARAM_CALLER:
-          {
-            ParamCaller pac = (ParamCaller) N;
-            SSAAbstractInvokeInstruction call = pac.getInstruction();
-            int numParamsPassed = call.getNumberOfUses();
-            Collection<Statement> result = HashSetFactory.make(5);
-            if (!dOptions.equals(DataDependenceOptions.NONE)) {
-              // data dependence successors
-              for (CGNode t : cg.getPossibleTargets(N.getNode(), call.getCallSite())) {
-                // in some languages (*cough* JavaScript *cough*) you can pass
-                // fewer parameters than the number of formals.  So, only loop
-                // over the parameters actually being passed here
-                for (int i = 0;
-                    i < t.getMethod().getNumberOfParameters() && i < numParamsPassed;
-                    i++) {
-                  if (dOptions.isTerminateAtCast()
-                      && call.isDispatch()
-                      && pac.getValueNumber() == call.getReceiver()) {
-                    // a virtual dispatch is just like a cast.
-                    continue;
-                  }
-                  if (dOptions.isTerminateAtCast() && isUninformativeForReflection(t)) {
-                    // don't track reflection into reflective invokes
-                    continue;
-                  }
-                  if (call.getUse(i) == pac.getValueNumber()) {
-                    Statement s = new ParamCallee(t, i + 1);
-                    addNode(s);
-                    result.add(s);
-                  }
+          return result.iterator();
+        }
+        case PARAM_CALLER -> {
+          ParamCaller pac = (ParamCaller) N;
+          SSAAbstractInvokeInstruction call = pac.getInstruction();
+          int numParamsPassed = call.getNumberOfUses();
+          Collection<Statement> result = HashSetFactory.make(5);
+          if (!dOptions.equals(DataDependenceOptions.NONE)) {
+            // data dependence successors
+            for (CGNode t : cg.getPossibleTargets(N.getNode(), call.getCallSite())) {
+              // in some languages (*cough* JavaScript *cough*) you can pass
+              // fewer parameters than the number of formals.  So, only loop
+              // over the parameters actually being passed here
+              for (int i = 0;
+                  i < t.getMethod().getNumberOfParameters() && i < numParamsPassed;
+                  i++) {
+                if (dOptions.isTerminateAtCast()
+                    && call.isDispatch()
+                    && pac.getValueNumber() == call.getReceiver()) {
+                  // a virtual dispatch is just like a cast.
+                  continue;
+                }
+                if (dOptions.isTerminateAtCast() && isUninformativeForReflection(t)) {
+                  // don't track reflection into reflective invokes
+                  continue;
+                }
+                if (call.getUse(i) == pac.getValueNumber()) {
+                  Statement s = new ParamCallee(t, i + 1);
+                  addNode(s);
+                  result.add(s);
                 }
               }
             }
-            return result.iterator();
           }
-        case HEAP_PARAM_CALLER:
+          return result.iterator();
+        }
+        case HEAP_PARAM_CALLER -> {
           HeapStatement.HeapParamCaller pc = (HeapStatement.HeapParamCaller) N;
           SSAAbstractInvokeInstruction call = pc.getCall();
           Collection<Statement> result = HashSetFactory.make(5);
@@ -601,9 +597,11 @@ public class SDG<T extends InstanceKey> extends AbstractNumberedGraph<Statement>
             }
           }
           return result.iterator();
-        default:
+        }
+        default -> {
           Assertions.UNREACHABLE(N.getKind().toString());
           return null;
+        }
       }
     }
 
@@ -636,7 +634,7 @@ public class SDG<T extends InstanceKey> extends AbstractNumberedGraph<Statement>
       addPDGStatementNodes(src.getNode());
       addPDGStatementNodes(dst.getNode());
       switch (src.getKind()) {
-        case NORMAL:
+        case NORMAL -> {
           if (cOptions.isIgnoreInterproc()) {
             return getPDG(src.getNode()).getEdgeLabels(src, dst);
           } else {
@@ -658,107 +656,105 @@ public class SDG<T extends InstanceKey> extends AbstractNumberedGraph<Statement>
               return getPDG(src.getNode()).getEdgeLabels(src, dst);
             }
           }
-        case CATCH:
+        }
+        case CATCH -> {
           assert src.getNode().equals(dst.getNode());
           return getPDG(src.getNode()).getEdgeLabels(src, dst);
-        case PHI:
-        case PI:
-        case EXC_RET_CALLER:
-        case NORMAL_RET_CALLER:
-        case PARAM_CALLEE:
-        case HEAP_PARAM_CALLEE:
-        case HEAP_RET_CALLER:
-        case METHOD_ENTRY:
-        case METHOD_EXIT:
+        }
+        case PHI,
+            PI,
+            EXC_RET_CALLER,
+            NORMAL_RET_CALLER,
+            PARAM_CALLEE,
+            HEAP_PARAM_CALLEE,
+            HEAP_RET_CALLER,
+            METHOD_ENTRY,
+            METHOD_EXIT -> {
           return getPDG(src.getNode()).getEdgeLabels(src, dst);
-        case EXC_RET_CALLEE:
-          {
-            if (dOptions.equals(DataDependenceOptions.NONE)) {
-              return Collections.emptySet();
-            }
-            if (dst.getKind().equals(Kind.EXC_RET_CALLER)) {
-              ExceptionalReturnCaller r = (ExceptionalReturnCaller) dst;
-              if (cg.getPossibleTargets(r.getNode(), r.getInstruction().getCallSite())
-                  .contains(src.getNode())) {
-                return Collections.singleton(Dependency.DATA_DEP);
-              } else {
-                return Collections.emptySet();
-              }
+        }
+        case EXC_RET_CALLEE -> {
+          if (dOptions.equals(DataDependenceOptions.NONE)) {
+            return Collections.emptySet();
+          }
+          if (dst.getKind().equals(Kind.EXC_RET_CALLER)) {
+            ExceptionalReturnCaller r = (ExceptionalReturnCaller) dst;
+            if (cg.getPossibleTargets(r.getNode(), r.getInstruction().getCallSite())
+                .contains(src.getNode())) {
+              return Collections.singleton(Dependency.DATA_DEP);
             } else {
               return Collections.emptySet();
             }
+          } else {
+            return Collections.emptySet();
           }
-        case NORMAL_RET_CALLEE:
-          {
-            if (dOptions.equals(DataDependenceOptions.NONE)) {
-              return Collections.emptySet();
-            }
-            if (dst.getKind().equals(Kind.NORMAL_RET_CALLER)) {
-              NormalReturnCaller r = (NormalReturnCaller) dst;
-              if (cg.getPossibleTargets(r.getNode(), r.getInstruction().getCallSite())
-                  .contains(src.getNode())) {
-                return Collections.singleton(Dependency.DATA_DEP);
-              } else {
-                return Collections.emptySet();
-              }
+        }
+        case NORMAL_RET_CALLEE -> {
+          if (dOptions.equals(DataDependenceOptions.NONE)) {
+            return Collections.emptySet();
+          }
+          if (dst.getKind().equals(Kind.NORMAL_RET_CALLER)) {
+            NormalReturnCaller r = (NormalReturnCaller) dst;
+            if (cg.getPossibleTargets(r.getNode(), r.getInstruction().getCallSite())
+                .contains(src.getNode())) {
+              return Collections.singleton(Dependency.DATA_DEP);
             } else {
               return Collections.emptySet();
             }
+          } else {
+            return Collections.emptySet();
           }
-        case HEAP_RET_CALLEE:
-          {
-            if (dOptions.equals(DataDependenceOptions.NONE)) {
-              return Collections.emptySet();
-            }
-            if (dst.getKind().equals(Kind.HEAP_RET_CALLER)) {
-              HeapStatement.HeapReturnCaller r = (HeapStatement.HeapReturnCaller) dst;
-              HeapStatement h = (HeapStatement) src;
-              if (h.getLocation().equals(r.getLocation())
-                  && cg.getPossibleTargets(r.getNode(), r.getCall().getCallSite())
-                      .contains(src.getNode())) {
-                return Collections.singleton(Dependency.HEAP_DATA_DEP);
-              } else {
-                return Collections.emptySet();
-              }
+        }
+        case HEAP_RET_CALLEE -> {
+          if (dOptions.equals(DataDependenceOptions.NONE)) {
+            return Collections.emptySet();
+          }
+          if (dst.getKind().equals(Kind.HEAP_RET_CALLER)) {
+            HeapStatement.HeapReturnCaller r = (HeapStatement.HeapReturnCaller) dst;
+            HeapStatement h = (HeapStatement) src;
+            if (h.getLocation().equals(r.getLocation())
+                && cg.getPossibleTargets(r.getNode(), r.getCall().getCallSite())
+                    .contains(src.getNode())) {
+              return Collections.singleton(Dependency.HEAP_DATA_DEP);
             } else {
               return Collections.emptySet();
             }
+          } else {
+            return Collections.emptySet();
           }
-        case PARAM_CALLER:
-          {
-            if (dOptions.equals(DataDependenceOptions.NONE)) {
+        }
+        case PARAM_CALLER -> {
+          if (dOptions.equals(DataDependenceOptions.NONE)) {
+            return Collections.emptySet();
+          }
+          if (dst.getKind().equals(Kind.PARAM_CALLEE)) {
+            ParamCallee callee = (ParamCallee) dst;
+            ParamCaller caller = (ParamCaller) src;
+            SSAAbstractInvokeInstruction call = caller.getInstruction();
+            final CGNode calleeNode = callee.getNode();
+            if (!cg.getPossibleTargets(caller.getNode(), call.getCallSite()).contains(calleeNode)) {
               return Collections.emptySet();
             }
-            if (dst.getKind().equals(Kind.PARAM_CALLEE)) {
-              ParamCallee callee = (ParamCallee) dst;
-              ParamCaller caller = (ParamCaller) src;
-              SSAAbstractInvokeInstruction call = caller.getInstruction();
-              final CGNode calleeNode = callee.getNode();
-              if (!cg.getPossibleTargets(caller.getNode(), call.getCallSite())
-                  .contains(calleeNode)) {
-                return Collections.emptySet();
-              }
-              if (dOptions.isTerminateAtCast()
-                  && call.isDispatch()
-                  && caller.getValueNumber() == call.getReceiver()) {
-                // a virtual dispatch is just like a cast.
-                return Collections.emptySet();
-              }
-              if (dOptions.isTerminateAtCast() && isUninformativeForReflection(calleeNode)) {
-                // don't track reflection into reflective invokes
-                return Collections.emptySet();
-              }
-              for (int i = 0; i < call.getNumberOfUses(); i++) {
-                if (call.getUse(i) == caller.getValueNumber()) {
-                  if (callee.getValueNumber() == i + 1) {
-                    return Collections.singleton(Dependency.DATA_DEP);
-                  }
+            if (dOptions.isTerminateAtCast()
+                && call.isDispatch()
+                && caller.getValueNumber() == call.getReceiver()) {
+              // a virtual dispatch is just like a cast.
+              return Collections.emptySet();
+            }
+            if (dOptions.isTerminateAtCast() && isUninformativeForReflection(calleeNode)) {
+              // don't track reflection into reflective invokes
+              return Collections.emptySet();
+            }
+            for (int i = 0; i < call.getNumberOfUses(); i++) {
+              if (call.getUse(i) == caller.getValueNumber()) {
+                if (callee.getValueNumber() == i + 1) {
+                  return Collections.singleton(Dependency.DATA_DEP);
                 }
               }
             }
-            return Collections.emptySet();
           }
-        case HEAP_PARAM_CALLER:
+          return Collections.emptySet();
+        }
+        case HEAP_PARAM_CALLER -> {
           if (dOptions.equals(DataDependenceOptions.NONE)) {
             return Collections.emptySet();
           }
@@ -776,9 +772,11 @@ public class SDG<T extends InstanceKey> extends AbstractNumberedGraph<Statement>
           } else {
             return Collections.emptySet();
           }
-        default:
+        }
+        default -> {
           Assertions.UNREACHABLE(src.getKind());
           return Collections.emptySet();
+        }
       }
     }
 

--- a/core/src/main/java/com/ibm/wala/ipa/slicer/SDGSupergraph.java
+++ b/core/src/main/java/com/ibm/wala/ipa/slicer/SDGSupergraph.java
@@ -56,45 +56,41 @@ class SDGSupergraph implements ISupergraph<Statement, PDG<? extends InstanceKey>
   public Iterator<? extends Statement> getCallSites(
       Statement r, PDG<? extends InstanceKey> callee) {
     switch (r.getKind()) {
-      case EXC_RET_CALLER:
-        {
-          ExceptionalReturnCaller n = (ExceptionalReturnCaller) r;
-          SSAAbstractInvokeInstruction call = n.getInstruction();
-          PDG<?> pdg = getProcOf(r);
-          return pdg.getCallStatements(call).iterator();
-        }
-      case NORMAL_RET_CALLER:
-        {
-          NormalReturnCaller n = (NormalReturnCaller) r;
-          SSAAbstractInvokeInstruction call = n.getInstruction();
-          PDG<?> pdg = getProcOf(r);
-          return pdg.getCallStatements(call).iterator();
-        }
-      case HEAP_RET_CALLER:
-        {
-          HeapStatement.HeapReturnCaller n = (HeapStatement.HeapReturnCaller) r;
-          SSAAbstractInvokeInstruction call = n.getCall();
-          PDG<?> pdg = getProcOf(r);
-          return pdg.getCallStatements(call).iterator();
-        }
-      default:
+      case EXC_RET_CALLER -> {
+        ExceptionalReturnCaller n = (ExceptionalReturnCaller) r;
+        SSAAbstractInvokeInstruction call = n.getInstruction();
+        PDG<?> pdg = getProcOf(r);
+        return pdg.getCallStatements(call).iterator();
+      }
+      case NORMAL_RET_CALLER -> {
+        NormalReturnCaller n = (NormalReturnCaller) r;
+        SSAAbstractInvokeInstruction call = n.getInstruction();
+        PDG<?> pdg = getProcOf(r);
+        return pdg.getCallStatements(call).iterator();
+      }
+      case HEAP_RET_CALLER -> {
+        HeapStatement.HeapReturnCaller n = (HeapStatement.HeapReturnCaller) r;
+        SSAAbstractInvokeInstruction call = n.getCall();
+        PDG<?> pdg = getProcOf(r);
+        return pdg.getCallStatements(call).iterator();
+      }
+      default -> {
         Assertions.UNREACHABLE(r.getKind().toString());
         return null;
+      }
     }
   }
 
   @Override
   public Iterator<? extends Statement> getCalledNodes(Statement call) {
-    switch (call.getKind()) {
-      case NORMAL:
-        return new FilterIterator<>(getSuccNodes(call), this::isEntry);
-      case PARAM_CALLER:
-      case HEAP_PARAM_CALLER:
-        return getSuccNodes(call);
-      default:
+    return switch (call.getKind()) {
+      case NORMAL -> new FilterIterator<>(getSuccNodes(call), this::isEntry);
+      case PARAM_CALLER, HEAP_PARAM_CALLER -> getSuccNodes(call);
+      default -> {
         Assertions.UNREACHABLE(call.getKind().toString());
-        return null;
-    }
+        yield null;
+      }
+    };
   }
 
   @Override
@@ -156,143 +152,133 @@ class SDGSupergraph implements ISupergraph<Statement, PDG<? extends InstanceKey>
   public Iterator<? extends Statement> getReturnSites(
       Statement call, PDG<? extends InstanceKey> callee) {
     switch (call.getKind()) {
-      case PARAM_CALLER:
-        {
-          ParamCaller n = (ParamCaller) call;
-          SSAAbstractInvokeInstruction st = n.getInstruction();
-          PDG<?> pdg = getProcOf(call);
-          return pdg.getCallerReturnStatements(st).iterator();
-        }
-      case HEAP_PARAM_CALLER:
-        {
-          HeapStatement.HeapParamCaller n = (HeapStatement.HeapParamCaller) call;
-          SSAAbstractInvokeInstruction st = n.getCall();
-          PDG<?> pdg = getProcOf(call);
-          return pdg.getCallerReturnStatements(st).iterator();
-        }
-      case NORMAL:
-        {
-          NormalStatement n = (NormalStatement) call;
-          SSAAbstractInvokeInstruction st = (SSAAbstractInvokeInstruction) n.getInstruction();
-          PDG<?> pdg = getProcOf(call);
-          return pdg.getCallerReturnStatements(st).iterator();
-        }
-      default:
+      case PARAM_CALLER -> {
+        ParamCaller n = (ParamCaller) call;
+        SSAAbstractInvokeInstruction st = n.getInstruction();
+        PDG<?> pdg = getProcOf(call);
+        return pdg.getCallerReturnStatements(st).iterator();
+      }
+      case HEAP_PARAM_CALLER -> {
+        HeapStatement.HeapParamCaller n = (HeapStatement.HeapParamCaller) call;
+        SSAAbstractInvokeInstruction st = n.getCall();
+        PDG<?> pdg = getProcOf(call);
+        return pdg.getCallerReturnStatements(st).iterator();
+      }
+      case NORMAL -> {
+        NormalStatement n = (NormalStatement) call;
+        SSAAbstractInvokeInstruction st = (SSAAbstractInvokeInstruction) n.getInstruction();
+        PDG<?> pdg = getProcOf(call);
+        return pdg.getCallerReturnStatements(st).iterator();
+      }
+      default -> {
         Assertions.UNREACHABLE(call.getKind().toString());
         return null;
+      }
     }
   }
 
   @Override
   public boolean isCall(Statement n) {
     switch (n.getKind()) {
-      case EXC_RET_CALLEE:
-      case EXC_RET_CALLER:
-      case HEAP_PARAM_CALLEE:
-      case NORMAL_RET_CALLEE:
-      case NORMAL_RET_CALLER:
-      case PARAM_CALLEE:
-      case PHI:
-      case HEAP_RET_CALLEE:
-      case HEAP_RET_CALLER:
-      case METHOD_ENTRY:
-      case METHOD_EXIT:
-      case CATCH:
-      case PI:
+      case EXC_RET_CALLEE,
+          EXC_RET_CALLER,
+          HEAP_PARAM_CALLEE,
+          NORMAL_RET_CALLEE,
+          NORMAL_RET_CALLER,
+          PARAM_CALLEE,
+          PHI,
+          HEAP_RET_CALLEE,
+          HEAP_RET_CALLER,
+          METHOD_ENTRY,
+          METHOD_EXIT,
+          CATCH,
+          PI -> {
         return false;
-      case HEAP_PARAM_CALLER:
-      case PARAM_CALLER:
+      }
+      case HEAP_PARAM_CALLER, PARAM_CALLER -> {
         return true;
-      case NORMAL:
+      }
+      case NORMAL -> {
         if (sdg.getCOptions().isIgnoreInterproc()) {
           return false;
         } else {
           NormalStatement s = (NormalStatement) n;
           return s.getInstruction() instanceof SSAAbstractInvokeInstruction;
         }
-      default:
+      }
+      default -> {
         Assertions.UNREACHABLE(n.getKind() + " " + n);
         return false;
+      }
     }
   }
 
   @Override
   public boolean isEntry(Statement n) {
-    switch (n.getKind()) {
-      case PARAM_CALLEE:
-      case HEAP_PARAM_CALLEE:
-      case METHOD_ENTRY:
-        return true;
-      case PHI:
-      case PI:
-      case NORMAL_RET_CALLER:
-      case PARAM_CALLER:
-      case HEAP_RET_CALLER:
-      case NORMAL:
-      case EXC_RET_CALLEE:
-      case EXC_RET_CALLER:
-      case HEAP_PARAM_CALLER:
-      case HEAP_RET_CALLEE:
-      case NORMAL_RET_CALLEE:
-      case CATCH:
-        return false;
-      default:
+    return switch (n.getKind()) {
+      case PARAM_CALLEE, HEAP_PARAM_CALLEE, METHOD_ENTRY -> true;
+      case PHI,
+          PI,
+          NORMAL_RET_CALLER,
+          PARAM_CALLER,
+          HEAP_RET_CALLER,
+          NORMAL,
+          EXC_RET_CALLEE,
+          EXC_RET_CALLER,
+          HEAP_PARAM_CALLER,
+          HEAP_RET_CALLEE,
+          NORMAL_RET_CALLEE,
+          CATCH ->
+          false;
+      default -> {
         Assertions.UNREACHABLE(n.toString());
-        return false;
-    }
+        yield false;
+      }
+    };
   }
 
   @Override
   public boolean isExit(Statement n) {
-    switch (n.getKind()) {
-      case PARAM_CALLEE:
-      case HEAP_PARAM_CALLEE:
-      case HEAP_PARAM_CALLER:
-      case PHI:
-      case PI:
-      case NORMAL_RET_CALLER:
-      case PARAM_CALLER:
-      case HEAP_RET_CALLER:
-      case NORMAL:
-      case EXC_RET_CALLER:
-      case METHOD_ENTRY:
-      case CATCH:
-        return false;
-      case HEAP_RET_CALLEE:
-      case EXC_RET_CALLEE:
-      case NORMAL_RET_CALLEE:
-      case METHOD_EXIT:
-        return true;
-      default:
-        Assertions.UNREACHABLE(n.toString());
-        return false;
-    }
+    return switch (n.getKind()) {
+      case PARAM_CALLEE,
+          HEAP_PARAM_CALLEE,
+          HEAP_PARAM_CALLER,
+          PHI,
+          PI,
+          NORMAL_RET_CALLER,
+          PARAM_CALLER,
+          HEAP_RET_CALLER,
+          NORMAL,
+          EXC_RET_CALLER,
+          METHOD_ENTRY,
+          CATCH ->
+          false;
+      case HEAP_RET_CALLEE, EXC_RET_CALLEE, NORMAL_RET_CALLEE, METHOD_EXIT -> true;
+    };
   }
 
   @Override
   public boolean isReturn(Statement n) {
-    switch (n.getKind()) {
-      case EXC_RET_CALLER:
-      case NORMAL_RET_CALLER:
-      case HEAP_RET_CALLER:
-        return true;
-      case EXC_RET_CALLEE:
-      case HEAP_PARAM_CALLEE:
-      case HEAP_PARAM_CALLER:
-      case HEAP_RET_CALLEE:
-      case NORMAL:
-      case NORMAL_RET_CALLEE:
-      case PARAM_CALLEE:
-      case PARAM_CALLER:
-      case PHI:
-      case PI:
-      case METHOD_ENTRY:
-      case CATCH:
-        return false;
-      default:
+    return switch (n.getKind()) {
+      case EXC_RET_CALLER, NORMAL_RET_CALLER, HEAP_RET_CALLER -> true;
+      case EXC_RET_CALLEE,
+          HEAP_PARAM_CALLEE,
+          HEAP_PARAM_CALLER,
+          HEAP_RET_CALLEE,
+          NORMAL,
+          NORMAL_RET_CALLEE,
+          PARAM_CALLEE,
+          PARAM_CALLER,
+          PHI,
+          PI,
+          METHOD_ENTRY,
+          CATCH ->
+          false;
+      default -> {
         Assertions.UNREACHABLE(n.getKind().toString());
-        return false;
-    }
+        yield false;
+      }
+    };
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/ipa/slicer/SliceFunctions.java
+++ b/core/src/main/java/com/ibm/wala/ipa/slicer/SliceFunctions.java
@@ -30,18 +30,15 @@ public class SliceFunctions implements IPartiallyBalancedFlowFunctions<Statement
       throw new IllegalArgumentException("src is null");
     }
     switch (src.getKind()) {
-      case NORMAL_RET_CALLER:
-      case PARAM_CALLER:
-      case EXC_RET_CALLER:
       // uh oh. anything that flows into the missing function will be killed.
-      case NORMAL:
+      case NORMAL_RET_CALLER, PARAM_CALLER, EXC_RET_CALLER, NORMAL -> {
         // only control dependence flows into the missing function.
         // this control dependence does not flow back to the caller.
         return ReachabilityFunctions.KILL_FLOW;
-      case HEAP_PARAM_CALLEE:
-      case HEAP_PARAM_CALLER:
-      case HEAP_RET_CALLEE:
-      case HEAP_RET_CALLER:
+        // only control dependence flows into the missing function.
+        // this control dependence does not flow back to the caller.
+      }
+      case HEAP_PARAM_CALLEE, HEAP_PARAM_CALLER, HEAP_RET_CALLEE, HEAP_RET_CALLER -> {
         if (dest instanceof HeapStatement) {
           HeapStatement hd = (HeapStatement) dest;
           HeapStatement hs = (HeapStatement) src;
@@ -53,9 +50,11 @@ public class SliceFunctions implements IPartiallyBalancedFlowFunctions<Statement
         } else {
           return ReachabilityFunctions.KILL_FLOW;
         }
-      default:
+      }
+      default -> {
         Assertions.UNREACHABLE(src.getKind().toString());
         return null;
+      }
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/LambdaSummaryClass.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/LambdaSummaryClass.java
@@ -410,24 +410,14 @@ public class LambdaSummaryClass extends SyntheticClass {
   }
 
   private static Dispatch getDispatchForMethodHandleKind(int kind) {
-    Dispatch code;
-    switch (kind) {
-      case REF_INVOKEVIRTUAL:
-        code = Dispatch.VIRTUAL;
-        break;
-      case REF_INVOKESTATIC:
-        code = Dispatch.STATIC;
-        break;
-      case REF_INVOKESPECIAL:
-      case REF_NEWINVOKESPECIAL:
-        code = Dispatch.SPECIAL;
-        break;
-      case REF_INVOKEINTERFACE:
-        code = Dispatch.INTERFACE;
-        break;
-      default:
-        throw new Error("unexpected dynamic invoke type " + kind);
-    }
+    Dispatch code =
+        switch (kind) {
+          case REF_INVOKEVIRTUAL -> Dispatch.VIRTUAL;
+          case REF_INVOKESTATIC -> Dispatch.STATIC;
+          case REF_INVOKESPECIAL, REF_NEWINVOKESPECIAL -> Dispatch.SPECIAL;
+          case REF_INVOKEINTERFACE -> Dispatch.INTERFACE;
+          default -> throw new Error("unexpected dynamic invoke type " + kind);
+        };
     return code;
   }
 

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/XMLMethodSummaryReader.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/XMLMethodSummaryReader.java
@@ -266,73 +266,46 @@ public class XMLMethodSummaryReader implements BytecodeConstants {
         Assertions.UNREACHABLE("Invalid element: " + qName);
       }
       switch (element) {
-        case E_CLASSLOADER:
-          {
-            String clName = atts.getValue(A_NAME);
-            governingLoader = classLoaderName2Ref(clName);
-          }
-          break;
-        case E_METHOD:
+        case E_CLASSLOADER -> {
+          String clName = atts.getValue(A_NAME);
+          governingLoader = classLoaderName2Ref(clName);
+        }
+        case E_METHOD -> {
           String mname = atts.getValue(A_NAME);
           if (mname.equals(A_WILDCARD)) {
             Assertions.UNREACHABLE("Wildcards not currently implemented.");
           } else {
             startMethod(atts);
           }
-          break;
-        case E_CLASS:
+        }
+        case E_CLASS -> {
           String cname = atts.getValue(A_NAME);
           if (cname.equals(A_WILDCARD)) {
             Assertions.UNREACHABLE("Wildcards not currently implemented");
           } else {
             startClass(cname, atts);
           }
-          break;
-        case E_PACKAGE:
+        }
+        case E_PACKAGE -> {
           governingPackage = Atom.findOrCreateUnicodeAtom(atts.getValue(A_NAME));
           String ignore = atts.getValue(A_IGNORE);
           if (ignore != null && ignore.equals(V_TRUE)) {
             ignoredPackages.add(governingPackage);
           }
-          break;
-        case E_CALL:
-          processCallSite(atts);
-          break;
-        case E_NEW:
-          processAllocation(atts);
-          break;
-        case E_PUTSTATIC:
-          processPutStatic(atts);
-          break;
-        case E_PUTFIELD:
-          processPutField(atts);
-          break;
-        case E_GETFIELD:
-          processGetField(atts);
-          break;
-        case E_ATHROW:
-          processAthrow(atts);
-          break;
-        case E_AASTORE:
-          processAastore(atts);
-          break;
-        case E_AALOAD:
-          processAaload(atts);
-          break;
-        case E_RETURN:
-          processReturn(atts);
-          break;
-        case E_POISON:
-          processPoison(atts);
-          break;
-        case E_CONSTANT:
-          processConstant(atts);
-          break;
-        case E_SUMMARY_SPEC:
-          break;
-        default:
-          Assertions.UNREACHABLE("Unexpected element: " + name);
-          break;
+        }
+        case E_CALL -> processCallSite(atts);
+        case E_NEW -> processAllocation(atts);
+        case E_PUTSTATIC -> processPutStatic(atts);
+        case E_PUTFIELD -> processPutField(atts);
+        case E_GETFIELD -> processGetField(atts);
+        case E_ATHROW -> processAthrow(atts);
+        case E_AASTORE -> processAastore(atts);
+        case E_AALOAD -> processAaload(atts);
+        case E_RETURN -> processReturn(atts);
+        case E_POISON -> processPoison(atts);
+        case E_CONSTANT -> processConstant(atts);
+        case E_SUMMARY_SPEC -> {}
+        default -> Assertions.UNREACHABLE("Unexpected element: " + name);
       }
     }
 
@@ -357,38 +330,29 @@ public class XMLMethodSummaryReader implements BytecodeConstants {
         Assertions.UNREACHABLE("Invalid element: " + name);
       }
       switch (element) {
-        case E_CLASSLOADER:
-          governingLoader = null;
-          break;
-        case E_METHOD:
+        case E_CLASSLOADER -> governingLoader = null;
+        case E_METHOD -> {
           if (governingMethod != null) {
             checkReturnValue(governingMethod);
           }
           governingMethod = null;
           symbolTable = null;
-          break;
-        case E_CLASS:
-          governingClass = null;
-          break;
-        case E_PACKAGE:
-          governingPackage = null;
-          break;
-        case E_CALL:
-        case E_GETFIELD:
-        case E_NEW:
-        case E_POISON:
-        case E_PUTSTATIC:
-        case E_PUTFIELD:
-        case E_AALOAD:
-        case E_AASTORE:
-        case E_ATHROW:
-        case E_SUMMARY_SPEC:
-        case E_RETURN:
-        case E_CONSTANT:
-          break;
-        default:
-          Assertions.UNREACHABLE("Unexpected element: " + name);
-          break;
+        }
+        case E_CLASS -> governingClass = null;
+        case E_PACKAGE -> governingPackage = null;
+        case E_CALL,
+            E_GETFIELD,
+            E_NEW,
+            E_POISON,
+            E_PUTSTATIC,
+            E_PUTFIELD,
+            E_AALOAD,
+            E_AASTORE,
+            E_ATHROW,
+            E_SUMMARY_SPEC,
+            E_RETURN,
+            E_CONSTANT -> {}
+        default -> Assertions.UNREACHABLE("Unexpected element: " + name);
       }
     }
 
@@ -427,38 +391,37 @@ public class XMLMethodSummaryReader implements BytecodeConstants {
       CallSiteReference site = null;
       int nParams = ref.getNumberOfParameters();
       switch (typeString) {
-        case "virtual":
+        case "virtual" -> {
           site =
               CallSiteReference.make(
                   governingMethod.getNumberOfStatements(),
                   ref,
                   IInvokeInstruction.Dispatch.VIRTUAL);
           nParams++;
-          break;
-        case "special":
+        }
+        case "special" -> {
           site =
               CallSiteReference.make(
                   governingMethod.getNumberOfStatements(),
                   ref,
                   IInvokeInstruction.Dispatch.SPECIAL);
           nParams++;
-          break;
-        case "interface":
+        }
+        case "interface" -> {
           site =
               CallSiteReference.make(
                   governingMethod.getNumberOfStatements(),
                   ref,
                   IInvokeInstruction.Dispatch.INTERFACE);
           nParams++;
-          break;
-        case "static":
-          site =
-              CallSiteReference.make(
-                  governingMethod.getNumberOfStatements(), ref, IInvokeInstruction.Dispatch.STATIC);
-          break;
-        default:
-          Assertions.UNREACHABLE("Invalid call type " + typeString);
-          break;
+        }
+        case "static" ->
+            site =
+                CallSiteReference.make(
+                    governingMethod.getNumberOfStatements(),
+                    ref,
+                    IInvokeInstruction.Dispatch.STATIC);
+        default -> Assertions.UNREACHABLE("Invalid call type " + typeString);
       }
 
       String paramCount = atts.getValue(A_NUM_ARGS);
@@ -861,18 +824,10 @@ public class XMLMethodSummaryReader implements BytecodeConstants {
       governingMethod.addPoison(reason);
       String level = atts.getValue(A_LEVEL);
       switch (level) {
-        case "severe":
-          governingMethod.setPoisonLevel(Warning.SEVERE);
-          break;
-        case "moderate":
-          governingMethod.setPoisonLevel(Warning.MODERATE);
-          break;
-        case "mild":
-          governingMethod.setPoisonLevel(Warning.MILD);
-          break;
-        default:
-          Assertions.UNREACHABLE("Unexpected level: " + level);
-          break;
+        case "severe" -> governingMethod.setPoisonLevel(Warning.SEVERE);
+        case "moderate" -> governingMethod.setPoisonLevel(Warning.MODERATE);
+        case "mild" -> governingMethod.setPoisonLevel(Warning.MILD);
+        default -> Assertions.UNREACHABLE("Unexpected level: " + level);
       }
     }
 
@@ -895,15 +850,10 @@ public class XMLMethodSummaryReader implements BytecodeConstants {
       String staticString = atts.getValue(A_STATIC);
       if (staticString != null) {
         switch (staticString) {
-          case "true":
-            isStatic = true;
-            break;
-          case "false":
-            isStatic = false;
-            break;
-          default:
-            Assertions.UNREACHABLE("Invalid attribute value " + A_STATIC + ": " + staticString);
-            break;
+          case "true" -> isStatic = true;
+          case "false" -> isStatic = false;
+          default ->
+              Assertions.UNREACHABLE("Invalid attribute value " + A_STATIC + ": " + staticString);
         }
       }
 
@@ -932,15 +882,10 @@ public class XMLMethodSummaryReader implements BytecodeConstants {
       String factoryString = atts.getValue(A_FACTORY);
       if (factoryString != null) {
         switch (factoryString) {
-          case "true":
-            governingMethod.setFactory(true);
-            break;
-          case "false":
-            governingMethod.setFactory(false);
-            break;
-          default:
-            Assertions.UNREACHABLE("Invalid attribute value " + A_FACTORY + ": " + factoryString);
-            break;
+          case "true" -> governingMethod.setFactory(true);
+          case "false" -> governingMethod.setFactory(false);
+          default ->
+              Assertions.UNREACHABLE("Invalid attribute value " + A_FACTORY + ": " + factoryString);
         }
       }
 

--- a/core/src/main/java/com/ibm/wala/ssa/AllIntegerDueToBranchePiPolicy.java
+++ b/core/src/main/java/com/ibm/wala/ssa/AllIntegerDueToBranchePiPolicy.java
@@ -35,15 +35,13 @@ public class AllIntegerDueToBranchePiPolicy implements SSAPiNodePolicy {
       SSAInstruction def2,
       SymbolTable symbolTable) {
     final List<Pair<Integer, SSAInstruction>> pis = this.getPis(cond, def1, def2, symbolTable);
-    switch (pis.size()) {
-      case 0:
-        return null;
-      case 1:
-        return pis.get(0);
-      default:
-        throw new IllegalArgumentException(
-            "getPi was called but pi nodes should be inserted for more than one variable. Use getPis instead.");
-    }
+    return switch (pis.size()) {
+      case 0 -> null;
+      case 1 -> pis.get(0);
+      default ->
+          throw new IllegalArgumentException(
+              "getPi was called but pi nodes should be inserted for more than one variable. Use getPis instead.");
+    };
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/ssa/SSAAbstractInvokeInstruction.java
+++ b/core/src/main/java/com/ibm/wala/ssa/SSAAbstractInvokeInstruction.java
@@ -91,14 +91,11 @@ public abstract class SSAAbstractInvokeInstruction extends SSAInstruction {
       assert i == 0;
       return exception;
     } else {
-      switch (i) {
-        case 0:
-          return getReturnValue(0);
-        case 1:
-          return exception;
-        default:
-          return getReturnValue(i - 1);
-      }
+      return switch (i) {
+        case 0 -> getReturnValue(0);
+        case 1 -> exception;
+        default -> getReturnValue(i - 1);
+      };
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/types/TypeName.java
+++ b/core/src/main/java/com/ibm/wala/types/TypeName.java
@@ -285,18 +285,12 @@ public final class TypeName implements Serializable {
             d >>= ElementBits) {
           final int masked = d & ElementMask;
           switch (masked) {
-            case ArrayMask:
-              result.append('[');
-              break;
-            case PointerMask:
-              result.append('*');
-              break;
-            case ReferenceMask:
-              result.append('&');
-              break;
-            default:
-              throw new UnsupportedOperationException(
-                  "unexpected masked type-name component " + masked);
+            case ArrayMask -> result.append('[');
+            case PointerMask -> result.append('*');
+            case ReferenceMask -> result.append('&');
+            default ->
+                throw new UnsupportedOperationException(
+                    "unexpected masked type-name component " + masked);
           }
         }
       }

--- a/core/src/main/java/com/ibm/wala/types/generics/FormalTypeParameter.java
+++ b/core/src/main/java/com/ibm/wala/types/generics/FormalTypeParameter.java
@@ -116,25 +116,23 @@ public class FormalTypeParameter extends Signature {
     do {
       assert (s.charAt(result) == ':');
       switch (s.charAt(++result)) {
-        case TypeReference.ClassTypeCode:
-          {
-            int depth = 0;
-            while (s.charAt(result) != ';' || depth > 0) {
-              if (s.charAt(result) == '<') {
-                depth++;
-              }
-              if (s.charAt(result) == '>') {
-                depth--;
-              }
-              result++;
+        case TypeReference.ClassTypeCode -> {
+          int depth = 0;
+          while (s.charAt(result) != ';' || depth > 0) {
+            if (s.charAt(result) == '<') {
+              depth++;
+            }
+            if (s.charAt(result) == '>') {
+              depth--;
             }
             result++;
-            break;
           }
-        case ':':
-          break;
-        default:
+          result++;
+        }
+        case ':' -> {}
+        default -> {
           assert false : "bad type signature list " + s + ' ' + (result - 1);
+        }
       }
     } while (s.charAt(result) == ':');
     return result;

--- a/core/src/main/java/com/ibm/wala/types/generics/TypeArgument.java
+++ b/core/src/main/java/com/ibm/wala/types/generics/TypeArgument.java
@@ -84,23 +84,21 @@ public class TypeArgument extends Signature {
   }
 
   private static TypeArgument makeTypeArgument(String s) {
-    switch (s.charAt(0)) {
-      case '*':
-        return WILDCARD;
-      case '+':
-        {
-          TypeSignature sig = TypeSignature.make(s.substring(1));
-          return new TypeArgument(sig, WildcardIndicator.PLUS);
-        }
-      case '-':
-        {
-          TypeSignature sig = TypeSignature.make(s.substring(1));
-          return new TypeArgument(sig, WildcardIndicator.MINUS);
-        }
-      default:
+    return switch (s.charAt(0)) {
+      case '*' -> WILDCARD;
+      case '+' -> {
+        TypeSignature sig = TypeSignature.make(s.substring(1));
+        yield new TypeArgument(sig, WildcardIndicator.PLUS);
+      }
+      case '-' -> {
+        TypeSignature sig = TypeSignature.make(s.substring(1));
+        yield new TypeArgument(sig, WildcardIndicator.MINUS);
+      }
+      default -> {
         TypeSignature sig = TypeSignature.make(s);
-        return new TypeArgument(sig, null);
-    }
+        yield new TypeArgument(sig, null);
+      }
+    };
   }
 
   /**
@@ -113,54 +111,42 @@ public class TypeArgument extends Signature {
     int i = 1;
     while (true) {
       switch (typeArgs.charAt(i++)) {
-        case TypeReference.ClassTypeCode:
-          {
-            int off = i - 1;
-            int depth = 0;
-            while (typeArgs.charAt(i++) != ';' || depth > 0) {
-              if (typeArgs.charAt(i - 1) == '<') {
-                depth++;
-              }
-              if (typeArgs.charAt(i - 1) == '>') {
-                depth--;
-              }
+        case TypeReference.ClassTypeCode -> {
+          int off = i - 1;
+          int depth = 0;
+          while (typeArgs.charAt(i++) != ';' || depth > 0) {
+            if (typeArgs.charAt(i - 1) == '<') {
+              depth++;
             }
-            args.add(typeArgs.substring(off, i));
-            continue;
+            if (typeArgs.charAt(i - 1) == '>') {
+              depth--;
+            }
           }
-        case TypeReference.ArrayTypeCode:
-          {
-            int off = i - 1;
-            while (typeArgs.charAt(i) == TypeReference.ArrayTypeCode) {
-              ++i;
-            }
-            if (typeArgs.charAt(i) == TypeReference.ClassTypeCode) {
-              while (typeArgs.charAt(i++) != ';')
-                ;
-            } else if (typeArgs.charAt(i++) == (byte) 'T') {
-              while (typeArgs.charAt(i++) != ';')
-                ;
-            }
-            args.add(typeArgs.substring(off, i));
-            continue;
+          args.add(typeArgs.substring(off, i));
+        }
+        case TypeReference.ArrayTypeCode -> {
+          int off = i - 1;
+          while (typeArgs.charAt(i) == TypeReference.ArrayTypeCode) {
+            ++i;
           }
-        case (byte) '-':
-        case (byte) '+':
-        case (byte) 'T':
-          { // type variable
-            int off = i - 1;
+          if (typeArgs.charAt(i) == TypeReference.ClassTypeCode) {
             while (typeArgs.charAt(i++) != ';')
               ;
-            args.add(typeArgs.substring(off, i));
-            continue;
+          } else if (typeArgs.charAt(i++) == (byte) 'T') {
+            while (typeArgs.charAt(i++) != ';')
+              ;
           }
-        case (byte) '*':
-          {
-            // a wildcard
+          args.add(typeArgs.substring(off, i));
+        }
+        case (byte) '-', (byte) '+', (byte) 'T' -> { // type variable
+          int off = i - 1;
+          while (typeArgs.charAt(i++) != ';')
+            ;
+          args.add(typeArgs.substring(off, i));
+        }
+        case (byte) '*' -> // a wildcard
             args.add("*");
-            continue;
-          }
-        case (byte) '>': // end of argument list
+        case (byte) '>' -> {
           int size = args.size();
           if (size == 0) {
             return null;
@@ -171,8 +157,10 @@ public class TypeArgument extends Signature {
             result[j] = it.next();
           }
           return result;
-        default:
+        }
+        default -> {
           assert false : "bad type argument list " + typeArgs;
+        }
       }
     }
   }

--- a/core/src/main/java/com/ibm/wala/types/generics/TypeSignature.java
+++ b/core/src/main/java/com/ibm/wala/types/generics/TypeSignature.java
@@ -41,34 +41,21 @@ public abstract class TypeSignature extends Signature {
       throw new IllegalArgumentException("illegal empty string s");
     }
     assert !s.isEmpty();
-    switch (s.charAt(0)) {
-      case TypeReference.VoidTypeCode:
-        return BaseType.VOID;
-      case TypeReference.BooleanTypeCode:
-        return BaseType.BOOLEAN;
-      case TypeReference.ByteTypeCode:
-        return BaseType.BYTE;
-      case TypeReference.ShortTypeCode:
-        return BaseType.SHORT;
-      case TypeReference.IntTypeCode:
-        return BaseType.INT;
-      case TypeReference.LongTypeCode:
-        return BaseType.LONG;
-      case TypeReference.FloatTypeCode:
-        return BaseType.FLOAT;
-      case TypeReference.DoubleTypeCode:
-        return BaseType.DOUBLE;
-      case TypeReference.CharTypeCode:
-        return BaseType.CHAR;
-      case 'L':
-        return ClassTypeSignature.makeClassTypeSig(s);
-      case 'T':
-        return TypeVariableSignature.make(s);
-      case TypeReference.ArrayTypeCode:
-        return ArrayTypeSignature.make(s);
-      default:
-        throw new IllegalArgumentException("malformed TypeSignature string:" + s);
-    }
+    return switch (s.charAt(0)) {
+      case TypeReference.VoidTypeCode -> BaseType.VOID;
+      case TypeReference.BooleanTypeCode -> BaseType.BOOLEAN;
+      case TypeReference.ByteTypeCode -> BaseType.BYTE;
+      case TypeReference.ShortTypeCode -> BaseType.SHORT;
+      case TypeReference.IntTypeCode -> BaseType.INT;
+      case TypeReference.LongTypeCode -> BaseType.LONG;
+      case TypeReference.FloatTypeCode -> BaseType.FLOAT;
+      case TypeReference.DoubleTypeCode -> BaseType.DOUBLE;
+      case TypeReference.CharTypeCode -> BaseType.CHAR;
+      case 'L' -> ClassTypeSignature.makeClassTypeSig(s);
+      case 'T' -> TypeVariableSignature.make(s);
+      case TypeReference.ArrayTypeCode -> ArrayTypeSignature.make(s);
+      default -> throw new IllegalArgumentException("malformed TypeSignature string:" + s);
+    };
   }
 
   public abstract boolean isTypeVariable();
@@ -101,92 +88,64 @@ public abstract class TypeSignature extends Signature {
     int i = 1;
     while (true) {
       switch (typeSigs.charAt(i++)) {
-        case TypeReference.VoidTypeCode:
-          sigs.add(TypeReference.VoidName.toString());
-          continue;
-        case TypeReference.BooleanTypeCode:
-          sigs.add(TypeReference.BooleanName.toString());
-          continue;
-        case TypeReference.ByteTypeCode:
-          sigs.add(TypeReference.ByteName.toString());
-          continue;
-        case TypeReference.ShortTypeCode:
-          sigs.add(TypeReference.ShortName.toString());
-          continue;
-        case TypeReference.IntTypeCode:
-          sigs.add(TypeReference.IntName.toString());
-          continue;
-        case TypeReference.LongTypeCode:
-          sigs.add(TypeReference.LongName.toString());
-          continue;
-        case TypeReference.FloatTypeCode:
-          sigs.add(TypeReference.FloatName.toString());
-          continue;
-        case TypeReference.DoubleTypeCode:
-          sigs.add(TypeReference.DoubleName.toString());
-          continue;
-        case TypeReference.CharTypeCode:
-          sigs.add(TypeReference.CharName.toString());
-          continue;
-        case TypeReference.ClassTypeCode:
-          {
-            int off = i - 1;
-            i = getEndIndexOfClassType(typeSigs, i);
-            sigs.add(typeSigs.substring(off, i));
-            continue;
+        case TypeReference.VoidTypeCode -> sigs.add(TypeReference.VoidName.toString());
+        case TypeReference.BooleanTypeCode -> sigs.add(TypeReference.BooleanName.toString());
+        case TypeReference.ByteTypeCode -> sigs.add(TypeReference.ByteName.toString());
+        case TypeReference.ShortTypeCode -> sigs.add(TypeReference.ShortName.toString());
+        case TypeReference.IntTypeCode -> sigs.add(TypeReference.IntName.toString());
+        case TypeReference.LongTypeCode -> sigs.add(TypeReference.LongName.toString());
+        case TypeReference.FloatTypeCode -> sigs.add(TypeReference.FloatName.toString());
+        case TypeReference.DoubleTypeCode -> sigs.add(TypeReference.DoubleName.toString());
+        case TypeReference.CharTypeCode -> sigs.add(TypeReference.CharName.toString());
+        case TypeReference.ClassTypeCode -> {
+          int off = i - 1;
+          i = getEndIndexOfClassType(typeSigs, i);
+          sigs.add(typeSigs.substring(off, i));
+        }
+        case TypeReference.ArrayTypeCode -> {
+          int arrayStart = i - 1;
+          while (typeSigs.charAt(i) == TypeReference.ArrayTypeCode) {
+            i++;
           }
-        case TypeReference.ArrayTypeCode:
-          {
-            int arrayStart = i - 1;
-            while (typeSigs.charAt(i) == TypeReference.ArrayTypeCode) {
+          switch (typeSigs.charAt(i)) {
+            case TypeReference.BooleanTypeCode,
+                TypeReference.ByteTypeCode,
+                TypeReference.ShortTypeCode,
+                TypeReference.IntTypeCode,
+                TypeReference.LongTypeCode,
+                TypeReference.FloatTypeCode,
+                TypeReference.DoubleTypeCode,
+                TypeReference.CharTypeCode -> {
+              sigs.add(typeSigs.substring(arrayStart, i + 1));
               i++;
             }
-            switch (typeSigs.charAt(i)) {
-              case TypeReference.BooleanTypeCode:
-              case TypeReference.ByteTypeCode:
-              case TypeReference.ShortTypeCode:
-              case TypeReference.IntTypeCode:
-              case TypeReference.LongTypeCode:
-              case TypeReference.FloatTypeCode:
-              case TypeReference.DoubleTypeCode:
-              case TypeReference.CharTypeCode:
-                sigs.add(typeSigs.substring(arrayStart, i + 1));
-                i++;
-                break;
-              case 'T':
-              case TypeReference.ClassTypeCode:
-                i++; // to skip 'L' or 'T'
-                i = getEndIndexOfClassType(typeSigs, i);
-                sigs.add(typeSigs.substring(arrayStart, i));
-                break;
-              default:
-                Assertions.UNREACHABLE("BANG " + typeSigs.charAt(i));
+            case 'T', TypeReference.ClassTypeCode -> {
+              i++; // to skip 'L' or 'T'
+              i = getEndIndexOfClassType(typeSigs, i);
+              sigs.add(typeSigs.substring(arrayStart, i));
             }
-            continue;
+            default -> Assertions.UNREACHABLE("BANG " + typeSigs.charAt(i));
           }
-        case (byte) 'T':
-          { // type variable
-            int off = i - 1;
-            while (typeSigs.charAt(i++) != ';')
-              ;
-            sigs.add(typeSigs.substring(off, i));
-            continue;
-          }
-        case (byte) '*': // unbounded wildcard
-          sigs.add("*");
-          break;
-        case (byte) '-': // bounded wildcard
-        case (byte) '+': // bounded wildcard
+        }
+        case (byte) 'T' -> { // type variable
+          int off = i - 1;
+          while (typeSigs.charAt(i++) != ';')
+            ;
+          sigs.add(typeSigs.substring(off, i));
+        }
+        case (byte) '*' -> // unbounded wildcard
+            sigs.add("*");
+        // bounded wildcard
+        case (byte) '-', (byte) '+' -> {
           int boundedStart = i - 1;
           i++; // to skip 'L'
           i = getEndIndexOfClassType(typeSigs, i);
           sigs.add(typeSigs.substring(boundedStart, i));
-          break;
-        case (byte) ')': // end of parameter list
-        case (byte) '>': // end of type argument list
-          return sigs.toArray(new String[0]);
-        default:
-          throw new IllegalArgumentException("bad type signature list " + typeSigs);
+        } // end of parameter list
+        case (byte) ')', (byte) '>' -> {
+          return sigs.toArray(new String[0]); // end of type argument list
+        }
+        default -> throw new IllegalArgumentException("bad type signature list " + typeSigs);
       }
     }
   }

--- a/core/src/test/java/com/ibm/wala/core/tests/exceptionpruning/ExceptionAnalysis2EdgeFilterTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/exceptionpruning/ExceptionAnalysis2EdgeFilterTest.java
@@ -179,25 +179,14 @@ public class ExceptionAnalysis2EdgeFilterTest {
     for (Map.Entry<String, Integer> entry : deletedExceptional.entrySet()) {
       final String key = entry.getKey();
       final int value = entry.getValue();
-      final int expected;
-      switch (key) {
-        case "testTryCatchMultipleExceptions":
-          expected = 12;
-          break;
-        case "testTryCatchOwnException":
-        case "testTryCatchImplicitException":
-          expected = 5;
-          break;
-        case "testTryCatchSuper":
-          expected = 3;
-          break;
-        case "main":
-          expected = 4;
-          break;
-        default:
-          expected = 0;
-          break;
-      }
+      final int expected =
+          switch (key) {
+            case "testTryCatchMultipleExceptions" -> 12;
+            case "testTryCatchOwnException", "testTryCatchImplicitException" -> 5;
+            case "testTryCatchSuper" -> 3;
+            case "main" -> 4;
+            default -> 0;
+          };
       assertThat(value).isEqualTo(expected);
     }
   }

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexCFG.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexCFG.java
@@ -409,15 +409,8 @@ public class DexCFG extends AbstractCFG<Instruction, DexCFG.BasicBlock> implemen
       if (pei == null) {
         throw new IllegalArgumentException("pei is null");
       }
-      switch (pei.getOpcode()) {
+      return switch (pei.getOpcode()) {
         // TODO: Make sure all the important cases and exceptions are covered.
-        case AGET:
-        case AGET_WIDE:
-        case AGET_OBJECT:
-        case AGET_BOOLEAN:
-        case AGET_BYTE:
-        case AGET_CHAR:
-        case AGET_SHORT:
         //      case OP_iaload:
         //      case OP_laload:
         //      case OP_faload:
@@ -426,98 +419,103 @@ public class DexCFG extends AbstractCFG<Instruction, DexCFG.BasicBlock> implemen
         //      case OP_baload:
         //      case OP_caload:
         //      case OP_saload:
-        case APUT:
-        case APUT_WIDE:
         //      case APUT_OBJECT:
-        case APUT_BOOLEAN:
-        case APUT_BYTE:
-        case APUT_CHAR:
-        case APUT_SHORT:
-          //      case OP_iastore:
-          //      case OP_lastore:
-          //      case OP_fastore:
-          //      case OP_dastore:
-          //      case OP_bastore:
-          //      case OP_castore:
-          //      case OP_sastore:
-          return JavaLanguage.getArrayAccessExceptions();
-        case APUT_OBJECT:
-          // case OP_aastore:
-          return JavaLanguage.getAaStoreExceptions();
-        case IGET:
-        case IGET_WIDE:
-        case IGET_OBJECT:
-        case IGET_BOOLEAN:
-        case IGET_BYTE:
-        case IGET_CHAR:
-        case IGET_SHORT:
+        case AGET,
+            AGET_WIDE,
+            AGET_OBJECT,
+            AGET_BOOLEAN,
+            AGET_BYTE,
+            AGET_CHAR,
+            AGET_SHORT,
+            APUT,
+            APUT_WIDE,
+            APUT_BOOLEAN,
+            APUT_BYTE,
+            APUT_CHAR,
+            APUT_SHORT ->
+            //      case OP_iastore:
+            //      case OP_lastore:
+            //      case OP_fastore:
+            //      case OP_dastore:
+            //      case OP_bastore:
+            //      case OP_castore:
+            //      case OP_sastore:
+            JavaLanguage.getArrayAccessExceptions();
+        case APUT_OBJECT ->
+            // case OP_aastore:
+            JavaLanguage.getAaStoreExceptions();
         //      case OP_getfield:
-        case IPUT:
-        case IPUT_WIDE:
-        case IPUT_OBJECT:
-        case IPUT_BOOLEAN:
-        case IPUT_BYTE:
-        case IPUT_CHAR:
-        case IPUT_SHORT:
         //      case OP_putfield:
 
         // Shrike imp does not include the static invoke calls, so likewise will do the same
-        case INVOKE_VIRTUAL:
-        case INVOKE_SUPER:
-        case INVOKE_DIRECT:
         // case INVOKE_STATIC:
-        case INVOKE_INTERFACE:
-        case INVOKE_VIRTUAL_RANGE:
-        case INVOKE_SUPER_RANGE:
-        case INVOKE_DIRECT_RANGE:
         // case INVOKE_STATIC_RANGE:
-        case INVOKE_INTERFACE_RANGE:
         //      case OP_invokevirtual:
         //      case OP_invokespecial:
         //      case OP_invokeinterface:
-        case ARRAY_LENGTH:
         //      case OP_arraylength:
-        case MONITOR_ENTER:
-        case MONITOR_EXIT:
         //      case OP_monitorenter:
         //      case OP_monitorexit:
         // we're currently ignoring MonitorStateExceptions, since J2EE stuff
         // should be
         // logically single-threaded
-        case THROW:
-          //      case OP_athrow:
-          // N.B: the caller must handle the explicitly-thrown exception
-          return JavaLanguage.getNullPointerException();
-        case DIV_INT:
-        case DIV_INT_2ADDR:
-        case DIV_INT_LIT16:
-        case DIV_INT_LIT8:
-        case REM_INT:
-        case REM_INT_2ADDR:
-        case REM_INT_LIT16:
-        case REM_INT_LIT8:
-        case DIV_LONG:
-        case DIV_LONG_2ADDR:
-        case REM_LONG:
-        case REM_LONG_2ADDR:
-          //      case OP_idiv:
-          //      case OP_irem:
-          //      case OP_ldiv:
-          //      case OP_lrem:
-          return JavaLanguage.getArithmeticException();
-        case NEW_INSTANCE:
-          // case OP_new:
-          return JavaLanguage.getNewScalarExceptions();
-        case NEW_ARRAY:
-        case FILLED_NEW_ARRAY:
-        case FILLED_NEW_ARRAY_RANGE:
-          //      case OP_newarray:
-          //      case OP_anewarray:
-          //      case OP_multianewarray:
-          return JavaLanguage.getNewArrayExceptions();
-        case CHECK_CAST:
-          //      case OP_checkcast:
-          return JavaLanguage.getClassCastException();
+        case IGET,
+            IGET_WIDE,
+            IGET_OBJECT,
+            IGET_BOOLEAN,
+            IGET_BYTE,
+            IGET_CHAR,
+            IGET_SHORT,
+            IPUT,
+            IPUT_WIDE,
+            IPUT_OBJECT,
+            IPUT_BOOLEAN,
+            IPUT_BYTE,
+            IPUT_CHAR,
+            IPUT_SHORT,
+            INVOKE_VIRTUAL,
+            INVOKE_SUPER,
+            INVOKE_DIRECT,
+            INVOKE_INTERFACE,
+            INVOKE_VIRTUAL_RANGE,
+            INVOKE_SUPER_RANGE,
+            INVOKE_DIRECT_RANGE,
+            INVOKE_INTERFACE_RANGE,
+            ARRAY_LENGTH,
+            MONITOR_ENTER,
+            MONITOR_EXIT,
+            THROW ->
+            //      case OP_athrow:
+            // N.B: the caller must handle the explicitly-thrown exception
+            JavaLanguage.getNullPointerException();
+        case DIV_INT,
+            DIV_INT_2ADDR,
+            DIV_INT_LIT16,
+            DIV_INT_LIT8,
+            REM_INT,
+            REM_INT_2ADDR,
+            REM_INT_LIT16,
+            REM_INT_LIT8,
+            DIV_LONG,
+            DIV_LONG_2ADDR,
+            REM_LONG,
+            REM_LONG_2ADDR ->
+            //      case OP_idiv:
+            //      case OP_irem:
+            //      case OP_ldiv:
+            //      case OP_lrem:
+            JavaLanguage.getArithmeticException();
+        case NEW_INSTANCE ->
+            // case OP_new:
+            JavaLanguage.getNewScalarExceptions();
+        case NEW_ARRAY, FILLED_NEW_ARRAY, FILLED_NEW_ARRAY_RANGE ->
+            //      case OP_newarray:
+            //      case OP_anewarray:
+            //      case OP_multianewarray:
+            JavaLanguage.getNewArrayExceptions();
+        case CHECK_CAST ->
+            //      case OP_checkcast:
+            JavaLanguage.getClassCastException();
 
         // I Don't think dalvik has to worry about this?
         //      case OP_ldc_w:
@@ -526,26 +524,25 @@ public class DexCFG extends AbstractCFG<Instruction, DexCFG.BasicBlock> implemen
         //        else
         //          return null;
 
-        case SGET:
-        case SGET_BOOLEAN:
-        case SGET_BYTE:
-        case SGET_CHAR:
-        case SGET_OBJECT:
-        case SGET_SHORT:
-        case SGET_WIDE:
-        case SPUT:
-        case SPUT_BOOLEAN:
-        case SPUT_BYTE:
-        case SPUT_CHAR:
-        case SPUT_OBJECT:
-        case SPUT_SHORT:
-        case SPUT_WIDE:
-          //      case OP_getstatic:
-          //      case OP_putstatic:
-          return JavaLanguage.getExceptionInInitializerError();
-        default:
-          return Collections.emptySet();
-      }
+        case SGET,
+            SGET_BOOLEAN,
+            SGET_BYTE,
+            SGET_CHAR,
+            SGET_OBJECT,
+            SGET_SHORT,
+            SGET_WIDE,
+            SPUT,
+            SPUT_BOOLEAN,
+            SPUT_BYTE,
+            SPUT_CHAR,
+            SPUT_OBJECT,
+            SPUT_SHORT,
+            SPUT_WIDE ->
+            //      case OP_getstatic:
+            //      case OP_putstatic:
+            JavaLanguage.getExceptionInInitializerError();
+        default -> Collections.emptySet();
+      };
     }
 
     private ExceptionHandler[] getExceptionHandlers() {

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexIMethod.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexIMethod.java
@@ -916,48 +916,42 @@ public class DexIMethod implements IBytecodeMethod<Instruction> {
       instLoc = currentCodeAddress;
       // pc += inst.getFormat().size;
       switch (inst.getOpcode()) {
-        case NOP:
-        case ARRAY_PAYLOAD:
-        case PACKED_SWITCH_PAYLOAD:
-        case SPARSE_SWITCH_PAYLOAD:
+        case NOP, ARRAY_PAYLOAD, PACKED_SWITCH_PAYLOAD, SPARSE_SWITCH_PAYLOAD -> {
           switch (inst.getOpcode().format) {
-            case ArrayPayload:
-              {
-                for (int i = 0; i < instructions.size(); i++) {
-                  if (instructions.getFromId(i) instanceof ArrayFill)
-                    if (instLoc
-                        == (((ArrayFill) getInstructionFromIndex(i)).tableAddressOffset
-                            + getAddressFromIndex(i))) {
-                      ((ArrayFill) getInstructionFromIndex(i))
-                          .setArrayDataTable((ArrayPayload) inst);
+            case ArrayPayload -> {
+              for (int i = 0; i < instructions.size(); i++) {
+                if (instructions.getFromId(i) instanceof ArrayFill)
+                  if (instLoc
+                      == (((ArrayFill) getInstructionFromIndex(i)).tableAddressOffset
+                          + getAddressFromIndex(i))) {
+                    ((ArrayFill) getInstructionFromIndex(i)).setArrayDataTable((ArrayPayload) inst);
 
-                      //                              Iterator<ArrayElement> b =
-                      // (((ArrayDataPseudoInstruction)inst).getElements());
-                      //                              while (b.hasNext())
-                      //                              {
-                      //                                  int ElementWidth =
-                      // ((ArrayDataPseudoInstruction)inst).getElementWidth();
-                      //                                  byte[] temp_byte = new byte[ElementWidth];
-                      //
-                      //                                  ArrayElement t = (ArrayElement)b.next();
-                      //                                  for (int j = 0; j < ElementWidth; j++)
-                      //                                      temp_byte[j] =
-                      // t.buffer[t.bufferIndex+(ElementWidth-1)-j];
-                      //
-                      //                                  ByteBuffer byte_buffer =
-                      // ByteBuffer.wrap(temp_byte);
-                      //
-                      //                                  System.out.println("Index: " +
-                      // t.bufferIndex + ", Width: " + t.elementWidth + ", Value: " +
-                      // byte_buffer.getChar());
-                      //                              }
+                    //                              Iterator<ArrayElement> b =
+                    // (((ArrayDataPseudoInstruction)inst).getElements());
+                    //                              while (b.hasNext())
+                    //                              {
+                    //                                  int ElementWidth =
+                    // ((ArrayDataPseudoInstruction)inst).getElementWidth();
+                    //                                  byte[] temp_byte = new byte[ElementWidth];
+                    //
+                    //                                  ArrayElement t = (ArrayElement)b.next();
+                    //                                  for (int j = 0; j < ElementWidth; j++)
+                    //                                      temp_byte[j] =
+                    // t.buffer[t.bufferIndex+(ElementWidth-1)-j];
+                    //
+                    //                                  ByteBuffer byte_buffer =
+                    // ByteBuffer.wrap(temp_byte);
+                    //
+                    //                                  System.out.println("Index: " +
+                    // t.bufferIndex + ", Width: " + t.elementWidth + ", Value: " +
+                    // byte_buffer.getChar());
+                    //                              }
 
-                      break;
-                    }
-                }
-                break;
+                    break;
+                  }
               }
-            case PackedSwitchPayload:
+            }
+            case PackedSwitchPayload -> {
               for (int i = 0; i < instructions.size(); i++) {
                 if (instructions.getFromId(i) instanceof Switch)
                   if (instLoc
@@ -971,36 +965,35 @@ public class DexIMethod implements IBytecodeMethod<Instruction> {
                     break;
                   }
               }
-              break;
-            case SparseSwitchPayload:
-              {
-                for (int i = 0; i < instructions.size(); i++) {
-                  if (instructions.getFromId(i) instanceof Switch)
-                    if (instLoc
-                        == (((Switch) getInstructionFromIndex(i)).tableAddressOffset
-                            + getAddressFromIndex(i))) {
-                      ((Switch) getInstructionFromIndex(i))
-                          .setSwitchPad(
-                              new SparseSwitchPad(
-                                  (SwitchPayload) inst,
-                                  getAddressFromIndex(i + 1) - getAddressFromIndex(i)));
-                      break;
-                    }
-                }
-                //                  System.out.println("Targets: " +
-                // ((SparseSwitchDataPseudoInstruction)inst).getTargetCount());
-                //                  Iterator<SparseSwitchTarget> i =
-                // (((SparseSwitchDataPseudoInstruction)inst).iterateKeysAndTargets());
-                //                  while (i.hasNext())
-                //                  {
-                //                      SparseSwitchTarget t = (SparseSwitchTarget)i.next();
-                //                      System.out.println("Key: " + t.key + ", TargetAddressOffset:
-                // " + t.targetAddressOffset);
-                //                  }
-                break;
+            }
+            case SparseSwitchPayload -> {
+              for (int i = 0; i < instructions.size(); i++) {
+                if (instructions.getFromId(i) instanceof Switch)
+                  if (instLoc
+                      == (((Switch) getInstructionFromIndex(i)).tableAddressOffset
+                          + getAddressFromIndex(i))) {
+                    ((Switch) getInstructionFromIndex(i))
+                        .setSwitchPad(
+                            new SparseSwitchPad(
+                                (SwitchPayload) inst,
+                                getAddressFromIndex(i + 1) - getAddressFromIndex(i)));
+                    break;
+                  }
               }
-            default:
+              //                  System.out.println("Targets: " +
+              // ((SparseSwitchDataPseudoInstruction)inst).getTargetCount());
+              //                  Iterator<SparseSwitchTarget> i =
+              // (((SparseSwitchDataPseudoInstruction)inst).iterateKeysAndTargets());
+              //                  while (i.hasNext())
+              //                  {
+              //                      SparseSwitchTarget t = (SparseSwitchTarget)i.next();
+              //                      System.out.println("Key: " + t.key + ", TargetAddressOffset:
+              // " + t.targetAddressOffset);
+              //                  }
+            }
+            default -> {
               class NOPInstruction extends Instruction {
+
                 private NOPInstruction(int pc, Opcode op, DexIMethod method) {
                   super(pc, op, method);
                 }
@@ -1012,149 +1005,134 @@ public class DexIMethod implements IBytecodeMethod<Instruction> {
               }
 
               instructions.add(new NOPInstruction(currentCodeAddress, Opcode.NOP, this));
-              break;
+            }
           }
-          break;
-        case MOVE:
-        case MOVE_OBJECT:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  UnaryOperation.OpID.MOVE,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case MOVE_FROM16:
-        case MOVE_OBJECT_FROM16:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  UnaryOperation.OpID.MOVE,
-                  ((Instruction22x) inst).getRegisterA(),
-                  ((Instruction22x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case MOVE_16:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  UnaryOperation.OpID.MOVE,
-                  ((Instruction32x) inst).getRegisterA(),
-                  ((Instruction32x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case MOVE_WIDE:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  UnaryOperation.OpID.MOVE_WIDE,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case MOVE_WIDE_FROM16:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  UnaryOperation.OpID.MOVE_WIDE,
-                  ((Instruction22x) inst).getRegisterA(),
-                  ((Instruction22x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case MOVE_WIDE_16:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  UnaryOperation.OpID.MOVE_WIDE,
-                  ((Instruction32x) inst).getRegisterA(),
-                  ((Instruction32x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case MOVE_OBJECT_16:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  UnaryOperation.OpID.MOVE,
-                  ((Instruction32x) inst).getRegisterA(),
-                  ((Instruction32x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case MOVE_RESULT:
-          // register b set as return register, -1;
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  UnaryOperation.OpID.MOVE,
-                  ((Instruction11x) inst).getRegisterA(),
-                  getReturnReg(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case MOVE_RESULT_WIDE:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  UnaryOperation.OpID.MOVE_WIDE,
-                  ((Instruction11x) inst).getRegisterA(),
-                  getReturnReg(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case MOVE_RESULT_OBJECT:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  UnaryOperation.OpID.MOVE,
-                  ((Instruction11x) inst).getRegisterA(),
-                  getReturnReg(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case MOVE_EXCEPTION:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  UnaryOperation.OpID.MOVE_EXCEPTION,
-                  ((Instruction11x) inst).getRegisterA(),
-                  getExceptionReg(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case RETURN_VOID:
-        case RETURN_VOID_NO_BARRIER:
-          instructions.add(new Return.ReturnVoid(instLoc, inst.getOpcode(), this));
-          break;
-        case RETURN:
-          // I think only primitives call return, and objects call return-object
-          instructions.add(
-              new Return.ReturnSingle(
-                  instLoc, ((Instruction11x) inst).getRegisterA(), true, inst.getOpcode(), this));
-          break;
-        case RETURN_WIDE:
-          // +1 to second parameter okay?
-          instructions.add(
-              new Return.ReturnDouble(
-                  instLoc,
-                  ((Instruction11x) inst).getRegisterA(),
-                  ((Instruction11x) inst).getRegisterA() + 1,
-                  inst.getOpcode(),
-                  this));
-          break;
-        case RETURN_OBJECT:
-          instructions.add(
-              new Return.ReturnSingle(
-                  instLoc, ((Instruction11x) inst).getRegisterA(), false, inst.getOpcode(), this));
-          break;
-        case CONST_4:
-          {
+        }
+        case MOVE, MOVE_OBJECT ->
+            instructions.add(
+                new UnaryOperation(
+                    instLoc,
+                    OpID.MOVE,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case MOVE_FROM16, MOVE_OBJECT_FROM16 ->
+            instructions.add(
+                new UnaryOperation(
+                    instLoc,
+                    OpID.MOVE,
+                    ((Instruction22x) inst).getRegisterA(),
+                    ((Instruction22x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case MOVE_16 ->
+            instructions.add(
+                new UnaryOperation(
+                    instLoc,
+                    OpID.MOVE,
+                    ((Instruction32x) inst).getRegisterA(),
+                    ((Instruction32x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case MOVE_WIDE ->
+            instructions.add(
+                new UnaryOperation(
+                    instLoc,
+                    OpID.MOVE_WIDE,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case MOVE_WIDE_FROM16 ->
+            instructions.add(
+                new UnaryOperation(
+                    instLoc,
+                    OpID.MOVE_WIDE,
+                    ((Instruction22x) inst).getRegisterA(),
+                    ((Instruction22x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case MOVE_WIDE_16 ->
+            instructions.add(
+                new UnaryOperation(
+                    instLoc,
+                    OpID.MOVE_WIDE,
+                    ((Instruction32x) inst).getRegisterA(),
+                    ((Instruction32x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case MOVE_OBJECT_16 ->
+            instructions.add(
+                new UnaryOperation(
+                    instLoc,
+                    OpID.MOVE,
+                    ((Instruction32x) inst).getRegisterA(),
+                    ((Instruction32x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case MOVE_RESULT ->
+            // register b set as return register, -1;
+            instructions.add(
+                new UnaryOperation(
+                    instLoc,
+                    OpID.MOVE,
+                    ((Instruction11x) inst).getRegisterA(),
+                    getReturnReg(),
+                    inst.getOpcode(),
+                    this));
+        case MOVE_RESULT_WIDE ->
+            instructions.add(
+                new UnaryOperation(
+                    instLoc,
+                    OpID.MOVE_WIDE,
+                    ((Instruction11x) inst).getRegisterA(),
+                    getReturnReg(),
+                    inst.getOpcode(),
+                    this));
+        case MOVE_RESULT_OBJECT ->
+            instructions.add(
+                new UnaryOperation(
+                    instLoc,
+                    OpID.MOVE,
+                    ((Instruction11x) inst).getRegisterA(),
+                    getReturnReg(),
+                    inst.getOpcode(),
+                    this));
+        case MOVE_EXCEPTION ->
+            instructions.add(
+                new UnaryOperation(
+                    instLoc,
+                    OpID.MOVE_EXCEPTION,
+                    ((Instruction11x) inst).getRegisterA(),
+                    getExceptionReg(),
+                    inst.getOpcode(),
+                    this));
+        case RETURN_VOID, RETURN_VOID_NO_BARRIER ->
+            instructions.add(new Return.ReturnVoid(instLoc, inst.getOpcode(), this));
+        case RETURN ->
+            // I think only primitives call return, and objects call return-object
+            instructions.add(
+                new Return.ReturnSingle(
+                    instLoc, ((Instruction11x) inst).getRegisterA(), true, inst.getOpcode(), this));
+        case RETURN_WIDE ->
+            // +1 to second parameter okay?
+            instructions.add(
+                new Return.ReturnDouble(
+                    instLoc,
+                    ((Instruction11x) inst).getRegisterA(),
+                    ((Instruction11x) inst).getRegisterA() + 1,
+                    inst.getOpcode(),
+                    this));
+        case RETURN_OBJECT ->
+            instructions.add(
+                new Return.ReturnSingle(
+                    instLoc,
+                    ((Instruction11x) inst).getRegisterA(),
+                    false,
+                    inst.getOpcode(),
+                    this));
+        case CONST_4 ->
             instructions.add(
                 new Constant.IntConstant(
                     instLoc,
@@ -1162,307 +1140,274 @@ public class DexIMethod implements IBytecodeMethod<Instruction> {
                     ((Instruction11n) inst).getRegisterA(),
                     inst.getOpcode(),
                     this));
-            break;
-          }
-        case CONST_16:
+        case CONST_16 ->
+            instructions.add(
+                new Constant.IntConstant(
+                    instLoc,
+                    ((Instruction21s) inst).getNarrowLiteral(),
+                    ((Instruction21s) inst).getRegisterA(),
+                    inst.getOpcode(),
+                    this));
+        case CONST ->
+            instructions.add(
+                new Constant.IntConstant(
+                    instLoc,
+                    ((Instruction31i) inst).getNarrowLiteral(),
+                    ((Instruction31i) inst).getRegisterA(),
+                    inst.getOpcode(),
+                    this));
+        case CONST_HIGH16 ->
+            instructions.add(
+                new Constant.IntConstant(
+                    instLoc,
+                    ((Instruction21ih) inst).getHatLiteral() << 16,
+                    ((Instruction21ih) inst).getRegisterA(),
+                    inst.getOpcode(),
+                    this));
+        case CONST_WIDE_16 ->
+            instructions.add(
+                new Constant.LongConstant(
+                    instLoc,
+                    ((Instruction21s) inst).getWideLiteral(),
+                    ((Instruction21s) inst).getRegisterA(),
+                    inst.getOpcode(),
+                    this));
+        case CONST_WIDE_32 ->
+            instructions.add(
+                new Constant.LongConstant(
+                    instLoc,
+                    ((Instruction31i) inst).getWideLiteral(),
+                    ((Instruction31i) inst).getRegisterA(),
+                    inst.getOpcode(),
+                    this));
+        case CONST_WIDE ->
+            instructions.add(
+                new Constant.LongConstant(
+                    instLoc,
+                    ((Instruction51l) inst).getWideLiteral(),
+                    ((Instruction51l) inst).getRegisterA(),
+                    inst.getOpcode(),
+                    this));
+        case CONST_WIDE_HIGH16 ->
+            instructions.add(
+                new Constant.LongConstant(
+                    instLoc,
+                    ((Instruction21lh) inst).getWideLiteral() << 16,
+                    ((Instruction21lh) inst).getRegisterA(),
+                    inst.getOpcode(),
+                    this));
+        case CONST_STRING ->
+            instructions.add(
+                new Constant.StringConstant(
+                    instLoc,
+                    ((StringReference) ((Instruction21c) inst).getReference()).getString(),
+                    ((Instruction21c) inst).getRegisterA(),
+                    inst.getOpcode(),
+                    this));
+        case CONST_STRING_JUMBO ->
+            instructions.add(
+                new Constant.StringConstant(
+                    instLoc,
+                    ((StringReference) ((Instruction31c) inst).getReference()).getString(),
+                    ((Instruction31c) inst).getRegisterA(),
+                    inst.getOpcode(),
+                    this));
+        case CONST_CLASS -> {
+          String cName =
+              ((org.jf.dexlib2.iface.reference.TypeReference)
+                      ((Instruction21c) inst).getReference())
+                  .getType();
+          if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
+
+          // IClass ic = this.myClass.loader.lookupClass(TypeName.findOrCreate(cName));
+          TypeReference typeRef =
+              TypeReference.findOrCreate(myClass.getClassLoader().getReference(), cName);
+
           instructions.add(
-              new Constant.IntConstant(
+              new Constant.ClassConstant(
                   instLoc,
-                  ((Instruction21s) inst).getNarrowLiteral(),
-                  ((Instruction21s) inst).getRegisterA(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case CONST:
-          instructions.add(
-              new Constant.IntConstant(
-                  instLoc,
-                  ((Instruction31i) inst).getNarrowLiteral(),
-                  ((Instruction31i) inst).getRegisterA(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case CONST_HIGH16:
-          instructions.add(
-              new Constant.IntConstant(
-                  instLoc,
-                  ((Instruction21ih) inst).getHatLiteral() << 16,
-                  ((Instruction21ih) inst).getRegisterA(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case CONST_WIDE_16:
-          instructions.add(
-              new Constant.LongConstant(
-                  instLoc,
-                  ((Instruction21s) inst).getWideLiteral(),
-                  ((Instruction21s) inst).getRegisterA(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case CONST_WIDE_32:
-          instructions.add(
-              new Constant.LongConstant(
-                  instLoc,
-                  ((Instruction31i) inst).getWideLiteral(),
-                  ((Instruction31i) inst).getRegisterA(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case CONST_WIDE:
-          instructions.add(
-              new Constant.LongConstant(
-                  instLoc,
-                  ((Instruction51l) inst).getWideLiteral(),
-                  ((Instruction51l) inst).getRegisterA(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case CONST_WIDE_HIGH16:
-          instructions.add(
-              new Constant.LongConstant(
-                  instLoc,
-                  ((Instruction21lh) inst).getWideLiteral() << 16,
-                  ((Instruction21lh) inst).getRegisterA(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case CONST_STRING:
-          instructions.add(
-              new Constant.StringConstant(
-                  instLoc,
-                  ((StringReference) ((Instruction21c) inst).getReference()).getString(),
+                  typeRef,
                   ((Instruction21c) inst).getRegisterA(),
                   inst.getOpcode(),
                   this));
-          break;
-        case CONST_STRING_JUMBO:
+          // logger.debug("myClass found name: " +
+          // this.myClass.loader.lookupClass(TypeName.findOrCreate(cName)).toString());
+        }
+        case MONITOR_ENTER ->
+            instructions.add(
+                new Monitor(
+                    instLoc, true, ((Instruction11x) inst).getRegisterA(), inst.getOpcode(), this));
+        case MONITOR_EXIT ->
+            instructions.add(
+                new Monitor(
+                    instLoc,
+                    false,
+                    ((Instruction11x) inst).getRegisterA(),
+                    inst.getOpcode(),
+                    this));
+        case CHECK_CAST -> {
+          String cName =
+              ((org.jf.dexlib2.iface.reference.TypeReference)
+                      ((Instruction21c) inst).getReference())
+                  .getType();
+          if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
+
+          // retrieving type reference correctly?
           instructions.add(
-              new Constant.StringConstant(
+              new CheckCast(
                   instLoc,
-                  ((StringReference) ((Instruction31c) inst).getReference()).getString(),
-                  ((Instruction31c) inst).getRegisterA(),
+                  TypeReference.findOrCreate(myClass.getClassLoader().getReference(), cName),
+                  ((Instruction21c) inst).getRegisterA(),
                   inst.getOpcode(),
                   this));
-          break;
-        case CONST_CLASS:
-          {
-            String cName =
-                ((org.jf.dexlib2.iface.reference.TypeReference)
-                        ((Instruction21c) inst).getReference())
-                    .getType();
-            if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
-
-            // IClass ic = this.myClass.loader.lookupClass(TypeName.findOrCreate(cName));
-            TypeReference typeRef =
-                TypeReference.findOrCreate(myClass.getClassLoader().getReference(), cName);
-
-            instructions.add(
-                new Constant.ClassConstant(
-                    instLoc,
-                    typeRef,
-                    ((Instruction21c) inst).getRegisterA(),
-                    inst.getOpcode(),
-                    this));
-            // logger.debug("myClass found name: " +
-            // this.myClass.loader.lookupClass(TypeName.findOrCreate(cName)).toString());
-            break;
-          }
-        case MONITOR_ENTER:
+        }
+        case INSTANCE_OF -> {
+          String cName =
+              ((org.jf.dexlib2.iface.reference.TypeReference)
+                      ((Instruction22c) inst).getReference())
+                  .getType();
+          if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
           instructions.add(
-              new Monitor(
-                  instLoc, true, ((Instruction11x) inst).getRegisterA(), inst.getOpcode(), this));
-          break;
-        case MONITOR_EXIT:
-          instructions.add(
-              new Monitor(
-                  instLoc, false, ((Instruction11x) inst).getRegisterA(), inst.getOpcode(), this));
-          break;
-        case CHECK_CAST:
-          {
-            String cName =
-                ((org.jf.dexlib2.iface.reference.TypeReference)
-                        ((Instruction21c) inst).getReference())
-                    .getType();
-            if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
-
-            // retrieving type reference correctly?
-            instructions.add(
-                new CheckCast(
-                    instLoc,
-                    TypeReference.findOrCreate(myClass.getClassLoader().getReference(), cName),
-                    ((Instruction21c) inst).getRegisterA(),
-                    inst.getOpcode(),
-                    this));
-            break;
-          }
-        case INSTANCE_OF:
-          {
-            String cName =
-                ((org.jf.dexlib2.iface.reference.TypeReference)
-                        ((Instruction22c) inst).getReference())
-                    .getType();
-            if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
-            instructions.add(
-                new InstanceOf(
-                    instLoc,
-                    ((Instruction22c) inst).getRegisterA(),
-                    TypeReference.findOrCreate(myClass.getClassLoader().getReference(), cName),
-                    ((Instruction22c) inst).getRegisterB(),
-                    inst.getOpcode(),
-                    this));
-            break;
-          }
-        case ARRAY_LENGTH:
-          instructions.add(
-              new ArrayLength(
+              new InstanceOf(
                   instLoc,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
+                  ((Instruction22c) inst).getRegisterA(),
+                  TypeReference.findOrCreate(myClass.getClassLoader().getReference(), cName),
+                  ((Instruction22c) inst).getRegisterB(),
                   inst.getOpcode(),
                   this));
-          break;
-        case NEW_INSTANCE:
-          {
-            // NewSiteReference use instLoc or pc?
-            String cName =
-                ((org.jf.dexlib2.iface.reference.TypeReference)
-                        ((Instruction21c) inst).getReference())
-                    .getType();
-            if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
-
+        }
+        case ARRAY_LENGTH ->
             instructions.add(
-                new New(
+                new ArrayLength(
                     instLoc,
-                    ((Instruction21c) inst).getRegisterA(),
-                    NewSiteReference.make(
-                        instLoc,
-                        TypeReference.findOrCreate(myClass.getClassLoader().getReference(), cName)),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
                     inst.getOpcode(),
                     this));
-            break;
-          }
-        case NEW_ARRAY:
-          {
-            int[] params = new int[1];
-            params[0] = ((Instruction22c) inst).getRegisterB();
-            //              MyLogger.log(LogLevel.INFO, "Type: "
-            // +((TypeIdItem)((Instruction22c)inst).getReferencedItem()).getTypeDescriptor());
+        case NEW_INSTANCE -> {
+          // NewSiteReference use instLoc or pc?
+          String cName =
+              ((org.jf.dexlib2.iface.reference.TypeReference)
+                      ((Instruction21c) inst).getReference())
+                  .getType();
+          if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
 
-            String cName =
-                ((org.jf.dexlib2.iface.reference.TypeReference)
-                        ((Instruction22c) inst).getReference())
-                    .getType();
-            if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
+          instructions.add(
+              new New(
+                  instLoc,
+                  ((Instruction21c) inst).getRegisterA(),
+                  NewSiteReference.make(
+                      instLoc,
+                      TypeReference.findOrCreate(myClass.getClassLoader().getReference(), cName)),
+                  inst.getOpcode(),
+                  this));
+        }
+        case NEW_ARRAY -> {
+          int[] params = new int[1];
+          params[0] = ((Instruction22c) inst).getRegisterB();
+          //              MyLogger.log(LogLevel.INFO, "Type: "
+          // +((TypeIdItem)((Instruction22c)inst).getReferencedItem()).getTypeDescriptor());
 
-            instructions.add(
-                new NewArray(
-                    instLoc,
-                    ((Instruction22c) inst).getRegisterA(),
-                    NewSiteReference.make(
-                        instLoc,
-                        TypeReference.findOrCreate(myClass.getClassLoader().getReference(), cName)),
-                    params,
-                    inst.getOpcode(),
-                    this));
-            break;
-          }
+          String cName =
+              ((org.jf.dexlib2.iface.reference.TypeReference)
+                      ((Instruction22c) inst).getReference())
+                  .getType();
+          if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
+
+          instructions.add(
+              new NewArray(
+                  instLoc,
+                  ((Instruction22c) inst).getRegisterA(),
+                  NewSiteReference.make(
+                      instLoc,
+                      TypeReference.findOrCreate(myClass.getClassLoader().getReference(), cName)),
+                  params,
+                  inst.getOpcode(),
+                  this));
+        }
+
         // TODO: FILLED ARRAYS
-        case FILLED_NEW_ARRAY:
-          {
-            int registerCount = ((Instruction35c) inst).getRegisterCount();
-            int[] params = new int[1];
-            params[0] = registerCount;
-            int[] args = new int[registerCount];
+        case FILLED_NEW_ARRAY -> {
+          int registerCount = ((Instruction35c) inst).getRegisterCount();
+          int[] params = new int[1];
+          params[0] = registerCount;
+          int[] args = new int[registerCount];
 
-            for (int i = 0; i < registerCount; i++) {
-              switch (i) {
-                case 0:
-                  args[0] = ((Instruction35c) inst).getRegisterD();
-                  break;
-                case 1:
-                  args[1] = ((Instruction35c) inst).getRegisterE();
-                  break;
-                case 2:
-                  args[2] = ((Instruction35c) inst).getRegisterF();
-                  break;
-                case 3:
-                  args[3] = ((Instruction35c) inst).getRegisterG();
-                  break;
-                case 4:
-                  args[4] = ((Instruction35c) inst).getRegisterC();
-                  break;
-                default:
+          for (int i = 0; i < registerCount; i++) {
+            switch (i) {
+              case 0 -> args[0] = ((Instruction35c) inst).getRegisterD();
+              case 1 -> args[1] = ((Instruction35c) inst).getRegisterE();
+              case 2 -> args[2] = ((Instruction35c) inst).getRegisterF();
+              case 3 -> args[3] = ((Instruction35c) inst).getRegisterG();
+              case 4 -> args[4] = ((Instruction35c) inst).getRegisterC();
+              default ->
                   throw new RuntimeException(
                       "Illegal instruction at " + instLoc + ": bad register count");
-              }
             }
-
-            String cName =
-                ((org.jf.dexlib2.iface.reference.TypeReference)
-                        ((Instruction35c) inst).getReference())
-                    .getType();
-            if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
-
-            NewSiteReference newSiteRef =
-                NewSiteReference.make(
-                    instLoc,
-                    TypeReference.findOrCreate(myClass.getClassLoader().getReference(), cName));
-            TypeReference myTypeRef =
-                TypeReference.findOrCreate(
-                    myClass.getClassLoader().getReference(),
-                    newSiteRef.getDeclaredType().getArrayElementType().getName().toString());
-
-            instructions.add(
-                new NewArrayFilled(
-                    instLoc,
-                    getReturnReg(),
-                    newSiteRef,
-                    myTypeRef,
-                    params,
-                    args,
-                    inst.getOpcode(),
-                    this));
-            break;
           }
-        case FILLED_NEW_ARRAY_RANGE:
-          {
-            int registerCount = ((Instruction3rc) inst).getRegisterCount();
-            int[] params = new int[1];
-            params[0] = registerCount;
-            int[] args = new int[registerCount];
 
-            for (int i = 0; i < registerCount; i++)
-              args[i] = ((Instruction3rc) inst).getStartRegister() + i;
+          String cName =
+              ((org.jf.dexlib2.iface.reference.TypeReference)
+                      ((Instruction35c) inst).getReference())
+                  .getType();
+          if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
 
-            String cName =
-                ((org.jf.dexlib2.iface.reference.TypeReference)
-                        ((Instruction3rc) inst).getReference())
-                    .getType();
-            if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
+          NewSiteReference newSiteRef =
+              NewSiteReference.make(
+                  instLoc,
+                  TypeReference.findOrCreate(myClass.getClassLoader().getReference(), cName));
+          TypeReference myTypeRef =
+              TypeReference.findOrCreate(
+                  myClass.getClassLoader().getReference(),
+                  newSiteRef.getDeclaredType().getArrayElementType().getName().toString());
 
-            NewSiteReference newSiteRef =
-                NewSiteReference.make(
-                    instLoc,
-                    TypeReference.findOrCreate(myClass.getClassLoader().getReference(), cName));
-            TypeReference myTypeRef =
-                TypeReference.findOrCreate(
-                    myClass.getClassLoader().getReference(),
-                    newSiteRef.getDeclaredType().getArrayElementType().getName().toString());
+          instructions.add(
+              new NewArrayFilled(
+                  instLoc,
+                  getReturnReg(),
+                  newSiteRef,
+                  myTypeRef,
+                  params,
+                  args,
+                  inst.getOpcode(),
+                  this));
+        }
+        case FILLED_NEW_ARRAY_RANGE -> {
+          int registerCount = ((Instruction3rc) inst).getRegisterCount();
+          int[] params = new int[1];
+          params[0] = registerCount;
+          int[] args = new int[registerCount];
 
-            instructions.add(
-                new NewArrayFilled(
-                    instLoc,
-                    getReturnReg(),
-                    newSiteRef,
-                    myTypeRef,
-                    params,
-                    args,
-                    inst.getOpcode(),
-                    this));
-            break;
-          }
-        case FILL_ARRAY_DATA:
+          for (int i = 0; i < registerCount; i++)
+            args[i] = ((Instruction3rc) inst).getStartRegister() + i;
+
+          String cName =
+              ((org.jf.dexlib2.iface.reference.TypeReference)
+                      ((Instruction3rc) inst).getReference())
+                  .getType();
+          if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
+
+          NewSiteReference newSiteRef =
+              NewSiteReference.make(
+                  instLoc,
+                  TypeReference.findOrCreate(myClass.getClassLoader().getReference(), cName));
+          TypeReference myTypeRef =
+              TypeReference.findOrCreate(
+                  myClass.getClassLoader().getReference(),
+                  newSiteRef.getDeclaredType().getArrayElementType().getName().toString());
+
+          instructions.add(
+              new NewArrayFilled(
+                  instLoc,
+                  getReturnReg(),
+                  newSiteRef,
+                  myTypeRef,
+                  params,
+                  args,
+                  inst.getOpcode(),
+                  this));
+        }
+        case FILL_ARRAY_DATA -> {
           // System.out.println("Array Reference: " + ((Instruction31t)inst).getRegisterA());
           // System.out.println("Table Address Offset: " + ((Instruction31t)inst).getCodeOffset());
 
@@ -1478,2068 +1423,1796 @@ public class DexIMethod implements IBytecodeMethod<Instruction> {
                       arrayElementType.getName().toString()),
                   inst.getOpcode(),
                   this));
-          break;
-        case THROW:
-          instructions.add(
-              new Throw(instLoc, ((Instruction11x) inst).getRegisterA(), inst.getOpcode(), this));
-          break;
-        case GOTO:
-          instructions.add(
-              new Goto(instLoc, ((Instruction10t) inst).getCodeOffset(), inst.getOpcode(), this));
-          break;
-        case GOTO_16:
-          instructions.add(
-              new Goto(instLoc, ((Instruction20t) inst).getCodeOffset(), inst.getOpcode(), this));
-          break;
-        case GOTO_32:
-          instructions.add(
-              new Goto(instLoc, ((Instruction30t) inst).getCodeOffset(), inst.getOpcode(), this));
-          break;
-
-        case PACKED_SWITCH:
-        case SPARSE_SWITCH:
-          instructions.add(
-              new Switch(
-                  instLoc,
-                  ((Instruction31t) inst).getRegisterA(),
-                  ((Instruction31t) inst).getCodeOffset(),
-                  inst.getOpcode(),
-                  this));
-          break;
-
-        case CMPL_FLOAT:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.CMPL_FLOAT,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case CMPG_FLOAT:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.CMPG_FLOAT,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case CMPL_DOUBLE:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.CMPL_DOUBLE,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case CMPG_DOUBLE:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.CMPG_DOUBLE,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case CMP_LONG:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.CMPL_LONG,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case IF_EQ:
-          instructions.add(
-              new Branch.BinaryBranch(
-                  instLoc,
-                  ((Instruction22t) inst).getCodeOffset(),
-                  Branch.BinaryBranch.CompareOp.EQ,
-                  ((Instruction22t) inst).getRegisterA(),
-                  ((Instruction22t) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case IF_NE:
-          instructions.add(
-              new Branch.BinaryBranch(
-                  instLoc,
-                  ((Instruction22t) inst).getCodeOffset(),
-                  Branch.BinaryBranch.CompareOp.NE,
-                  ((Instruction22t) inst).getRegisterA(),
-                  ((Instruction22t) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case IF_LT:
-          instructions.add(
-              new Branch.BinaryBranch(
-                  instLoc,
-                  ((Instruction22t) inst).getCodeOffset(),
-                  Branch.BinaryBranch.CompareOp.LT,
-                  ((Instruction22t) inst).getRegisterA(),
-                  ((Instruction22t) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case IF_GE:
-          instructions.add(
-              new Branch.BinaryBranch(
-                  instLoc,
-                  ((Instruction22t) inst).getCodeOffset(),
-                  Branch.BinaryBranch.CompareOp.GE,
-                  ((Instruction22t) inst).getRegisterA(),
-                  ((Instruction22t) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case IF_GT:
-          instructions.add(
-              new Branch.BinaryBranch(
-                  instLoc,
-                  ((Instruction22t) inst).getCodeOffset(),
-                  Branch.BinaryBranch.CompareOp.GT,
-                  ((Instruction22t) inst).getRegisterA(),
-                  ((Instruction22t) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case IF_LE:
-          instructions.add(
-              new Branch.BinaryBranch(
-                  instLoc,
-                  ((Instruction22t) inst).getCodeOffset(),
-                  Branch.BinaryBranch.CompareOp.LE,
-                  ((Instruction22t) inst).getRegisterA(),
-                  ((Instruction22t) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case IF_EQZ:
-          instructions.add(
-              new Branch.UnaryBranch(
-                  instLoc,
-                  ((Instruction21t) inst).getCodeOffset(),
-                  Branch.UnaryBranch.CompareOp.EQZ,
-                  ((Instruction21t) inst).getRegisterA(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case IF_NEZ:
-          instructions.add(
-              new Branch.UnaryBranch(
-                  instLoc,
-                  ((Instruction21t) inst).getCodeOffset(),
-                  Branch.UnaryBranch.CompareOp.NEZ,
-                  ((Instruction21t) inst).getRegisterA(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case IF_LTZ:
-          instructions.add(
-              new Branch.UnaryBranch(
-                  instLoc,
-                  ((Instruction21t) inst).getCodeOffset(),
-                  Branch.UnaryBranch.CompareOp.LTZ,
-                  ((Instruction21t) inst).getRegisterA(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case IF_GEZ:
-          instructions.add(
-              new Branch.UnaryBranch(
-                  instLoc,
-                  ((Instruction21t) inst).getCodeOffset(),
-                  Branch.UnaryBranch.CompareOp.GEZ,
-                  ((Instruction21t) inst).getRegisterA(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case IF_GTZ:
-          instructions.add(
-              new Branch.UnaryBranch(
-                  instLoc,
-                  ((Instruction21t) inst).getCodeOffset(),
-                  Branch.UnaryBranch.CompareOp.GTZ,
-                  ((Instruction21t) inst).getRegisterA(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case IF_LEZ:
-          instructions.add(
-              new Branch.UnaryBranch(
-                  instLoc,
-                  ((Instruction21t) inst).getCodeOffset(),
-                  Branch.UnaryBranch.CompareOp.LEZ,
-                  ((Instruction21t) inst).getRegisterA(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case AGET:
-          instructions.add(
-              new ArrayGet(
-                  instLoc,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  Type.t_int,
-                  inst.getOpcode(),
-                  this));
-          break;
-        case AGET_WIDE:
-          instructions.add(
-              new ArrayGet(
-                  instLoc,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  Type.t_wide,
-                  inst.getOpcode(),
-                  this));
-          break;
-        case AGET_OBJECT:
-          instructions.add(
-              new ArrayGet(
-                  instLoc,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  Type.t_object,
-                  inst.getOpcode(),
-                  this));
-          break;
-        case AGET_BOOLEAN:
-          instructions.add(
-              new ArrayGet(
-                  instLoc,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  Type.t_boolean,
-                  inst.getOpcode(),
-                  this));
-          break;
-        case AGET_BYTE:
-          instructions.add(
-              new ArrayGet(
-                  instLoc,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  Type.t_byte,
-                  inst.getOpcode(),
-                  this));
-          break;
-        case AGET_CHAR:
-          instructions.add(
-              new ArrayGet(
-                  instLoc,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  Type.t_char,
-                  inst.getOpcode(),
-                  this));
-          break;
-        case AGET_SHORT:
-          instructions.add(
-              new ArrayGet(
-                  instLoc,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  Type.t_short,
-                  inst.getOpcode(),
-                  this));
-          break;
-        case APUT:
-          instructions.add(
-              new ArrayPut(
-                  instLoc,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  Type.t_int,
-                  inst.getOpcode(),
-                  this));
-          break;
-        case APUT_WIDE:
-          instructions.add(
-              new ArrayPut(
-                  instLoc,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  Type.t_wide,
-                  inst.getOpcode(),
-                  this));
-          break;
-        case APUT_OBJECT:
-          instructions.add(
-              new ArrayPut(
-                  instLoc,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  Type.t_object,
-                  inst.getOpcode(),
-                  this));
-          break;
-        case APUT_BOOLEAN:
-          instructions.add(
-              new ArrayPut(
-                  instLoc,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  Type.t_boolean,
-                  inst.getOpcode(),
-                  this));
-          break;
-        case APUT_BYTE:
-          instructions.add(
-              new ArrayPut(
-                  instLoc,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  Type.t_byte,
-                  inst.getOpcode(),
-                  this));
-          break;
-        case APUT_CHAR:
-          instructions.add(
-              new ArrayPut(
-                  instLoc,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  Type.t_char,
-                  inst.getOpcode(),
-                  this));
-          break;
-        case APUT_SHORT:
-          instructions.add(
-              new ArrayPut(
-                  instLoc,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  Type.t_short,
-                  inst.getOpcode(),
-                  this));
-          break;
-        case IGET:
-        case IGET_WIDE:
-        case IGET_OBJECT:
-        case IGET_BOOLEAN:
-        case IGET_BYTE:
-        case IGET_CHAR:
-        case IGET_SHORT:
-          {
-            String cName =
-                ((FieldReference) ((Instruction22c) inst).getReference()).getDefiningClass();
-            String fName = ((FieldReference) ((Instruction22c) inst).getReference()).getName();
-            String ftName = ((FieldReference) ((Instruction22c) inst).getReference()).getType();
-
-            if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
-            if (fName.endsWith(";")) fName = fName.substring(0, fName.length() - 1);
-            if (ftName.endsWith(";")) ftName = ftName.substring(0, ftName.length() - 1);
-
+        }
+        case THROW ->
             instructions.add(
-                new GetField.GetInstanceField(
+                new Throw(instLoc, ((Instruction11x) inst).getRegisterA(), inst.getOpcode(), this));
+        case GOTO ->
+            instructions.add(
+                new Goto(instLoc, ((Instruction10t) inst).getCodeOffset(), inst.getOpcode(), this));
+        case GOTO_16 ->
+            instructions.add(
+                new Goto(instLoc, ((Instruction20t) inst).getCodeOffset(), inst.getOpcode(), this));
+        case GOTO_32 ->
+            instructions.add(
+                new Goto(instLoc, ((Instruction30t) inst).getCodeOffset(), inst.getOpcode(), this));
+        case PACKED_SWITCH, SPARSE_SWITCH ->
+            instructions.add(
+                new Switch(
                     instLoc,
-                    ((Instruction22c) inst).getRegisterA(),
-                    ((Instruction22c) inst).getRegisterB(),
-                    cName,
-                    fName,
-                    ftName,
+                    ((Instruction31t) inst).getRegisterA(),
+                    ((Instruction31t) inst).getCodeOffset(),
                     inst.getOpcode(),
                     this));
-            break;
-          }
-        case IPUT:
-        case IPUT_WIDE:
-        case IPUT_OBJECT:
-        case IPUT_BOOLEAN:
-        case IPUT_BYTE:
-        case IPUT_CHAR:
-        case IPUT_SHORT:
-          {
-            String cName =
-                ((FieldReference) ((Instruction22c) inst).getReference()).getDefiningClass();
-            String fName = ((FieldReference) ((Instruction22c) inst).getReference()).getName();
-            String ftName = ((FieldReference) ((Instruction22c) inst).getReference()).getType();
-
-            if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
-            if (fName.endsWith(";")) fName = fName.substring(0, fName.length() - 1);
-            if (ftName.endsWith(";")) ftName = ftName.substring(0, ftName.length() - 1);
-
+        case CMPL_FLOAT ->
             instructions.add(
-                new PutField.PutInstanceField(
+                new BinaryOperation(
                     instLoc,
-                    ((TwoRegisterInstruction) inst).getRegisterA(),
-                    ((TwoRegisterInstruction) inst).getRegisterB(),
-                    cName,
-                    fName,
-                    ftName,
+                    BinaryOperation.OpID.CMPL_FLOAT,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
                     inst.getOpcode(),
                     this));
-            break;
-          }
-        case SGET:
-        case SGET_WIDE:
-        case SGET_OBJECT:
-        case SGET_BOOLEAN:
-        case SGET_BYTE:
-        case SGET_CHAR:
-        case SGET_SHORT:
-          {
-            String cName =
-                ((FieldReference) ((Instruction21c) inst).getReference()).getDefiningClass();
-            String fName = ((FieldReference) ((Instruction21c) inst).getReference()).getName();
-            String ftName = ((FieldReference) ((Instruction21c) inst).getReference()).getType();
-
-            if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
-            if (fName.endsWith(";")) fName = fName.substring(0, fName.length() - 1);
-            if (ftName.endsWith(";")) ftName = ftName.substring(0, ftName.length() - 1);
-
+        case CMPG_FLOAT ->
             instructions.add(
-                new GetField.GetStaticField(
+                new BinaryOperation(
                     instLoc,
-                    ((Instruction21c) inst).getRegisterA(),
-                    cName,
-                    fName,
-                    ftName,
+                    BinaryOperation.OpID.CMPG_FLOAT,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
                     inst.getOpcode(),
                     this));
-            break;
-          }
-        case SPUT:
-        case SPUT_WIDE:
-        case SPUT_OBJECT:
-        case SPUT_BOOLEAN:
-        case SPUT_BYTE:
-        case SPUT_CHAR:
-        case SPUT_SHORT:
-          {
-            String cName =
-                ((FieldReference) ((Instruction21c) inst).getReference()).getDefiningClass();
-            String fName = ((FieldReference) ((Instruction21c) inst).getReference()).getName();
-            String ftName = ((FieldReference) ((Instruction21c) inst).getReference()).getType();
-
-            if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
-            if (fName.endsWith(";")) fName = fName.substring(0, fName.length() - 1);
-            if (ftName.endsWith(";")) ftName = ftName.substring(0, ftName.length() - 1);
-
+        case CMPL_DOUBLE ->
             instructions.add(
-                new PutField.PutStaticField(
+                new BinaryOperation(
                     instLoc,
-                    ((Instruction21c) inst).getRegisterA(),
-                    cName,
-                    fName,
-                    ftName,
+                    BinaryOperation.OpID.CMPL_DOUBLE,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
                     inst.getOpcode(),
                     this));
-            break;
-          }
-        case INVOKE_VIRTUAL:
-          {
-            int registerCount = ((Instruction35c) inst).getRegisterCount();
-            int[] args = new int[registerCount];
+        case CMPG_DOUBLE ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.CMPG_DOUBLE,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case CMP_LONG ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.CMPL_LONG,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case IF_EQ ->
+            instructions.add(
+                new Branch.BinaryBranch(
+                    instLoc,
+                    ((Instruction22t) inst).getCodeOffset(),
+                    Branch.BinaryBranch.CompareOp.EQ,
+                    ((Instruction22t) inst).getRegisterA(),
+                    ((Instruction22t) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case IF_NE ->
+            instructions.add(
+                new Branch.BinaryBranch(
+                    instLoc,
+                    ((Instruction22t) inst).getCodeOffset(),
+                    Branch.BinaryBranch.CompareOp.NE,
+                    ((Instruction22t) inst).getRegisterA(),
+                    ((Instruction22t) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case IF_LT ->
+            instructions.add(
+                new Branch.BinaryBranch(
+                    instLoc,
+                    ((Instruction22t) inst).getCodeOffset(),
+                    Branch.BinaryBranch.CompareOp.LT,
+                    ((Instruction22t) inst).getRegisterA(),
+                    ((Instruction22t) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case IF_GE ->
+            instructions.add(
+                new Branch.BinaryBranch(
+                    instLoc,
+                    ((Instruction22t) inst).getCodeOffset(),
+                    Branch.BinaryBranch.CompareOp.GE,
+                    ((Instruction22t) inst).getRegisterA(),
+                    ((Instruction22t) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case IF_GT ->
+            instructions.add(
+                new Branch.BinaryBranch(
+                    instLoc,
+                    ((Instruction22t) inst).getCodeOffset(),
+                    Branch.BinaryBranch.CompareOp.GT,
+                    ((Instruction22t) inst).getRegisterA(),
+                    ((Instruction22t) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case IF_LE ->
+            instructions.add(
+                new Branch.BinaryBranch(
+                    instLoc,
+                    ((Instruction22t) inst).getCodeOffset(),
+                    Branch.BinaryBranch.CompareOp.LE,
+                    ((Instruction22t) inst).getRegisterA(),
+                    ((Instruction22t) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case IF_EQZ ->
+            instructions.add(
+                new Branch.UnaryBranch(
+                    instLoc,
+                    ((Instruction21t) inst).getCodeOffset(),
+                    Branch.UnaryBranch.CompareOp.EQZ,
+                    ((Instruction21t) inst).getRegisterA(),
+                    inst.getOpcode(),
+                    this));
+        case IF_NEZ ->
+            instructions.add(
+                new Branch.UnaryBranch(
+                    instLoc,
+                    ((Instruction21t) inst).getCodeOffset(),
+                    Branch.UnaryBranch.CompareOp.NEZ,
+                    ((Instruction21t) inst).getRegisterA(),
+                    inst.getOpcode(),
+                    this));
+        case IF_LTZ ->
+            instructions.add(
+                new Branch.UnaryBranch(
+                    instLoc,
+                    ((Instruction21t) inst).getCodeOffset(),
+                    Branch.UnaryBranch.CompareOp.LTZ,
+                    ((Instruction21t) inst).getRegisterA(),
+                    inst.getOpcode(),
+                    this));
+        case IF_GEZ ->
+            instructions.add(
+                new Branch.UnaryBranch(
+                    instLoc,
+                    ((Instruction21t) inst).getCodeOffset(),
+                    Branch.UnaryBranch.CompareOp.GEZ,
+                    ((Instruction21t) inst).getRegisterA(),
+                    inst.getOpcode(),
+                    this));
+        case IF_GTZ ->
+            instructions.add(
+                new Branch.UnaryBranch(
+                    instLoc,
+                    ((Instruction21t) inst).getCodeOffset(),
+                    Branch.UnaryBranch.CompareOp.GTZ,
+                    ((Instruction21t) inst).getRegisterA(),
+                    inst.getOpcode(),
+                    this));
+        case IF_LEZ ->
+            instructions.add(
+                new Branch.UnaryBranch(
+                    instLoc,
+                    ((Instruction21t) inst).getCodeOffset(),
+                    Branch.UnaryBranch.CompareOp.LEZ,
+                    ((Instruction21t) inst).getRegisterA(),
+                    inst.getOpcode(),
+                    this));
+        case AGET ->
+            instructions.add(
+                new ArrayGet(
+                    instLoc,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    Type.t_int,
+                    inst.getOpcode(),
+                    this));
+        case AGET_WIDE ->
+            instructions.add(
+                new ArrayGet(
+                    instLoc,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    Type.t_wide,
+                    inst.getOpcode(),
+                    this));
+        case AGET_OBJECT ->
+            instructions.add(
+                new ArrayGet(
+                    instLoc,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    Type.t_object,
+                    inst.getOpcode(),
+                    this));
+        case AGET_BOOLEAN ->
+            instructions.add(
+                new ArrayGet(
+                    instLoc,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    Type.t_boolean,
+                    inst.getOpcode(),
+                    this));
+        case AGET_BYTE ->
+            instructions.add(
+                new ArrayGet(
+                    instLoc,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    Type.t_byte,
+                    inst.getOpcode(),
+                    this));
+        case AGET_CHAR ->
+            instructions.add(
+                new ArrayGet(
+                    instLoc,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    Type.t_char,
+                    inst.getOpcode(),
+                    this));
+        case AGET_SHORT ->
+            instructions.add(
+                new ArrayGet(
+                    instLoc,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    Type.t_short,
+                    inst.getOpcode(),
+                    this));
+        case APUT ->
+            instructions.add(
+                new ArrayPut(
+                    instLoc,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    Type.t_int,
+                    inst.getOpcode(),
+                    this));
+        case APUT_WIDE ->
+            instructions.add(
+                new ArrayPut(
+                    instLoc,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    Type.t_wide,
+                    inst.getOpcode(),
+                    this));
+        case APUT_OBJECT ->
+            instructions.add(
+                new ArrayPut(
+                    instLoc,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    Type.t_object,
+                    inst.getOpcode(),
+                    this));
+        case APUT_BOOLEAN ->
+            instructions.add(
+                new ArrayPut(
+                    instLoc,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    Type.t_boolean,
+                    inst.getOpcode(),
+                    this));
+        case APUT_BYTE ->
+            instructions.add(
+                new ArrayPut(
+                    instLoc,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    Type.t_byte,
+                    inst.getOpcode(),
+                    this));
+        case APUT_CHAR ->
+            instructions.add(
+                new ArrayPut(
+                    instLoc,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    Type.t_char,
+                    inst.getOpcode(),
+                    this));
+        case APUT_SHORT ->
+            instructions.add(
+                new ArrayPut(
+                    instLoc,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    Type.t_short,
+                    inst.getOpcode(),
+                    this));
+        case IGET, IGET_WIDE, IGET_OBJECT, IGET_BOOLEAN, IGET_BYTE, IGET_CHAR, IGET_SHORT -> {
+          String cName =
+              ((FieldReference) ((Instruction22c) inst).getReference()).getDefiningClass();
+          String fName = ((FieldReference) ((Instruction22c) inst).getReference()).getName();
+          String ftName = ((FieldReference) ((Instruction22c) inst).getReference()).getType();
 
-            for (int i = 0; i < registerCount; i++) {
-              switch (i) {
-                case 0:
-                  args[0] = ((Instruction35c) inst).getRegisterC();
-                  break;
-                case 1:
-                  args[1] = ((Instruction35c) inst).getRegisterD();
-                  break;
-                case 2:
-                  args[2] = ((Instruction35c) inst).getRegisterE();
-                  break;
-                case 3:
-                  args[3] = ((Instruction35c) inst).getRegisterF();
-                  break;
-                case 4:
-                  args[4] = ((Instruction35c) inst).getRegisterG();
-                  break;
-                default:
+          if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
+          if (fName.endsWith(";")) fName = fName.substring(0, fName.length() - 1);
+          if (ftName.endsWith(";")) ftName = ftName.substring(0, ftName.length() - 1);
+
+          instructions.add(
+              new GetField.GetInstanceField(
+                  instLoc,
+                  ((Instruction22c) inst).getRegisterA(),
+                  ((Instruction22c) inst).getRegisterB(),
+                  cName,
+                  fName,
+                  ftName,
+                  inst.getOpcode(),
+                  this));
+        }
+        case IPUT, IPUT_WIDE, IPUT_OBJECT, IPUT_BOOLEAN, IPUT_BYTE, IPUT_CHAR, IPUT_SHORT -> {
+          String cName =
+              ((FieldReference) ((Instruction22c) inst).getReference()).getDefiningClass();
+          String fName = ((FieldReference) ((Instruction22c) inst).getReference()).getName();
+          String ftName = ((FieldReference) ((Instruction22c) inst).getReference()).getType();
+
+          if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
+          if (fName.endsWith(";")) fName = fName.substring(0, fName.length() - 1);
+          if (ftName.endsWith(";")) ftName = ftName.substring(0, ftName.length() - 1);
+
+          instructions.add(
+              new PutField.PutInstanceField(
+                  instLoc,
+                  ((TwoRegisterInstruction) inst).getRegisterA(),
+                  ((TwoRegisterInstruction) inst).getRegisterB(),
+                  cName,
+                  fName,
+                  ftName,
+                  inst.getOpcode(),
+                  this));
+        }
+        case SGET, SGET_WIDE, SGET_OBJECT, SGET_BOOLEAN, SGET_BYTE, SGET_CHAR, SGET_SHORT -> {
+          String cName =
+              ((FieldReference) ((Instruction21c) inst).getReference()).getDefiningClass();
+          String fName = ((FieldReference) ((Instruction21c) inst).getReference()).getName();
+          String ftName = ((FieldReference) ((Instruction21c) inst).getReference()).getType();
+
+          if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
+          if (fName.endsWith(";")) fName = fName.substring(0, fName.length() - 1);
+          if (ftName.endsWith(";")) ftName = ftName.substring(0, ftName.length() - 1);
+
+          instructions.add(
+              new GetField.GetStaticField(
+                  instLoc,
+                  ((Instruction21c) inst).getRegisterA(),
+                  cName,
+                  fName,
+                  ftName,
+                  inst.getOpcode(),
+                  this));
+        }
+        case SPUT, SPUT_WIDE, SPUT_OBJECT, SPUT_BOOLEAN, SPUT_BYTE, SPUT_CHAR, SPUT_SHORT -> {
+          String cName =
+              ((FieldReference) ((Instruction21c) inst).getReference()).getDefiningClass();
+          String fName = ((FieldReference) ((Instruction21c) inst).getReference()).getName();
+          String ftName = ((FieldReference) ((Instruction21c) inst).getReference()).getType();
+
+          if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
+          if (fName.endsWith(";")) fName = fName.substring(0, fName.length() - 1);
+          if (ftName.endsWith(";")) ftName = ftName.substring(0, ftName.length() - 1);
+
+          instructions.add(
+              new PutField.PutStaticField(
+                  instLoc,
+                  ((Instruction21c) inst).getRegisterA(),
+                  cName,
+                  fName,
+                  ftName,
+                  inst.getOpcode(),
+                  this));
+        }
+        case INVOKE_VIRTUAL -> {
+          int registerCount = ((Instruction35c) inst).getRegisterCount();
+          int[] args = new int[registerCount];
+
+          for (int i = 0; i < registerCount; i++) {
+            switch (i) {
+              case 0 -> args[0] = ((Instruction35c) inst).getRegisterC();
+              case 1 -> args[1] = ((Instruction35c) inst).getRegisterD();
+              case 2 -> args[2] = ((Instruction35c) inst).getRegisterE();
+              case 3 -> args[3] = ((Instruction35c) inst).getRegisterF();
+              case 4 -> args[4] = ((Instruction35c) inst).getRegisterG();
+              default ->
                   throw new RuntimeException(
                       "Illegal instruction at " + instLoc + ": bad register count");
-              }
             }
-
-            String cName =
-                ((org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction35c) inst).getReference())
-                    .getDefiningClass();
-            String mName =
-                ((org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction35c) inst).getReference())
-                    .getName();
-            String pName =
-                DexUtil.getSignature(
-                    (org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction35c) inst).getReference());
-
-            if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
-            //              if (mName.endsWith(";"))
-            //                  mName = mName.substring(0,mName.length()-1);
-            //              if (pName.endsWith(";"))
-            //                  pName = pName.substring(0,pName.length()-1);
-
-            //              for (IMethod m:
-            // this.myClass.loader.lookupClass(TypeName.findOrCreate(cName)).getDeclaredMethods())
-            //                  System.out.println(m.getDescriptor().toString());
-
-            handleINVOKE_VIRTUAL(instLoc, cName, mName, pName, args, inst.getOpcode());
-            // instructions.add(new Invoke.InvokeVirtual(instLoc, cName, mName, pName, args,
-            // inst.opcode, this));
-            // logger.debug("\t" + inst.opcode.toString() + " class: "+ cName + ", method name: " +
-            // mName + ", prototype string: " + pName);
-
-            break;
           }
-        case INVOKE_SUPER:
-          {
-            int registerCount = ((Instruction35c) inst).getRegisterCount();
-            int[] args = new int[registerCount];
 
-            for (int i = 0; i < registerCount; i++) {
-              switch (i) {
-                case 0:
-                  args[0] = ((Instruction35c) inst).getRegisterC();
-                  break;
-                case 1:
-                  args[1] = ((Instruction35c) inst).getRegisterD();
-                  break;
-                case 2:
-                  args[2] = ((Instruction35c) inst).getRegisterE();
-                  break;
-                case 3:
-                  args[3] = ((Instruction35c) inst).getRegisterF();
-                  break;
-                case 4:
-                  args[4] = ((Instruction35c) inst).getRegisterG();
-                  break;
-                default:
+          String cName =
+              ((org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction35c) inst).getReference())
+                  .getDefiningClass();
+          String mName =
+              ((org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction35c) inst).getReference())
+                  .getName();
+          String pName =
+              DexUtil.getSignature(
+                  (org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction35c) inst).getReference());
+
+          if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
+          //              if (mName.endsWith(";"))
+          //                  mName = mName.substring(0,mName.length()-1);
+          //              if (pName.endsWith(";"))
+          //                  pName = pName.substring(0,pName.length()-1);
+
+          //              for (IMethod m:
+          // this.myClass.loader.lookupClass(TypeName.findOrCreate(cName)).getDeclaredMethods())
+          //                  System.out.println(m.getDescriptor().toString());
+
+          handleINVOKE_VIRTUAL(instLoc, cName, mName, pName, args, inst.getOpcode());
+          // instructions.add(new Invoke.InvokeVirtual(instLoc, cName, mName, pName, args,
+          // inst.opcode, this));
+          // logger.debug("\t" + inst.opcode.toString() + " class: "+ cName + ", method name: " +
+          // mName + ", prototype string: " + pName);
+
+        }
+        case INVOKE_SUPER -> {
+          int registerCount = ((Instruction35c) inst).getRegisterCount();
+          int[] args = new int[registerCount];
+
+          for (int i = 0; i < registerCount; i++) {
+            switch (i) {
+              case 0 -> args[0] = ((Instruction35c) inst).getRegisterC();
+              case 1 -> args[1] = ((Instruction35c) inst).getRegisterD();
+              case 2 -> args[2] = ((Instruction35c) inst).getRegisterE();
+              case 3 -> args[3] = ((Instruction35c) inst).getRegisterF();
+              case 4 -> args[4] = ((Instruction35c) inst).getRegisterG();
+              default ->
                   throw new RuntimeException(
                       "Illegal instruction at " + instLoc + ": bad register count");
-              }
             }
-
-            String cName =
-                ((org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction35c) inst).getReference())
-                    .getDefiningClass();
-            String mName =
-                ((org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction35c) inst).getReference())
-                    .getName();
-            String pName =
-                DexUtil.getSignature(
-                    (org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction35c) inst).getReference());
-
-            if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
-
-            instructions.add(
-                new Invoke.InvokeSuper(instLoc, cName, mName, pName, args, inst.getOpcode(), this));
-            break;
           }
-        case INVOKE_DIRECT:
-          {
-            int registerCount = ((Instruction35c) inst).getRegisterCount();
-            int[] args = new int[registerCount];
 
-            for (int i = 0; i < registerCount; i++) {
-              switch (i) {
-                case 0:
-                  args[0] = ((Instruction35c) inst).getRegisterC();
-                  break;
-                case 1:
-                  args[1] = ((Instruction35c) inst).getRegisterD();
-                  break;
-                case 2:
-                  args[2] = ((Instruction35c) inst).getRegisterE();
-                  break;
-                case 3:
-                  args[3] = ((Instruction35c) inst).getRegisterF();
-                  break;
-                case 4:
-                  args[4] = ((Instruction35c) inst).getRegisterG();
-                  break;
-                default:
+          String cName =
+              ((org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction35c) inst).getReference())
+                  .getDefiningClass();
+          String mName =
+              ((org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction35c) inst).getReference())
+                  .getName();
+          String pName =
+              DexUtil.getSignature(
+                  (org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction35c) inst).getReference());
+
+          if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
+
+          instructions.add(
+              new Invoke.InvokeSuper(instLoc, cName, mName, pName, args, inst.getOpcode(), this));
+        }
+        case INVOKE_DIRECT -> {
+          int registerCount = ((Instruction35c) inst).getRegisterCount();
+          int[] args = new int[registerCount];
+
+          for (int i = 0; i < registerCount; i++) {
+            switch (i) {
+              case 0 -> args[0] = ((Instruction35c) inst).getRegisterC();
+              case 1 -> args[1] = ((Instruction35c) inst).getRegisterD();
+              case 2 -> args[2] = ((Instruction35c) inst).getRegisterE();
+              case 3 -> args[3] = ((Instruction35c) inst).getRegisterF();
+              case 4 -> args[4] = ((Instruction35c) inst).getRegisterG();
+              default ->
                   throw new RuntimeException(
                       "Illegal instruction at " + instLoc + ": bad register count");
-              }
             }
-
-            //              logger.debug(inst.opcode.toString() + " class:
-            // "+((MethodIdItem)((Instruction35c)inst).getReferencedItem()).getContainingClass().getTypeDescriptor() + ", method name: " + ((MethodIdItem)((Instruction35c)inst).getReferencedItem()).getMethodName().getStringValue() + ", prototype string: " + ((MethodIdItem)((Instruction35c)inst).getReferencedItem()).getPrototype().getPrototypeString());
-            String cName =
-                ((org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction35c) inst).getReference())
-                    .getDefiningClass();
-            String mName =
-                ((org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction35c) inst).getReference())
-                    .getName();
-            String pName =
-                DexUtil.getSignature(
-                    (org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction35c) inst).getReference());
-
-            if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
-
-            instructions.add(
-                new Invoke.InvokeDirect(
-                    instLoc, cName, mName, pName, args, inst.getOpcode(), this));
-
-            break;
           }
-        case INVOKE_STATIC:
-          {
-            int registerCount = ((Instruction35c) inst).getRegisterCount();
-            int[] args = new int[registerCount];
 
-            for (int i = 0; i < registerCount; i++) {
-              switch (i) {
-                case 0:
-                  args[0] = ((Instruction35c) inst).getRegisterC();
-                  break;
-                case 1:
-                  args[1] = ((Instruction35c) inst).getRegisterD();
-                  break;
-                case 2:
-                  args[2] = ((Instruction35c) inst).getRegisterE();
-                  break;
-                case 3:
-                  args[3] = ((Instruction35c) inst).getRegisterF();
-                  break;
-                case 4:
-                  args[4] = ((Instruction35c) inst).getRegisterG();
-                  break;
-                default:
+          //              logger.debug(inst.opcode.toString() + " class:
+          // "+((MethodIdItem)((Instruction35c)inst).getReferencedItem()).getContainingClass().getTypeDescriptor() + ", method name: " + ((MethodIdItem)((Instruction35c)inst).getReferencedItem()).getMethodName().getStringValue() + ", prototype string: " + ((MethodIdItem)((Instruction35c)inst).getReferencedItem()).getPrototype().getPrototypeString());
+          String cName =
+              ((org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction35c) inst).getReference())
+                  .getDefiningClass();
+          String mName =
+              ((org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction35c) inst).getReference())
+                  .getName();
+          String pName =
+              DexUtil.getSignature(
+                  (org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction35c) inst).getReference());
+
+          if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
+
+          instructions.add(
+              new Invoke.InvokeDirect(instLoc, cName, mName, pName, args, inst.getOpcode(), this));
+        }
+        case INVOKE_STATIC -> {
+          int registerCount = ((Instruction35c) inst).getRegisterCount();
+          int[] args = new int[registerCount];
+
+          for (int i = 0; i < registerCount; i++) {
+            switch (i) {
+              case 0 -> args[0] = ((Instruction35c) inst).getRegisterC();
+              case 1 -> args[1] = ((Instruction35c) inst).getRegisterD();
+              case 2 -> args[2] = ((Instruction35c) inst).getRegisterE();
+              case 3 -> args[3] = ((Instruction35c) inst).getRegisterF();
+              case 4 -> args[4] = ((Instruction35c) inst).getRegisterG();
+              default ->
                   throw new RuntimeException(
                       "Illegal instruction at " + instLoc + ": bad register count");
-              }
             }
-
-            // logger.debug(inst.opcode.toString() + " class:
-            // "+((MethodIdItem)((Instruction35c)inst).getReferencedItem()).getContainingClass().getTypeDescriptor() + ", method name: " + ((MethodIdItem)((Instruction35c)inst).getReferencedItem()).getMethodName().getStringValue() + ", prototype string: " + ((MethodIdItem)((Instruction35c)inst).getReferencedItem()).getPrototype().getPrototypeString());
-            String cName =
-                ((org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction35c) inst).getReference())
-                    .getDefiningClass();
-            String mName =
-                ((org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction35c) inst).getReference())
-                    .getName();
-            String pName =
-                DexUtil.getSignature(
-                    (org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction35c) inst).getReference());
-
-            if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
-
-            instructions.add(
-                new Invoke.InvokeStatic(
-                    instLoc, cName, mName, pName, args, inst.getOpcode(), this));
-
-            break;
           }
-        case INVOKE_INTERFACE:
-          {
-            int registerCount = ((Instruction35c) inst).getRegisterCount();
-            int[] args = new int[registerCount];
 
-            for (int i = 0; i < registerCount; i++) {
-              switch (i) {
-                case 0:
-                  args[0] = ((Instruction35c) inst).getRegisterC();
-                  break;
-                case 1:
-                  args[1] = ((Instruction35c) inst).getRegisterD();
-                  break;
-                case 2:
-                  args[2] = ((Instruction35c) inst).getRegisterE();
-                  break;
-                case 3:
-                  args[3] = ((Instruction35c) inst).getRegisterF();
-                  break;
-                case 4:
-                  args[4] = ((Instruction35c) inst).getRegisterG();
-                  break;
-                default:
+          // logger.debug(inst.opcode.toString() + " class:
+          // "+((MethodIdItem)((Instruction35c)inst).getReferencedItem()).getContainingClass().getTypeDescriptor() + ", method name: " + ((MethodIdItem)((Instruction35c)inst).getReferencedItem()).getMethodName().getStringValue() + ", prototype string: " + ((MethodIdItem)((Instruction35c)inst).getReferencedItem()).getPrototype().getPrototypeString());
+          String cName =
+              ((org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction35c) inst).getReference())
+                  .getDefiningClass();
+          String mName =
+              ((org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction35c) inst).getReference())
+                  .getName();
+          String pName =
+              DexUtil.getSignature(
+                  (org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction35c) inst).getReference());
+
+          if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
+
+          instructions.add(
+              new Invoke.InvokeStatic(instLoc, cName, mName, pName, args, inst.getOpcode(), this));
+        }
+        case INVOKE_INTERFACE -> {
+          int registerCount = ((Instruction35c) inst).getRegisterCount();
+          int[] args = new int[registerCount];
+
+          for (int i = 0; i < registerCount; i++) {
+            switch (i) {
+              case 0 -> args[0] = ((Instruction35c) inst).getRegisterC();
+              case 1 -> args[1] = ((Instruction35c) inst).getRegisterD();
+              case 2 -> args[2] = ((Instruction35c) inst).getRegisterE();
+              case 3 -> args[3] = ((Instruction35c) inst).getRegisterF();
+              case 4 -> args[4] = ((Instruction35c) inst).getRegisterG();
+              default ->
                   throw new RuntimeException(
                       "Illegal instruction at " + instLoc + ": bad register count");
-              }
             }
-
-            String cName =
-                ((org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction35c) inst).getReference())
-                    .getDefiningClass();
-            String mName =
-                ((org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction35c) inst).getReference())
-                    .getName();
-            String pName =
-                DexUtil.getSignature(
-                    (org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction35c) inst).getReference());
-
-            if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
-
-            instructions.add(
-                new Invoke.InvokeInterface(
-                    instLoc, cName, mName, pName, args, inst.getOpcode(), this));
-            break;
           }
-        case INVOKE_VIRTUAL_RANGE:
-          {
-            int registerCount = ((Instruction3rc) inst).getRegisterCount();
-            int[] args = new int[registerCount];
 
-            for (int i = 0; i < registerCount; i++)
-              args[i] = ((Instruction3rc) inst).getStartRegister() + i;
+          String cName =
+              ((org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction35c) inst).getReference())
+                  .getDefiningClass();
+          String mName =
+              ((org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction35c) inst).getReference())
+                  .getName();
+          String pName =
+              DexUtil.getSignature(
+                  (org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction35c) inst).getReference());
 
-            String cName =
-                ((org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction3rc) inst).getReference())
-                    .getDefiningClass();
-            String mName =
-                ((org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction3rc) inst).getReference())
-                    .getName();
-            String pName =
-                DexUtil.getSignature(
-                    (org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction3rc) inst).getReference());
+          if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
 
-            if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
+          instructions.add(
+              new Invoke.InvokeInterface(
+                  instLoc, cName, mName, pName, args, inst.getOpcode(), this));
+        }
+        case INVOKE_VIRTUAL_RANGE -> {
+          int registerCount = ((Instruction3rc) inst).getRegisterCount();
+          int[] args = new int[registerCount];
 
+          for (int i = 0; i < registerCount; i++)
+            args[i] = ((Instruction3rc) inst).getStartRegister() + i;
+
+          String cName =
+              ((org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction3rc) inst).getReference())
+                  .getDefiningClass();
+          String mName =
+              ((org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction3rc) inst).getReference())
+                  .getName();
+          String pName =
+              DexUtil.getSignature(
+                  (org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction3rc) inst).getReference());
+
+          if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
+
+          instructions.add(
+              new Invoke.InvokeVirtual(instLoc, cName, mName, pName, args, inst.getOpcode(), this));
+        }
+        case INVOKE_SUPER_RANGE -> {
+          int registerCount = ((Instruction3rc) inst).getRegisterCount();
+          int[] args = new int[registerCount];
+
+          for (int i = 0; i < registerCount; i++)
+            args[i] = ((Instruction3rc) inst).getStartRegister() + i;
+
+          String cName =
+              ((org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction3rc) inst).getReference())
+                  .getDefiningClass();
+          String mName =
+              ((org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction3rc) inst).getReference())
+                  .getName();
+          String pName =
+              DexUtil.getSignature(
+                  (org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction3rc) inst).getReference());
+
+          if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
+
+          instructions.add(
+              new Invoke.InvokeSuper(instLoc, cName, mName, pName, args, inst.getOpcode(), this));
+        }
+        case INVOKE_DIRECT_RANGE -> {
+          int registerCount = ((Instruction3rc) inst).getRegisterCount();
+          int[] args = new int[registerCount];
+
+          for (int i = 0; i < registerCount; i++)
+            args[i] = ((Instruction3rc) inst).getStartRegister() + i;
+
+          String cName =
+              ((org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction3rc) inst).getReference())
+                  .getDefiningClass();
+          String mName =
+              ((org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction3rc) inst).getReference())
+                  .getName();
+          String pName =
+              DexUtil.getSignature(
+                  (org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction3rc) inst).getReference());
+
+          if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
+
+          instructions.add(
+              new Invoke.InvokeDirect(instLoc, cName, mName, pName, args, inst.getOpcode(), this));
+        }
+        case INVOKE_STATIC_RANGE -> {
+          int registerCount = ((Instruction3rc) inst).getRegisterCount();
+          int[] args = new int[registerCount];
+
+          for (int i = 0; i < registerCount; i++)
+            args[i] = ((Instruction3rc) inst).getStartRegister() + i;
+
+          String cName =
+              ((org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction3rc) inst).getReference())
+                  .getDefiningClass();
+          String mName =
+              ((org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction3rc) inst).getReference())
+                  .getName();
+          String pName =
+              DexUtil.getSignature(
+                  (org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction3rc) inst).getReference());
+
+          if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
+
+          instructions.add(
+              new Invoke.InvokeStatic(instLoc, cName, mName, pName, args, inst.getOpcode(), this));
+        }
+        case INVOKE_INTERFACE_RANGE -> {
+          int registerCount = ((Instruction3rc) inst).getRegisterCount();
+          int[] args = new int[registerCount];
+
+          for (int i = 0; i < registerCount; i++)
+            args[i] = ((Instruction3rc) inst).getStartRegister() + i;
+
+          String cName =
+              ((org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction3rc) inst).getReference())
+                  .getDefiningClass();
+          String mName =
+              ((org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction3rc) inst).getReference())
+                  .getName();
+          String pName =
+              DexUtil.getSignature(
+                  (org.jf.dexlib2.iface.reference.MethodReference)
+                      ((Instruction3rc) inst).getReference());
+
+          if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
+
+          instructions.add(
+              new Invoke.InvokeInterface(
+                  instLoc, cName, mName, pName, args, inst.getOpcode(), this));
+        }
+        case NEG_INT ->
             instructions.add(
-                new Invoke.InvokeVirtual(
-                    instLoc, cName, mName, pName, args, inst.getOpcode(), this));
-            break;
-          }
-        case INVOKE_SUPER_RANGE:
-          {
-            int registerCount = ((Instruction3rc) inst).getRegisterCount();
-            int[] args = new int[registerCount];
-
-            for (int i = 0; i < registerCount; i++)
-              args[i] = ((Instruction3rc) inst).getStartRegister() + i;
-
-            String cName =
-                ((org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction3rc) inst).getReference())
-                    .getDefiningClass();
-            String mName =
-                ((org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction3rc) inst).getReference())
-                    .getName();
-            String pName =
-                DexUtil.getSignature(
-                    (org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction3rc) inst).getReference());
-
-            if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
-
-            instructions.add(
-                new Invoke.InvokeSuper(instLoc, cName, mName, pName, args, inst.getOpcode(), this));
-            break;
-          }
-        case INVOKE_DIRECT_RANGE:
-          {
-            int registerCount = ((Instruction3rc) inst).getRegisterCount();
-            int[] args = new int[registerCount];
-
-            for (int i = 0; i < registerCount; i++)
-              args[i] = ((Instruction3rc) inst).getStartRegister() + i;
-
-            String cName =
-                ((org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction3rc) inst).getReference())
-                    .getDefiningClass();
-            String mName =
-                ((org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction3rc) inst).getReference())
-                    .getName();
-            String pName =
-                DexUtil.getSignature(
-                    (org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction3rc) inst).getReference());
-
-            if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
-
-            instructions.add(
-                new Invoke.InvokeDirect(
-                    instLoc, cName, mName, pName, args, inst.getOpcode(), this));
-            break;
-          }
-        case INVOKE_STATIC_RANGE:
-          {
-            int registerCount = ((Instruction3rc) inst).getRegisterCount();
-            int[] args = new int[registerCount];
-
-            for (int i = 0; i < registerCount; i++)
-              args[i] = ((Instruction3rc) inst).getStartRegister() + i;
-
-            String cName =
-                ((org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction3rc) inst).getReference())
-                    .getDefiningClass();
-            String mName =
-                ((org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction3rc) inst).getReference())
-                    .getName();
-            String pName =
-                DexUtil.getSignature(
-                    (org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction3rc) inst).getReference());
-
-            if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
-
-            instructions.add(
-                new Invoke.InvokeStatic(
-                    instLoc, cName, mName, pName, args, inst.getOpcode(), this));
-
-            break;
-          }
-        case INVOKE_INTERFACE_RANGE:
-          {
-            int registerCount = ((Instruction3rc) inst).getRegisterCount();
-            int[] args = new int[registerCount];
-
-            for (int i = 0; i < registerCount; i++)
-              args[i] = ((Instruction3rc) inst).getStartRegister() + i;
-
-            String cName =
-                ((org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction3rc) inst).getReference())
-                    .getDefiningClass();
-            String mName =
-                ((org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction3rc) inst).getReference())
-                    .getName();
-            String pName =
-                DexUtil.getSignature(
-                    (org.jf.dexlib2.iface.reference.MethodReference)
-                        ((Instruction3rc) inst).getReference());
-
-            if (cName.endsWith(";")) cName = cName.substring(0, cName.length() - 1);
-
-            instructions.add(
-                new Invoke.InvokeInterface(
-                    instLoc, cName, mName, pName, args, inst.getOpcode(), this));
-            break;
-          }
-        case NEG_INT:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  OpID.NEGINT,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case NOT_INT:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  OpID.NOTINT,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case NEG_LONG:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  OpID.NEGLONG,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case NOT_LONG:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  OpID.NOTLONG,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case NEG_FLOAT:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  OpID.NEGFLOAT,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case NEG_DOUBLE:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  OpID.NEGDOUBLE,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case INT_TO_LONG:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  OpID.INTTOLONG,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case INT_TO_FLOAT:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  OpID.INTTOFLOAT,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case INT_TO_DOUBLE:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  OpID.INTTODOUBLE,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case LONG_TO_INT:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  OpID.LONGTOINT,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case LONG_TO_FLOAT:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  OpID.LONGTOFLOAT,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case LONG_TO_DOUBLE:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  OpID.LONGTODOUBLE,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case FLOAT_TO_INT:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  OpID.FLOATTOINT,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case FLOAT_TO_LONG:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  OpID.FLOATTOLONG,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case FLOAT_TO_DOUBLE:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  OpID.FLOATTODOUBLE,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case DOUBLE_TO_INT:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  OpID.DOUBLETOINT,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case DOUBLE_TO_LONG:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  OpID.DOUBLETOLONG,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case DOUBLE_TO_FLOAT:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  OpID.DOUBLETOFLOAT,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case INT_TO_BYTE:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  OpID.INTTOBYTE,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case INT_TO_CHAR:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  OpID.INTTOCHAR,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case INT_TO_SHORT:
-          instructions.add(
-              new UnaryOperation(
-                  instLoc,
-                  OpID.INTTOSHORT,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case ADD_INT:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.ADD_INT,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case SUB_INT:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.SUB_INT,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case MUL_INT:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.MUL_INT,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case DIV_INT:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.DIV_INT,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case REM_INT:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.REM_INT,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case AND_INT:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.AND_INT,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case OR_INT:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.OR_INT,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case XOR_INT:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.XOR_INT,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case SHL_INT:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.SHL_INT,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case SHR_INT:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.SHR_INT,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case USHR_INT:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.USHR_INT,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case ADD_LONG:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.ADD_LONG,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case SUB_LONG:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.SUB_LONG,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case MUL_LONG:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.MUL_LONG,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case DIV_LONG:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.DIV_LONG,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case REM_LONG:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.REM_LONG,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case AND_LONG:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.AND_LONG,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case OR_LONG:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.OR_LONG,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case XOR_LONG:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.XOR_LONG,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case SHL_LONG:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.SHL_LONG,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case SHR_LONG:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.SHR_LONG,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case USHR_LONG:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.USHR_LONG,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case ADD_FLOAT:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.ADD_FLOAT,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case SUB_FLOAT:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.SUB_FLOAT,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case MUL_FLOAT:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.MUL_FLOAT,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case DIV_FLOAT:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.DIV_FLOAT,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case REM_FLOAT:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.REM_FLOAT,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case ADD_DOUBLE:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.ADD_DOUBLE,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case SUB_DOUBLE:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.SUB_DOUBLE,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case MUL_DOUBLE:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.MUL_DOUBLE,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case DIV_DOUBLE:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.DIV_DOUBLE,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case REM_DOUBLE:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.REM_DOUBLE,
-                  ((Instruction23x) inst).getRegisterA(),
-                  ((Instruction23x) inst).getRegisterB(),
-                  ((Instruction23x) inst).getRegisterC(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case ADD_INT_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.ADD_INT,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case SUB_INT_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.SUB_INT,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case MUL_INT_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.MUL_INT,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case DIV_INT_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.DIV_INT,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case REM_INT_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.REM_INT,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case AND_INT_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.AND_INT,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case OR_INT_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.OR_INT,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case XOR_INT_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.XOR_INT,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case SHL_INT_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.SHL_INT,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case SHR_INT_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.SHR_INT,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case USHR_INT_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.USHR_INT,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case ADD_LONG_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.ADD_LONG,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case SUB_LONG_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.SUB_LONG,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case MUL_LONG_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.MUL_LONG,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case DIV_LONG_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.DIV_LONG,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case REM_LONG_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.REM_LONG,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case AND_LONG_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.AND_LONG,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case OR_LONG_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.OR_LONG,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case XOR_LONG_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.XOR_LONG,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case SHL_LONG_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.SHL_LONG,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case SHR_LONG_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.SHR_LONG,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case USHR_LONG_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.USHR_LONG,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case ADD_FLOAT_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.ADD_FLOAT,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case SUB_FLOAT_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.SUB_FLOAT,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case MUL_FLOAT_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.MUL_FLOAT,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case DIV_FLOAT_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.DIV_FLOAT,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case REM_FLOAT_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.REM_FLOAT,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case ADD_DOUBLE_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.ADD_DOUBLE,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case SUB_DOUBLE_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.SUB_DOUBLE,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case MUL_DOUBLE_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.MUL_DOUBLE,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case DIV_DOUBLE_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.DIV_DOUBLE,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case REM_DOUBLE_2ADDR:
-          instructions.add(
-              new BinaryOperation(
-                  instLoc,
-                  BinaryOperation.OpID.REM_DOUBLE,
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterA(),
-                  ((Instruction12x) inst).getRegisterB(),
-                  inst.getOpcode(),
-                  this));
-          break;
-        case ADD_INT_LIT16:
-          {
-            Literal lit = new Literal.LongLiteral(((Instruction22s) inst).getWideLiteral());
-            instructions.add(
-                new BinaryLiteralOperation(
+                new UnaryOperation(
                     instLoc,
-                    BinaryLiteralOperation.OpID.ADD_INT,
-                    ((Instruction22s) inst).getRegisterA(),
-                    ((Instruction22s) inst).getRegisterB(),
-                    lit,
+                    OpID.NEGINT,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
                     inst.getOpcode(),
                     this));
-            break;
-          }
-        case RSUB_INT:
-          {
-            Literal lit = new Literal.LongLiteral(((Instruction22s) inst).getWideLiteral());
+        case NOT_INT ->
             instructions.add(
-                new BinaryLiteralOperation(
+                new UnaryOperation(
                     instLoc,
-                    BinaryLiteralOperation.OpID.RSUB_INT,
-                    ((Instruction22s) inst).getRegisterA(),
-                    ((Instruction22s) inst).getRegisterB(),
-                    lit,
+                    OpID.NOTINT,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
                     inst.getOpcode(),
                     this));
-            break;
-          }
-        case MUL_INT_LIT16:
-          {
-            Literal lit = new Literal.LongLiteral(((Instruction22s) inst).getWideLiteral());
+        case NEG_LONG ->
             instructions.add(
-                new BinaryLiteralOperation(
+                new UnaryOperation(
                     instLoc,
-                    BinaryLiteralOperation.OpID.MUL_INT,
-                    ((Instruction22s) inst).getRegisterA(),
-                    ((Instruction22s) inst).getRegisterB(),
-                    lit,
+                    OpID.NEGLONG,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
                     inst.getOpcode(),
                     this));
-            break;
-          }
-        case DIV_INT_LIT16:
-          {
-            Literal lit = new Literal.LongLiteral(((Instruction22s) inst).getWideLiteral());
+        case NOT_LONG ->
             instructions.add(
-                new BinaryLiteralOperation(
+                new UnaryOperation(
                     instLoc,
-                    BinaryLiteralOperation.OpID.DIV_INT,
-                    ((Instruction22s) inst).getRegisterA(),
-                    ((Instruction22s) inst).getRegisterB(),
-                    lit,
+                    OpID.NOTLONG,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
                     inst.getOpcode(),
                     this));
-            break;
-          }
-        case REM_INT_LIT16:
-          {
-            Literal lit = new Literal.LongLiteral(((Instruction22s) inst).getWideLiteral());
+        case NEG_FLOAT ->
             instructions.add(
-                new BinaryLiteralOperation(
+                new UnaryOperation(
                     instLoc,
-                    BinaryLiteralOperation.OpID.REM_INT,
-                    ((Instruction22s) inst).getRegisterA(),
-                    ((Instruction22s) inst).getRegisterB(),
-                    lit,
+                    OpID.NEGFLOAT,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
                     inst.getOpcode(),
                     this));
-            break;
-          }
-        case AND_INT_LIT16:
-          {
-            Literal lit = new Literal.LongLiteral(((Instruction22s) inst).getWideLiteral());
+        case NEG_DOUBLE ->
             instructions.add(
-                new BinaryLiteralOperation(
+                new UnaryOperation(
                     instLoc,
-                    BinaryLiteralOperation.OpID.AND_INT,
-                    ((Instruction22s) inst).getRegisterA(),
-                    ((Instruction22s) inst).getRegisterB(),
-                    lit,
+                    OpID.NEGDOUBLE,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
                     inst.getOpcode(),
                     this));
-            break;
-          }
-        case OR_INT_LIT16:
-          {
-            Literal lit = new Literal.LongLiteral(((Instruction22s) inst).getWideLiteral());
+        case INT_TO_LONG ->
             instructions.add(
-                new BinaryLiteralOperation(
+                new UnaryOperation(
                     instLoc,
-                    BinaryLiteralOperation.OpID.OR_INT,
-                    ((Instruction22s) inst).getRegisterA(),
-                    ((Instruction22s) inst).getRegisterB(),
-                    lit,
+                    OpID.INTTOLONG,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
                     inst.getOpcode(),
                     this));
-            break;
-          }
-        case XOR_INT_LIT16:
-          {
-            Literal lit = new Literal.LongLiteral(((Instruction22s) inst).getWideLiteral());
+        case INT_TO_FLOAT ->
             instructions.add(
-                new BinaryLiteralOperation(
+                new UnaryOperation(
                     instLoc,
-                    BinaryLiteralOperation.OpID.XOR_INT,
-                    ((Instruction22s) inst).getRegisterA(),
-                    ((Instruction22s) inst).getRegisterB(),
-                    lit,
+                    OpID.INTTOFLOAT,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
                     inst.getOpcode(),
                     this));
-            break;
-          }
-        case ADD_INT_LIT8:
-          {
-            Literal lit = new Literal.LongLiteral(((Instruction22b) inst).getWideLiteral());
+        case INT_TO_DOUBLE ->
             instructions.add(
-                new BinaryLiteralOperation(
+                new UnaryOperation(
                     instLoc,
-                    BinaryLiteralOperation.OpID.ADD_INT,
-                    ((Instruction22b) inst).getRegisterA(),
-                    ((Instruction22b) inst).getRegisterB(),
-                    lit,
+                    OpID.INTTODOUBLE,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
                     inst.getOpcode(),
                     this));
-            break;
-          }
-        case RSUB_INT_LIT8:
-          {
-            Literal lit = new Literal.LongLiteral(((Instruction22b) inst).getWideLiteral());
+        case LONG_TO_INT ->
             instructions.add(
-                new BinaryLiteralOperation(
+                new UnaryOperation(
                     instLoc,
-                    BinaryLiteralOperation.OpID.RSUB_INT,
-                    ((Instruction22b) inst).getRegisterA(),
-                    ((Instruction22b) inst).getRegisterB(),
-                    lit,
+                    OpID.LONGTOINT,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
                     inst.getOpcode(),
                     this));
-            break;
-          }
-        case MUL_INT_LIT8:
-          {
-            Literal lit = new Literal.LongLiteral(((Instruction22b) inst).getWideLiteral());
+        case LONG_TO_FLOAT ->
             instructions.add(
-                new BinaryLiteralOperation(
+                new UnaryOperation(
                     instLoc,
-                    BinaryLiteralOperation.OpID.MUL_INT,
-                    ((Instruction22b) inst).getRegisterA(),
-                    ((Instruction22b) inst).getRegisterB(),
-                    lit,
+                    OpID.LONGTOFLOAT,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
                     inst.getOpcode(),
                     this));
-            break;
-          }
-        case DIV_INT_LIT8:
-          {
-            Literal lit = new Literal.LongLiteral(((Instruction22b) inst).getWideLiteral());
+        case LONG_TO_DOUBLE ->
             instructions.add(
-                new BinaryLiteralOperation(
+                new UnaryOperation(
                     instLoc,
-                    BinaryLiteralOperation.OpID.DIV_INT,
-                    ((Instruction22b) inst).getRegisterA(),
-                    ((Instruction22b) inst).getRegisterB(),
-                    lit,
+                    OpID.LONGTODOUBLE,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
                     inst.getOpcode(),
                     this));
-            break;
-          }
-        case REM_INT_LIT8:
-          {
-            Literal lit = new Literal.LongLiteral(((Instruction22b) inst).getWideLiteral());
+        case FLOAT_TO_INT ->
             instructions.add(
-                new BinaryLiteralOperation(
+                new UnaryOperation(
                     instLoc,
-                    BinaryLiteralOperation.OpID.REM_INT,
-                    ((Instruction22b) inst).getRegisterA(),
-                    ((Instruction22b) inst).getRegisterB(),
-                    lit,
+                    OpID.FLOATTOINT,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
                     inst.getOpcode(),
                     this));
-            break;
-          }
-        case AND_INT_LIT8:
-          {
-            Literal lit = new Literal.LongLiteral(((Instruction22b) inst).getWideLiteral());
+        case FLOAT_TO_LONG ->
             instructions.add(
-                new BinaryLiteralOperation(
+                new UnaryOperation(
                     instLoc,
-                    BinaryLiteralOperation.OpID.AND_INT,
-                    ((Instruction22b) inst).getRegisterA(),
-                    ((Instruction22b) inst).getRegisterB(),
-                    lit,
+                    OpID.FLOATTOLONG,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
                     inst.getOpcode(),
                     this));
-            break;
-          }
-        case OR_INT_LIT8:
-          {
-            Literal lit = new Literal.LongLiteral(((Instruction22b) inst).getWideLiteral());
+        case FLOAT_TO_DOUBLE ->
             instructions.add(
-                new BinaryLiteralOperation(
+                new UnaryOperation(
                     instLoc,
-                    BinaryLiteralOperation.OpID.OR_INT,
-                    ((Instruction22b) inst).getRegisterA(),
-                    ((Instruction22b) inst).getRegisterB(),
-                    lit,
+                    OpID.FLOATTODOUBLE,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
                     inst.getOpcode(),
                     this));
-            break;
-          }
-        case XOR_INT_LIT8:
-          {
-            Literal lit = new Literal.LongLiteral(((Instruction22b) inst).getWideLiteral());
+        case DOUBLE_TO_INT ->
             instructions.add(
-                new BinaryLiteralOperation(
+                new UnaryOperation(
                     instLoc,
-                    BinaryLiteralOperation.OpID.XOR_INT,
-                    ((Instruction22b) inst).getRegisterA(),
-                    ((Instruction22b) inst).getRegisterB(),
-                    lit,
+                    OpID.DOUBLETOINT,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
                     inst.getOpcode(),
                     this));
-            break;
-          }
-        case SHL_INT_LIT8:
-          {
-            Literal lit = new Literal.LongLiteral(((Instruction22b) inst).getWideLiteral());
+        case DOUBLE_TO_LONG ->
             instructions.add(
-                new BinaryLiteralOperation(
+                new UnaryOperation(
                     instLoc,
-                    BinaryLiteralOperation.OpID.SHL_INT,
-                    ((Instruction22b) inst).getRegisterA(),
-                    ((Instruction22b) inst).getRegisterB(),
-                    lit,
+                    OpID.DOUBLETOLONG,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
                     inst.getOpcode(),
                     this));
-            break;
-          }
-        case SHR_INT_LIT8:
-          {
-            Literal lit = new Literal.LongLiteral(((Instruction22b) inst).getWideLiteral());
+        case DOUBLE_TO_FLOAT ->
             instructions.add(
-                new BinaryLiteralOperation(
+                new UnaryOperation(
                     instLoc,
-                    BinaryLiteralOperation.OpID.SHR_INT,
-                    ((Instruction22b) inst).getRegisterA(),
-                    ((Instruction22b) inst).getRegisterB(),
-                    lit,
+                    OpID.DOUBLETOFLOAT,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
                     inst.getOpcode(),
                     this));
-            break;
-          }
-        case USHR_INT_LIT8:
-          {
-            Literal lit = new Literal.LongLiteral(((Instruction22b) inst).getWideLiteral());
+        case INT_TO_BYTE ->
             instructions.add(
-                new BinaryLiteralOperation(
+                new UnaryOperation(
                     instLoc,
-                    BinaryLiteralOperation.OpID.USHR_INT,
-                    ((Instruction22b) inst).getRegisterA(),
-                    ((Instruction22b) inst).getRegisterB(),
-                    lit,
+                    OpID.INTTOBYTE,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
                     inst.getOpcode(),
                     this));
-            break;
-          }
-        default:
-          throw new RuntimeException(
-              "not implemented instruction: 0x"
-                  + inst.getOpcode().toString()
-                  + " in "
-                  + eMethod.getDefiningClass()
-                  + ':'
-                  + eMethod.getName());
+        case INT_TO_CHAR ->
+            instructions.add(
+                new UnaryOperation(
+                    instLoc,
+                    OpID.INTTOCHAR,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case INT_TO_SHORT ->
+            instructions.add(
+                new UnaryOperation(
+                    instLoc,
+                    OpID.INTTOSHORT,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case ADD_INT ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.ADD_INT,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case SUB_INT ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.SUB_INT,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case MUL_INT ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.MUL_INT,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case DIV_INT ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.DIV_INT,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case REM_INT ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.REM_INT,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case AND_INT ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.AND_INT,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case OR_INT ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.OR_INT,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case XOR_INT ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.XOR_INT,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case SHL_INT ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.SHL_INT,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case SHR_INT ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.SHR_INT,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case USHR_INT ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.USHR_INT,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case ADD_LONG ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.ADD_LONG,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case SUB_LONG ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.SUB_LONG,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case MUL_LONG ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.MUL_LONG,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case DIV_LONG ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.DIV_LONG,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case REM_LONG ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.REM_LONG,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case AND_LONG ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.AND_LONG,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case OR_LONG ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.OR_LONG,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case XOR_LONG ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.XOR_LONG,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case SHL_LONG ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.SHL_LONG,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case SHR_LONG ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.SHR_LONG,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case USHR_LONG ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.USHR_LONG,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case ADD_FLOAT ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.ADD_FLOAT,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case SUB_FLOAT ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.SUB_FLOAT,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case MUL_FLOAT ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.MUL_FLOAT,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case DIV_FLOAT ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.DIV_FLOAT,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case REM_FLOAT ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.REM_FLOAT,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case ADD_DOUBLE ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.ADD_DOUBLE,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case SUB_DOUBLE ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.SUB_DOUBLE,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case MUL_DOUBLE ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.MUL_DOUBLE,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case DIV_DOUBLE ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.DIV_DOUBLE,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case REM_DOUBLE ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.REM_DOUBLE,
+                    ((Instruction23x) inst).getRegisterA(),
+                    ((Instruction23x) inst).getRegisterB(),
+                    ((Instruction23x) inst).getRegisterC(),
+                    inst.getOpcode(),
+                    this));
+        case ADD_INT_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.ADD_INT,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case SUB_INT_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.SUB_INT,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case MUL_INT_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.MUL_INT,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case DIV_INT_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.DIV_INT,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case REM_INT_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.REM_INT,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case AND_INT_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.AND_INT,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case OR_INT_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.OR_INT,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case XOR_INT_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.XOR_INT,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case SHL_INT_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.SHL_INT,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case SHR_INT_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.SHR_INT,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case USHR_INT_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.USHR_INT,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case ADD_LONG_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.ADD_LONG,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case SUB_LONG_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.SUB_LONG,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case MUL_LONG_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.MUL_LONG,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case DIV_LONG_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.DIV_LONG,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case REM_LONG_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.REM_LONG,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case AND_LONG_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.AND_LONG,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case OR_LONG_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.OR_LONG,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case XOR_LONG_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.XOR_LONG,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case SHL_LONG_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.SHL_LONG,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case SHR_LONG_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.SHR_LONG,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case USHR_LONG_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.USHR_LONG,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case ADD_FLOAT_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.ADD_FLOAT,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case SUB_FLOAT_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.SUB_FLOAT,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case MUL_FLOAT_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.MUL_FLOAT,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case DIV_FLOAT_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.DIV_FLOAT,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case REM_FLOAT_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.REM_FLOAT,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case ADD_DOUBLE_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.ADD_DOUBLE,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case SUB_DOUBLE_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.SUB_DOUBLE,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case MUL_DOUBLE_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.MUL_DOUBLE,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case DIV_DOUBLE_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.DIV_DOUBLE,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case REM_DOUBLE_2ADDR ->
+            instructions.add(
+                new BinaryOperation(
+                    instLoc,
+                    BinaryOperation.OpID.REM_DOUBLE,
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterA(),
+                    ((Instruction12x) inst).getRegisterB(),
+                    inst.getOpcode(),
+                    this));
+        case ADD_INT_LIT16 -> {
+          Literal lit = new Literal.LongLiteral(((Instruction22s) inst).getWideLiteral());
+          instructions.add(
+              new BinaryLiteralOperation(
+                  instLoc,
+                  BinaryLiteralOperation.OpID.ADD_INT,
+                  ((Instruction22s) inst).getRegisterA(),
+                  ((Instruction22s) inst).getRegisterB(),
+                  lit,
+                  inst.getOpcode(),
+                  this));
+        }
+        case RSUB_INT -> {
+          Literal lit = new Literal.LongLiteral(((Instruction22s) inst).getWideLiteral());
+          instructions.add(
+              new BinaryLiteralOperation(
+                  instLoc,
+                  BinaryLiteralOperation.OpID.RSUB_INT,
+                  ((Instruction22s) inst).getRegisterA(),
+                  ((Instruction22s) inst).getRegisterB(),
+                  lit,
+                  inst.getOpcode(),
+                  this));
+        }
+        case MUL_INT_LIT16 -> {
+          Literal lit = new Literal.LongLiteral(((Instruction22s) inst).getWideLiteral());
+          instructions.add(
+              new BinaryLiteralOperation(
+                  instLoc,
+                  BinaryLiteralOperation.OpID.MUL_INT,
+                  ((Instruction22s) inst).getRegisterA(),
+                  ((Instruction22s) inst).getRegisterB(),
+                  lit,
+                  inst.getOpcode(),
+                  this));
+        }
+        case DIV_INT_LIT16 -> {
+          Literal lit = new Literal.LongLiteral(((Instruction22s) inst).getWideLiteral());
+          instructions.add(
+              new BinaryLiteralOperation(
+                  instLoc,
+                  BinaryLiteralOperation.OpID.DIV_INT,
+                  ((Instruction22s) inst).getRegisterA(),
+                  ((Instruction22s) inst).getRegisterB(),
+                  lit,
+                  inst.getOpcode(),
+                  this));
+        }
+        case REM_INT_LIT16 -> {
+          Literal lit = new Literal.LongLiteral(((Instruction22s) inst).getWideLiteral());
+          instructions.add(
+              new BinaryLiteralOperation(
+                  instLoc,
+                  BinaryLiteralOperation.OpID.REM_INT,
+                  ((Instruction22s) inst).getRegisterA(),
+                  ((Instruction22s) inst).getRegisterB(),
+                  lit,
+                  inst.getOpcode(),
+                  this));
+        }
+        case AND_INT_LIT16 -> {
+          Literal lit = new Literal.LongLiteral(((Instruction22s) inst).getWideLiteral());
+          instructions.add(
+              new BinaryLiteralOperation(
+                  instLoc,
+                  BinaryLiteralOperation.OpID.AND_INT,
+                  ((Instruction22s) inst).getRegisterA(),
+                  ((Instruction22s) inst).getRegisterB(),
+                  lit,
+                  inst.getOpcode(),
+                  this));
+        }
+        case OR_INT_LIT16 -> {
+          Literal lit = new Literal.LongLiteral(((Instruction22s) inst).getWideLiteral());
+          instructions.add(
+              new BinaryLiteralOperation(
+                  instLoc,
+                  BinaryLiteralOperation.OpID.OR_INT,
+                  ((Instruction22s) inst).getRegisterA(),
+                  ((Instruction22s) inst).getRegisterB(),
+                  lit,
+                  inst.getOpcode(),
+                  this));
+        }
+        case XOR_INT_LIT16 -> {
+          Literal lit = new Literal.LongLiteral(((Instruction22s) inst).getWideLiteral());
+          instructions.add(
+              new BinaryLiteralOperation(
+                  instLoc,
+                  BinaryLiteralOperation.OpID.XOR_INT,
+                  ((Instruction22s) inst).getRegisterA(),
+                  ((Instruction22s) inst).getRegisterB(),
+                  lit,
+                  inst.getOpcode(),
+                  this));
+        }
+        case ADD_INT_LIT8 -> {
+          Literal lit = new Literal.LongLiteral(((Instruction22b) inst).getWideLiteral());
+          instructions.add(
+              new BinaryLiteralOperation(
+                  instLoc,
+                  BinaryLiteralOperation.OpID.ADD_INT,
+                  ((Instruction22b) inst).getRegisterA(),
+                  ((Instruction22b) inst).getRegisterB(),
+                  lit,
+                  inst.getOpcode(),
+                  this));
+        }
+        case RSUB_INT_LIT8 -> {
+          Literal lit = new Literal.LongLiteral(((Instruction22b) inst).getWideLiteral());
+          instructions.add(
+              new BinaryLiteralOperation(
+                  instLoc,
+                  BinaryLiteralOperation.OpID.RSUB_INT,
+                  ((Instruction22b) inst).getRegisterA(),
+                  ((Instruction22b) inst).getRegisterB(),
+                  lit,
+                  inst.getOpcode(),
+                  this));
+        }
+        case MUL_INT_LIT8 -> {
+          Literal lit = new Literal.LongLiteral(((Instruction22b) inst).getWideLiteral());
+          instructions.add(
+              new BinaryLiteralOperation(
+                  instLoc,
+                  BinaryLiteralOperation.OpID.MUL_INT,
+                  ((Instruction22b) inst).getRegisterA(),
+                  ((Instruction22b) inst).getRegisterB(),
+                  lit,
+                  inst.getOpcode(),
+                  this));
+        }
+        case DIV_INT_LIT8 -> {
+          Literal lit = new Literal.LongLiteral(((Instruction22b) inst).getWideLiteral());
+          instructions.add(
+              new BinaryLiteralOperation(
+                  instLoc,
+                  BinaryLiteralOperation.OpID.DIV_INT,
+                  ((Instruction22b) inst).getRegisterA(),
+                  ((Instruction22b) inst).getRegisterB(),
+                  lit,
+                  inst.getOpcode(),
+                  this));
+        }
+        case REM_INT_LIT8 -> {
+          Literal lit = new Literal.LongLiteral(((Instruction22b) inst).getWideLiteral());
+          instructions.add(
+              new BinaryLiteralOperation(
+                  instLoc,
+                  BinaryLiteralOperation.OpID.REM_INT,
+                  ((Instruction22b) inst).getRegisterA(),
+                  ((Instruction22b) inst).getRegisterB(),
+                  lit,
+                  inst.getOpcode(),
+                  this));
+        }
+        case AND_INT_LIT8 -> {
+          Literal lit = new Literal.LongLiteral(((Instruction22b) inst).getWideLiteral());
+          instructions.add(
+              new BinaryLiteralOperation(
+                  instLoc,
+                  BinaryLiteralOperation.OpID.AND_INT,
+                  ((Instruction22b) inst).getRegisterA(),
+                  ((Instruction22b) inst).getRegisterB(),
+                  lit,
+                  inst.getOpcode(),
+                  this));
+        }
+        case OR_INT_LIT8 -> {
+          Literal lit = new Literal.LongLiteral(((Instruction22b) inst).getWideLiteral());
+          instructions.add(
+              new BinaryLiteralOperation(
+                  instLoc,
+                  BinaryLiteralOperation.OpID.OR_INT,
+                  ((Instruction22b) inst).getRegisterA(),
+                  ((Instruction22b) inst).getRegisterB(),
+                  lit,
+                  inst.getOpcode(),
+                  this));
+        }
+        case XOR_INT_LIT8 -> {
+          Literal lit = new Literal.LongLiteral(((Instruction22b) inst).getWideLiteral());
+          instructions.add(
+              new BinaryLiteralOperation(
+                  instLoc,
+                  BinaryLiteralOperation.OpID.XOR_INT,
+                  ((Instruction22b) inst).getRegisterA(),
+                  ((Instruction22b) inst).getRegisterB(),
+                  lit,
+                  inst.getOpcode(),
+                  this));
+        }
+        case SHL_INT_LIT8 -> {
+          Literal lit = new Literal.LongLiteral(((Instruction22b) inst).getWideLiteral());
+          instructions.add(
+              new BinaryLiteralOperation(
+                  instLoc,
+                  BinaryLiteralOperation.OpID.SHL_INT,
+                  ((Instruction22b) inst).getRegisterA(),
+                  ((Instruction22b) inst).getRegisterB(),
+                  lit,
+                  inst.getOpcode(),
+                  this));
+        }
+        case SHR_INT_LIT8 -> {
+          Literal lit = new Literal.LongLiteral(((Instruction22b) inst).getWideLiteral());
+          instructions.add(
+              new BinaryLiteralOperation(
+                  instLoc,
+                  BinaryLiteralOperation.OpID.SHR_INT,
+                  ((Instruction22b) inst).getRegisterA(),
+                  ((Instruction22b) inst).getRegisterB(),
+                  lit,
+                  inst.getOpcode(),
+                  this));
+        }
+        case USHR_INT_LIT8 -> {
+          Literal lit = new Literal.LongLiteral(((Instruction22b) inst).getWideLiteral());
+          instructions.add(
+              new BinaryLiteralOperation(
+                  instLoc,
+                  BinaryLiteralOperation.OpID.USHR_INT,
+                  ((Instruction22b) inst).getRegisterA(),
+                  ((Instruction22b) inst).getRegisterB(),
+                  lit,
+                  inst.getOpcode(),
+                  this));
+        }
+        default ->
+            throw new RuntimeException(
+                "not implemented instruction: 0x"
+                    + inst.getOpcode().toString()
+                    + " in "
+                    + eMethod.getDefiningClass()
+                    + ':'
+                    + eMethod.getName());
       }
       currentCodeAddress += inst.getCodeUnits();
     }

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexUtil.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/classLoader/DexUtil.java
@@ -81,80 +81,72 @@ public class DexUtil {
 
   static ElementValue getValue(ClassLoaderReference clr, EncodedValue v) {
     switch (v.getValueType()) {
-      case ANNOTATION:
-        {
-          Map<String, ElementValue> values = HashMapFactory.make();
-          String at = ((AnnotationEncodedValue) v).getType();
+      case ANNOTATION -> {
+        Map<String, ElementValue> values = HashMapFactory.make();
+        String at = ((AnnotationEncodedValue) v).getType();
 
-          for (AnnotationElement elt : ((AnnotationEncodedValue) v).getElements()) {
-            String name = elt.getName();
-            EncodedValue ev = elt.getValue();
-            ElementValue value = getValue(clr, ev);
-            values.put(name, value);
-          }
-
-          return new AnnotationAttribute(at, values);
+        for (AnnotationElement elt : ((AnnotationEncodedValue) v).getElements()) {
+          String name = elt.getName();
+          EncodedValue ev = elt.getValue();
+          ElementValue value = getValue(clr, ev);
+          values.put(name, value);
         }
 
-      case ARRAY:
-        {
-          List<? extends EncodedValue> vs = ((ArrayEncodedValue) v).getValue();
-          ElementValue[] rs = new ElementValue[vs.size()];
-          int idx = 0;
-          for (EncodedValue ev : vs) {
-            rs[idx++] = getValue(clr, ev);
-          }
-          return new ArrayElementValue(rs);
+        return new AnnotationAttribute(at, values);
+      }
+      case ARRAY -> {
+        List<? extends EncodedValue> vs = ((ArrayEncodedValue) v).getValue();
+        ElementValue[] rs = new ElementValue[vs.size()];
+        int idx = 0;
+        for (EncodedValue ev : vs) {
+          rs[idx++] = getValue(clr, ev);
         }
-
-      case BOOLEAN:
+        return new ArrayElementValue(rs);
+      }
+      case BOOLEAN -> {
         Boolean bl = ((BooleanEncodedValue) v).getValue();
         return new ConstantElementValue(bl);
-
-      case BYTE:
+      }
+      case BYTE -> {
         Byte bt = ((ByteEncodedValue) v).getValue();
         return new ConstantElementValue(bt);
-
-      case CHAR:
+      }
+      case CHAR -> {
         Character c = ((CharEncodedValue) v).getValue();
         return new ConstantElementValue(c);
-
-      case DOUBLE:
+      }
+      case DOUBLE -> {
         Double d = ((DoubleEncodedValue) v).getValue();
         return new ConstantElementValue(d);
-
-      case ENUM:
-        {
-          org.jf.dexlib2.iface.reference.FieldReference o = ((EnumEncodedValue) v).getValue();
-          return new EnumElementValue(o.getType(), o.getName());
-        }
-
-      case FIELD:
-        {
-          org.jf.dexlib2.iface.reference.FieldReference o =
-              v.getValueType() == ENUM
-                  ? ((EnumEncodedValue) v).getValue()
-                  : ((FieldEncodedValue) v).getValue();
-          String fieldName = o.getName();
-          TypeReference ft = getTypeRef(o.getType(), clr);
-          TypeReference ct = getTypeRef(o.getDefiningClass(), clr);
-          return new ConstantElementValue(
-              FieldReference.findOrCreate(ct, Atom.findOrCreateUnicodeAtom(fieldName), ft));
-        }
-
-      case FLOAT:
+      }
+      case ENUM -> {
+        org.jf.dexlib2.iface.reference.FieldReference o = ((EnumEncodedValue) v).getValue();
+        return new EnumElementValue(o.getType(), o.getName());
+      }
+      case FIELD -> {
+        org.jf.dexlib2.iface.reference.FieldReference o =
+            v.getValueType() == ENUM
+                ? ((EnumEncodedValue) v).getValue()
+                : ((FieldEncodedValue) v).getValue();
+        String fieldName = o.getName();
+        TypeReference ft = getTypeRef(o.getType(), clr);
+        TypeReference ct = getTypeRef(o.getDefiningClass(), clr);
+        return new ConstantElementValue(
+            FieldReference.findOrCreate(ct, Atom.findOrCreateUnicodeAtom(fieldName), ft));
+      }
+      case FLOAT -> {
         Float f = ((FloatEncodedValue) v).getValue();
         return new ConstantElementValue(f);
-
-      case INT:
+      }
+      case INT -> {
         Integer iv = ((IntEncodedValue) v).getValue();
         return new ConstantElementValue(iv);
-
-      case LONG:
+      }
+      case LONG -> {
         Long l = ((LongEncodedValue) v).getValue();
         return new ConstantElementValue(l);
-
-      case METHOD:
+      }
+      case METHOD -> {
         org.jf.dexlib2.iface.reference.MethodReference m = ((MethodEncodedValue) v).getValue();
         TypeReference ct = getTypeRef(m.getDefiningClass(), clr);
         String methodName = m.getName();
@@ -164,25 +156,26 @@ public class DexUtil {
                 ct,
                 Atom.findOrCreateUnicodeAtom(methodName),
                 Descriptor.findOrCreateUTF8(methodSig)));
-
-      case NULL:
+      }
+      case NULL -> {
         return new ConstantElementValue(null);
-
-      case SHORT:
+      }
+      case SHORT -> {
         Short s = ((ShortEncodedValue) v).getValue();
         return new ConstantElementValue(s);
-
-      case STRING:
+      }
+      case STRING -> {
         String str = ((StringEncodedValue) v).getValue();
         return new ConstantElementValue(str);
-
-      case TYPE:
+      }
+      case TYPE -> {
         String t = ((TypeEncodedValue) v).getValue();
         return new ConstantElementValue(getTypeName(t) + ";");
-
-      default:
+      }
+      default -> {
         assert false : v;
         return null;
+      }
     }
   }
 

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/dex/instructions/ArrayGet.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/dex/instructions/ArrayGet.java
@@ -88,23 +88,14 @@ public class ArrayGet extends Instruction {
   }
 
   public static TypeReference getType(Type type) {
-    switch (type) {
-      case t_int:
-        return TypeReference.Int;
-      case t_wide:
-        return TypeReference.Long;
-      case t_boolean:
-        return TypeReference.Boolean;
-      case t_byte:
-        return TypeReference.Byte;
-      case t_char:
-        return TypeReference.Char;
-      case t_object:
-        return TypeReference.JavaLangObject;
-      case t_short:
-        return TypeReference.Short;
-      default:
-        return null;
-    }
+    return switch (type) {
+      case t_int -> TypeReference.Int;
+      case t_wide -> TypeReference.Long;
+      case t_boolean -> TypeReference.Boolean;
+      case t_byte -> TypeReference.Byte;
+      case t_char -> TypeReference.Char;
+      case t_object -> TypeReference.JavaLangObject;
+      case t_short -> TypeReference.Short;
+    };
   }
 }

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/dex/instructions/BinaryLiteralOperation.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/dex/instructions/BinaryLiteralOperation.java
@@ -126,115 +126,66 @@ public class BinaryLiteralOperation extends Instruction {
   }
 
   public IBinaryOpInstruction.IOperator getOperator() {
-    switch (op) {
-      case CMPL_FLOAT:
-      case CMPL_DOUBLE:
-      case CMPL_LONG:
-      case CMPL_INT:
-        return DalvikBinaryOp.LT;
-      case CMPG_FLOAT:
-      case CMPG_DOUBLE:
-      case CMPG_LONG:
-      case CMPG_INT:
-        return DalvikBinaryOp.GT;
-      case ADD_INT:
-      case ADD_LONG:
-      case ADD_DOUBLE:
-      case ADD_FLOAT:
-        return IBinaryOpInstruction.Operator.ADD;
-      case RSUB_INT:
-      case RSUB_LONG:
-      case RSUB_DOUBLE:
-      case RSUB_FLOAT:
-        return IBinaryOpInstruction.Operator.SUB;
-      case MUL_INT:
-      case MUL_LONG:
-      case MUL_DOUBLE:
-      case MUL_FLOAT:
-        return IBinaryOpInstruction.Operator.MUL;
-      case DIV_INT:
-      case DIV_LONG:
-      case DIV_DOUBLE:
-      case DIV_FLOAT:
-        return IBinaryOpInstruction.Operator.DIV;
-      case REM_INT:
-      case REM_LONG:
-      case REM_DOUBLE:
-      case REM_FLOAT:
-        return IBinaryOpInstruction.Operator.REM;
-      case AND_INT:
-      case AND_LONG:
-        return IBinaryOpInstruction.Operator.AND;
-      case OR_INT:
-      case OR_LONG:
-        return IBinaryOpInstruction.Operator.OR;
-      case XOR_INT:
-      case XOR_LONG:
-        return IBinaryOpInstruction.Operator.XOR;
-      case SHL_INT:
-      case SHL_LONG:
-        return IShiftInstruction.Operator.SHL;
-      case SHR_INT:
-      case SHR_LONG:
-        return IShiftInstruction.Operator.SHR;
-      case USHR_INT:
-      case USHR_LONG:
-        return IShiftInstruction.Operator.USHR;
-      default:
-        return null;
-    }
+    return switch (op) {
+      case CMPL_FLOAT, CMPL_DOUBLE, CMPL_LONG, CMPL_INT -> DalvikBinaryOp.LT;
+      case CMPG_FLOAT, CMPG_DOUBLE, CMPG_LONG, CMPG_INT -> DalvikBinaryOp.GT;
+      case ADD_INT, ADD_LONG, ADD_DOUBLE, ADD_FLOAT -> IBinaryOpInstruction.Operator.ADD;
+      case RSUB_INT, RSUB_LONG, RSUB_DOUBLE, RSUB_FLOAT -> IBinaryOpInstruction.Operator.SUB;
+      case MUL_INT, MUL_LONG, MUL_DOUBLE, MUL_FLOAT -> IBinaryOpInstruction.Operator.MUL;
+      case DIV_INT, DIV_LONG, DIV_DOUBLE, DIV_FLOAT -> IBinaryOpInstruction.Operator.DIV;
+      case REM_INT, REM_LONG, REM_DOUBLE, REM_FLOAT -> IBinaryOpInstruction.Operator.REM;
+      case AND_INT, AND_LONG -> IBinaryOpInstruction.Operator.AND;
+      case OR_INT, OR_LONG -> IBinaryOpInstruction.Operator.OR;
+      case XOR_INT, XOR_LONG -> IBinaryOpInstruction.Operator.XOR;
+      case SHL_INT, SHL_LONG -> IShiftInstruction.Operator.SHL;
+      case SHR_INT, SHR_LONG -> IShiftInstruction.Operator.SHR;
+      case USHR_INT, USHR_LONG -> IShiftInstruction.Operator.USHR;
+    };
   }
 
   public boolean isFloat() {
-    switch (op) {
-      case CMPL_FLOAT:
-      case CMPG_FLOAT:
-      case CMPL_DOUBLE:
-      case CMPG_DOUBLE:
-      case ADD_FLOAT:
-      case RSUB_FLOAT:
-      case MUL_FLOAT:
-      case DIV_FLOAT:
-      case REM_FLOAT:
-      case ADD_DOUBLE:
-      case RSUB_DOUBLE:
-      case MUL_DOUBLE:
-      case DIV_DOUBLE:
-      case REM_DOUBLE:
-        return true;
-      default:
-        return false;
-    }
+    return switch (op) {
+      case CMPL_FLOAT,
+          CMPG_FLOAT,
+          CMPL_DOUBLE,
+          CMPG_DOUBLE,
+          ADD_FLOAT,
+          RSUB_FLOAT,
+          MUL_FLOAT,
+          DIV_FLOAT,
+          REM_FLOAT,
+          ADD_DOUBLE,
+          RSUB_DOUBLE,
+          MUL_DOUBLE,
+          DIV_DOUBLE,
+          REM_DOUBLE ->
+          true;
+      default -> false;
+    };
   }
 
   public boolean isUnsigned() {
-    switch (op) {
-      case AND_INT:
-      case OR_INT:
-      case XOR_INT:
-      case SHL_INT:
-      case USHR_INT:
-      case AND_LONG:
-      case OR_LONG:
-      case XOR_LONG:
-      case SHL_LONG:
-      case USHR_LONG:
-        return true;
-      default:
-        return false;
-    }
+    return switch (op) {
+      case AND_INT,
+          OR_INT,
+          XOR_INT,
+          SHL_INT,
+          USHR_INT,
+          AND_LONG,
+          OR_LONG,
+          XOR_LONG,
+          SHL_LONG,
+          USHR_LONG ->
+          true;
+      default -> false;
+    };
   }
 
   public boolean isSub() {
-    switch (op) {
-      case RSUB_DOUBLE:
-      case RSUB_FLOAT:
-      case RSUB_INT:
-      case RSUB_LONG:
-        return true;
-      default:
-        return false;
-    }
+    return switch (op) {
+      case RSUB_DOUBLE, RSUB_FLOAT, RSUB_INT, RSUB_LONG -> true;
+      default -> false;
+    };
   }
 
   @Override

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/dex/instructions/BinaryOperation.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/dex/instructions/BinaryOperation.java
@@ -129,102 +129,58 @@ public class BinaryOperation extends Instruction {
   }
 
   public IBinaryOpInstruction.IOperator getOperator() {
-    switch (op) {
-      case CMPL_FLOAT:
-      case CMPL_INT:
-      case CMPL_LONG:
-      case CMPL_DOUBLE:
-        return DalvikBinaryOp.LT;
-      case CMPG_FLOAT:
-      case CMPG_INT:
-      case CMPG_LONG:
-      case CMPG_DOUBLE:
-        return DalvikBinaryOp.GT;
-      case ADD_INT:
-      case ADD_DOUBLE:
-      case ADD_FLOAT:
-      case ADD_LONG:
-        return IBinaryOpInstruction.Operator.ADD;
-      case SUB_INT:
-      case SUB_DOUBLE:
-      case SUB_FLOAT:
-      case SUB_LONG:
-        return IBinaryOpInstruction.Operator.SUB;
-      case MUL_INT:
-      case MUL_DOUBLE:
-      case MUL_FLOAT:
-      case MUL_LONG:
-        return IBinaryOpInstruction.Operator.MUL;
-      case DIV_INT:
-      case DIV_DOUBLE:
-      case DIV_FLOAT:
-      case DIV_LONG:
-        return IBinaryOpInstruction.Operator.DIV;
-      case REM_INT:
-      case REM_DOUBLE:
-      case REM_FLOAT:
-      case REM_LONG:
-        return IBinaryOpInstruction.Operator.REM;
-      case AND_INT:
-      case AND_LONG:
-        return IBinaryOpInstruction.Operator.AND;
-      case OR_INT:
-      case OR_LONG:
-        return IBinaryOpInstruction.Operator.OR;
-      case XOR_INT:
-      case XOR_LONG:
-        return IBinaryOpInstruction.Operator.XOR;
-      case SHL_INT:
-      case SHL_LONG:
-        return IShiftInstruction.Operator.SHL;
-      case SHR_INT:
-      case SHR_LONG:
-        return IShiftInstruction.Operator.SHR;
-      case USHR_INT:
-      case USHR_LONG:
-        return IShiftInstruction.Operator.USHR;
-      default:
-        return null;
-    }
+    return switch (op) {
+      case CMPL_FLOAT, CMPL_INT, CMPL_LONG, CMPL_DOUBLE -> DalvikBinaryOp.LT;
+      case CMPG_FLOAT, CMPG_INT, CMPG_LONG, CMPG_DOUBLE -> DalvikBinaryOp.GT;
+      case ADD_INT, ADD_DOUBLE, ADD_FLOAT, ADD_LONG -> IBinaryOpInstruction.Operator.ADD;
+      case SUB_INT, SUB_DOUBLE, SUB_FLOAT, SUB_LONG -> IBinaryOpInstruction.Operator.SUB;
+      case MUL_INT, MUL_DOUBLE, MUL_FLOAT, MUL_LONG -> IBinaryOpInstruction.Operator.MUL;
+      case DIV_INT, DIV_DOUBLE, DIV_FLOAT, DIV_LONG -> IBinaryOpInstruction.Operator.DIV;
+      case REM_INT, REM_DOUBLE, REM_FLOAT, REM_LONG -> IBinaryOpInstruction.Operator.REM;
+      case AND_INT, AND_LONG -> IBinaryOpInstruction.Operator.AND;
+      case OR_INT, OR_LONG -> IBinaryOpInstruction.Operator.OR;
+      case XOR_INT, XOR_LONG -> IBinaryOpInstruction.Operator.XOR;
+      case SHL_INT, SHL_LONG -> IShiftInstruction.Operator.SHL;
+      case SHR_INT, SHR_LONG -> IShiftInstruction.Operator.SHR;
+      case USHR_INT, USHR_LONG -> IShiftInstruction.Operator.USHR;
+    };
   }
 
   public boolean isFloat() {
-    switch (op) {
-      case CMPL_FLOAT:
-      case CMPG_FLOAT:
-      case CMPL_DOUBLE:
-      case CMPG_DOUBLE:
-      case ADD_FLOAT:
-      case SUB_FLOAT:
-      case MUL_FLOAT:
-      case DIV_FLOAT:
-      case REM_FLOAT:
-      case ADD_DOUBLE:
-      case SUB_DOUBLE:
-      case MUL_DOUBLE:
-      case DIV_DOUBLE:
-      case REM_DOUBLE:
-        return true;
-      default:
-        return false;
-    }
+    return switch (op) {
+      case CMPL_FLOAT,
+          CMPG_FLOAT,
+          CMPL_DOUBLE,
+          CMPG_DOUBLE,
+          ADD_FLOAT,
+          SUB_FLOAT,
+          MUL_FLOAT,
+          DIV_FLOAT,
+          REM_FLOAT,
+          ADD_DOUBLE,
+          SUB_DOUBLE,
+          MUL_DOUBLE,
+          DIV_DOUBLE,
+          REM_DOUBLE ->
+          true;
+      default -> false;
+    };
   }
 
   public boolean isUnsigned() {
-    switch (op) {
-      case AND_INT:
-      case OR_INT:
-      case XOR_INT:
-      case SHL_INT:
-      case USHR_INT:
-      case AND_LONG:
-      case OR_LONG:
-      case XOR_LONG:
-      case SHL_LONG:
-      case USHR_LONG:
-        return true;
-      default:
-        return false;
-    }
+    return switch (op) {
+      case AND_INT,
+          OR_INT,
+          XOR_INT,
+          SHL_INT,
+          USHR_INT,
+          AND_LONG,
+          OR_LONG,
+          XOR_LONG,
+          SHL_LONG,
+          USHR_LONG ->
+          true;
+      default -> false;
+    };
   }
 }

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/dex/instructions/Branch.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/dex/instructions/Branch.java
@@ -85,22 +85,14 @@ public abstract class Branch extends Instruction {
 
     @Override
     public IOperator getOperator() {
-      switch (op) {
-        case EQZ:
-          return IConditionalBranchInstruction.Operator.EQ;
-        case NEZ:
-          return IConditionalBranchInstruction.Operator.NE;
-        case LTZ:
-          return IConditionalBranchInstruction.Operator.LT;
-        case LEZ:
-          return IConditionalBranchInstruction.Operator.LE;
-        case GTZ:
-          return IConditionalBranchInstruction.Operator.GT;
-        case GEZ:
-          return IConditionalBranchInstruction.Operator.GE;
-        default:
-          return null;
-      }
+      return switch (op) {
+        case EQZ -> IConditionalBranchInstruction.Operator.EQ;
+        case NEZ -> IConditionalBranchInstruction.Operator.NE;
+        case LTZ -> IConditionalBranchInstruction.Operator.LT;
+        case LEZ -> IConditionalBranchInstruction.Operator.LE;
+        case GTZ -> IConditionalBranchInstruction.Operator.GT;
+        case GEZ -> IConditionalBranchInstruction.Operator.GE;
+      };
     }
   }
 
@@ -134,22 +126,14 @@ public abstract class Branch extends Instruction {
 
     @Override
     public IOperator getOperator() {
-      switch (op) {
-        case EQ:
-          return IConditionalBranchInstruction.Operator.EQ;
-        case NE:
-          return IConditionalBranchInstruction.Operator.NE;
-        case LT:
-          return IConditionalBranchInstruction.Operator.LT;
-        case LE:
-          return IConditionalBranchInstruction.Operator.LE;
-        case GT:
-          return IConditionalBranchInstruction.Operator.GT;
-        case GE:
-          return IConditionalBranchInstruction.Operator.GE;
-        default:
-          return null;
-      }
+      return switch (op) {
+        case EQ -> IConditionalBranchInstruction.Operator.EQ;
+        case NE -> IConditionalBranchInstruction.Operator.NE;
+        case LT -> IConditionalBranchInstruction.Operator.LT;
+        case LE -> IConditionalBranchInstruction.Operator.LE;
+        case GT -> IConditionalBranchInstruction.Operator.GT;
+        case GE -> IConditionalBranchInstruction.Operator.GE;
+      };
     }
   }
 

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/dex/instructions/UnaryOperation.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/dex/instructions/UnaryOperation.java
@@ -112,53 +112,43 @@ public class UnaryOperation extends Instruction {
   }
 
   public boolean isConversion() {
-    switch (op) {
-      case DOUBLETOLONG:
-      case DOUBLETOFLOAT:
-      case INTTOBYTE:
-      case INTTOCHAR:
-      case INTTOSHORT:
-      case DOUBLETOINT:
-      case FLOATTODOUBLE:
-      case FLOATTOLONG:
-      case FLOATTOINT:
-      case LONGTODOUBLE:
-      case LONGTOFLOAT:
-      case LONGTOINT:
-      case INTTODOUBLE:
-      case INTTOFLOAT:
-      case INTTOLONG:
-        return true;
-      default:
-        return false;
-    }
+    return switch (op) {
+      case DOUBLETOLONG,
+          DOUBLETOFLOAT,
+          INTTOBYTE,
+          INTTOCHAR,
+          INTTOSHORT,
+          DOUBLETOINT,
+          FLOATTODOUBLE,
+          FLOATTOLONG,
+          FLOATTOINT,
+          LONGTODOUBLE,
+          LONGTOFLOAT,
+          LONGTOINT,
+          INTTODOUBLE,
+          INTTOFLOAT,
+          INTTOLONG ->
+          true;
+      default -> false;
+    };
   }
 
   public boolean isMove() {
-    switch (op) {
-      case MOVE:
-      case MOVE_WIDE:
-        return true;
-      default:
-        return false;
-    }
+    return switch (op) {
+      case MOVE, MOVE_WIDE -> true;
+      default -> false;
+    };
   }
 
   public IOperator getOperator() {
-    switch (op) {
+    return switch (op) {
       // SSA unary ops
-      case NOT:
-      case NOTLONG:
-      case NOTINT:
-        return DalvikUnaryOp.BITNOT;
-      case NEGINT:
-      case NEGDOUBLE:
-      case NEGFLOAT:
-      case NEGLONG:
-        return IUnaryOpInstruction.Operator.NEG;
-      default:
+      case NOT, NOTLONG, NOTINT -> DalvikUnaryOp.BITNOT;
+      case NEGINT, NEGDOUBLE, NEGFLOAT, NEGLONG -> IUnaryOpInstruction.Operator.NEG;
+      default -> {
         Assertions.UNREACHABLE();
-        return null;
-    }
+        yield null;
+      }
+    };
   }
 }

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/AndroidModelParameterManager.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/parameters/AndroidModelParameterManager.java
@@ -272,15 +272,9 @@ public class AndroidModelParameterManager {
                 }
 
                 switch (param.status) {
-                  case FREE:
-                    param.status = ValueStatus.ALLOCATED;
-                    break;
-                  case FREE_INVALIDATED:
-                    param.status = ValueStatus.INVALIDATED;
-                    break;
-                  case FREE_CLOSED:
-                    param.status = ValueStatus.CLOSED;
-                    break;
+                  case FREE -> param.status = ValueStatus.ALLOCATED;
+                  case FREE_INVALIDATED -> param.status = ValueStatus.INVALIDATED;
+                  case FREE_CLOSED -> param.status = ValueStatus.CLOSED;
                 }
                 param.setInScope = currentScope;
                 //                    param.setBy = setBy;

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/SystemServiceModel.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/androidModel/stubs/SystemServiceModel.java
@@ -206,109 +206,93 @@ public class SystemServiceModel extends AndroidModel {
     final SSAValue retVal;
 
     switch (this.target) {
-      case "phone":
+      case "phone" ->
+          retVal =
+              instantiator.createInstance(
+                  AndroidTypes.TelephonyManager,
+                  false,
+                  new SSAValue.UniqueKey(),
+                  new HashSet<>(pAcc.all()));
+
+      // } else if (this.target.equals("Lwindow")) { // TODO: Is an interface
+      //
+      //    final TypeName wmN = TypeName.findOrCreate("Landroid/view/WindowManager");
+      //    final TypeReference wmT = TypeReference.findOrCreate(ClassLoaderReference.Primordial,
+      // wmN);
+      //    retVal = instantiator.createInstance(wmT, false, new SSAValue.UniqueKey(), new
+      // HashSet<Parameter>(pAcc.all()));
+      // } else if (this.target.equals("Llayout_inflater")) {
+      // } else if (this.target.equals("Lactivity")) {
+      // } else if (this.target.equals("Lpower")) {
+      // } else if (this.target.equals("Lalarm")) {
+      // } else if (this.target.equals("Lnotification")) {
+      case "keyguard" -> {
+        final TypeName n = TypeName.findOrCreate("Landroid/app/KeyguardManager");
+        final TypeReference T = TypeReference.findOrCreate(ClassLoaderReference.Primordial, n);
         retVal =
             instantiator.createInstance(
-                AndroidTypes.TelephonyManager,
-                false,
-                new SSAValue.UniqueKey(),
-                new HashSet<>(pAcc.all()));
-        // } else if (this.target.equals("Lwindow")) { // TODO: Is an interface
-        //
-        //    final TypeName wmN = TypeName.findOrCreate("Landroid/view/WindowManager");
-        //    final TypeReference wmT = TypeReference.findOrCreate(ClassLoaderReference.Primordial,
-        // wmN);
-        //    retVal = instantiator.createInstance(wmT, false, new SSAValue.UniqueKey(), new
-        // HashSet<Parameter>(pAcc.all()));
-        // } else if (this.target.equals("Llayout_inflater")) {
-        // } else if (this.target.equals("Lactivity")) {
-        // } else if (this.target.equals("Lpower")) {
-        // } else if (this.target.equals("Lalarm")) {
-        // } else if (this.target.equals("Lnotification")) {
-        break;
-      case "keyguard":
-        {
-          final TypeName n = TypeName.findOrCreate("Landroid/app/KeyguardManager");
-          final TypeReference T = TypeReference.findOrCreate(ClassLoaderReference.Primordial, n);
-          retVal =
-              instantiator.createInstance(
-                  T, false, new SSAValue.UniqueKey(), new HashSet<>(pAcc.all()));
-          break;
-        }
-      case "location":
-        {
-          final TypeName n = TypeName.findOrCreate("Landroid/location/LocationManager");
-          final TypeReference T = TypeReference.findOrCreate(ClassLoaderReference.Primordial, n);
-          retVal =
-              instantiator.createInstance(
-                  T, false, new SSAValue.UniqueKey(), new HashSet<>(pAcc.all()));
-          break;
-        }
-      case "search":
-        {
-          // TODO: Param: Handler
-          final TypeName n = TypeName.findOrCreate("Landroid/app/SearchManager");
-          final TypeReference T = TypeReference.findOrCreate(ClassLoaderReference.Primordial, n);
-          retVal =
-              instantiator.createInstance(
-                  T, false, new SSAValue.UniqueKey(), new HashSet<>(pAcc.all()));
-          // } else if (this.target.equals("Lvibrator")) { // TODO: Is abstract
-          break;
-        }
-      case "connection":
-        {
-          // TODO: use ConnectivityManager.from
-          final TypeName n = TypeName.findOrCreate("Landroid/net/ConnectivityManager");
-          final TypeReference T = TypeReference.findOrCreate(ClassLoaderReference.Primordial, n);
-          retVal =
-              instantiator.createInstance(
-                  T, false, new SSAValue.UniqueKey(), new HashSet<>(pAcc.all()));
-          break;
-        }
-      case "wifi":
-        {
-          // Handle Params: Context context, IWifiManager service
-          final TypeName n = TypeName.findOrCreate("Landroid/net/wifi/WifiManager");
-          final TypeReference T = TypeReference.findOrCreate(ClassLoaderReference.Primordial, n);
-          retVal =
-              instantiator.createInstance(
-                  T, false, new SSAValue.UniqueKey(), new HashSet<>(pAcc.all()));
-          break;
-        }
-      case "input_method":
-        {
-          // TODO: Use InputMethodManager.getInstance?
-          final TypeName n = TypeName.findOrCreate("Landroid/view/inputmethod/InputMethodManager");
-          final TypeReference T = TypeReference.findOrCreate(ClassLoaderReference.Primordial, n);
-          retVal =
-              instantiator.createInstance(
-                  T, false, new SSAValue.UniqueKey(), new HashSet<>(pAcc.all()));
-          break;
-        }
-      case "uimode":
-        {
-          final TypeName n = TypeName.findOrCreate("Landroid/app/UiModeManager");
-          final TypeReference T = TypeReference.findOrCreate(ClassLoaderReference.Primordial, n);
-          retVal =
-              instantiator.createInstance(
-                  T, false, new SSAValue.UniqueKey(), new HashSet<>(pAcc.all()));
-          break;
-        }
-      case "download":
-        {
-          // TODO: Params ContentResolver resolver, String packageName
-          final TypeName n = TypeName.findOrCreate("Landroid/app/DownloadManager");
-          final TypeReference T = TypeReference.findOrCreate(ClassLoaderReference.Primordial, n);
-          retVal =
-              instantiator.createInstance(
-                  T, false, new SSAValue.UniqueKey(), new HashSet<>(pAcc.all()));
-          break;
-        }
-      default:
+                T, false, new SSAValue.UniqueKey(), new HashSet<>(pAcc.all()));
+      }
+      case "location" -> {
+        final TypeName n = TypeName.findOrCreate("Landroid/location/LocationManager");
+        final TypeReference T = TypeReference.findOrCreate(ClassLoaderReference.Primordial, n);
+        retVal =
+            instantiator.createInstance(
+                T, false, new SSAValue.UniqueKey(), new HashSet<>(pAcc.all()));
+      }
+      case "search" -> {
+        // TODO: Param: Handler
+        final TypeName n = TypeName.findOrCreate("Landroid/app/SearchManager");
+        final TypeReference T = TypeReference.findOrCreate(ClassLoaderReference.Primordial, n);
+        retVal =
+            instantiator.createInstance(
+                T, false, new SSAValue.UniqueKey(), new HashSet<>(pAcc.all()));
+        // } else if (this.target.equals("Lvibrator")) { // TODO: Is abstract
+      }
+      case "connection" -> {
+        // TODO: use ConnectivityManager.from
+        final TypeName n = TypeName.findOrCreate("Landroid/net/ConnectivityManager");
+        final TypeReference T = TypeReference.findOrCreate(ClassLoaderReference.Primordial, n);
+        retVal =
+            instantiator.createInstance(
+                T, false, new SSAValue.UniqueKey(), new HashSet<>(pAcc.all()));
+      }
+      case "wifi" -> {
+        // Handle Params: Context context, IWifiManager service
+        final TypeName n = TypeName.findOrCreate("Landroid/net/wifi/WifiManager");
+        final TypeReference T = TypeReference.findOrCreate(ClassLoaderReference.Primordial, n);
+        retVal =
+            instantiator.createInstance(
+                T, false, new SSAValue.UniqueKey(), new HashSet<>(pAcc.all()));
+      }
+      case "input_method" -> {
+        // TODO: Use InputMethodManager.getInstance?
+        final TypeName n = TypeName.findOrCreate("Landroid/view/inputmethod/InputMethodManager");
+        final TypeReference T = TypeReference.findOrCreate(ClassLoaderReference.Primordial, n);
+        retVal =
+            instantiator.createInstance(
+                T, false, new SSAValue.UniqueKey(), new HashSet<>(pAcc.all()));
+      }
+      case "uimode" -> {
+        final TypeName n = TypeName.findOrCreate("Landroid/app/UiModeManager");
+        final TypeReference T = TypeReference.findOrCreate(ClassLoaderReference.Primordial, n);
+        retVal =
+            instantiator.createInstance(
+                T, false, new SSAValue.UniqueKey(), new HashSet<>(pAcc.all()));
+      }
+      case "download" -> {
+        // TODO: Params ContentResolver resolver, String packageName
+        final TypeName n = TypeName.findOrCreate("Landroid/app/DownloadManager");
+        final TypeReference T = TypeReference.findOrCreate(ClassLoaderReference.Primordial, n);
+        retVal =
+            instantiator.createInstance(
+                T, false, new SSAValue.UniqueKey(), new HashSet<>(pAcc.all()));
+      }
+      default -> {
         retVal = pm.getUnmanaged(TypeReference.JavaLangObject, "notFound");
         this.body.addConstant(retVal.getNumber(), new ConstantValue(null));
         retVal.setAssigned();
-        break;
+      }
     }
 
     { // Add return statement on intent

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/impl/AndroidEntryPoint.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/impl/AndroidEntryPoint.java
@@ -253,30 +253,38 @@ public class AndroidEntryPoint extends DexEntryPoint {
      */
     public ExecutionOrder(String label) {
       switch (label) {
-        case "AT_FIRST":
+        case "AT_FIRST" -> {
           this.value = ExecutionOrder.AT_FIRST.getOrderValue();
           return;
-        case "BEFORE_LOOP":
+        }
+        case "BEFORE_LOOP" -> {
           this.value = ExecutionOrder.BEFORE_LOOP.getOrderValue();
           return;
-        case "START_OF_LOOP":
+        }
+        case "START_OF_LOOP" -> {
           this.value = ExecutionOrder.START_OF_LOOP.getOrderValue();
           return;
-        case "MIDDLE_OF_LOOP":
+        }
+        case "MIDDLE_OF_LOOP" -> {
           this.value = ExecutionOrder.MIDDLE_OF_LOOP.getOrderValue();
           return;
-        case "MULTIPLE_TIMES_IN_LOOP":
+        }
+        case "MULTIPLE_TIMES_IN_LOOP" -> {
           this.value = ExecutionOrder.MULTIPLE_TIMES_IN_LOOP.getOrderValue();
           return;
-        case "END_OF_LOOP":
+        }
+        case "END_OF_LOOP" -> {
           this.value = ExecutionOrder.END_OF_LOOP.getOrderValue();
           return;
-        case "AFTER_LOOP":
+        }
+        case "AFTER_LOOP" -> {
           this.value = ExecutionOrder.AFTER_LOOP.getOrderValue();
           return;
-        case "AT_LAST":
+        }
+        case "AT_LAST" -> {
           this.value = ExecutionOrder.AT_LAST.getOrderValue();
           return;
+        }
       }
       throw new IllegalArgumentException(
           "ExecutionOrder was constructed from an illegal label: " + label);

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/Intent.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/Intent.java
@@ -136,16 +136,13 @@ public class Intent implements Cloneable, ContextItem, Comparable<Intent> {
 
   public void setExplicit() {
     switch (explicit) {
-      case UNSET:
-        // TODO: This is dangerous?
-        explicit = Explicit.EXPLICIT;
-        break;
-      case EXPLICIT:
-        unbind();
-        break;
-      default:
-        throw new UnsupportedOperationException(
-            String.format("unexpected explicitness setting %s", explicit));
+      case UNSET ->
+          // TODO: This is dangerous?
+          explicit = Explicit.EXPLICIT;
+      case EXPLICIT -> unbind();
+      default ->
+          throw new UnsupportedOperationException(
+              String.format("unexpected explicitness setting %s", explicit));
     }
   }
 

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentContextInterpreter.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentContextInterpreter.java
@@ -180,13 +180,12 @@ public class IntentContextInterpreter implements SSAContextInterpreter {
           }
           { // Fetch model and info
             switch (type) {
-              case INTERNAL_TARGET:
+              case INTERNAL_TARGET -> {
                 info = intentStarters.getInfo(method.getReference());
 
                 model = new MicroModel(this.cha, this.options, this.cache, intent.getAction());
-
-                break;
-              case SYSTEM_SERVICE:
+              }
+              case SYSTEM_SERVICE -> {
                 info =
                     new IntentStarters.StartInfo(
                         node.getMethod().getReference().getDeclaringClass(),
@@ -196,35 +195,33 @@ public class IntentContextInterpreter implements SSAContextInterpreter {
 
                 model =
                     new SystemServiceModel(this.cha, this.options, this.cache, intent.getAction());
-
-                break;
-              case EXTERNAL_TARGET:
+              }
+              case EXTERNAL_TARGET -> {
                 info = intentStarters.getInfo(method.getReference());
 
                 model =
                     new ExternalModel(
                         this.cha, this.options, this.cache, fetchTargetComponent(intent, method));
-
-                break;
-              case STANDARD_ACTION:
+              }
               // TODO!
               // In Order to correctly evaluate a standard-action we would also have to look
               // at the URI of the Intent.
-              case UNKNOWN_TARGET:
+              case STANDARD_ACTION, UNKNOWN_TARGET -> {
                 info = intentStarters.getInfo(method.getReference());
 
                 model =
                     new UnknownTargetModel(
                         this.cha, this.options, this.cache, fetchTargetComponent(intent, method));
-
-                break;
-              case IGNORE:
+              }
+              case IGNORE -> {
                 return null;
-              default:
-                throw new java.lang.UnsupportedOperationException(
-                    "The Intent-Type "
-                        + intent.getType()
-                        + " is not known to IntentContextInterpreter");
+              }
+              default ->
+                  throw new UnsupportedOperationException(
+                      "The Intent-Type "
+                          + intent.getType()
+                          + " is not known to IntentContextInterpreter");
+
                 // return method.makeIR(ctx, this.options.getSSAOptions());
             }
 

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentContextSelector.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ipa/callgraph/propagation/cfa/IntentContextSelector.java
@@ -206,11 +206,11 @@ public class IntentContextSelector implements ContextSelector {
       final InstanceKey actionKey;
       { // fetch actionKey, uriKey
         switch (callee.getNumberOfParameters()) {
-          case 1:
+          case 1 -> {
             logger.debug("Handling Intent()");
             actionKey = null;
-            break;
-          case 2:
+          }
+          case 2 -> {
             if (calleeSel.equals(Selector.make("<init>(Ljava/lang/String;)V"))) {
               logger.debug("Handling Intent(String action)");
               actionKey = actualParameters[1];
@@ -229,8 +229,8 @@ public class IntentContextSelector implements ContextSelector {
               logger.error("No handling implemented for: {}", callee);
               actionKey = null;
             }
-            break;
-          case 3:
+          }
+          case 3 -> {
             if (calleeSel.equals(Selector.make("<init>(Ljava/lang/String;Landroid/net/Uri;)V"))) {
               logger.debug("Handling Intent(String action, Uri uri)");
               // TODO: Use Information of the URI...
@@ -244,8 +244,8 @@ public class IntentContextSelector implements ContextSelector {
               logger.error("No handling implemented for: {}", callee);
               actionKey = null;
             }
-            break;
-          case 5:
+          }
+          case 5 -> {
             if (calleeSel.equals(
                 Selector.make(
                     "<init>(Ljava/lang/String;Landroid/net/Uri;Landroid/content/Context;Ljava/lang/Class;)V"))) {
@@ -256,10 +256,11 @@ public class IntentContextSelector implements ContextSelector {
               logger.error("No handling implemented for: {}", callee);
               actionKey = null;
             }
-            break;
-          default:
+          }
+          default -> {
             logger.error("Can't extract Info from Intent-Constructor: {} (not implemented)", site);
             actionKey = null;
+          }
         }
       } // of fetch actionKey
 
@@ -427,24 +428,26 @@ public class IntentContextSelector implements ContextSelector {
       // Intent(String action, Uri uri, Context packageContext, Class<?> cls)
 
       // Select all params;
-      switch (numArgs) {
-        case 0:
-          return EmptyIntSet.instance;
-        case 1:
-          return IntSetUtil.make(new int[] {0, 1});
-        case 2:
+      return switch (numArgs) {
+        case 0 -> EmptyIntSet.instance;
+        case 1 -> IntSetUtil.make(new int[] {0, 1});
+        case 2 -> {
           logger.debug("Got Intent Constructor of: {}", site.getDeclaredTarget().getSelector());
-          return IntSetUtil.make(new int[] {0, 1, 2});
-        case 3:
+          yield IntSetUtil.make(new int[] {0, 1, 2});
+        }
+        case 3 -> {
           logger.debug("Got Intent Constructor of: {}", site.getDeclaredTarget().getSelector());
-          return IntSetUtil.make(new int[] {0, 1, 2, 3});
-        case 4:
+          yield IntSetUtil.make(new int[] {0, 1, 2, 3});
+        }
+        case 4 -> {
           logger.debug("Got Intent Constructor of: {}", site.getDeclaredTarget().getSelector());
-          return IntSetUtil.make(new int[] {0, 1, 2, 3, 4});
-        default:
+          yield IntSetUtil.make(new int[] {0, 1, 2, 3, 4});
+        }
+        default -> {
           logger.debug("Got Intent Constructor of: {}", site.getDeclaredTarget().getSelector());
-          return IntSetUtil.make(new int[] {0, 1, 2, 3, 4, 5});
-      }
+          yield IntSetUtil.make(new int[] {0, 1, 2, 3, 4, 5});
+        }
+      };
     } else if (site.isSpecial()
         && target.getDeclaringClass().getName().equals(AndroidTypes.IntentSenderName)) {
 

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ssa/DexSSABuilder.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ssa/DexSSABuilder.java
@@ -1183,74 +1183,75 @@ public class DexSSABuilder extends AbstractIntRegisterMachine {
           TypeReference fromType, toType;
           boolean overflows = false;
           // TODO: figure out if any of these can overflow
-          switch (instruction.op) {
-            case DOUBLETOLONG:
-              fromType = TypeReference.Double;
-              toType = TypeReference.Long;
-              break;
-            case DOUBLETOFLOAT:
-              fromType = TypeReference.Double;
-              toType = TypeReference.Float;
-              break;
-            case INTTOBYTE:
-              fromType = TypeReference.Int;
-              toType = TypeReference.Byte;
-              break;
-            case INTTOCHAR:
-              fromType = TypeReference.Int;
-              toType = TypeReference.Char;
-              break;
-            case INTTOSHORT:
-              fromType = TypeReference.Int;
-              toType = TypeReference.Short;
-              break;
-            case DOUBLETOINT:
-              fromType = TypeReference.Double;
-              toType = TypeReference.Int;
-              break;
-            case FLOATTODOUBLE:
-              fromType = TypeReference.Float;
-              toType = TypeReference.Double;
-              break;
-            case FLOATTOLONG:
-              fromType = TypeReference.Float;
-              toType = TypeReference.Long;
-              break;
-            case FLOATTOINT:
-              fromType = TypeReference.Float;
-              toType = TypeReference.Int;
-              break;
-            case LONGTODOUBLE:
-              fromType = TypeReference.Long;
-              toType = TypeReference.Double;
-              break;
-            case LONGTOFLOAT:
-              fromType = TypeReference.Long;
-              toType = TypeReference.Float;
-              break;
-            case LONGTOINT:
-              fromType = TypeReference.Long;
-              toType = TypeReference.Int;
-              break;
-            case INTTODOUBLE:
-              fromType = TypeReference.Int;
-              toType = TypeReference.Double;
-              break;
-            case INTTOFLOAT:
-              fromType = TypeReference.Int;
-              toType = TypeReference.Float;
-              break;
-            case INTTOLONG:
-              fromType = TypeReference.Int;
-              toType = TypeReference.Long;
-              break;
-            default:
-              throw new IllegalArgumentException(
-                  "unknown conversion type "
-                      + instruction.op
-                      + " in unary instruction: "
-                      + instruction);
-          }
+          toType =
+              switch (instruction.op) {
+                case DOUBLETOLONG -> {
+                  fromType = TypeReference.Double;
+                  yield TypeReference.Long;
+                }
+                case DOUBLETOFLOAT -> {
+                  fromType = TypeReference.Double;
+                  yield TypeReference.Float;
+                }
+                case INTTOBYTE -> {
+                  fromType = TypeReference.Int;
+                  yield TypeReference.Byte;
+                }
+                case INTTOCHAR -> {
+                  fromType = TypeReference.Int;
+                  yield TypeReference.Char;
+                }
+                case INTTOSHORT -> {
+                  fromType = TypeReference.Int;
+                  yield TypeReference.Short;
+                }
+                case DOUBLETOINT -> {
+                  fromType = TypeReference.Double;
+                  yield TypeReference.Int;
+                }
+                case FLOATTODOUBLE -> {
+                  fromType = TypeReference.Float;
+                  yield TypeReference.Double;
+                }
+                case FLOATTOLONG -> {
+                  fromType = TypeReference.Float;
+                  yield TypeReference.Long;
+                }
+                case FLOATTOINT -> {
+                  fromType = TypeReference.Float;
+                  yield TypeReference.Int;
+                }
+                case LONGTODOUBLE -> {
+                  fromType = TypeReference.Long;
+                  yield TypeReference.Double;
+                }
+                case LONGTOFLOAT -> {
+                  fromType = TypeReference.Long;
+                  yield TypeReference.Float;
+                }
+                case LONGTOINT -> {
+                  fromType = TypeReference.Long;
+                  yield TypeReference.Int;
+                }
+                case INTTODOUBLE -> {
+                  fromType = TypeReference.Int;
+                  yield TypeReference.Double;
+                }
+                case INTTOFLOAT -> {
+                  fromType = TypeReference.Int;
+                  yield TypeReference.Float;
+                }
+                case INTTOLONG -> {
+                  fromType = TypeReference.Int;
+                  yield TypeReference.Long;
+                }
+                default ->
+                    throw new IllegalArgumentException(
+                        "unknown conversion type "
+                            + instruction.op
+                            + " in unary instruction: "
+                            + instruction);
+              };
           int dest = instruction.destination;
           int result = reuseOrCreateDef();
           setLocal(dest, result);

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidSettingFactory.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidSettingFactory.java
@@ -250,20 +250,20 @@ public class AndroidSettingFactory {
       mUri = Atom.findOrCreateAsciiAtom(uri);
     }
     switch (type) {
-      case INTERNAL_TARGET:
+      case INTERNAL_TARGET -> {
         if (uri != null) {
           ret = new InternalIntent(action, mUri);
         } else {
           ret = new InternalIntent(action);
         }
-        break;
-      default:
+      }
+      default -> {
         if (uri != null) {
           ret = new StandardIntent(action, mUri);
         } else {
           ret = new StandardIntent(action);
         }
-        break;
+      }
     }
 
     return ret;

--- a/ide/jdt/src/main/java/com/ibm/wala/ide/util/JavaEclipseProjectPath.java
+++ b/ide/jdt/src/main/java/com/ibm/wala/ide/util/JavaEclipseProjectPath.java
@@ -84,8 +84,7 @@ public class JavaEclipseProjectPath extends EclipseProjectPath<IClasspathEntry, 
     entry = JavaCore.getResolvedClasspathEntry(entry);
     final int entryKind = entry.getEntryKind();
     switch (entryKind) {
-      case IClasspathEntry.CPE_SOURCE:
-        {
+      case IClasspathEntry.CPE_SOURCE ->
           resolveSourcePathEntry(
               includeSource ? JavaSourceLoader.SOURCE : Loader.APPLICATION,
               includeSource,
@@ -94,38 +93,26 @@ public class JavaEclipseProjectPath extends EclipseProjectPath<IClasspathEntry, 
               entry.getOutputLocation(),
               entry.getExclusionPatterns(),
               "java");
-          break;
+      case IClasspathEntry.CPE_LIBRARY -> resolveLibraryPathEntry(loader, entry.getPath());
+      case IClasspathEntry.CPE_PROJECT -> resolveProjectPathEntry(includeSource, entry.getPath());
+      case IClasspathEntry.CPE_CONTAINER -> {
+        try {
+          IClasspathContainer cont = JavaCore.getClasspathContainer(entry.getPath(), project);
+          IClasspathEntry[] entries = cont.getClasspathEntries();
+          resolveClasspathEntries(
+              project,
+              Arrays.asList(entries),
+              cont.getKind() == IClasspathContainer.K_APPLICATION ? loader : Loader.PRIMORDIAL,
+              includeSource,
+              false);
+        } catch (CoreException e) {
+          System.err.println(e);
+          Assertions.UNREACHABLE();
         }
-      case IClasspathEntry.CPE_LIBRARY:
-        {
-          resolveLibraryPathEntry(loader, entry.getPath());
-          break;
-        }
-      case IClasspathEntry.CPE_PROJECT:
-        {
-          resolveProjectPathEntry(includeSource, entry.getPath());
-          break;
-        }
-      case IClasspathEntry.CPE_CONTAINER:
-        {
-          try {
-            IClasspathContainer cont = JavaCore.getClasspathContainer(entry.getPath(), project);
-            IClasspathEntry[] entries = cont.getClasspathEntries();
-            resolveClasspathEntries(
-                project,
-                Arrays.asList(entries),
-                cont.getKind() == IClasspathContainer.K_APPLICATION ? loader : Loader.PRIMORDIAL,
-                includeSource,
-                false);
-          } catch (CoreException e) {
-            System.err.println(e);
-            Assertions.UNREACHABLE();
-          }
-          break;
-        }
-      default:
-        throw new UnsupportedOperationException(
-            String.format("unexpected classpath entry kind %s", entryKind));
+      }
+      default ->
+          throw new UnsupportedOperationException(
+              String.format("unexpected classpath entry kind %s", entryKind));
     }
   }
 

--- a/ide/jdt/src/main/java/com/ibm/wala/ide/util/JdtUtil.java
+++ b/ide/jdt/src/main/java/com/ibm/wala/ide/util/JdtUtil.java
@@ -389,64 +389,44 @@ public class JdtUtil {
       int i = 1;
       while (true) {
         switch (d.charAt(i++)) {
-          case TypeReference.VoidTypeCode:
-            sigs.add(TypeReference.VoidName.toString());
-            continue;
-          case TypeReference.BooleanTypeCode:
-            sigs.add(TypeReference.BooleanName.toString());
-            continue;
-          case TypeReference.ByteTypeCode:
-            sigs.add(TypeReference.ByteName.toString());
-            continue;
-          case TypeReference.ShortTypeCode:
-            sigs.add(TypeReference.ShortName.toString());
-            continue;
-          case TypeReference.IntTypeCode:
-            sigs.add(TypeReference.IntName.toString());
-            continue;
-          case TypeReference.LongTypeCode:
-            sigs.add(TypeReference.LongName.toString());
-            continue;
-          case TypeReference.FloatTypeCode:
-            sigs.add(TypeReference.FloatName.toString());
-            continue;
-          case TypeReference.DoubleTypeCode:
-            sigs.add(TypeReference.DoubleName.toString());
-            continue;
-          case TypeReference.CharTypeCode:
-            sigs.add(TypeReference.CharName.toString());
-            continue;
-          case TypeReference.ArrayTypeCode:
-            {
-              int off = i - 1;
-              while (d.charAt(i) == TypeReference.ArrayTypeCode) {
-                ++i;
-              }
-              if (d.charAt(i++) == TypeReference.ClassTypeCode) {
-                while (d.charAt(i++) != ';')
-                  ;
-                sigs.add(d.substring(off, i).replaceAll("/", "."));
-              } else {
-                sigs.add(d.substring(off, i));
-              }
-              continue;
+          case TypeReference.VoidTypeCode -> sigs.add(TypeReference.VoidName.toString());
+          case TypeReference.BooleanTypeCode -> sigs.add(TypeReference.BooleanName.toString());
+          case TypeReference.ByteTypeCode -> sigs.add(TypeReference.ByteName.toString());
+          case TypeReference.ShortTypeCode -> sigs.add(TypeReference.ShortName.toString());
+          case TypeReference.IntTypeCode -> sigs.add(TypeReference.IntName.toString());
+          case TypeReference.LongTypeCode -> sigs.add(TypeReference.LongName.toString());
+          case TypeReference.FloatTypeCode -> sigs.add(TypeReference.FloatName.toString());
+          case TypeReference.DoubleTypeCode -> sigs.add(TypeReference.DoubleName.toString());
+          case TypeReference.CharTypeCode -> sigs.add(TypeReference.CharName.toString());
+          case TypeReference.ArrayTypeCode -> {
+            int off = i - 1;
+            while (d.charAt(i) == TypeReference.ArrayTypeCode) {
+              ++i;
             }
-          case (byte) ')': // end of parameter list
-            return toArray(sigs);
-          default:
-            {
-              // a class
-              int off = i - 1;
-              char c;
-              do {
-                c = d.charAt(i++);
-              } while (c != ',' && c != ')');
-              sigs.add('L' + d.substring(off, i - 1) + ';');
+            if (d.charAt(i++) == TypeReference.ClassTypeCode) {
+              while (d.charAt(i++) != ';')
+                ;
+              sigs.add(d.substring(off, i).replaceAll("/", "."));
+            } else {
+              sigs.add(d.substring(off, i));
+            }
+          }
+          case (byte) ')' -> {
+            return toArray(sigs); // end of parameter list
+          }
+          default -> {
+            // a class
+            int off = i - 1;
+            char c;
+            do {
+              c = d.charAt(i++);
+            } while (c != ',' && c != ')');
+            sigs.add('L' + d.substring(off, i - 1) + ';');
 
-              if (c == ')') {
-                return toArray(sigs);
-              }
+            if (c == ')') {
+              return toArray(sigs);
             }
+          }
         }
       }
     } catch (StringIndexOutOfBoundsException e) {

--- a/ide/jsdt/src/main/java/com/ibm/wala/ide/util/JavaScriptEclipseProjectPath.java
+++ b/ide/jsdt/src/main/java/com/ibm/wala/ide/util/JavaScriptEclipseProjectPath.java
@@ -109,18 +109,18 @@ public class JavaScriptEclipseProjectPath
     IIncludePathEntry e = JavaScriptCore.getResolvedIncludepathEntry(entry);
     final int entryKind = e.getEntryKind();
     switch (entryKind) {
-      case IIncludePathEntry.CPE_SOURCE:
-        resolveSourcePathEntry(
-            JSLoader.JAVASCRIPT,
-            true,
-            cpeFromMainProject,
-            e.getPath(),
-            null,
-            e.getExclusionPatterns(),
-            "js");
-        break;
-      default:
+      case IIncludePathEntry.CPE_SOURCE ->
+          resolveSourcePathEntry(
+              JSLoader.JAVASCRIPT,
+              true,
+              cpeFromMainProject,
+              e.getPath(),
+              null,
+              e.getExclusionPatterns(),
+              "js");
+      default -> {
         // do nothing
+      }
     }
   }
 

--- a/scandroid/src/main/java/org/scandroid/util/DexDotUtil.java
+++ b/scandroid/src/main/java/org/scandroid/util/DexDotUtil.java
@@ -15,7 +15,6 @@ package org.scandroid.util;
 import com.ibm.wala.util.WalaException;
 import com.ibm.wala.util.collections.Iterator2Collection;
 import com.ibm.wala.util.collections.Iterator2Iterable;
-import com.ibm.wala.util.debug.Assertions;
 import com.ibm.wala.util.graph.Graph;
 import com.ibm.wala.util.viz.DotUtil;
 import com.ibm.wala.util.viz.NodeDecorator;
@@ -47,19 +46,12 @@ public class DexDotUtil extends DotUtil {
   //    }
 
   private static String outputTypeCmdLineParam() {
-    switch (outputType) {
-      case PS:
-        return "-Tps";
-      case EPS:
-        return "-Teps";
-      case SVG:
-        return "-Tsvg";
-      case PDF:
-        return "-Tpdf";
-      default:
-        Assertions.UNREACHABLE();
-        return null;
-    }
+    return switch (outputType) {
+      case PS -> "-Tps";
+      case EPS -> "-Teps";
+      case SVG -> "-Tsvg";
+      case PDF -> "-Tpdf";
+    };
   }
 
   /** Some versions of dot appear to croak on long labels. Reduce this if so. */

--- a/scandroid/src/main/java/org/scandroid/util/EntryPoints.java
+++ b/scandroid/src/main/java/org/scandroid/util/EntryPoints.java
@@ -331,16 +331,13 @@ public class EntryPoints {
   }
 
   private ArrayList<String[]> chooseIntentList(String name) {
-    switch (name) {
-      case "receiver":
-        return ReceiverIntentList;
-      case "service":
-        return ServiceIntentList;
-      default:
-        return ActivityIntentList;
+    return switch (name) {
+      case "receiver" -> ReceiverIntentList;
+      case "service" -> ServiceIntentList;
+      default -> ActivityIntentList;
         //          throw new UnimplementedError("EntryPoints intent category not yet covered: " +
         // name);
-    }
+    };
   }
 
   public LinkedList<Entrypoint> getEntries() {

--- a/shrike/src/main/java/com/ibm/wala/shrike/bench/Bench.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/bench/Bench.java
@@ -68,13 +68,11 @@ public class Bench {
         args = instrumenter.parseStandardArgs(args);
         if (args.length > 0) {
           switch (args[0]) {
-            case "-do-exit":
-              doExit = true;
-              break;
-            case "-do-exception":
+            case "-do-exit" -> doExit = true;
+            case "-do-exception" -> {
               doExit = true;
               doException = true;
-              break;
+            }
           }
         }
         instrumenter = new OfflineInstrumenter();

--- a/shrike/src/main/java/com/ibm/wala/shrike/cg/OfflineDynamicCallGraph.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/cg/OfflineDynamicCallGraph.java
@@ -443,29 +443,18 @@ public class OfflineDynamicCallGraph {
               for (int i = 1; i < p.getItemCount(); i++) {
                 final byte itemType = p.getItemType(i);
                 switch (itemType) {
-                  case CONSTANT_Integer:
-                    entries.put(p.getCPInt(i), i);
-                    break;
-                  case CONSTANT_Long:
-                    entries.put(p.getCPLong(i), i);
-                    break;
-                  case CONSTANT_Float:
-                    entries.put(p.getCPFloat(i), i);
-                    break;
-                  case CONSTANT_Double:
-                    entries.put(p.getCPDouble(i), i);
-                    break;
-                  case CONSTANT_Utf8:
-                    entries.put(p.getCPUtf8(i), i);
-                    break;
-                  case CONSTANT_String:
-                    entries.put(new CWStringItem(p.getCPString(i), CONSTANT_String), i);
-                    break;
-                  case CONSTANT_Class:
-                    entries.put(new CWStringItem(p.getCPClass(i), CONSTANT_Class), i);
-                    break;
-                  default:
+                  case CONSTANT_Integer -> entries.put(p.getCPInt(i), i);
+                  case CONSTANT_Long -> entries.put(p.getCPLong(i), i);
+                  case CONSTANT_Float -> entries.put(p.getCPFloat(i), i);
+                  case CONSTANT_Double -> entries.put(p.getCPDouble(i), i);
+                  case CONSTANT_Utf8 -> entries.put(p.getCPUtf8(i), i);
+                  case CONSTANT_String ->
+                      entries.put(new CWStringItem(p.getCPString(i), CONSTANT_String), i);
+                  case CONSTANT_Class ->
+                      entries.put(new CWStringItem(p.getCPClass(i), CONSTANT_Class), i);
+                  default -> {
                     // do nothing
+                  }
                 }
               }
             }

--- a/shrike/src/main/java/com/ibm/wala/shrike/copywriter/CopyWriter.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/copywriter/CopyWriter.java
@@ -159,81 +159,75 @@ public class CopyWriter {
     }
 
     switch (name) {
-      case "Code":
-        {
-          CodeReader r = new CodeReader(iter);
-          CTDecoder decoder = new CTDecoder(r);
-          decoder.decode();
-          MethodData md =
-              new MethodData(
-                  decoder,
-                  cr.getMethodAccessFlags(m),
-                  CTDecoder.convertClassToType(cr.getName()),
-                  cr.getMethodName(m),
-                  cr.getMethodType(m));
-          CTCompiler compiler = CTCompiler.make(w, md);
-          compiler.compile();
-          if (compiler.getAuxiliaryMethods().length > 0)
-            throw new Error("Where did this auxiliary method come from?");
-          Compiler.Output out = compiler.getOutput();
-          CodeWriter cw = new CodeWriter(w);
-          cw.setMaxLocals(out.getMaxLocals());
-          cw.setMaxStack(out.getMaxStack());
-          cw.setCode(out.getCode());
-          cw.setRawHandlers(out.getRawHandlers());
-          AttrIterator iterator = new AttrIterator();
-          r.initAttributeIterator(iterator);
-          cw.setAttributes(collectAttributes(cr, m, w, iterator));
-          return cw;
+      case "Code" -> {
+        CodeReader r = new CodeReader(iter);
+        CTDecoder decoder = new CTDecoder(r);
+        decoder.decode();
+        MethodData md =
+            new MethodData(
+                decoder,
+                cr.getMethodAccessFlags(m),
+                CTDecoder.convertClassToType(cr.getName()),
+                cr.getMethodName(m),
+                cr.getMethodType(m));
+        CTCompiler compiler = CTCompiler.make(w, md);
+        compiler.compile();
+        if (compiler.getAuxiliaryMethods().length > 0)
+          throw new Error("Where did this auxiliary method come from?");
+        Compiler.Output out = compiler.getOutput();
+        CodeWriter cw = new CodeWriter(w);
+        cw.setMaxLocals(out.getMaxLocals());
+        cw.setMaxStack(out.getMaxStack());
+        cw.setCode(out.getCode());
+        cw.setRawHandlers(out.getRawHandlers());
+        AttrIterator iterator = new AttrIterator();
+        r.initAttributeIterator(iterator);
+        cw.setAttributes(collectAttributes(cr, m, w, iterator));
+        return cw;
+      }
+      case "ConstantValue" -> {
+        ConstantValueReader r = new ConstantValueReader(iter);
+        ConstantValueWriter cw = new ConstantValueWriter(w);
+        cw.setValueCPIndex(transformCPIndex(r.getValueCPIndex()));
+        return cw;
+      }
+      case "SourceFile" -> {
+        SourceFileReader r = new SourceFileReader(iter);
+        SourceFileWriter cw = new SourceFileWriter(w);
+        cw.setSourceFileCPIndex(transformCPIndex(r.getSourceFileCPIndex()));
+        return cw;
+      }
+      case "LocalVariableTableReader" -> {
+        LocalVariableTableReader lr = new LocalVariableTableReader(iter);
+        LocalVariableTableWriter lw = new LocalVariableTableWriter(w);
+        int[] table = lr.getRawTable();
+        for (int i = 0; i < table.length; i += 5) {
+          table[i + 2] = transformCPIndex(table[i + 2]);
+          table[i + 3] = transformCPIndex(table[i + 3]);
         }
-      case "ConstantValue":
-        {
-          ConstantValueReader r = new ConstantValueReader(iter);
-          ConstantValueWriter cw = new ConstantValueWriter(w);
-          cw.setValueCPIndex(transformCPIndex(r.getValueCPIndex()));
-          return cw;
+        lw.setRawTable(table);
+        return lw;
+      }
+      case "Exceptions" -> {
+        ExceptionsReader lr = new ExceptionsReader(iter);
+        ExceptionsWriter lw = new ExceptionsWriter(w);
+        int[] table = lr.getRawTable();
+        Arrays.setAll(table, i -> transformCPIndex(table[i]));
+        lw.setRawTable(table);
+        return lw;
+      }
+      case "InnerClasses" -> {
+        InnerClassesReader lr = new InnerClassesReader(iter);
+        InnerClassesWriter lw = new InnerClassesWriter(w);
+        int[] table = lr.getRawTable();
+        for (int i = 0; i < table.length; i += 4) {
+          table[i] = transformCPIndex(table[i]);
+          table[i + 1] = transformCPIndex(table[i + 1]);
+          table[i + 2] = transformCPIndex(table[i + 2]);
         }
-      case "SourceFile":
-        {
-          SourceFileReader r = new SourceFileReader(iter);
-          SourceFileWriter cw = new SourceFileWriter(w);
-          cw.setSourceFileCPIndex(transformCPIndex(r.getSourceFileCPIndex()));
-          return cw;
-        }
-      case "LocalVariableTableReader":
-        {
-          LocalVariableTableReader lr = new LocalVariableTableReader(iter);
-          LocalVariableTableWriter lw = new LocalVariableTableWriter(w);
-          int[] table = lr.getRawTable();
-          for (int i = 0; i < table.length; i += 5) {
-            table[i + 2] = transformCPIndex(table[i + 2]);
-            table[i + 3] = transformCPIndex(table[i + 3]);
-          }
-          lw.setRawTable(table);
-          return lw;
-        }
-      case "Exceptions":
-        {
-          ExceptionsReader lr = new ExceptionsReader(iter);
-          ExceptionsWriter lw = new ExceptionsWriter(w);
-          int[] table = lr.getRawTable();
-          Arrays.setAll(table, i -> transformCPIndex(table[i]));
-          lw.setRawTable(table);
-          return lw;
-        }
-      case "InnerClasses":
-        {
-          InnerClassesReader lr = new InnerClassesReader(iter);
-          InnerClassesWriter lw = new InnerClassesWriter(w);
-          int[] table = lr.getRawTable();
-          for (int i = 0; i < table.length; i += 4) {
-            table[i] = transformCPIndex(table[i]);
-            table[i + 1] = transformCPIndex(table[i + 1]);
-            table[i + 2] = transformCPIndex(table[i + 2]);
-          }
-          lw.setRawTable(table);
-          return lw;
-        }
+        lw.setRawTable(table);
+        return lw;
+      }
     }
 
     throw new UnknownAttributeException(name);
@@ -252,33 +246,24 @@ public class CopyWriter {
   private static int copyEntry(ConstantPoolParser cp, ClassWriter w, int i)
       throws InvalidClassFileException {
     byte t = cp.getItemType(i);
-    switch (t) {
-      case ClassConstants.CONSTANT_String:
-        return w.addCPString(cp.getCPString(i));
-      case ClassConstants.CONSTANT_Class:
-        return w.addCPClass(cp.getCPClass(i));
-      case ClassConstants.CONSTANT_FieldRef:
-        return w.addCPFieldRef(cp.getCPRefClass(i), cp.getCPRefName(i), cp.getCPRefType(i));
-      case ClassConstants.CONSTANT_InterfaceMethodRef:
-        return w.addCPInterfaceMethodRef(
-            cp.getCPRefClass(i), cp.getCPRefName(i), cp.getCPRefType(i));
-      case ClassConstants.CONSTANT_MethodRef:
-        return w.addCPMethodRef(cp.getCPRefClass(i), cp.getCPRefName(i), cp.getCPRefType(i));
-      case ClassConstants.CONSTANT_NameAndType:
-        return w.addCPNAT(cp.getCPNATName(i), cp.getCPNATType(i));
-      case ClassConstants.CONSTANT_Integer:
-        return w.addCPInt(cp.getCPInt(i));
-      case ClassConstants.CONSTANT_Float:
-        return w.addCPFloat(cp.getCPFloat(i));
-      case ClassConstants.CONSTANT_Long:
-        return w.addCPLong(cp.getCPLong(i));
-      case ClassConstants.CONSTANT_Double:
-        return w.addCPDouble(cp.getCPDouble(i));
-      case ClassConstants.CONSTANT_Utf8:
-        return w.addCPUtf8(cp.getCPUtf8(i));
-      default:
-        return -1;
-    }
+    return switch (t) {
+      case ClassConstants.CONSTANT_String -> w.addCPString(cp.getCPString(i));
+      case ClassConstants.CONSTANT_Class -> w.addCPClass(cp.getCPClass(i));
+      case ClassConstants.CONSTANT_FieldRef ->
+          w.addCPFieldRef(cp.getCPRefClass(i), cp.getCPRefName(i), cp.getCPRefType(i));
+      case ClassConstants.CONSTANT_InterfaceMethodRef ->
+          w.addCPInterfaceMethodRef(cp.getCPRefClass(i), cp.getCPRefName(i), cp.getCPRefType(i));
+      case ClassConstants.CONSTANT_MethodRef ->
+          w.addCPMethodRef(cp.getCPRefClass(i), cp.getCPRefName(i), cp.getCPRefType(i));
+      case ClassConstants.CONSTANT_NameAndType ->
+          w.addCPNAT(cp.getCPNATName(i), cp.getCPNATType(i));
+      case ClassConstants.CONSTANT_Integer -> w.addCPInt(cp.getCPInt(i));
+      case ClassConstants.CONSTANT_Float -> w.addCPFloat(cp.getCPFloat(i));
+      case ClassConstants.CONSTANT_Long -> w.addCPLong(cp.getCPLong(i));
+      case ClassConstants.CONSTANT_Double -> w.addCPDouble(cp.getCPDouble(i));
+      case ClassConstants.CONSTANT_Utf8 -> w.addCPUtf8(cp.getCPUtf8(i));
+      default -> -1;
+    };
   }
 
   private void doClass(final ClassInstrumenter ci) throws Exception {
@@ -308,17 +293,16 @@ public class CopyWriter {
     if (1 < CPCount) {
       final byte itemType = cp.getItemType(1);
       switch (itemType) {
-        case ClassConstants.CONSTANT_Long:
-        case ClassConstants.CONSTANT_Double:
+        case ClassConstants.CONSTANT_Long, ClassConstants.CONSTANT_Double -> {
           // item 1 is a double-word item, so the next real item is at 3
           // to make sure item 3 is allocated at index 3, we'll need to
           // insert a dummy entry at index 2
           r = w.addCPUtf8("");
           if (r != 2) throw new Error("Invalid constant pool index for dummy: " + r);
-          break;
-        default:
-          throw new UnsupportedOperationException(
-              String.format("unexpected constant-pool item type %s", itemType));
+        }
+        default ->
+            throw new UnsupportedOperationException(
+                String.format("unexpected constant-pool item type %s", itemType));
       }
     }
     for (int i = 2; i < CPCount; i++) {

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/ComparisonInstruction.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/ComparisonInstruction.java
@@ -33,15 +33,15 @@ public final class ComparisonInstruction extends Instruction implements ICompari
       throws IllegalArgumentException {
     int t = Util.getTypeIndex(type);
     switch (t) {
-      case TYPE_long_index:
+      case TYPE_long_index -> {
         if (operator != Operator.CMP) {
           throw new IllegalArgumentException(
               "Operator " + operator + " is not a valid comparison operator for longs");
         } else {
           return preallocatedLCMP;
         }
-      case TYPE_float_index:
-      case TYPE_double_index:
+      }
+      case TYPE_float_index, TYPE_double_index -> {
         if (operator == Operator.CMP) {
           throw new IllegalArgumentException(
               "Operator "
@@ -51,8 +51,8 @@ public final class ComparisonInstruction extends Instruction implements ICompari
           return preallocatedFloatingCompares[
               (operator.ordinal() - Operator.CMPL.ordinal()) + (t - TYPE_float_index) * 2];
         }
-      default:
-        throw new IllegalArgumentException("Type " + type + " cannot be compared");
+      }
+      default -> throw new IllegalArgumentException("Type " + type + " cannot be compared");
     }
   }
 
@@ -71,34 +71,22 @@ public final class ComparisonInstruction extends Instruction implements ICompari
    */
   @Override
   public Operator getOperator() {
-    switch (opcode) {
-      case OP_lcmp:
-        return Operator.CMP;
-      case OP_fcmpl:
-      case OP_dcmpl:
-        return Operator.CMPL;
-      case OP_dcmpg:
-      case OP_fcmpg:
-        return Operator.CMPG;
-      default:
-        throw new Error("Unknown opcode");
-    }
+    return switch (opcode) {
+      case OP_lcmp -> Operator.CMP;
+      case OP_fcmpl, OP_dcmpl -> Operator.CMPL;
+      case OP_dcmpg, OP_fcmpg -> Operator.CMPG;
+      default -> throw new Error("Unknown opcode");
+    };
   }
 
   @Override
   public String getType() {
-    switch (opcode) {
-      case OP_lcmp:
-        return TYPE_long;
-      case OP_fcmpg:
-      case OP_fcmpl:
-        return TYPE_float;
-      case OP_dcmpl:
-      case OP_dcmpg:
-        return TYPE_double;
-      default:
-        throw new Error("Unknown opcode");
-    }
+    return switch (opcode) {
+      case OP_lcmp -> TYPE_long;
+      case OP_fcmpg, OP_fcmpl -> TYPE_float;
+      case OP_dcmpl, OP_dcmpg -> TYPE_double;
+      default -> throw new Error("Unknown opcode");
+    };
   }
 
   @Override

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/Compiler.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/Compiler.java
@@ -747,40 +747,29 @@ public abstract class Compiler implements Constants {
                 cpIndex = ci.getCPIndex();
               } else {
                 String t = instr.getPushedType(null);
-                switch (t) {
-                  case TYPE_int:
-                    cpIndex =
-                        allocateConstantPoolInteger(
-                            ((ConstantInstruction.ConstInt) instr).getIntValue());
-                    break;
-                  case TYPE_String:
-                    cpIndex =
-                        allocateConstantPoolString(
-                            (String) ((ConstantInstruction.ConstString) instr).getValue());
-                    break;
-                  case TYPE_Class:
-                    cpIndex =
-                        allocateConstantPoolClassType(
-                            ((ClassToken) ((ConstantInstruction.ConstClass) instr).getValue())
-                                .getTypeName());
-                    break;
-                  case TYPE_MethodType:
-                    cpIndex =
-                        allocateConstantPoolMethodType(
-                            ((String) ((ConstantInstruction.ConstMethodType) instr).getValue()));
-                    break;
-                  case TYPE_MethodHandle:
-                    cpIndex =
-                        allocateConstantPoolMethodHandle(
-                            ((ReferenceToken)
-                                ((ConstantInstruction.ConstMethodHandle) instr).getValue()));
-                    break;
-                  default:
-                    cpIndex =
-                        allocateConstantPoolFloat(
-                            ((ConstantInstruction.ConstFloat) instr).getFloatValue());
-                    break;
-                }
+                cpIndex =
+                    switch (t) {
+                      case TYPE_int ->
+                          allocateConstantPoolInteger(
+                              ((ConstantInstruction.ConstInt) instr).getIntValue());
+                      case TYPE_String ->
+                          allocateConstantPoolString(
+                              (String) ((ConstantInstruction.ConstString) instr).getValue());
+                      case TYPE_Class ->
+                          allocateConstantPoolClassType(
+                              ((ClassToken) ((ConstantInstruction.ConstClass) instr).getValue())
+                                  .getTypeName());
+                      case TYPE_MethodType ->
+                          allocateConstantPoolMethodType(
+                              ((String) ((ConstantInstruction.ConstMethodType) instr).getValue()));
+                      case TYPE_MethodHandle ->
+                          allocateConstantPoolMethodHandle(
+                              ((ReferenceToken)
+                                  ((ConstantInstruction.ConstMethodHandle) instr).getValue()));
+                      default ->
+                          allocateConstantPoolFloat(
+                              ((ConstantInstruction.ConstFloat) instr).getFloatValue());
+                    };
               }
 
               if (cpIndex < 256) {

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/ConditionalBranchInstruction.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/ConditionalBranchInstruction.java
@@ -27,23 +27,21 @@ public final class ConditionalBranchInstruction extends Instruction
   public static ConditionalBranchInstruction make(String type, Operator operator, int label)
       throws IllegalArgumentException {
     int t = Util.getTypeIndex(type);
-    short opcode;
-
-    switch (t) {
-      case TYPE_int_index:
-        opcode = (short) (OP_if_icmpeq + (operator.ordinal() - Operator.EQ.ordinal()));
-        break;
-      case TYPE_Object_index:
-        if (operator != Operator.EQ && operator != Operator.NE) {
-          throw new IllegalArgumentException(
-              "Cannot test for condition " + operator + " on a reference");
-        }
-        opcode = (short) (OP_if_acmpeq + (operator.ordinal() - Operator.EQ.ordinal()));
-        break;
-      default:
-        throw new IllegalArgumentException(
-            "Cannot conditionally branch on a value of type " + type);
-    }
+    short opcode =
+        switch (t) {
+          case TYPE_int_index ->
+              (short) (OP_if_icmpeq + (operator.ordinal() - Operator.EQ.ordinal()));
+          case TYPE_Object_index -> {
+            if (operator != Operator.EQ && operator != Operator.NE) {
+              throw new IllegalArgumentException(
+                  "Cannot test for condition " + operator + " on a reference");
+            }
+            yield (short) (OP_if_acmpeq + (operator.ordinal() - Operator.EQ.ordinal()));
+          }
+          default ->
+              throw new IllegalArgumentException(
+                  "Cannot conditionally branch on a value of type " + type);
+        };
 
     return make(opcode, label);
   }

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/ConstantInstruction.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/ConstantInstruction.java
@@ -702,18 +702,13 @@ public abstract class ConstantInstruction extends Instruction {
       return makeClass((String) constant);
     } else {
       try {
-        switch (Util.getTypeIndex(type)) {
-          case TYPE_int_index:
-            return make(((Number) constant).intValue());
-          case TYPE_long_index:
-            return make(((Number) constant).longValue());
-          case TYPE_float_index:
-            return make(((Number) constant).floatValue());
-          case TYPE_double_index:
-            return make(((Number) constant).doubleValue());
-          default:
-            throw new IllegalArgumentException("Invalid type for constant: " + type);
-        }
+        return switch (Util.getTypeIndex(type)) {
+          case TYPE_int_index -> make(((Number) constant).intValue());
+          case TYPE_long_index -> make(((Number) constant).longValue());
+          case TYPE_float_index -> make(((Number) constant).floatValue());
+          case TYPE_double_index -> make(((Number) constant).doubleValue());
+          default -> throw new IllegalArgumentException("Invalid type for constant: " + type);
+        };
       } catch (ClassCastException e) {
         throw new IllegalArgumentException(e);
       }
@@ -745,28 +740,18 @@ public abstract class ConstantInstruction extends Instruction {
   }
 
   public static ConstantInstruction make(ConstantPoolReader cp, int index) {
-    switch (cp.getConstantPoolItemType(index)) {
-      case CONSTANT_Integer:
-        return new LazyInt(OP_ldc_w, cp, index);
-      case CONSTANT_Long:
-        return new LazyLong(OP_ldc2_w, cp, index);
-      case CONSTANT_Float:
-        return new LazyFloat(OP_ldc_w, cp, index);
-      case CONSTANT_Double:
-        return new LazyDouble(OP_ldc2_w, cp, index);
-      case CONSTANT_String:
-        return new LazyString(OP_ldc_w, cp, index);
-      case CONSTANT_Class:
-        return new LazyClass(OP_ldc_w, cp, index);
-      case CONSTANT_MethodHandle:
-        return new LazyMethodHandle(OP_ldc_w, cp, index);
-      case CONSTANT_MethodType:
-        return new LazyMethodType(OP_ldc_w, cp, index);
-      case CONSTANT_InvokeDynamic:
-        return new LazyInvokeDynamic(OP_ldc_w, cp, index);
-      default:
-        return null;
-    }
+    return switch (cp.getConstantPoolItemType(index)) {
+      case CONSTANT_Integer -> new LazyInt(OP_ldc_w, cp, index);
+      case CONSTANT_Long -> new LazyLong(OP_ldc2_w, cp, index);
+      case CONSTANT_Float -> new LazyFloat(OP_ldc_w, cp, index);
+      case CONSTANT_Double -> new LazyDouble(OP_ldc2_w, cp, index);
+      case CONSTANT_String -> new LazyString(OP_ldc_w, cp, index);
+      case CONSTANT_Class -> new LazyClass(OP_ldc_w, cp, index);
+      case CONSTANT_MethodHandle -> new LazyMethodHandle(OP_ldc_w, cp, index);
+      case CONSTANT_MethodType -> new LazyMethodType(OP_ldc_w, cp, index);
+      case CONSTANT_InvokeDynamic -> new LazyInvokeDynamic(OP_ldc_w, cp, index);
+      default -> null;
+    };
   }
 
   @Override
@@ -823,18 +808,13 @@ public abstract class ConstantInstruction extends Instruction {
       for (int i = 0; i < len; i++) {
         char ch = s.charAt(i);
         switch (ch) {
-          case '"':
+          case '"' -> {
             buf.append('\\');
             buf.append(ch);
-            break;
-          case '\n':
-            buf.append("\\\n");
-            break;
-          case '\t':
-            buf.append("\\\t");
-            break;
-          default:
-            buf.append(ch);
+          }
+          case '\n' -> buf.append("\\\n");
+          case '\t' -> buf.append("\\\t");
+          default -> buf.append(ch);
         }
       }
       buf.append('\"');

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/Decoder.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/Decoder.java
@@ -238,26 +238,17 @@ public abstract class Decoder implements Constants {
   }
 
   private static String getPrimitiveType(int t) throws InvalidBytecodeException {
-    switch (t) {
-      case T_BOOLEAN:
-        return TYPE_boolean;
-      case T_CHAR:
-        return TYPE_char;
-      case T_FLOAT:
-        return TYPE_float;
-      case T_DOUBLE:
-        return TYPE_double;
-      case T_BYTE:
-        return TYPE_byte;
-      case T_SHORT:
-        return TYPE_short;
-      case T_INT:
-        return TYPE_int;
-      case T_LONG:
-        return TYPE_long;
-      default:
-        throw new InvalidBytecodeException("Unknown primitive type " + t);
-    }
+    return switch (t) {
+      case T_BOOLEAN -> TYPE_boolean;
+      case T_CHAR -> TYPE_char;
+      case T_FLOAT -> TYPE_float;
+      case T_DOUBLE -> TYPE_double;
+      case T_BYTE -> TYPE_byte;
+      case T_SHORT -> TYPE_short;
+      case T_INT -> TYPE_int;
+      case T_LONG -> TYPE_long;
+      default -> throw new InvalidBytecodeException("Unknown primitive type " + t);
+    };
   }
 
   private static class RetInfo {
@@ -487,86 +478,60 @@ public abstract class Decoder implements Constants {
       index++;
 
       switch (opcode) {
-        case OP_nop:
-          break;
-        case OP_bipush:
+        case OP_nop -> {}
+        case OP_bipush -> {
           i = ConstantInstruction.make(code[index]);
           index++;
-          break;
-        case OP_sipush:
+        }
+        case OP_sipush -> {
           i = ConstantInstruction.make(decodeShort(index));
           index += 2;
-          break;
-        case OP_ldc:
+        }
+        case OP_ldc -> {
           i = makeConstantPoolLoad(code[index] & 0xFF);
           index++;
-          break;
-        case OP_ldc_w:
+        }
+        case OP_ldc_w -> {
           i = makeConstantPoolLoad(decodeUShort(index));
           index += 2;
-          break;
-        case OP_ldc2_w:
+        }
+        case OP_ldc2_w -> {
           i = makeConstantPoolLoad(decodeUShort(index));
           index += 2;
-          break;
-        case OP_iload:
-        case OP_lload:
-        case OP_fload:
-        case OP_dload:
-        case OP_aload:
+        }
+        case OP_iload, OP_lload, OP_fload, OP_dload, OP_aload -> {
           i =
               LoadInstruction.make(
                   indexedTypes[opcode - OP_iload],
                   wide ? decodeUShort(index) : (code[index] & 0xFF));
           index += wide ? 2 : 1;
-          break;
-        case OP_istore:
-        case OP_lstore:
-        case OP_fstore:
-        case OP_dstore:
-        case OP_astore:
+        }
+        case OP_istore, OP_lstore, OP_fstore, OP_dstore, OP_astore -> {
           i =
               StoreInstruction.make(
                   indexedTypes[opcode - OP_istore],
                   wide ? decodeUShort(index) : (code[index] & 0xFF));
           index += wide ? 2 : 1;
-          break;
-        case OP_pop2:
-          i = PopInstruction.make(elemCount(stackWords, stackLen - 1));
-          break;
-        case OP_dup_x2:
-          i = DupInstruction.make(1, elemCount(stackWords, stackLen - 2));
-          break;
-        case OP_dup2:
-          i = DupInstruction.make(elemCount(stackWords, stackLen - 1), 0);
-          break;
-        case OP_dup2_x1:
-          i = DupInstruction.make(elemCount(stackWords, stackLen - 1), 1);
-          break;
-        case OP_dup2_x2:
-          {
-            int twoDown = elemCount(stackWords, stackLen - 1);
-            i = DupInstruction.make(twoDown, elemCount(stackWords, stackLen - twoDown - 1));
-            break;
-          }
-        case OP_iinc:
-          {
-            int v = wide ? decodeUShort(index) : (code[index] & 0xFF);
-            int c = wide ? decodeShort(index + 2) : code[index + 1];
+        }
+        case OP_pop2 -> i = PopInstruction.make(elemCount(stackWords, stackLen - 1));
+        case OP_dup_x2 -> i = DupInstruction.make(1, elemCount(stackWords, stackLen - 2));
+        case OP_dup2 -> i = DupInstruction.make(elemCount(stackWords, stackLen - 1), 0);
+        case OP_dup2_x1 -> i = DupInstruction.make(elemCount(stackWords, stackLen - 1), 1);
+        case OP_dup2_x2 -> {
+          int twoDown = elemCount(stackWords, stackLen - 1);
+          i = DupInstruction.make(twoDown, elemCount(stackWords, stackLen - twoDown - 1));
+        }
+        case OP_iinc -> {
+          int v = wide ? decodeUShort(index) : (code[index] & 0xFF);
+          int c = wide ? decodeShort(index + 2) : code[index + 1];
 
-            decoded.add(LoadInstruction.make(TYPE_int, v));
-            decoded.add(ConstantInstruction.make(c));
-            decoded.add(BinaryOpInstruction.make(TYPE_int, Operator.ADD));
-            i = StoreInstruction.make(TYPE_int, v);
-            index += wide ? 4 : 2;
-            break;
-          }
-        case OP_ifeq:
-        case OP_ifne:
-        case OP_iflt:
-        case OP_ifle:
-        case OP_ifgt:
-        case OP_ifge:
+          decoded.add(LoadInstruction.make(TYPE_int, v));
+          decoded.add(ConstantInstruction.make(c));
+          decoded.add(BinaryOpInstruction.make(TYPE_int, Operator.ADD));
+          i = StoreInstruction.make(TYPE_int, v);
+          index += wide ? 4 : 2;
+        }
+        case OP_ifeq, OP_ifne, OP_iflt, OP_ifle, OP_ifgt, OP_ifge -> {
           decoded.add(makeZero);
           i =
               ConditionalBranchInstruction.make(
@@ -574,40 +539,26 @@ public abstract class Decoder implements Constants {
                   ConditionalBranchInstruction.Operator.values()[opcode - OP_ifeq],
                   (index - 1) + decodeShort(index));
           index += 2;
-          break;
-        case OP_if_icmpeq:
-        case OP_if_icmpne:
-        case OP_if_icmplt:
-        case OP_if_icmple:
-        case OP_if_icmpgt:
-        case OP_if_icmpge:
+        }
+        case OP_if_icmpeq, OP_if_icmpne, OP_if_icmplt, OP_if_icmple, OP_if_icmpgt, OP_if_icmpge -> {
           i = ConditionalBranchInstruction.make((short) opcode, (index - 1) + decodeShort(index));
           index += 2;
-          break;
-        case OP_if_acmpeq:
-        case OP_if_acmpne:
+        }
+        case OP_if_acmpeq, OP_if_acmpne -> {
           i =
               ConditionalBranchInstruction.make(
                   TYPE_Object,
                   ConditionalBranchInstruction.Operator.values()[opcode - OP_if_acmpeq],
                   (index - 1) + decodeShort(index));
           index += 2;
-          break;
-        case OP_goto:
+        }
+        case OP_goto -> {
           i = GotoInstruction.make((index - 1) + decodeShort(index));
           index += 2;
-          break;
-        case OP_jsr:
-          {
-            index += 2;
-            break;
-          }
-        case OP_jsr_w:
-          {
-            index += 4;
-            break;
-          }
-        case OP_ret:
+        }
+        case OP_jsr -> index += 2;
+        case OP_jsr_w -> index += 4;
+        case OP_ret -> {
           int v = wide ? decodeUShort(index) : (code[index] & 0xFF);
           i = GotoInstruction.make(-1 - v);
 
@@ -617,120 +568,102 @@ public abstract class Decoder implements Constants {
           retInfo[index - (wide ? 2 : 1)] = new RetInfo(-1, v, stackLen, stackWords);
 
           index += wide ? 2 : 1;
-          break;
-        case OP_tableswitch:
-          {
-            int start = index - 1;
-            while ((index & 3) != 0) {
-              index++;
-            }
-            int def = start + decodeInt(index);
-            int low = decodeInt(index + 4);
-            int high = decodeInt(index + 8);
-            int[] t = new int[(high - low + 1) * 2];
+        }
+        case OP_tableswitch -> {
+          int start = index - 1;
+          while ((index & 3) != 0) {
+            index++;
+          }
+          int def = start + decodeInt(index);
+          int low = decodeInt(index + 4);
+          int high = decodeInt(index + 8);
+          int[] t = new int[(high - low + 1) * 2];
 
-            for (int j = 0; j < t.length; j += 2) {
-              t[j] = j / 2 + low;
-              t[j + 1] = start + decodeInt(index + 12 + j * 2);
-            }
-            i = SwitchInstruction.make(t, def);
-            index += 12 + (high - low + 1) * 4;
-            break;
+          for (int j = 0; j < t.length; j += 2) {
+            t[j] = j / 2 + low;
+            t[j + 1] = start + decodeInt(index + 12 + j * 2);
           }
-        case OP_lookupswitch:
-          {
-            int start = index - 1;
-            while ((index & 3) != 0) {
-              index++;
-            }
-            int def = start + decodeInt(index);
-            int n = decodeInt(index + 4);
-            int[] t = new int[n * 2];
+          i = SwitchInstruction.make(t, def);
+          index += 12 + (high - low + 1) * 4;
+        }
+        case OP_lookupswitch -> {
+          int start = index - 1;
+          while ((index & 3) != 0) {
+            index++;
+          }
+          int def = start + decodeInt(index);
+          int n = decodeInt(index + 4);
+          int[] t = new int[n * 2];
 
-            for (int j = 0; j < t.length; j += 2) {
-              t[j] = decodeInt(index + 8 + j * 4);
-              t[j + 1] = start + decodeInt(index + 12 + j * 4);
-            }
-            i = SwitchInstruction.make(t, def);
-            index += 8 + n * 8;
-            break;
+          for (int j = 0; j < t.length; j += 2) {
+            t[j] = decodeInt(index + 8 + j * 4);
+            t[j + 1] = start + decodeInt(index + 12 + j * 4);
           }
-        case OP_getstatic:
-        case OP_getfield:
-          {
-            int f = decodeUShort(index);
-            i = GetInstruction.make(constantPool, f, opcode == OP_getstatic);
-            index += 2;
-            break;
-          }
-        case OP_putstatic:
-        case OP_putfield:
-          {
-            int f = decodeUShort(index);
-            i = PutInstruction.make(constantPool, f, opcode == OP_putstatic);
-            index += 2;
-            break;
-          }
-        case OP_invokevirtual:
-        case OP_invokespecial:
-        case OP_invokestatic:
-          {
-            int m = decodeUShort(index);
-            i = InvokeInstruction.make(constantPool, m, opcode);
-            index += 2;
-            break;
-          }
-        case OP_invokeinterface:
-          {
-            int m = decodeUShort(index);
-            i = InvokeInstruction.make(constantPool, m, opcode);
-            index += 4;
-            break;
-          }
-        case OP_invokedynamic:
-          {
-            int m = decodeUShort(index);
-            i = InvokeDynamicInstruction.make(constantPool, m, opcode);
-            index += 4;
-            break;
-          }
-        case OP_new:
+          i = SwitchInstruction.make(t, def);
+          index += 8 + n * 8;
+        }
+        case OP_getstatic, OP_getfield -> {
+          int f = decodeUShort(index);
+          i = GetInstruction.make(constantPool, f, opcode == OP_getstatic);
+          index += 2;
+        }
+        case OP_putstatic, OP_putfield -> {
+          int f = decodeUShort(index);
+          i = PutInstruction.make(constantPool, f, opcode == OP_putstatic);
+          index += 2;
+        }
+        case OP_invokevirtual, OP_invokespecial, OP_invokestatic -> {
+          int m = decodeUShort(index);
+          i = InvokeInstruction.make(constantPool, m, opcode);
+          index += 2;
+        }
+        case OP_invokeinterface -> {
+          int m = decodeUShort(index);
+          i = InvokeInstruction.make(constantPool, m, opcode);
+          index += 4;
+        }
+        case OP_invokedynamic -> {
+          int m = decodeUShort(index);
+          i = InvokeDynamicInstruction.make(constantPool, m, opcode);
+          index += 4;
+        }
+        case OP_new -> {
           i = NewInstruction.make(constantPool.getConstantPoolClassType(decodeUShort(index)), 0);
           index += 2;
-          break;
-        case OP_newarray:
+        }
+        case OP_newarray -> {
           i = NewInstruction.make(Util.makeArray(getPrimitiveType(code[index])), 1);
           index++;
-          break;
-        case OP_anewarray:
+        }
+        case OP_anewarray -> {
           i =
               NewInstruction.make(
                   Util.makeArray(constantPool.getConstantPoolClassType(decodeUShort(index))), 1);
           index += 2;
-          break;
-        case OP_checkcast:
+        }
+        case OP_checkcast -> {
           i = CheckCastInstruction.make(constantPool.getConstantPoolClassType(decodeUShort(index)));
           index += 2;
-          break;
-        case OP_instanceof:
+        }
+        case OP_instanceof -> {
           i =
               InstanceofInstruction.make(
                   constantPool.getConstantPoolClassType(decodeUShort(index)));
           index += 2;
-          break;
-        case OP_wide:
+        }
+        case OP_wide -> {
           wide = true;
           opcode = code[index] & 0xFF;
           continue;
-        case OP_multianewarray:
+        }
+        case OP_multianewarray -> {
           i =
               NewInstruction.make(
                   constantPool.getConstantPoolClassType(decodeUShort(index)),
                   code[index + 2] & 0xFF);
           index += 3;
-          break;
-        case OP_ifnull:
-        case OP_ifnonnull:
+        }
+        case OP_ifnull, OP_ifnonnull -> {
           decoded.add(ConstantInstruction.make(TYPE_Object, null));
           i =
               ConditionalBranchInstruction.make(
@@ -738,13 +671,12 @@ public abstract class Decoder implements Constants {
                   ConditionalBranchInstruction.Operator.values()[opcode - OP_ifnull],
                   (index - 1) + decodeShort(index));
           index += 2;
-          break;
-        case OP_goto_w:
+        }
+        case OP_goto_w -> {
           i = GotoInstruction.make((index - 1) + decodeInt(index));
           index += 4;
-          break;
-        default:
-          throw new InvalidBytecodeException("Unknown opcode " + opcode);
+        }
+        default -> throw new InvalidBytecodeException("Unknown opcode " + opcode);
       }
 
       break;

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/InvokeDynamicInstruction.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/InvokeDynamicInstruction.java
@@ -45,18 +45,13 @@ public class InvokeDynamicInstruction extends Instruction implements IInvokeInst
   @Override
   public Dispatch getInvocationCode() {
     int invokeType = getBootstrap().invokeType();
-    switch (invokeType) {
-      case 5:
-        return Dispatch.VIRTUAL;
-      case 6:
-        return Dispatch.STATIC;
-      case 7:
-        return Dispatch.SPECIAL;
-      case 9:
-        return Dispatch.INTERFACE;
-      default:
-        throw new Error("unexpected dynamic invoke type " + invokeType);
-    }
+    return switch (invokeType) {
+      case 5 -> Dispatch.VIRTUAL;
+      case 6 -> Dispatch.STATIC;
+      case 7 -> Dispatch.SPECIAL;
+      case 9 -> Dispatch.INTERFACE;
+      default -> throw new Error("unexpected dynamic invoke type " + invokeType);
+    };
   }
 
   @Override

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/InvokeInstruction.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/InvokeInstruction.java
@@ -41,20 +41,10 @@ public class InvokeInstruction extends Instruction implements IInvokeInstruction
     }
     short opcode = 0;
     switch (mode) {
-      case VIRTUAL:
-        opcode = OP_invokevirtual;
-        break;
-      case SPECIAL:
-        opcode = OP_invokespecial;
-        break;
-      case STATIC:
-        opcode = OP_invokestatic;
-        break;
-      case INTERFACE:
-        opcode = OP_invokeinterface;
-        break;
-      default:
-        assert false;
+      case VIRTUAL -> opcode = OP_invokevirtual;
+      case SPECIAL -> opcode = OP_invokespecial;
+      case STATIC -> opcode = OP_invokestatic;
+      case INTERFACE -> opcode = OP_invokeinterface;
     }
     return new InvokeInstruction(opcode, type, className, methodName);
   }
@@ -148,18 +138,13 @@ public class InvokeInstruction extends Instruction implements IInvokeInstruction
   }
 
   public final String getInvocationModeString() {
-    switch (opcode) {
-      case Constants.OP_invokestatic:
-        return "STATIC";
-      case Constants.OP_invokeinterface:
-        return "INTERFACE";
-      case Constants.OP_invokespecial:
-        return "SPECIAL";
-      case Constants.OP_invokevirtual:
-        return "VIRTUAL";
-      default:
-        throw new Error("Unknown mode: " + opcode);
-    }
+    return switch (opcode) {
+      case Constants.OP_invokestatic -> "STATIC";
+      case Constants.OP_invokeinterface -> "INTERFACE";
+      case Constants.OP_invokespecial -> "SPECIAL";
+      case Constants.OP_invokevirtual -> "VIRTUAL";
+      default -> throw new Error("Unknown mode: " + opcode);
+    };
   }
 
   @Override
@@ -218,17 +203,12 @@ public class InvokeInstruction extends Instruction implements IInvokeInstruction
 
   @Override
   public Dispatch getInvocationCode() {
-    switch (opcode) {
-      case Constants.OP_invokestatic:
-        return Dispatch.STATIC;
-      case Constants.OP_invokeinterface:
-        return Dispatch.INTERFACE;
-      case Constants.OP_invokespecial:
-        return Dispatch.SPECIAL;
-      case Constants.OP_invokevirtual:
-        return Dispatch.VIRTUAL;
-      default:
-        throw new Error("Unknown mode: " + opcode);
-    }
+    return switch (opcode) {
+      case Constants.OP_invokestatic -> Dispatch.STATIC;
+      case Constants.OP_invokeinterface -> Dispatch.INTERFACE;
+      case Constants.OP_invokespecial -> Dispatch.SPECIAL;
+      case Constants.OP_invokevirtual -> Dispatch.VIRTUAL;
+      default -> throw new Error("Unknown mode: " + opcode);
+    };
   }
 }

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/MethodEditor.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/MethodEditor.java
@@ -157,18 +157,14 @@ public final class MethodEditor {
   }
 
   private static String getStateMessage(int state) {
-    switch (state) {
-      case BEFORE_PASS:
-        return "This operation can only be performed before or after an editing pass";
-      case DURING_PASS:
-        return "This operation can only be performed during an editing pass";
-      case EMITTING_CODE:
-        return "This operation can only be performed while applying patches and emitting code";
-      case BEFORE_END_PASS:
-        return "This operation can only be performed after applying patches";
-      default:
-        return "This operation cannot be performed in this state";
-    }
+    return switch (state) {
+      case BEFORE_PASS -> "This operation can only be performed before or after an editing pass";
+      case DURING_PASS -> "This operation can only be performed during an editing pass";
+      case EMITTING_CODE ->
+          "This operation can only be performed while applying patches and emitting code";
+      case BEFORE_END_PASS -> "This operation can only be performed after applying patches";
+      default -> "This operation cannot be performed in this state";
+    };
   }
 
   /**

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/NewInstruction.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/NewInstruction.java
@@ -50,10 +50,8 @@ public final class NewInstruction extends Instruction {
       short opcode;
 
       switch (arrayBoundsCount) {
-        case 0:
-          opcode = OP_new;
-          break;
-        case 1:
+        case 0 -> opcode = OP_new;
+        case 1 -> {
           char ch = type.charAt(1);
           if (ch != 'L' && ch != '[') {
             // array of primitive type
@@ -61,10 +59,8 @@ public final class NewInstruction extends Instruction {
           } else {
             opcode = OP_anewarray;
           }
-          break;
-        default:
-          opcode = OP_multianewarray;
-          break;
+        }
+        default -> opcode = OP_multianewarray;
       }
       return new NewInstruction(opcode, type, (short) arrayBoundsCount);
     }

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/Util.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/Util.java
@@ -48,27 +48,20 @@ public final class Util {
    * @return the JVM "stack word size" for the given JVM type, looking at index 'index'
    */
   static byte getWordSize(String s, int index) {
-    switch (s.charAt(index)) {
-      case 'V':
-        return 0;
-      case 'J':
-      case 'D':
-        return 2;
-      default:
-        return 1;
-    }
+    return switch (s.charAt(index)) {
+      case 'V' -> 0;
+      case 'J', 'D' -> 2;
+      default -> 1;
+    };
   }
 
   /** Computes the character length of the internal JVM type given by s.substring(i). */
   private static int getTypeLength(String s, int i) {
-    switch (s.charAt(i)) {
-      case 'L':
-        return s.indexOf(';', i) - i + 1;
-      case '[':
-        return getTypeLength(s, i + 1) + 1;
-      default:
-        return 1;
-    }
+    return switch (s.charAt(i)) {
+      case 'L' -> s.indexOf(';', i) - i + 1;
+      case '[' -> getTypeLength(s, i + 1) + 1;
+      default -> 1;
+    };
   }
 
   /**
@@ -288,15 +281,10 @@ public final class Util {
     if (t == null || t.isEmpty()) {
       throw new IllegalArgumentException("invalid t: " + t);
     }
-    switch (t.charAt(0)) {
-      case 'Z':
-      case 'C':
-      case 'B':
-      case 'S':
-        return "I";
-      default:
-        return t;
-    }
+    return switch (t.charAt(0)) {
+      case 'Z', 'C', 'B', 'S' -> "I";
+      default -> t;
+    };
   }
 
   /** Compute the type "array of t". */
@@ -311,12 +299,10 @@ public final class Util {
     if (t == null || t.isEmpty()) {
       return false;
     } else {
-      switch (t.charAt(0)) {
-        case '[':
-          return true;
-        default:
-          return false;
-      }
+      return switch (t.charAt(0)) {
+        case '[' -> true;
+        default -> false;
+      };
     }
   }
 
@@ -327,13 +313,10 @@ public final class Util {
     if (t == null || t.isEmpty()) {
       return false;
     } else {
-      switch (t.charAt(0)) {
-        case 'L':
-        case '[':
-          return false;
-        default:
-          return true;
-      }
+      return switch (t.charAt(0)) {
+        case 'L', '[' -> false;
+        default -> true;
+      };
     }
   }
 

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/analysis/ClassHierarchy.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/analysis/ClassHierarchy.java
@@ -49,13 +49,11 @@ public final class ClassHierarchy {
         } else {
           AnalysisResult v = checkSuperinterfacesContain(hierarchy, iface, t2, visited);
           switch (v) {
-            case YES:
+            case YES -> {
               return YES;
-            case MAYBE:
-              r = MAYBE;
-              break;
-            case NO:
-              break;
+            }
+            case MAYBE -> r = MAYBE;
+            case NO -> {}
           }
         }
       }
@@ -90,13 +88,11 @@ public final class ClassHierarchy {
       for (c = t1; c != null; c = hierarchy.getSuperClass(c)) {
         AnalysisResult v = checkSuperinterfacesContain(hierarchy, c, t2, visited);
         switch (v) {
-          case YES:
+          case YES -> {
             return YES;
-          case MAYBE:
-            r = MAYBE;
-            break;
-          case NO:
-            break;
+          }
+          case MAYBE -> r = MAYBE;
+          case NO -> {}
         }
       }
     }
@@ -124,13 +120,11 @@ public final class ClassHierarchy {
         } else {
           AnalysisResult v = checkSubtypesContain(hierarchy, subtype, t2, visited);
           switch (v) {
-            case YES:
+            case YES -> {
               return YES;
-            case MAYBE:
-              r = MAYBE;
-              break;
-            case NO:
-              break;
+            }
+            case MAYBE -> r = MAYBE;
+            case NO -> {}
           }
         }
       }
@@ -168,7 +162,7 @@ public final class ClassHierarchy {
       return MAYBE;
     } else {
       switch (t1.charAt(0)) {
-        case 'L':
+        case 'L' -> {
           if (t1.equals(Constants.TYPE_null)) {
             return YES;
           } else if (t2.startsWith("[")) {
@@ -178,7 +172,8 @@ public final class ClassHierarchy {
           } else {
             return checkSubtypeOfHierarchy(hierarchy, t1, t2);
           }
-        case '[':
+        }
+        case '[' -> {
           if (t2.equals(Constants.TYPE_Object)
               || t2.equals("Ljava/io/Serializable;")
               || t2.equals("Ljava/lang/Cloneable;")) {
@@ -188,8 +183,10 @@ public final class ClassHierarchy {
           } else {
             return NO;
           }
-        default:
+        }
+        default -> {
           return NO;
+        }
       }
     }
   }
@@ -340,15 +337,12 @@ public final class ClassHierarchy {
       }
     }
 
-    switch (t2SupersSize) {
-      case 1:
-        return t2Supers.iterator().next();
-      case 0:
-        return Constants.TYPE_Object;
-      default:
-        return Constants.TYPE_unknown; // some non-representable combination of
+    return switch (t2SupersSize) {
+      case 1 -> t2Supers.iterator().next();
+      case 0 -> Constants.TYPE_Object;
+      default -> Constants.TYPE_unknown; // some non-representable combination of
         // class and interfaces
-    }
+    };
   }
 
   /**
@@ -375,7 +369,7 @@ public final class ClassHierarchy {
       }
 
       switch (t1.charAt(0)) {
-        case 'L':
+        case 'L' -> {
           // two non-array types
           // if either one is constant null, return the other one
           if (t1.equals(Constants.TYPE_null)) {
@@ -388,33 +382,35 @@ public final class ClassHierarchy {
           } else {
             return findCommonSupertypeHierarchy(hierarchy, t1, t2);
           }
-        case '[':
-          {
-            char ch2 = t2.charAt(0);
-            switch (ch2) {
-              case '[':
-                char ch1_1 = t1.charAt(1);
-                if (ch1_1 == '[' || ch1_1 == 'L') {
-                  return '[' + findCommonSupertype(hierarchy, t1.substring(1), t2.substring(1));
-                } else {
-                  return Constants.TYPE_Object;
-                }
-              case 'L':
-                switch (t2) {
-                  case Constants.TYPE_null:
-                    return t1;
-                  case "Ljava/io/Serializable;":
-                  case "Ljava/lang/Cloneable;":
-                    return t2;
-                  default:
-                    return Constants.TYPE_Object;
-                }
-              default:
-                return null;
+          // two non-array types
+          // if either one is constant null, return the other one
+        }
+        case '[' -> {
+          char ch2 = t2.charAt(0);
+          switch (ch2) {
+            case '[' -> {
+              char ch1_1 = t1.charAt(1);
+              if (ch1_1 == '[' || ch1_1 == 'L') {
+                return '[' + findCommonSupertype(hierarchy, t1.substring(1), t2.substring(1));
+              } else {
+                return Constants.TYPE_Object;
+              }
+            }
+            case 'L' -> {
+              return switch (t2) {
+                case Constants.TYPE_null -> t1;
+                case "Ljava/io/Serializable;", "Ljava/lang/Cloneable;" -> t2;
+                default -> Constants.TYPE_Object;
+              };
+            }
+            default -> {
+              return null;
             }
           }
-        default:
+        }
+        default -> {
           return null;
+        }
       }
     }
   }

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/shrikeCT/tools/AddSerialVersion.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/shrikeCT/tools/AddSerialVersion.java
@@ -145,15 +145,9 @@ public class AddSerialVersion {
             methods[methodCount] = m;
             methodSigs[m] = name + r.getMethodType(m);
             switch (name) {
-              case "<clinit>":
-                methodKinds[m] = 0;
-                break;
-              case "<init>":
-                methodKinds[m] = 1;
-                break;
-              default:
-                methodKinds[m] = 2;
-                break;
+              case "<clinit>" -> methodKinds[m] = 0;
+              case "<init>" -> methodKinds[m] = 1;
+              default -> methodKinds[m] = 2;
             }
             methodCount++;
           }

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/shrikeCT/tools/ClassPrinter.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/shrikeCT/tools/ClassPrinter.java
@@ -306,42 +306,29 @@ public class ClassPrinter {
   private static String getCPItemString(ConstantPoolParser cp, int i)
       throws InvalidClassFileException {
     int t = cp.getItemType(i);
-    switch (t) {
-      case ClassConstants.CONSTANT_Utf8:
-        return "Utf8 " + quoteString(cp.getCPUtf8(i));
-      case ClassConstants.CONSTANT_Class:
-        return "Class " + cp.getCPClass(i);
-      case ClassConstants.CONSTANT_String:
-        return "String " + quoteString(cp.getCPString(i));
-      case ClassConstants.CONSTANT_Integer:
-        return "Integer " + cp.getCPInt(i);
-      case ClassConstants.CONSTANT_Float:
-        return "Float " + cp.getCPFloat(i);
-      case ClassConstants.CONSTANT_Double:
-        return "Double " + cp.getCPDouble(i);
-      case ClassConstants.CONSTANT_Long:
-        return "Long " + cp.getCPLong(i);
-      case ClassConstants.CONSTANT_MethodRef:
-        return "Method "
-            + cp.getCPRefClass(i)
-            + ' '
-            + cp.getCPRefName(i)
-            + ' '
-            + cp.getCPRefType(i);
-      case ClassConstants.CONSTANT_FieldRef:
-        return "Field " + cp.getCPRefClass(i) + ' ' + cp.getCPRefName(i) + ' ' + cp.getCPRefType(i);
-      case ClassConstants.CONSTANT_InterfaceMethodRef:
-        return "InterfaceMethod "
-            + cp.getCPRefClass(i)
-            + ' '
-            + cp.getCPRefName(i)
-            + ' '
-            + cp.getCPRefType(i);
-      case ClassConstants.CONSTANT_NameAndType:
-        return "NameAndType " + cp.getCPNATType(i) + ' ' + cp.getCPNATName(i);
-      default:
-        return "Unknown type " + t;
-    }
+    return switch (t) {
+      case ClassConstants.CONSTANT_Utf8 -> "Utf8 " + quoteString(cp.getCPUtf8(i));
+      case ClassConstants.CONSTANT_Class -> "Class " + cp.getCPClass(i);
+      case ClassConstants.CONSTANT_String -> "String " + quoteString(cp.getCPString(i));
+      case ClassConstants.CONSTANT_Integer -> "Integer " + cp.getCPInt(i);
+      case ClassConstants.CONSTANT_Float -> "Float " + cp.getCPFloat(i);
+      case ClassConstants.CONSTANT_Double -> "Double " + cp.getCPDouble(i);
+      case ClassConstants.CONSTANT_Long -> "Long " + cp.getCPLong(i);
+      case ClassConstants.CONSTANT_MethodRef ->
+          "Method " + cp.getCPRefClass(i) + ' ' + cp.getCPRefName(i) + ' ' + cp.getCPRefType(i);
+      case ClassConstants.CONSTANT_FieldRef ->
+          "Field " + cp.getCPRefClass(i) + ' ' + cp.getCPRefName(i) + ' ' + cp.getCPRefType(i);
+      case ClassConstants.CONSTANT_InterfaceMethodRef ->
+          "InterfaceMethod "
+              + cp.getCPRefClass(i)
+              + ' '
+              + cp.getCPRefName(i)
+              + ' '
+              + cp.getCPRefType(i);
+      case ClassConstants.CONSTANT_NameAndType ->
+          "NameAndType " + cp.getCPNATType(i) + ' ' + cp.getCPNATName(i);
+      default -> "Unknown type " + t;
+    };
   }
 
   private static String quoteString(String string) {
@@ -350,22 +337,12 @@ public class ClassPrinter {
     for (int i = 0; i < string.length(); i++) {
       char ch = string.charAt(i);
       switch (ch) {
-        case '\r':
-          buf.append("\\r");
-          break;
-        case '\n':
-          buf.append("\\n");
-          break;
-        case '\\':
-          buf.append("\\\\");
-          break;
-        case '\t':
-          buf.append("\\t");
-          break;
-        case '\"':
-          buf.append("\\\"");
-          break;
-        default:
+        case '\r' -> buf.append("\\r");
+        case '\n' -> buf.append("\\n");
+        case '\\' -> buf.append("\\\\");
+        case '\t' -> buf.append("\\t");
+        case '\"' -> buf.append("\\\"");
+        default -> {
           if (ch >= 32 && ch <= 127) {
             buf.append(ch);
           } else {
@@ -374,6 +351,7 @@ public class ClassPrinter {
             buf.append("0".repeat(4 - h.length()));
             buf.append(h);
           }
+        }
       }
     }
     buf.append('"');

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/AnnotationsReader.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/AnnotationsReader.java
@@ -298,27 +298,30 @@ public class AnnotationsReader extends AttributeReader {
     // meaning of this short depends on the tag
     int nextShort = cr.getUShort(offset + 1);
     switch (tag) {
-      case 'B':
-      case 'C':
-      case 'I':
-      case 'S':
-      case 'Z':
+      case 'B', 'C', 'I', 'S', 'Z' -> {
         return Pair.make(new ConstantElementValue(cr.getCP().getCPInt(nextShort)), 3);
-      case 'J':
+      }
+      case 'J' -> {
         return Pair.make(new ConstantElementValue(cr.getCP().getCPLong(nextShort)), 3);
-      case 'D':
+      }
+      case 'D' -> {
         return Pair.make(new ConstantElementValue(cr.getCP().getCPDouble(nextShort)), 3);
-      case 'F':
+      }
+      case 'F' -> {
         return Pair.make(new ConstantElementValue(cr.getCP().getCPFloat(nextShort)), 3);
-      case 's': // string
-      case 'c': // class; just represent as a constant element with the type name
-        return Pair.make(new ConstantElementValue(cr.getCP().getCPUtf8(nextShort)), 3);
-      case 'e': // enum
+      } // string
+      case 's', 'c' -> {
+        return Pair.make(
+            new ConstantElementValue(cr.getCP().getCPUtf8(nextShort)),
+            3); // class; just represent as a constant element with the type name
+      }
+      case 'e' -> {
         return Pair.make(
             new EnumElementValue(
                 cr.getCP().getCPUtf8(nextShort), cr.getCP().getCPUtf8(cr.getUShort(offset + 3))),
-            5);
-      case '[': // array
+            5); // enum
+      }
+      case '[' -> {
         @SuppressWarnings("UnnecessaryLocalVariable")
         int numValues = nextShort;
         int numArrayBytes = 3; // start with 3 for the tag and num_values bytes
@@ -333,13 +336,17 @@ public class AnnotationsReader extends AttributeReader {
           numArrayBytes += arrayElemValueAndSize.snd;
         }
         return Pair.make(new ArrayElementValue(vals), numArrayBytes);
-      case '@': // annotation
+      }
+      case '@' -> {
         Pair<AnnotationAttribute, Integer> attributeAndSize = getAttributeAndSize(offset + 1);
         // add 1 to size for the tag
         return Pair.make(attributeAndSize.fst, attributeAndSize.snd + 1);
-      default:
+        // add 1 to size for the tag
+      }
+      default -> {
         assert false;
         return null;
+      }
     }
   }
 

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/BootstrapMethodsReader.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/BootstrapMethodsReader.java
@@ -134,21 +134,28 @@ public class BootstrapMethodsReader extends AttributeReader {
                 int index = callArgumentIndex(i);
                 int t = callArgumentKind(i);
                 switch (t) {
-                  case ClassConstants.CONSTANT_Utf8:
+                  case ClassConstants.CONSTANT_Utf8 -> {
                     return cp.getCPUtf8(index);
-                  case ClassConstants.CONSTANT_Class:
+                  }
+                  case ClassConstants.CONSTANT_Class -> {
                     return cp.getCPClass(index);
-                  case ClassConstants.CONSTANT_String:
+                  }
+                  case ClassConstants.CONSTANT_String -> {
                     return cp.getCPString(index);
-                  case ClassConstants.CONSTANT_Integer:
+                  }
+                  case ClassConstants.CONSTANT_Integer -> {
                     return cp.getCPInt(index);
-                  case ClassConstants.CONSTANT_Float:
+                  }
+                  case ClassConstants.CONSTANT_Float -> {
                     return cp.getCPFloat(index);
-                  case ClassConstants.CONSTANT_Double:
+                  }
+                  case ClassConstants.CONSTANT_Double -> {
                     return cp.getCPDouble(index);
-                  case ClassConstants.CONSTANT_Long:
+                  }
+                  case ClassConstants.CONSTANT_Long -> {
                     return cp.getCPLong(index);
-                  case ClassConstants.CONSTANT_MethodHandle:
+                  }
+                  case ClassConstants.CONSTANT_MethodHandle -> {
                     String className = cp.getCPHandleClass(index);
                     String eltName = cp.getCPHandleName(index);
                     String eltDesc = cp.getCPHandleType(index);
@@ -161,10 +168,13 @@ public class BootstrapMethodsReader extends AttributeReader {
                     Lookup lk = MethodHandles.lookup().in(cls);
                     m.setAccessible(true);
                     return lk.unreflect(m);
-                  case ClassConstants.CONSTANT_MethodType:
+                  }
+                  case ClassConstants.CONSTANT_MethodType -> {
                     return MethodType.fromMethodDescriptorString(cp.getCPMethodType(index), cl);
-                  default:
+                  }
+                  default -> {
                     assert false : "invalid type " + t;
+                  }
                 }
               } catch (IllegalArgumentException
                   | IllegalAccessException

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/ClassWriter.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/ClassWriter.java
@@ -261,49 +261,33 @@ public class ClassWriter implements ClassConstants {
       for (int i = 1; i < nextCPIndex; i++) {
         byte t = cp.getItemType(i);
         switch (t) {
-          case CONSTANT_String:
-            cachedCPEntries.put(new CWStringItem(cp.getCPString(i), CONSTANT_String), i);
-            break;
-          case CONSTANT_Class:
-            cachedCPEntries.put(new CWStringItem(cp.getCPClass(i), CONSTANT_Class), i);
-            break;
-          case CONSTANT_MethodType:
-            cachedCPEntries.put(new CWStringItem(cp.getCPMethodType(i), CONSTANT_MethodType), i);
-            break;
-          case CONSTANT_MethodHandle:
-          case CONSTANT_FieldRef:
-          case CONSTANT_InterfaceMethodRef:
-          case CONSTANT_MethodRef:
-            cachedCPEntries.put(
-                new CWRef(t, cp.getCPRefClass(i), cp.getCPRefName(i), cp.getCPRefType(i)), i);
-            break;
-          case CONSTANT_NameAndType:
-            cachedCPEntries.put(new CWNAT(cp.getCPNATName(i), cp.getCPNATType(i)), i);
-            break;
-          case CONSTANT_InvokeDynamic:
-            cachedCPEntries.put(
-                new CWInvokeDynamic(
-                    cp.getCPDynBootstrap(i), cp.getCPDynName(i), cp.getCPDynType(i)),
-                i);
-            break;
-          case CONSTANT_Integer:
-            cachedCPEntries.put(cp.getCPInt(i), i);
-            break;
-          case CONSTANT_Float:
-            cachedCPEntries.put(cp.getCPFloat(i), i);
-            break;
-          case CONSTANT_Long:
-            cachedCPEntries.put(cp.getCPLong(i), i);
-            break;
-          case CONSTANT_Double:
-            cachedCPEntries.put(cp.getCPDouble(i), i);
-            break;
-          case CONSTANT_Utf8:
-            cachedCPEntries.put(cp.getCPUtf8(i), i);
-            break;
-          default:
-            throw new UnsupportedOperationException(
-                String.format("unexpected constant-pool item type %s", t));
+          case CONSTANT_String ->
+              cachedCPEntries.put(new CWStringItem(cp.getCPString(i), CONSTANT_String), i);
+          case CONSTANT_Class ->
+              cachedCPEntries.put(new CWStringItem(cp.getCPClass(i), CONSTANT_Class), i);
+          case CONSTANT_MethodType ->
+              cachedCPEntries.put(new CWStringItem(cp.getCPMethodType(i), CONSTANT_MethodType), i);
+          case CONSTANT_MethodHandle,
+              CONSTANT_FieldRef,
+              CONSTANT_InterfaceMethodRef,
+              CONSTANT_MethodRef ->
+              cachedCPEntries.put(
+                  new CWRef(t, cp.getCPRefClass(i), cp.getCPRefName(i), cp.getCPRefType(i)), i);
+          case CONSTANT_NameAndType ->
+              cachedCPEntries.put(new CWNAT(cp.getCPNATName(i), cp.getCPNATType(i)), i);
+          case CONSTANT_InvokeDynamic ->
+              cachedCPEntries.put(
+                  new CWInvokeDynamic(
+                      cp.getCPDynBootstrap(i), cp.getCPDynName(i), cp.getCPDynType(i)),
+                  i);
+          case CONSTANT_Integer -> cachedCPEntries.put(cp.getCPInt(i), i);
+          case CONSTANT_Float -> cachedCPEntries.put(cp.getCPFloat(i), i);
+          case CONSTANT_Long -> cachedCPEntries.put(cp.getCPLong(i), i);
+          case CONSTANT_Double -> cachedCPEntries.put(cp.getCPDouble(i), i);
+          case CONSTANT_Utf8 -> cachedCPEntries.put(cp.getCPUtf8(i), i);
+          default ->
+              throw new UnsupportedOperationException(
+                  String.format("unexpected constant-pool item type %s", t));
         }
       }
     }
@@ -800,77 +784,52 @@ public class ClassWriter implements ClassConstants {
         byte t = item.getType();
         int offset;
         switch (t) {
-          case CONSTANT_Class:
-          case CONSTANT_String:
-          case CONSTANT_MethodType:
+          case CONSTANT_Class, CONSTANT_String, CONSTANT_MethodType -> {
             offset = reserveBuf(3);
             setUShort(buf, offset + 1, addCPUtf8(((CWStringItem) item).s));
-            break;
-          case CONSTANT_NameAndType:
-            {
-              offset = reserveBuf(5);
-              CWNAT nat = (CWNAT) item;
-              setUShort(buf, offset + 1, addCPUtf8(nat.n));
-              setUShort(buf, offset + 3, addCPUtf8(nat.t));
-              break;
-            }
-          case CONSTANT_InvokeDynamic:
-            {
-              offset = reserveBuf(5);
-              CWInvokeDynamic inv = (CWInvokeDynamic) item;
-              setUShort(buf, offset + 1, inv.b.getIndexInClassFile());
-              setUShort(buf, offset + 3, addCPNAT(inv.n, inv.t));
-              break;
-            }
-          case CONSTANT_MethodHandle:
-            {
-              offset = reserveBuf(4);
-              CWHandle handle = (CWHandle) item;
-              final byte kind = handle.getKind();
-              setUByte(buf, offset + 1, kind);
-              switch (kind) {
-                case REF_getStatic:
-                case REF_getField:
-                case REF_putField:
-                case REF_putStatic:
-                  {
-                    int x = addCPFieldRef(handle.c, handle.n, handle.t);
-                    setUShort(buf, offset + 2, x);
-                    break;
-                  }
-                case REF_invokeVirtual:
-                case REF_newInvokeSpecial:
-                case REF_invokeSpecial:
-                case REF_invokeStatic:
-                  {
-                    int x = addCPMethodRef(handle.c, handle.n, handle.t);
-                    setUShort(buf, offset + 2, x);
-                    break;
-                  }
-                case REF_invokeInterface:
-                  {
-                    int x = addCPInterfaceMethodRef(handle.c, handle.n, handle.t);
-                    setUShort(buf, offset + 2, x);
-                    break;
-                  }
-                default:
+          }
+          case CONSTANT_NameAndType -> {
+            offset = reserveBuf(5);
+            CWNAT nat = (CWNAT) item;
+            setUShort(buf, offset + 1, addCPUtf8(nat.n));
+            setUShort(buf, offset + 3, addCPUtf8(nat.t));
+          }
+          case CONSTANT_InvokeDynamic -> {
+            offset = reserveBuf(5);
+            CWInvokeDynamic inv = (CWInvokeDynamic) item;
+            setUShort(buf, offset + 1, inv.b.getIndexInClassFile());
+            setUShort(buf, offset + 3, addCPNAT(inv.n, inv.t));
+          }
+          case CONSTANT_MethodHandle -> {
+            offset = reserveBuf(4);
+            CWHandle handle = (CWHandle) item;
+            final byte kind = handle.getKind();
+            setUByte(buf, offset + 1, kind);
+            switch (kind) {
+              case REF_getStatic, REF_getField, REF_putField, REF_putStatic -> {
+                int x = addCPFieldRef(handle.c, handle.n, handle.t);
+                setUShort(buf, offset + 2, x);
+              }
+              case REF_invokeVirtual, REF_newInvokeSpecial, REF_invokeSpecial, REF_invokeStatic -> {
+                int x = addCPMethodRef(handle.c, handle.n, handle.t);
+                setUShort(buf, offset + 2, x);
+              }
+              case REF_invokeInterface -> {
+                int x = addCPInterfaceMethodRef(handle.c, handle.n, handle.t);
+                setUShort(buf, offset + 2, x);
+              }
+              default ->
                   throw new UnsupportedOperationException(
                       String.format("unexpected ref kind %s", kind));
-              }
-              break;
             }
-          case CONSTANT_MethodRef:
-          case CONSTANT_FieldRef:
-          case CONSTANT_InterfaceMethodRef:
-            {
-              offset = reserveBuf(5);
-              CWRef ref = (CWRef) item;
-              setUShort(buf, offset + 1, addCPClass(ref.c));
-              setUShort(buf, offset + 3, addCPNAT(ref.n, ref.t));
-              break;
-            }
-          default:
-            throw new Error("Invalid type: " + t);
+          }
+          case CONSTANT_MethodRef, CONSTANT_FieldRef, CONSTANT_InterfaceMethodRef -> {
+            offset = reserveBuf(5);
+            CWRef ref = (CWRef) item;
+            setUShort(buf, offset + 1, addCPClass(ref.c));
+            setUShort(buf, offset + 3, addCPNAT(ref.n, ref.t));
+          }
+          default -> throw new Error("Invalid type: " + t);
         }
         buf[offset] = t;
       } else {

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/ConstantPoolParser.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/ConstantPoolParser.java
@@ -247,14 +247,10 @@ public final class ConstantPoolParser implements ClassConstants {
 
   /** Does b represent the tag of a constant pool reference to an (interface) method or field? */
   public static boolean isRef(byte b) {
-    switch (b) {
-      case CONSTANT_MethodRef:
-      case CONSTANT_FieldRef:
-      case CONSTANT_InterfaceMethodRef:
-        return true;
-      default:
-        return false;
-    }
+    return switch (b) {
+      case CONSTANT_MethodRef, CONSTANT_FieldRef, CONSTANT_InterfaceMethodRef -> true;
+      default -> false;
+    };
   }
 
   /**
@@ -621,36 +617,29 @@ public final class ConstantPoolParser implements ClassConstants {
       byte tag = getByte(offset);
       int itemLen;
       switch (tag) {
-        case CONSTANT_String:
-        case CONSTANT_Class:
-        case CONSTANT_MethodType:
-        case CONSTANT_Module:
-        case CONSTANT_Package:
-          itemLen = 2;
-          break;
-        case CONSTANT_NameAndType:
-        case CONSTANT_MethodRef:
-        case CONSTANT_FieldRef:
-        case CONSTANT_InterfaceMethodRef:
-        case CONSTANT_Integer:
-        case CONSTANT_Float:
-        case CONSTANT_Dynamic:
-        case CONSTANT_InvokeDynamic:
-          itemLen = 4;
-          break;
-        case CONSTANT_Long:
-        case CONSTANT_Double:
+        case CONSTANT_String,
+            CONSTANT_Class,
+            CONSTANT_MethodType,
+            CONSTANT_Module,
+            CONSTANT_Package ->
+            itemLen = 2;
+        case CONSTANT_NameAndType,
+            CONSTANT_MethodRef,
+            CONSTANT_FieldRef,
+            CONSTANT_InterfaceMethodRef,
+            CONSTANT_Integer,
+            CONSTANT_Float,
+            CONSTANT_Dynamic,
+            CONSTANT_InvokeDynamic ->
+            itemLen = 4;
+        case CONSTANT_Long, CONSTANT_Double -> {
           itemLen = 8;
           i++; // ick
-          break;
-        case CONSTANT_Utf8:
-          itemLen = 2 + getUShort(offset + 1);
-          break;
-        case CONSTANT_MethodHandle:
-          itemLen = 3;
-          break;
-        default:
-          throw new InvalidClassFileException(offset, "unknown constant pool entry type" + tag);
+        }
+        case CONSTANT_Utf8 -> itemLen = 2 + getUShort(offset + 1);
+        case CONSTANT_MethodHandle -> itemLen = 3;
+        default ->
+            throw new InvalidClassFileException(offset, "unknown constant pool entry type" + tag);
       }
       checkLength(offset, itemLen);
       offset += itemLen + 1;

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/TypeAnnotationsReader.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/TypeAnnotationsReader.java
@@ -209,49 +209,44 @@ public class TypeAnnotationsReader extends AnnotationsReader {
   private Pair<TypeAnnotationTarget, Integer> getTypeAnnotationTargetAndSize(
       int begin, TargetInfo target_info) throws InvalidClassFileException {
     switch (target_info) {
-      case type_parameter_target:
-        {
-          checkSize(begin, 1);
-          return Pair.make(new TypeParameterTarget(cr.getUnsignedByte(begin)), 1);
+      case type_parameter_target -> {
+        checkSize(begin, 1);
+        return Pair.make(new TypeParameterTarget(cr.getUnsignedByte(begin)), 1);
+      }
+      case supertype_target -> {
+        checkSize(begin, 2);
+        final int interfaceIndex = cr.getUShort(begin);
+        final String superType;
+        if (interfaceIndex == 65535) {
+          superType = cr.getSuperName();
+        } else {
+          superType = cr.getInterfaceName(interfaceIndex);
         }
-      case supertype_target:
-        {
-          checkSize(begin, 2);
-          final int interfaceIndex = cr.getUShort(begin);
-          final String superType;
-          if (interfaceIndex == 65535) {
-            superType = cr.getSuperName();
-          } else {
-            superType = cr.getInterfaceName(interfaceIndex);
-          }
-          return Pair.make(new SuperTypeTarget(superType), 2);
-        }
-      case type_parameter_bound_target:
-        {
-          checkSize(begin, 2);
-          return Pair.make(
-              new TypeParameterBoundTarget(
-                  cr.getUnsignedByte(begin),
-                  cr.getUnsignedByte(begin + 1),
-                  signatureReader.getSignature()),
-              2);
-        }
-      case empty_target:
-        {
-          return Pair.make(new EmptyTarget(), 0);
-        }
-      case formal_parameter_target:
-        {
-          checkSize(begin, 1);
-          return Pair.make(new FormalParameterTarget(cr.getUnsignedByte(begin)), 1);
-        }
-      case throws_target:
-        {
-          assert exceptionReader != null;
-          checkSize(begin, 2);
-          final int throwsIndex = cr.getUShort(begin);
-          return Pair.make(new ThrowsTarget(exceptionReader.getClasses()[throwsIndex]), 2);
-        }
+        return Pair.make(new SuperTypeTarget(superType), 2);
+      }
+      case type_parameter_bound_target -> {
+        checkSize(begin, 2);
+        return Pair.make(
+            new TypeParameterBoundTarget(
+                cr.getUnsignedByte(begin),
+                cr.getUnsignedByte(begin + 1),
+                signatureReader.getSignature()),
+            2);
+      }
+      case empty_target -> {
+        return Pair.make(new EmptyTarget(), 0);
+      }
+      case formal_parameter_target -> {
+        checkSize(begin, 1);
+        return Pair.make(new FormalParameterTarget(cr.getUnsignedByte(begin)), 1);
+      }
+      case throws_target -> {
+        assert exceptionReader != null;
+        checkSize(begin, 2);
+        final int throwsIndex = cr.getUShort(begin);
+        return Pair.make(new ThrowsTarget(exceptionReader.getClasses()[throwsIndex]), 2);
+      }
+
       /*
       * localvar_target {
       * u2 table_length;
@@ -261,54 +256,48 @@ public class TypeAnnotationsReader extends AnnotationsReader {
       *   } table[table_length];
       * }
       */
-      case localvar_target:
-        {
-          checkSize(begin, 2);
-          final int table_length = cr.getUShort(begin);
-          final int offset = begin + 2;
-          checkSize(offset, (2 + 2 + 2) * table_length);
-          int[] start_pc = new int[table_length];
-          int[] length = new int[table_length];
-          int[] index = new int[table_length];
+      case localvar_target -> {
+        checkSize(begin, 2);
+        final int table_length = cr.getUShort(begin);
+        final int offset = begin + 2;
+        checkSize(offset, (2 + 2 + 2) * table_length);
+        int[] start_pc = new int[table_length];
+        int[] length = new int[table_length];
+        int[] index = new int[table_length];
 
-          for (int i = 0; i < table_length; i++) {
-            start_pc[i] = cr.getUShort(offset + (2 + 2 + 2) * i);
-            length[i] = cr.getUShort(offset + 2 + (2 + 2 + 2) * i);
-            index[i] = cr.getUShort(offset + 4 + (2 + 2 + 2) * i);
-          }
-          return Pair.make(
-              new LocalVarTarget(start_pc, length, index), 2 + (2 + 2 + 2) * table_length);
+        for (int i = 0; i < table_length; i++) {
+          start_pc[i] = cr.getUShort(offset + (2 + 2 + 2) * i);
+          length[i] = cr.getUShort(offset + 2 + (2 + 2 + 2) * i);
+          index[i] = cr.getUShort(offset + 4 + (2 + 2 + 2) * i);
         }
-      case catch_target:
-        {
-          assert codeReader != null;
-          checkSize(begin, 2);
-          int exception_table_index = cr.getUShort(begin);
-          int[] rawHandler = new int[4];
-          System.arraycopy(
-              codeReader.getRawHandlers(), exception_table_index * 4, rawHandler, 0, 4);
-          final String catchType =
-              rawHandler[3] == 0
-                  ? CatchTarget.ALL_EXCEPTIONS
-                  : cr.getCP().getCPClass(rawHandler[3]);
-          return Pair.make(new CatchTarget(rawHandler, catchType), 2);
-        }
-      case offset_target:
-        {
-          checkSize(begin, 2);
-          int offset = cr.getUShort(begin);
-          return Pair.make(new OffsetTarget(offset), 2);
-        }
-      case type_argument_target:
-        {
-          checkSize(begin, 3);
-          int offset = cr.getUShort(begin);
-          int type_argument_index = cr.getUnsignedByte(begin);
-          return Pair.make(new TypeArgumentTarget(offset, type_argument_index), 3);
-        }
-      default:
+        return Pair.make(
+            new LocalVarTarget(start_pc, length, index), 2 + (2 + 2 + 2) * table_length);
+      }
+      case catch_target -> {
+        assert codeReader != null;
+        checkSize(begin, 2);
+        int exception_table_index = cr.getUShort(begin);
+        int[] rawHandler = new int[4];
+        System.arraycopy(codeReader.getRawHandlers(), exception_table_index * 4, rawHandler, 0, 4);
+        final String catchType =
+            rawHandler[3] == 0 ? CatchTarget.ALL_EXCEPTIONS : cr.getCP().getCPClass(rawHandler[3]);
+        return Pair.make(new CatchTarget(rawHandler, catchType), 2);
+      }
+      case offset_target -> {
+        checkSize(begin, 2);
+        int offset = cr.getUShort(begin);
+        return Pair.make(new OffsetTarget(offset), 2);
+      }
+      case type_argument_target -> {
+        checkSize(begin, 3);
+        int offset = cr.getUShort(begin);
+        int type_argument_index = cr.getUnsignedByte(begin);
+        return Pair.make(new TypeArgumentTarget(offset, type_argument_index), 3);
+      }
+      default -> {
         Assertions.UNREACHABLE();
         return null;
+      }
     }
   }
 

--- a/shrike/src/main/java/com/ibm/wala/shrike/sourcepos/CRTData.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/sourcepos/CRTData.java
@@ -100,12 +100,12 @@ public final class CRTData {
       source_start = new Position(source_start_position);
     } catch (InvalidPositionException e) {
       switch (e.getThisCause()) {
-        case LINE_NUMBER_ZERO:
-          throw new InvalidCRTDataException(WARN_INVALID_START_LINE_NUMBER);
-        case COLUMN_NUMBER_ZERO:
-          throw new InvalidCRTDataException(WARN_INVALID_START_COLUMN_NUMBER);
-        default:
+        case LINE_NUMBER_ZERO -> throw new InvalidCRTDataException(WARN_INVALID_START_LINE_NUMBER);
+        case COLUMN_NUMBER_ZERO ->
+            throw new InvalidCRTDataException(WARN_INVALID_START_COLUMN_NUMBER);
+        default -> {
           assert false;
+        }
       }
     }
 
@@ -114,12 +114,12 @@ public final class CRTData {
       source_end = new Position(source_end_position);
     } catch (InvalidPositionException e) {
       switch (e.getThisCause()) {
-        case LINE_NUMBER_ZERO:
-          throw new InvalidCRTDataException(WARN_INVALID_END_LINE_NUMBER);
-        case COLUMN_NUMBER_ZERO:
-          throw new InvalidCRTDataException(WARN_INVALID_END_COLUMN_NUMBER);
-        default:
+        case LINE_NUMBER_ZERO -> throw new InvalidCRTDataException(WARN_INVALID_END_LINE_NUMBER);
+        case COLUMN_NUMBER_ZERO ->
+            throw new InvalidCRTDataException(WARN_INVALID_END_COLUMN_NUMBER);
+        default -> {
           assert false;
+        }
       }
     }
 
@@ -129,16 +129,14 @@ public final class CRTData {
     } catch (InvalidRangeException e) {
       final Cause cause = e.getThisCause();
       switch (cause) {
-        case END_BEFORE_START:
-          throw new InvalidCRTDataException(
-              WARN_END_BEFORE_START, source_start.toString(), source_end.toString());
-        case START_UNDEFINED:
-          throw new InvalidCRTDataException(WARN_START_UNDEFINED);
-        case END_UNDEFINED:
-          throw new InvalidCRTDataException(WARN_END_UNDEFINED);
-        default:
-          throw new UnsupportedOperationException(
-              String.format("cannot convert %s into an InvalidCRTDataException", cause));
+        case END_BEFORE_START ->
+            throw new InvalidCRTDataException(
+                WARN_END_BEFORE_START, source_start.toString(), source_end.toString());
+        case START_UNDEFINED -> throw new InvalidCRTDataException(WARN_START_UNDEFINED);
+        case END_UNDEFINED -> throw new InvalidCRTDataException(WARN_END_UNDEFINED);
+        default ->
+            throw new UnsupportedOperationException(
+                String.format("cannot convert %s into an InvalidCRTDataException", cause));
       }
     } finally {
       this.source_positions = range;

--- a/shrike/src/main/java/com/ibm/wala/shrike/sourcepos/MethodPositions.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/sourcepos/MethodPositions.java
@@ -50,9 +50,6 @@ public final class MethodPositions extends PositionsAttribute {
   private static final String ERR_END_BEFORE_START =
       "Error in MethodPositions attribute: %2$s (%4$s) is before %1$s (%3$s).";
 
-  private static final String ERR_UNKNOWN_REASON =
-      "Error in MethodPositions attribute: unknown reason %1$s.";
-
   private static final String WARN_INVALID_BLOCK_END =
       "Warning in MethodPositions attribute: Invalid method block end position.";
 
@@ -128,17 +125,10 @@ public final class MethodPositions extends PositionsAttribute {
       } catch (InvalidRangeException e) {
         final Cause thisCause = e.getThisCause();
         switch (thisCause) {
-          case END_BEFORE_START:
-            Debug.warn(ERR_END_BEFORE_START, startVarName, endVarName, start, end);
-            break;
-          case START_UNDEFINED:
-            Debug.warn(ERR_POSITION_UNDEFINED, startVarName);
-            break;
-          case END_UNDEFINED:
-            Debug.warn(ERR_POSITION_UNDEFINED, endVarName);
-            break;
-          default:
-            Debug.warn(ERR_UNKNOWN_REASON, thisCause);
+          case END_BEFORE_START ->
+              Debug.warn(ERR_END_BEFORE_START, startVarName, endVarName, start, end);
+          case START_UNDEFINED -> Debug.warn(ERR_POSITION_UNDEFINED, startVarName);
+          case END_UNDEFINED -> Debug.warn(ERR_POSITION_UNDEFINED, endVarName);
         }
       }
     }
@@ -168,14 +158,17 @@ public final class MethodPositions extends PositionsAttribute {
       pos = new Position(in.readInt());
     } catch (InvalidPositionException e) {
       switch (e.getThisCause()) {
-        case LINE_NUMBER_ZERO:
+        case LINE_NUMBER_ZERO -> {
           Debug.warn(ERR_LINE_ZERO, varName);
           throw e;
-        case COLUMN_NUMBER_ZERO:
+        }
+        case COLUMN_NUMBER_ZERO -> {
           Debug.warn(ERR_COLUMN_ZERO, varName);
           throw e;
-        default:
+        }
+        default -> {
           assert false;
+        }
       }
     }
     return pos;

--- a/util/src/main/java/com/ibm/wala/util/collections/Pair.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/Pair.java
@@ -57,16 +57,17 @@ public class Pair<T, U> implements Serializable {
 
       @Override
       public Object next() {
-        switch (nextFlag) {
-          case 1:
+        return switch (nextFlag) {
+          case 1 -> {
             nextFlag++;
-            return fst;
-          case 2:
+            yield fst;
+          }
+          case 2 -> {
             nextFlag = 0;
-            return snd;
-          default:
-            throw new NoSuchElementException();
-        }
+            yield snd;
+          }
+          default -> throw new NoSuchElementException();
+        };
       }
 
       @Override

--- a/util/src/main/java/com/ibm/wala/util/intset/BasicNaturalRelation.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/BasicNaturalRelation.java
@@ -86,28 +86,17 @@ public final class BasicNaturalRelation implements IBinaryNaturalRelation, Seria
     smallStore = new IntVector[implementation.length];
     for (int i = 0; i < implementation.length; i++) {
       switch (implementation[i]) {
-        case SIMPLE:
-          smallStore[i] = new SimpleIntVector(EMPTY_CODE);
-          break;
-        case TWO_LEVEL:
-          smallStore[i] = new TwoLevelIntVector(EMPTY_CODE);
-          break;
-        case SIMPLE_SPACE_STINGY:
-          smallStore[i] = new TunedSimpleIntVector(EMPTY_CODE, 1, 1.1f);
-          break;
-        default:
-          throw new IllegalArgumentException("unsupported implementation " + implementation[i]);
+        case SIMPLE -> smallStore[i] = new SimpleIntVector(EMPTY_CODE);
+        case TWO_LEVEL -> smallStore[i] = new TwoLevelIntVector(EMPTY_CODE);
+        case SIMPLE_SPACE_STINGY -> smallStore[i] = new TunedSimpleIntVector(EMPTY_CODE, 1, 1.1f);
+        default ->
+            throw new IllegalArgumentException("unsupported implementation " + implementation[i]);
       }
     }
     switch (vectorImpl) {
-      case SIMPLE:
-        delegateStore = new SimpleVector<>();
-        break;
-      case TWO_LEVEL:
-        delegateStore = new TwoLevelVector<>();
-        break;
-      default:
-        throw new IllegalArgumentException("unsupported implementation " + vectorImpl);
+      case SIMPLE -> delegateStore = new SimpleVector<>();
+      case TWO_LEVEL -> delegateStore = new TwoLevelVector<>();
+      default -> throw new IllegalArgumentException("unsupported implementation " + vectorImpl);
     }
   }
 
@@ -287,34 +276,32 @@ public final class BasicNaturalRelation implements IBinaryNaturalRelation, Seria
       } else {
         int ssLength = smallStore.length;
         switch (ssLength) {
-          case 2:
-            {
-              int ss1 = smallStore[1].get(x);
-              if (ss1 == EMPTY_CODE) {
-                return SparseIntSet.singleton(ss0);
-              } else {
-                return SparseIntSet.pair(ss0, ss1);
-              }
+          case 2 -> {
+            int ss1 = smallStore[1].get(x);
+            if (ss1 == EMPTY_CODE) {
+              return SparseIntSet.singleton(ss0);
+            } else {
+              return SparseIntSet.pair(ss0, ss1);
             }
-          case 1:
+          }
+          case 1 -> {
             return SparseIntSet.singleton(ss0);
-          default:
-            {
-              int ss1 = smallStore[1].get(x);
-              if (ss1 == EMPTY_CODE) {
-                return SparseIntSet.singleton(ss0);
-              } else {
-                MutableSparseIntSet result =
-                    MutableSparseIntSet.createMutableSparseIntSet(ssLength);
-                for (IntVector element : smallStore) {
-                  if (element.get(x) == EMPTY_CODE) {
-                    break;
-                  }
-                  result.add(element.get(x));
+          }
+          default -> {
+            int ss1 = smallStore[1].get(x);
+            if (ss1 == EMPTY_CODE) {
+              return SparseIntSet.singleton(ss0);
+            } else {
+              MutableSparseIntSet result = MutableSparseIntSet.createMutableSparseIntSet(ssLength);
+              for (IntVector element : smallStore) {
+                if (element.get(x) == EMPTY_CODE) {
+                  break;
                 }
-                return result;
+                result.add(element.get(x));
               }
+              return result;
             }
+          }
         }
       }
     }


### PR DESCRIPTION
Also remove many `continue` statements that are no longer needed after this refactor.

Also remove many `default` clauses that are recognized as statically unreachable after this refactor.

IntelliJ IDEA made nearly all changes in this commit.  The only human interventions are as follows:

* remove a `// fall through` comment in `StringStuff.java` that is no longer appropriate after this refactor

* remove `MethodPositions.ERR_UNKNOWN_REASON`, which was previously only used in a statically unreachable `default` clause

* add several `switch`-related Error Prone checks to `java.gradle.kts`