### PR TITLE
Update to NullAway 0.13.6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-com-uber-nullaway = "0.13.5"
+com-uber-nullaway = "0.13.6"
 #noinspection UnusedVersionCatalogEntry
 eclipse = "4.30.0"
 eclipse-wst-jsdt = "1.0.201.v2010012803"


### PR DESCRIPTION
Release 0.13.5 was [faulty](https://github.com/uber/NullAway/releases/tag/v0.13.5).