### PR TITLE
Use more `switch` expressions

### DIFF
--- a/.idea/inspectionProfiles/No_Back_Sliding.xml
+++ b/.idea/inspectionProfiles/No_Back_Sliding.xml
@@ -101,7 +101,7 @@
       <scope name="Java Sources as Test Subjects" level="WEAK WARNING" enabled="false" />
     </inspection_tool>
     <inspection_tool class="DuplicateThrows" enabled="true" level="WARNING" enabled_by_default="true">
-      <scope name="Java Sources as Test Subjects" level="WARNING" enabled="false" />
+      <scope name="Java Sources as Test Subjects" level="WARNING" enabled="false" editorAttributes="NOT_USED_ELEMENT_ATTRIBUTES" />
     </inspection_tool>
     <inspection_tool class="DuplicatedCode" enabled="false" level="WEAK WARNING" enabled_by_default="true" />
     <inspection_tool class="Duplicates" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
@@ -238,9 +238,6 @@
     </inspection_tool>
     <inspection_tool class="IgnoreUnusedEntry" enabled="false" level="UNUSED ENTRY" enabled_by_default="false" />
     <inspection_tool class="ImplicitArrayToString" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="InfiniteRecursion" enabled="true" level="WARNING" enabled_by_default="true">
-      <scope name="Java Sources as Test Subjects" level="WARNING" enabled="false" />
-    </inspection_tool>
     <inspection_tool class="InfiniteRecursionJS" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Eclipse Build Artifacts" level="WARNING" enabled="false" />
       <scope name="JavaScript Test Subjects" level="WARNING" enabled="false" />
@@ -735,6 +732,9 @@
     <inspection_tool class="UnnecessaryContinueJS" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Eclipse Build Artifacts" level="WARNING" enabled="false" />
       <scope name="JavaScript Test Subjects" level="WARNING" enabled="false" />
+    </inspection_tool>
+    <inspection_tool class="UnnecessaryDefault" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="onlyReportSwitchExpressions" value="false" />
     </inspection_tool>
     <inspection_tool class="UnnecessaryEnumModifier" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="UnnecessaryInheritDoc" enabled="true" level="WARNING" enabled_by_default="true" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -68,4 +68,7 @@
   <component name="TaskProjectConfiguration">
     <server type="GitHub" url="https://github.com" />
   </component>
+  <component name="com.github.lipiridi.spotless.applier.ui.settings.ModuleSettingsState">
+    <option name="applyOnRootProject" value="true" />
+  </component>
 </project>

--- a/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
+++ b/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
@@ -4801,12 +4801,13 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
       fakeCtor.parameters().add(svd);
 
       // the type
-      switch (i) {
-        case 1 ->
-            paramTypes.add(fTypeDict.getCAstTypeFor(ast.resolveWellKnownType("java.lang.String")));
-        case 2 -> paramTypes.add(fTypeDict.getCAstTypeFor(ast.resolveWellKnownType("int")));
-        default -> paramTypes.add(fTypeDict.getCAstTypeFor(ctor.getParameterTypes()[i - 3]));
-      }
+      paramTypes.add(
+          fTypeDict.getCAstTypeFor(
+              switch (i) {
+                case 1 -> ast.resolveWellKnownType("java.lang.String");
+                case 2 -> ast.resolveWellKnownType("int");
+                default -> ctor.getParameterTypes()[i - 3];
+              }));
     }
 
     // PART IIb: create the statements in the constructor

--- a/cast/java/src/main/java/com/ibm/wala/cast/java/translator/JavaCAst2IRTranslator.java
+++ b/cast/java/src/main/java/com/ibm/wala/cast/java/translator/JavaCAst2IRTranslator.java
@@ -406,21 +406,15 @@ public class JavaCAst2IRTranslator extends AstTranslator {
   }
 
   private CAstEntity getEnclosingTypeInternal(CAstEntity entity) {
-    switch (entity.getKind()) {
-      case CAstEntity.TYPE_ENTITY -> {
-        return entity;
-      }
-      case CAstEntity.FUNCTION_ENTITY -> {
-        if (entity.getQualifiers().contains(CAstQualifier.STATIC)) return null;
-        else return getEnclosingTypeInternal(getParent(entity));
-      }
-      case CAstEntity.FILE_ENTITY -> {
-        return null;
-      }
-      default -> {
-        return getEnclosingTypeInternal(getParent(entity));
-      }
-    }
+    return switch (entity.getKind()) {
+      case CAstEntity.TYPE_ENTITY -> entity;
+      case CAstEntity.FUNCTION_ENTITY ->
+          entity.getQualifiers().contains(CAstQualifier.STATIC)
+              ? null
+              : getEnclosingTypeInternal(getParent(entity));
+      case CAstEntity.FILE_ENTITY -> null;
+      default -> getEnclosingTypeInternal(getParent(entity));
+    };
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/cfg/Util.java
+++ b/core/src/main/java/com/ibm/wala/cfg/Util.java
@@ -159,35 +159,16 @@ public class Util {
     SSAConditionalBranchInstruction c = (SSAConditionalBranchInstruction) getLastInstruction(G, bb);
     final ConditionalBranchInstruction.Operator operator =
         (ConditionalBranchInstruction.Operator) c.getOperator();
-    switch (operator) {
-      case EQ -> {
-        if (c1 == c2) return getTakenSuccessor(G, bb);
-        else return getNotTakenSuccessor(G, bb);
-      }
-      case NE -> {
-        if (c1 != c2) return getTakenSuccessor(G, bb);
-        else return getNotTakenSuccessor(G, bb);
-      }
-      case LT -> {
-        if (c1 < c2) return getTakenSuccessor(G, bb);
-        else return getNotTakenSuccessor(G, bb);
-      }
-      case GE -> {
-        if (c1 >= c2) return getTakenSuccessor(G, bb);
-        else return getNotTakenSuccessor(G, bb);
-      }
-      case GT -> {
-        if (c1 > c2) return getTakenSuccessor(G, bb);
-        else return getNotTakenSuccessor(G, bb);
-      }
-      case LE -> {
-        if (c1 <= c2) return getTakenSuccessor(G, bb);
-        else return getNotTakenSuccessor(G, bb);
-      }
-      default ->
-          throw new UnsupportedOperationException(
-              String.format("unexpected operator %s", operator));
-    }
+    return switch (operator) {
+          case EQ -> c1 == c2;
+          case NE -> c1 != c2;
+          case LT -> c1 < c2;
+          case GE -> c1 >= c2;
+          case GT -> c1 > c2;
+          case LE -> c1 <= c2;
+        }
+        ? getTakenSuccessor(G, bb)
+        : getNotTakenSuccessor(G, bb);
   }
 
   /**

--- a/core/src/main/java/com/ibm/wala/cfg/exc/intra/NullPointerState.java
+++ b/core/src/main/java/com/ibm/wala/cfg/exc/intra/NullPointerState.java
@@ -225,12 +225,13 @@ public class NullPointerState extends AbstractVariable<NullPointerState> {
   public String toString() {
     StringBuilder buf = new StringBuilder("<");
     for (State var : vars) {
-      switch (var) {
-        case BOTH -> buf.append('*');
-        case NOT_NULL -> buf.append('1');
-        case NULL -> buf.append('0');
-        case UNKNOWN -> buf.append('?');
-      }
+      buf.append(
+          switch (var) {
+            case BOTH -> '*';
+            case NOT_NULL -> '1';
+            case NULL -> '0';
+            case UNKNOWN -> '?';
+          });
     }
     buf.append('>');
 

--- a/core/src/main/java/com/ibm/wala/cfg/exc/intra/ParameterState.java
+++ b/core/src/main/java/com/ibm/wala/cfg/exc/intra/ParameterState.java
@@ -120,12 +120,13 @@ public class ParameterState extends AbstractVariable<ParameterState> {
     Set<Entry<Integer, State>> paramsSet = params.entrySet();
 
     for (Entry<Integer, State> param : paramsSet) {
-      switch (param.getValue()) {
-        case BOTH -> buf.append('*');
-        case NOT_NULL -> buf.append('1');
-        case NULL -> buf.append('0');
-        case UNKNOWN -> buf.append('?');
-      }
+      buf.append(
+          switch (param.getValue()) {
+            case BOTH -> '*';
+            case NOT_NULL -> '1';
+            case NULL -> '0';
+            case UNKNOWN -> '?';
+          });
     }
     buf.append('>');
 

--- a/core/src/main/java/com/ibm/wala/classLoader/JavaLanguage.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/JavaLanguage.java
@@ -666,7 +666,7 @@ public class JavaLanguage extends LanguageImpl implements BytecodeLanguage, Cons
     if (pei == null) {
       throw new IllegalArgumentException("pei is null");
     }
-    switch (((Instruction) pei).getOpcode()) {
+    return switch (((Instruction) pei).getOpcode()) {
       case OP_iaload,
           OP_laload,
           OP_faload,
@@ -681,16 +681,13 @@ public class JavaLanguage extends LanguageImpl implements BytecodeLanguage, Cons
           OP_dastore,
           OP_bastore,
           OP_castore,
-          OP_sastore -> {
-        return getArrayAccessExceptions();
-      }
-      case OP_aastore -> {
-        return getAaStoreExceptions();
-      }
+          OP_sastore ->
+          getArrayAccessExceptions();
+      case OP_aastore -> getAaStoreExceptions();
       // we're currently ignoring MonitorStateExceptions, since J2EE stuff
       // should be
       // logically single-threaded
-      // N.B: the caller must handle the explicitly-thrown exception
+      // N.B: for `OP_athrow`, the caller must handle the explicitly-thrown exception
       case OP_getfield,
           OP_putfield,
           OP_invokevirtual,
@@ -699,33 +696,19 @@ public class JavaLanguage extends LanguageImpl implements BytecodeLanguage, Cons
           OP_monitorenter,
           OP_monitorexit,
           OP_athrow,
-          OP_arraylength -> {
-        return getNullPointerException();
-      }
-      case OP_idiv, OP_irem, OP_ldiv, OP_lrem -> {
-        return getArithmeticException();
-      }
-      case OP_new -> {
-        return newScalarExceptions;
-      }
-      case OP_newarray, OP_anewarray, OP_multianewarray -> {
-        return newArrayExceptions;
-      }
-      case OP_checkcast -> {
-        return getClassCastException();
-      }
-      case OP_ldc_w -> {
-        if (((ConstantInstruction) pei).getType().equals(TYPE_Class))
-          return getClassNotFoundException();
-        else return null;
-      }
-      case OP_getstatic, OP_putstatic -> {
-        return getExceptionInInitializerError();
-      }
-      default -> {
-        return Collections.emptySet();
-      }
-    }
+          OP_arraylength ->
+          getNullPointerException();
+      case OP_idiv, OP_irem, OP_ldiv, OP_lrem -> getArithmeticException();
+      case OP_new -> newScalarExceptions;
+      case OP_newarray, OP_anewarray, OP_multianewarray -> newArrayExceptions;
+      case OP_checkcast -> getClassCastException();
+      case OP_ldc_w ->
+          ((ConstantInstruction) pei).getType().equals(TYPE_Class)
+              ? getClassNotFoundException()
+              : null;
+      case OP_getstatic, OP_putstatic -> getExceptionInInitializerError();
+      default -> Collections.emptySet();
+    };
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/core/util/ssa/ParameterAccessor.java
+++ b/core/src/main/java/com/ibm/wala/core/util/ssa/ParameterAccessor.java
@@ -277,68 +277,50 @@ public class ParameterAccessor {
 
     @Override
     public String toString() {
-      switch (this.disp) {
-        case THIS -> {
-          return "Implicit this-parameter of "
-              + this.mRef.getName()
-              + " as "
-              + this.type
-              + " accessible using "
-              + "SSA-Value "
-              + this.number;
-        }
-        case PARAM -> {
-          if (this.key instanceof NamedKey) {
-            return "Parameter "
-                + getNumberInDescriptor()
-                + " \""
-                + getVariableName()
-                + "\" of "
+      return switch (this.disp) {
+        case THIS ->
+            "Implicit this-parameter of "
                 + this.mRef.getName()
-                + " is "
+                + " as "
+                + this.type
+                + " accessible using "
+                + "SSA-Value "
+                + this.number;
+        case PARAM ->
+            this.key instanceof NamedKey
+                ? "Parameter "
+                    + getNumberInDescriptor()
+                    + " \""
+                    + getVariableName()
+                    + "\" of "
+                    + this.mRef.getName()
+                    + " is "
+                    + this.type
+                    + " accessible using SSA-Value "
+                    + this.number
+                : "Parameter "
+                    + getNumberInDescriptor()
+                    + " of "
+                    + this.mRef.getName()
+                    + " is "
+                    + this.type
+                    + " accessible using SSA-Value "
+                    + this.number;
+        case RETURN ->
+            "Return Value of "
+                + this.mRef.getName()
+                + " as "
                 + this.type
                 + " accessible using SSA-Value "
                 + this.number;
-          } else {
-            return "Parameter "
-                + getNumberInDescriptor()
-                + " of "
-                + this.mRef.getName()
-                + " is "
+        case NEW ->
+            "New instance of "
                 + this.type
-                + " accessible using SSA-Value "
+                + " accessible in "
+                + this.mRef.getName()
+                + " using number "
                 + this.number;
-          }
-        }
-        case RETURN -> {
-          return "Return Value of "
-              + this.mRef.getName()
-              + " as "
-              + this.type
-              + " accessible using SSA-Value "
-              + this.number;
-        }
-        case NEW -> {
-          return "New instance of "
-              + this.type
-              + " accessible in "
-              + this.mRef.getName()
-              + " using number "
-              + this.number;
-        }
-        default -> {
-          return "Parameter "
-              + getNumberInDescriptor()
-              + " - "
-              + this.disp
-              + " of "
-              + this.mRef.getName()
-              + " as "
-              + this.type
-              + " accessible using SSA-Value "
-              + this.number;
-        }
-      }
+      };
     }
   }
 
@@ -597,21 +579,10 @@ public class ParameterAccessor {
               + this);
     }
 
-    switch (this.base) {
-      case IMETHOD -> {
-        return no + this.implicitThis; // + this.implicitThis; // TODO: Verify
-      }
-      case METHOD_REFERENCE -> {
-        if (this.implicitThis > 0) {
-          return no + this.implicitThis; //
-        } else {
-          return no;
-        }
-      }
-      default ->
-          throw new UnsupportedOperationException(
-              "No implementation of getParameter() for base " + this.base);
-    }
+    return switch (this.base) {
+      case IMETHOD -> no + this.implicitThis; // + this.implicitThis; // TODO: Verify
+      case METHOD_REFERENCE -> this.implicitThis > 0 ? no + this.implicitThis : no;
+    };
   }
 
   /**

--- a/core/src/main/java/com/ibm/wala/core/util/strings/StringStuff.java
+++ b/core/src/main/java/com/ibm/wala/core/util/strings/StringStuff.java
@@ -148,50 +148,26 @@ public class StringStuff {
     if (b.length() < i + 1) {
       throw new IllegalArgumentException("invalid descriptor: " + b);
     }
-    switch (b.get(i)) {
-      case TypeReference.VoidTypeCode -> {
-        return TypeReference.Void.getName();
-      }
-      case TypeReference.BooleanTypeCode -> {
-        return TypeReference.Boolean.getName();
-      }
-      case TypeReference.ByteTypeCode -> {
-        return TypeReference.Byte.getName();
-      }
-      case TypeReference.ShortTypeCode -> {
-        return TypeReference.Short.getName();
-      }
-      case TypeReference.IntTypeCode -> {
-        return TypeReference.Int.getName();
-      }
-      case TypeReference.LongTypeCode -> {
-        return TypeReference.Long.getName();
-      }
-      case TypeReference.FloatTypeCode -> {
-        return TypeReference.Float.getName();
-      }
-      case TypeReference.DoubleTypeCode -> {
-        return TypeReference.Double.getName();
-      }
-      case TypeReference.CharTypeCode -> {
-        return TypeReference.Char.getName();
-      }
-      case TypeReference.OtherPrimitiveTypeCode -> {
-        if (b.get(b.length() - 1) == ';') {
-          return l.lookupPrimitiveType(new String(b.substring(i + 1, b.length() - i - 2)));
-        } else {
-          return l.lookupPrimitiveType(new String(b.substring(i + 1, b.length() - i - 1)));
-        }
-      }
-      case TypeReference.ClassTypeCode, TypeReference.ArrayTypeCode -> {
-        if (b.get(b.length() - 1) == ';') {
-          return TypeName.findOrCreate(b, i, b.length() - i - 1);
-        } else {
-          return TypeName.findOrCreate(b, i, b.length() - i);
-        }
-      }
+    return switch (b.get(i)) {
+      case TypeReference.VoidTypeCode -> TypeReference.Void.getName();
+      case TypeReference.BooleanTypeCode -> TypeReference.Boolean.getName();
+      case TypeReference.ByteTypeCode -> TypeReference.Byte.getName();
+      case TypeReference.ShortTypeCode -> TypeReference.Short.getName();
+      case TypeReference.IntTypeCode -> TypeReference.Int.getName();
+      case TypeReference.LongTypeCode -> TypeReference.Long.getName();
+      case TypeReference.FloatTypeCode -> TypeReference.Float.getName();
+      case TypeReference.DoubleTypeCode -> TypeReference.Double.getName();
+      case TypeReference.CharTypeCode -> TypeReference.Char.getName();
+      case TypeReference.OtherPrimitiveTypeCode ->
+          b.get(b.length() - 1) == ';'
+              ? l.lookupPrimitiveType(new String(b.substring(i + 1, b.length() - i - 2)))
+              : l.lookupPrimitiveType(new String(b.substring(i + 1, b.length() - i - 1)));
+      case TypeReference.ClassTypeCode, TypeReference.ArrayTypeCode ->
+          b.get(b.length() - 1) == ';'
+              ? TypeName.findOrCreate(b, i, b.length() - i - 1)
+              : TypeName.findOrCreate(b, i, b.length() - i);
       default -> throw new IllegalArgumentException("unexpected type in descriptor " + b);
-    }
+    };
   }
 
   public static TypeName[] parseForParameterNames(String descriptor)

--- a/core/src/main/java/com/ibm/wala/types/TypeName.java
+++ b/core/src/main/java/com/ibm/wala/types/TypeName.java
@@ -284,14 +284,15 @@ public final class TypeName implements Serializable {
             d != 0;
             d >>= ElementBits) {
           final int masked = d & ElementMask;
-          switch (masked) {
-            case ArrayMask -> result.append('[');
-            case PointerMask -> result.append('*');
-            case ReferenceMask -> result.append('&');
-            default ->
-                throw new UnsupportedOperationException(
-                    "unexpected masked type-name component " + masked);
-          }
+          result.append(
+              switch (masked) {
+                case ArrayMask -> '[';
+                case PointerMask -> '*';
+                case ReferenceMask -> '&';
+                default ->
+                    throw new UnsupportedOperationException(
+                        "unexpected masked type-name component " + masked);
+              });
         }
       }
       if (!isPrimitive) {

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidSettingFactory.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidSettingFactory.java
@@ -244,29 +244,15 @@ public class AndroidSettingFactory {
     }
 
     final Atom action = Atom.findOrCreateAsciiAtom(name);
-    final Intent ret;
     Atom mUri = null;
     if (uri != null) {
       mUri = Atom.findOrCreateAsciiAtom(uri);
     }
-    switch (type) {
-      case INTERNAL_TARGET -> {
-        if (uri != null) {
-          ret = new InternalIntent(action, mUri);
-        } else {
-          ret = new InternalIntent(action);
-        }
-      }
-      default -> {
-        if (uri != null) {
-          ret = new StandardIntent(action, mUri);
-        } else {
-          ret = new StandardIntent(action);
-        }
-      }
-    }
-
-    return ret;
+    return switch (type) {
+      case INTERNAL_TARGET ->
+          uri != null ? new InternalIntent(action, mUri) : new InternalIntent(action);
+      default -> uri != null ? new StandardIntent(action, mUri) : new StandardIntent(action);
+    };
   }
 
   //

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/InvokeInstruction.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/InvokeInstruction.java
@@ -39,13 +39,13 @@ public class InvokeInstruction extends Instruction implements IInvokeInstruction
     if (mode == null) {
       throw new NullPointerException("mode must not be null");
     }
-    short opcode = 0;
-    switch (mode) {
-      case VIRTUAL -> opcode = OP_invokevirtual;
-      case SPECIAL -> opcode = OP_invokespecial;
-      case STATIC -> opcode = OP_invokestatic;
-      case INTERFACE -> opcode = OP_invokeinterface;
-    }
+    short opcode =
+        switch (mode) {
+          case VIRTUAL -> OP_invokevirtual;
+          case SPECIAL -> OP_invokespecial;
+          case STATIC -> OP_invokestatic;
+          case INTERFACE -> OP_invokeinterface;
+        };
     return new InvokeInstruction(opcode, type, className, methodName);
   }
 

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/analysis/ClassHierarchy.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/analysis/ClassHierarchy.java
@@ -161,33 +161,23 @@ public final class ClassHierarchy {
     } else if (t1.equals(Constants.TYPE_unknown) || t2.equals(Constants.TYPE_unknown)) {
       return MAYBE;
     } else {
-      switch (t1.charAt(0)) {
-        case 'L' -> {
-          if (t1.equals(Constants.TYPE_null)) {
-            return YES;
-          } else if (t2.startsWith("[")) {
-            return NO;
-          } else if (hierarchy == null) {
-            return MAYBE;
-          } else {
-            return checkSubtypeOfHierarchy(hierarchy, t1, t2);
-          }
-        }
-        case '[' -> {
-          if (t2.equals(Constants.TYPE_Object)
-              || t2.equals("Ljava/io/Serializable;")
-              || t2.equals("Ljava/lang/Cloneable;")) {
-            return YES;
-          } else if (t2.startsWith("[")) {
-            return isSubtypeOf(hierarchy, t1.substring(1), t2.substring(1));
-          } else {
-            return NO;
-          }
-        }
-        default -> {
-          return NO;
-        }
-      }
+      return switch (t1.charAt(0)) {
+        case 'L' ->
+            t1.equals(Constants.TYPE_null)
+                ? YES
+                : t2.startsWith("[")
+                    ? NO
+                    : hierarchy == null ? MAYBE : checkSubtypeOfHierarchy(hierarchy, t1, t2);
+        case '[' ->
+            t2.equals(Constants.TYPE_Object)
+                    || t2.equals("Ljava/io/Serializable;")
+                    || t2.equals("Ljava/lang/Cloneable;")
+                ? YES
+                : t2.startsWith("[")
+                    ? isSubtypeOf(hierarchy, t1.substring(1), t2.substring(1))
+                    : NO;
+        default -> NO;
+      };
     }
   }
 

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/shrikeCT/tools/AddSerialVersion.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/shrikeCT/tools/AddSerialVersion.java
@@ -144,11 +144,12 @@ public class AddSerialVersion {
           if (name.equals("<clinit>") || (flags & ClassConstants.ACC_PRIVATE) == 0) {
             methods[methodCount] = m;
             methodSigs[m] = name + r.getMethodType(m);
-            switch (name) {
-              case "<clinit>" -> methodKinds[m] = 0;
-              case "<init>" -> methodKinds[m] = 1;
-              default -> methodKinds[m] = 2;
-            }
+            methodKinds[m] =
+                switch (name) {
+                  case "<clinit>" -> 0;
+                  case "<init>" -> 1;
+                  default -> 2;
+                };
             methodCount++;
           }
         }

--- a/shrike/src/main/java/com/ibm/wala/shrike/sourcepos/CRTData.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/sourcepos/CRTData.java
@@ -128,13 +128,13 @@ public final class CRTData {
       range = new Range(source_start, source_end);
     } catch (InvalidRangeException e) {
       final Cause cause = e.getThisCause();
-      switch (cause) {
+      throw switch (cause) {
         case END_BEFORE_START ->
-            throw new InvalidCRTDataException(
+            new InvalidCRTDataException(
                 WARN_END_BEFORE_START, source_start.toString(), source_end.toString());
-        case START_UNDEFINED -> throw new InvalidCRTDataException(WARN_START_UNDEFINED);
-        case END_UNDEFINED -> throw new InvalidCRTDataException(WARN_END_UNDEFINED);
-      }
+        case START_UNDEFINED -> new InvalidCRTDataException(WARN_START_UNDEFINED);
+        case END_UNDEFINED -> new InvalidCRTDataException(WARN_END_UNDEFINED);
+      };
     } finally {
       this.source_positions = range;
     }

--- a/util/src/main/java/com/ibm/wala/util/intset/BasicNaturalRelation.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/BasicNaturalRelation.java
@@ -85,19 +85,22 @@ public final class BasicNaturalRelation implements IBinaryNaturalRelation, Seria
     }
     smallStore = new IntVector[implementation.length];
     for (int i = 0; i < implementation.length; i++) {
-      switch (implementation[i]) {
-        case SIMPLE -> smallStore[i] = new SimpleIntVector(EMPTY_CODE);
-        case TWO_LEVEL -> smallStore[i] = new TwoLevelIntVector(EMPTY_CODE);
-        case SIMPLE_SPACE_STINGY -> smallStore[i] = new TunedSimpleIntVector(EMPTY_CODE, 1, 1.1f);
-        default ->
-            throw new IllegalArgumentException("unsupported implementation " + implementation[i]);
-      }
+      smallStore[i] =
+          switch (implementation[i]) {
+            case SIMPLE -> new SimpleIntVector(EMPTY_CODE);
+            case TWO_LEVEL -> new TwoLevelIntVector(EMPTY_CODE);
+            case SIMPLE_SPACE_STINGY -> new TunedSimpleIntVector(EMPTY_CODE, 1, 1.1f);
+            default ->
+                throw new IllegalArgumentException(
+                    "unsupported implementation " + implementation[i]);
+          };
     }
-    switch (vectorImpl) {
-      case SIMPLE -> delegateStore = new SimpleVector<>();
-      case TWO_LEVEL -> delegateStore = new TwoLevelVector<>();
-      default -> throw new IllegalArgumentException("unsupported implementation " + vectorImpl);
-    }
+    delegateStore =
+        switch (vectorImpl) {
+          case SIMPLE -> new SimpleVector<>();
+          case TWO_LEVEL -> new TwoLevelVector<>();
+          default -> throw new IllegalArgumentException("unsupported implementation " + vectorImpl);
+        };
   }
 
   public BasicNaturalRelation() {


### PR DESCRIPTION
These manual refactorings turn some `switch` statements into `switch` expressions.  The latter might take some getting used to if you haven't seen them before.  Personally, I like the way that `switch` expressions let one lift common code up out of the `switch`.  For example, we might have a `switch` statement where every `case` returns some value.  In that situation, `return switch ...` makes it clear that we are *definitely* returning; the `switch` only decides *what* value to return, not *whether* to return at all.