### PR TITLE
Avoid array fields in `record` classes

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -66,6 +66,7 @@ tasks.withType<JavaCompile>().configureEach {
       error("AnnotationPosition")
       error("AssertEqualsArgumentOrderChecker")
       error("ArgumentSelectionDefectChecker")
+      error("ArrayRecordComponent")
       error("FallThrough")
       error("IfChainToSwitch")
       error("ProtectedMembersInFinalClass")

--- a/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/ecj/ECJSourceModuleTranslator.java
+++ b/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/ecj/ECJSourceModuleTranslator.java
@@ -37,6 +37,7 @@
  */
 package com.ibm.wala.cast.java.translator.jdt.ecj;
 
+import com.google.common.collect.ImmutableList;
 import com.ibm.wala.cast.java.loader.JavaSourceLoaderImpl;
 import com.ibm.wala.cast.java.translator.Java2IRTranslator;
 import com.ibm.wala.cast.java.translator.SourceModuleTranslator;
@@ -90,7 +91,9 @@ public class ECJSourceModuleTranslator implements SourceModuleTranslator {
    * JrtModule} entries instead of jar or jmod paths.
    */
   private record ClassPath(
-      String[] sources, String[] libs, boolean includeRunningVMBootclasspath) {}
+      ImmutableList<String> sources,
+      ImmutableList<String> libs,
+      boolean includeRunningVMBootclasspath) {}
 
   protected static class ECJJavaToCAstTranslator extends JDTJava2CAstTranslator<Position> {
     public ECJJavaToCAstTranslator(
@@ -184,8 +187,8 @@ public class ECJSourceModuleTranslator implements SourceModuleTranslator {
 
   protected boolean dump;
   protected ECJSourceLoaderImpl sourceLoader;
-  private final String[] sources;
-  private final String[] libs;
+  private final ImmutableList<String> sources;
+  private final ImmutableList<String> libs;
   private final boolean includeRunningVMBootclasspath;
   private final StringFilter exclusions;
 
@@ -207,8 +210,8 @@ public class ECJSourceModuleTranslator implements SourceModuleTranslator {
   }
 
   private static ClassPath computeClassPath(AnalysisScope scope) {
-    List<String> sources = new ArrayList<>();
-    List<String> libs = new ArrayList<>();
+    ImmutableList.Builder<String> sources = ImmutableList.builder();
+    ImmutableList.Builder<String> libs = ImmutableList.builder();
     boolean includeRunningVMBootclasspath = false;
     for (ClassLoaderReference cl : scope.getLoaders()) {
 
@@ -243,8 +246,7 @@ public class ECJSourceModuleTranslator implements SourceModuleTranslator {
       }
     }
 
-    return new ClassPath(
-        sources.toArray(new String[0]), libs.toArray(new String[0]), includeRunningVMBootclasspath);
+    return new ClassPath(sources.build(), libs.build(), includeRunningVMBootclasspath);
   }
 
   /*
@@ -267,7 +269,11 @@ public class ECJSourceModuleTranslator implements SourceModuleTranslator {
     @SuppressWarnings("deprecation")
     final ASTParser parser = ASTParser.newParser(AST.JLS8);
     parser.setResolveBindings(true);
-    parser.setEnvironment(libs, this.sources, null, includeRunningVMBootclasspath);
+    parser.setEnvironment(
+        libs.toArray(String[]::new),
+        this.sources.toArray(String[]::new),
+        null,
+        includeRunningVMBootclasspath);
     Hashtable<String, String> options = JavaCore.getOptions();
     options.put(JavaCore.COMPILER_SOURCE, "11");
     parser.setCompilerOptions(options);


### PR DESCRIPTION
For `record` classes, the compiler-generated `equals` and `hashCode` methods treat arrays shallowly. That's rarely what we want. The generated `toString` methods also do not do well with array fields.

I'm not sure whether those methods are actually ever used with `ClassPath` specifically, but I'd rather not wonder. Let's use immutable lists instead of arrays just to be safe. Let's also tell Error Prone to report an error if any instances of this antipattern arise in the future.

Note: all types and type signatures affected by this change are `private`, so this change causes no backward incompatibility problems.
