### PR TITLE
Privatize another package-private inner class

### DIFF
--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/analysis/ClassHierarchyStore.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/analysis/ClassHierarchyStore.java
@@ -21,7 +21,7 @@ import java.util.Iterator;
 public final class ClassHierarchyStore implements ClassHierarchyProvider {
   private static final String[] noClasses = new String[0];
 
-  static final class ClassInfo {
+  private static final class ClassInfo {
     final boolean isInterface;
 
     final boolean isFinal;


### PR DESCRIPTION
`ClassHierarchyStore.ClassInfo` was previously visible only to its containing package, but was never used outside `ClassHierarchyStore`. So let's make `ClassHierarchyStore.ClassInfo` `private` to further shrink the internal API surface.