### PR TITLE
Tighten access modifiers to shrink internal API surface

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -68,6 +68,7 @@ tasks.withType<JavaCompile>().configureEach {
       error("ArgumentSelectionDefectChecker")
       error("FallThrough")
       error("IfChainToSwitch")
+      error("ProtectedMembersInFinalClass")
       error("RefactorSwitch")
       error("StringConcatToTextBlock")
       error("StatementSwitchToExpressionSwitch")

--- a/cast/src/main/java/com/ibm/wala/cast/tree/rewrite/AstConstantFolder.java
+++ b/cast/src/main/java/com/ibm/wala/cast/tree/rewrite/AstConstantFolder.java
@@ -23,7 +23,7 @@ public class AstConstantFolder {
     return false;
   }
 
-  static class AssignSkipContext extends NonCopyingContext {
+  private static class AssignSkipContext extends NonCopyingContext {
     private final Set<CAstNode> skip = HashSetFactory.make();
   }
 

--- a/core/src/main/java/com/ibm/wala/ssa/SSABuilder.java
+++ b/core/src/main/java/com/ibm/wala/ssa/SSABuilder.java
@@ -377,7 +377,7 @@ public class SSABuilder extends AbstractIntStackMachine {
     }
 
     /** Update the machine state to account for an instruction */
-    class NodeVisitor extends BasicStackMachineVisitor {
+    private class NodeVisitor extends BasicStackMachineVisitor {
 
       /**
        * @see
@@ -965,7 +965,7 @@ public class SSABuilder extends AbstractIntStackMachine {
       }
     }
 
-    class EdgeVisitor extends com.ibm.wala.shrike.shrikeBT.IInstruction.Visitor {
+    private class EdgeVisitor extends com.ibm.wala.shrike.shrikeBT.IInstruction.Visitor {
 
       @Override
       public void visitInvoke(IInvokeInstruction instruction) {

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ssa/DexSSABuilder.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ssa/DexSSABuilder.java
@@ -415,7 +415,7 @@ public class DexSSABuilder extends AbstractIntRegisterMachine {
     }
 
     /** Update the machine state to account for an instruction */
-    class NodeVisitor extends BasicRegisterMachineVisitor {
+    private class NodeVisitor extends BasicRegisterMachineVisitor {
       private final SSACFG cfg;
 
       public NodeVisitor(SSACFG cfg) {
@@ -1389,7 +1389,7 @@ public class DexSSABuilder extends AbstractIntRegisterMachine {
       }
     }
 
-    class EdgeVisitor extends Visitor {
+    private class EdgeVisitor extends Visitor {
 
       @Override
       public void visitInvoke(Invoke instruction) {

--- a/shrike/src/main/java/com/ibm/wala/shrike/copywriter/CopyWriter.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/copywriter/CopyWriter.java
@@ -63,7 +63,7 @@ public class CopyWriter {
 
   private int replace;
 
-  static class UnknownAttributeException extends Exception {
+  private static class UnknownAttributeException extends Exception {
     @Serial private static final long serialVersionUID = 8845177787110364793L;
 
     UnknownAttributeException(String t) {

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/Compiler.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/Compiler.java
@@ -414,7 +414,7 @@ public abstract class Compiler implements Constants {
     computeStackWordsAt(0, 0, new byte[instructions.length * 2], new boolean[instructions.length]);
   }
 
-  abstract static class Patch {
+  private abstract static class Patch {
     final int instrStart;
 
     final int instrOffset;
@@ -430,7 +430,7 @@ public abstract class Compiler implements Constants {
     abstract boolean apply();
   }
 
-  class ShortPatch extends Patch {
+  private class ShortPatch extends Patch {
     ShortPatch(int instrStart, int instrOffset, int targetLabel) {
       super(instrStart, instrOffset, targetLabel);
     }
@@ -447,7 +447,7 @@ public abstract class Compiler implements Constants {
     }
   }
 
-  class IntPatch extends Patch {
+  private class IntPatch extends Patch {
     IntPatch(int instrStart, int instrOffset, int targetLabel) {
       super(instrStart, instrOffset, targetLabel);
     }
@@ -1263,7 +1263,7 @@ public abstract class Compiler implements Constants {
     return r;
   }
 
-  static class HelperPatch {
+  private static class HelperPatch {
     final int start;
 
     final int length;

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/ClassWriter.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/ClassWriter.java
@@ -105,7 +105,7 @@ public class ClassWriter implements ClassConstants {
     }
   }
 
-  static class CWRef extends CWItem {
+  private static class CWRef extends CWItem {
     protected final String c;
 
     protected final String n;
@@ -142,7 +142,7 @@ public class ClassWriter implements ClassConstants {
     }
   }
 
-  static class CWHandle extends CWRef {
+  private static class CWHandle extends CWRef {
     private final byte kind;
 
     CWHandle(byte type, byte kind, String c, String n, String t) {
@@ -165,7 +165,7 @@ public class ClassWriter implements ClassConstants {
     }
   }
 
-  static class CWNAT extends CWItem {
+  private static class CWNAT extends CWItem {
     private final String n;
 
     private final String t;
@@ -196,7 +196,7 @@ public class ClassWriter implements ClassConstants {
     }
   }
 
-  static class CWInvokeDynamic extends CWItem {
+  private static class CWInvokeDynamic extends CWItem {
     private final BootstrapMethod b;
 
     private final String n;

--- a/util/src/main/java/com/ibm/wala/util/graph/traverse/DFS.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/traverse/DFS.java
@@ -116,7 +116,7 @@ public class DFS {
   }
 
   /** Comparator class to order the nodes in the DFS according to the depth first order */
-  static class DFSComparator<T> implements Comparator<T> {
+  private static class DFSComparator<T> implements Comparator<T> {
     private final Map<T, Integer> order;
 
     DFSComparator(Map<T, Integer> order) {

--- a/util/src/main/java/com/ibm/wala/util/heapTrace/HeapTracer.java
+++ b/util/src/main/java/com/ibm/wala/util/heapTrace/HeapTracer.java
@@ -537,7 +537,7 @@ public class HeapTracer {
    * @author sfink
    *     <p>Statistics about objects reached from a single root
    */
-  class Demographics {
+  private class Demographics {
     /** mapping: Object (key) -&gt; Integer (number of instances in a partition) */
     private final HashMap<Object, Integer> instanceCount = HashMapFactory.make();
 


### PR DESCRIPTION
Change package-private nested types to `private` where possible.  The tightened types were already inaccessible outside their declaring packages, so existing third-party code cannot depend on them.  Thus, this narrowing of _internal_ APIs has no backward-incompatible impact on _public_ APIs.  However, it does shrink the surface area that must be documented, maintained, and stabilized for internal consumers.

Also enable `ProtectedMembersInFinalClass` as an Error Prone error, thereby preventing accidental reintroduction of overly broad access modifiers in `final` classes.