### PR TITLE
Remove redundant `System.arraycopy`

### DIFF
--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/Compiler.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/Compiler.java
@@ -1778,7 +1778,6 @@ public abstract class Compiler implements Constants {
     }
 
     for (HelperPatch p : patches) {
-      System.arraycopy(p.code, 0, instructions, p.start, p.code.length);
       for (int j = 0; j < p.length; j++) {
         int index = j + p.start;
         if (j < p.code.length) {


### PR DESCRIPTION
In the patch-application loop, every element that `System.arraycopy` copies from `p.code` into `instructions[p.start…]` is immediately overwritten by the `for` loop that follows. The pre-loop copy is unnecessary.