### PR TITLE
Annotate some strings as embedded JavaScript

### DIFF
--- a/cast/build.gradle.kts
+++ b/cast/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
   testFixturesApi(libs.junit.jupiter.api)
   testFixturesApi(projects.core)
   testFixturesImplementation(libs.assertj.core)
+  testFixturesImplementation(libs.jetbrains.annotations)
   testFixturesImplementation(projects.util)
   testFixturesImplementation(testFixtures(projects.util))
   testImplementation(libs.assertj.core)

--- a/cast/js/build.gradle.kts
+++ b/cast/js/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
   testFixturesApi(projects.util)
   testFixturesApi(testFixtures(projects.cast))
   testFixturesImplementation(libs.assertj.core)
+  testFixturesImplementation(libs.jetbrains.annotations)
   testFixturesImplementation(testFixtures(projects.util))
   testImplementation(libs.assertj.core)
   testImplementation(libs.junit.jupiter.api)

--- a/cast/js/rhino/build.gradle.kts
+++ b/cast/js/rhino/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
   testFixturesImplementation(projects.core)
   testImplementation(libs.assertj.core)
   testImplementation(libs.gson)
+  testImplementation(libs.jetbrains.annotations)
   testImplementation(libs.junit.jupiter.api)
   testImplementation(testFixtures(projects.cast.js))
 }

--- a/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/test/TestRhinoSourceMap.java
+++ b/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/test/TestRhinoSourceMap.java
@@ -28,7 +28,9 @@ import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.types.TypeName;
 import com.ibm.wala.util.collections.HashMapFactory;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Map;
+import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -39,10 +41,12 @@ public class TestRhinoSourceMap {
     setTranslatorFactory(new CAstRhinoTranslatorFactory());
   }
 
-  private static final String[][] jquery_spec_testSource = {
-    new String[] {
-      "Ltests/jquery_spec_test.js/anonymous__0/isEmptyDataObject",
-      """
+  private record Assertion(String key, @Language("JavaScript") String source) {}
+
+  private static final Assertion[] jquery_spec_testSource = {
+    new Assertion(
+        "Ltests/jquery_spec_test.js/anonymous__0/isEmptyDataObject",
+        """
         function isEmptyDataObject(obj) {
             for (var name in obj) {
                 if (name !== "toJSON") {
@@ -50,11 +54,10 @@ public class TestRhinoSourceMap {
                 }
             }
             return true;
-        }"""
-    },
-    new String[] {
-      "Ltests/jquery_spec_test.js/anonymous__0/anonymous__59/anonymous__62/anonymous__63/anonymous__64/anonymous__65",
-      """
+        }"""),
+    new Assertion(
+        "Ltests/jquery_spec_test.js/anonymous__0/anonymous__59/anonymous__62/anonymous__63/anonymous__64/anonymous__65",
+        """
         function anonymous__65() {
             returned = fn.apply(this, arguments);
             if (returned && jQuery.isFunction(returned.promise)) {
@@ -62,11 +65,10 @@ public class TestRhinoSourceMap {
             } else {
                 newDefer[action](returned);
             }
-        }"""
-    },
-    new String[] {
-      "Ltests/jquery_spec_test.js/anonymous__0/anonymous__386/anonymous__392",
-      """
+        }"""),
+    new Assertion(
+        "Ltests/jquery_spec_test.js/anonymous__0/anonymous__386/anonymous__392",
+        """
         function anonymous__392(map) {
             if (map) {
                 var tmp;
@@ -80,18 +82,16 @@ public class TestRhinoSourceMap {
                 }
             }
             return this;
-        }"""
-    },
-    new String[] {
-      "Ltests/jquery_spec_test.js/anonymous__0/getWindow",
-      """
+        }"""),
+    new Assertion(
+        "Ltests/jquery_spec_test.js/anonymous__0/getWindow",
+        """
     function getWindow(elem) {
         return jQuery.isWindow(elem) ? elem : elem.nodeType === 9 ? elem.defaultView || elem.parentWindow : false;
-    }"""
-    },
-    new String[] {
-      "Ltests/jquery_spec_test.js/anonymous__0/anonymous__1/anonymous__7",
-      """
+    }"""),
+    new Assertion(
+        "Ltests/jquery_spec_test.js/anonymous__0/anonymous__1/anonymous__7",
+        """
         function anonymous__7(elems, name, selector) {
             var ret = this.constructor();
             if (jQuery.isArray(elems)) {
@@ -107,11 +107,10 @@ public class TestRhinoSourceMap {
                 ret.selector = this.selector + "." + name + "(" + selector + ")";
             }
             return ret;
-        }"""
-    },
-    new String[] {
-      "Ltests/jquery_spec_test.js/anonymous__0/anonymous__1/anonymous__17",
-      """
+        }"""),
+    new Assertion(
+        "Ltests/jquery_spec_test.js/anonymous__0/anonymous__1/anonymous__17",
+        """
         function anonymous__17() {
             var options, name, src, copy, copyIsArray, clone, target = arguments[0] || {}, i = 1, length = arguments.length, deep = false;
             if (typeof target === "boolean") {
@@ -149,8 +148,7 @@ public class TestRhinoSourceMap {
                 }
             }
             return target;
-        }"""
-    }
+        }""")
   };
 
   @Test
@@ -159,12 +157,10 @@ public class TestRhinoSourceMap {
     checkFunctionBodies("jquery_spec_test.js", jquery_spec_testSource);
   }
 
-  private static void checkFunctionBodies(String fileName, String[][] assertions)
+  private static void checkFunctionBodies(String fileName, Assertion[] assertions)
       throws IOException, ClassHierarchyException {
-    Map<String, String> sources = HashMapFactory.make();
-    for (String[] assertion : assertions) {
-      sources.put(assertion[0], assertion[1]);
-    }
+    Map<String, String> sources =
+        Arrays.stream(assertions).collect(HashMapFactory.toMap(Assertion::key, Assertion::source));
 
     JavaScriptLoaderFactory loaders = makeLoaders(null);
     AnalysisScope scope = makeScriptScope("tests", fileName, loaders);

--- a/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestCorrelatedPairExtraction.java
+++ b/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestCorrelatedPairExtraction.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
+import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -44,11 +45,12 @@ public abstract class TestCorrelatedPairExtraction {
 
   @TempDir private File tmpDir;
 
-  public void testRewriter(String in, String out) {
+  public void testRewriter(@Language("JavaScript") String in, @Language("JavaScript") String out) {
     testRewriter(null, in, out);
   }
 
-  public void testRewriter(String testName, String in, String out) {
+  public void testRewriter(
+      String testName, @Language("JavaScript") String in, @Language("JavaScript") String out) {
     try {
       final var tmp = File.createTempFile("test", ".js", tmpDir);
       FileUtil.writeFile(tmp, in);


### PR DESCRIPTION
IntelliJ IDEA has nice editing features to support code embedded in literal strings.  Let's help the IDE recognize a few more cases where that's happening.