### PR TITLE
Remove unnecessary "unchecked" warning suppressions

### DIFF
--- a/core/src/testSubjects/java/slice/TestListIterator.java
+++ b/core/src/testSubjects/java/slice/TestListIterator.java
@@ -15,7 +15,6 @@ public class TestListIterator {
     private E[] elements;
     private int size = 0;
 
-    @SuppressWarnings("unchecked")
     public ArrayList() {
       elements = (E[]) new Object[10];
     }
@@ -23,7 +22,7 @@ public class TestListIterator {
     @Override
     public void add(E e) {
       if (size == elements.length) {
-        @SuppressWarnings("unchecked")
+
         E[] newElements = (E[]) new Object[elements.length * 2];
         System.arraycopy(elements, 0, newElements, 0, elements.length);
         elements = newElements;

--- a/util/src/main/java/com/ibm/wala/util/collections/BimodalMap.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/BimodalMap.java
@@ -103,7 +103,6 @@ public class BimodalMap<K, V extends @Nullable Object> implements Map<K, V> {
   }
 
   @Override
-  @SuppressWarnings("unchecked")
   public void putAll(Map<? extends K, ? extends V> t) throws UnsupportedOperationException {
     if (t == null) {
       throw new IllegalArgumentException("null t");
@@ -140,13 +139,11 @@ public class BimodalMap<K, V extends @Nullable Object> implements Map<K, V> {
   }
 
   @Override
-  @SuppressWarnings("unchecked")
   public Set<K> keySet() {
     return (backingStore == null) ? Collections.emptySet() : backingStore.keySet();
   }
 
   @Override
-  @SuppressWarnings("unchecked")
   public Collection<V> values() {
     return (backingStore == null) ? Collections.emptySet() : backingStore.values();
   }
@@ -155,7 +152,6 @@ public class BimodalMap<K, V extends @Nullable Object> implements Map<K, V> {
    * @throws UnimplementedError if the backingStore implementation does
    */
   @Override
-  @SuppressWarnings("unchecked")
   public Set<Map.Entry<K, V>> entrySet() {
     return (backingStore == null) ? Collections.emptySet() : backingStore.entrySet();
   }

--- a/util/src/main/java/com/ibm/wala/util/graph/traverse/DFSFinishTimeIterator.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/traverse/DFSFinishTimeIterator.java
@@ -86,7 +86,6 @@ public abstract class DFSFinishTimeIterator<T> extends ArrayList<T> implements I
    * @return the next graph node in finishing time order.
    */
   @Override
-  @SuppressWarnings("unchecked")
   public @Nullable T next() throws NoSuchElementException {
     if (!hasNext()) {
       throw new NoSuchElementException();


### PR DESCRIPTION
Each of these suppressions was presumably needed at some point, but everything compiles fine without them now.