### PR TITLE
Deprecate the unused `options` parameter on `Language.getFakeRootMethod`

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -16,3 +16,21 @@ modules will receive `org.jspecify:jspecify:1.0.0` on its compile and runtime
 classpaths automatically, matching [JSpecify’s recommendation that the
 annotations library be an API dependency whenever the annotations appear in
 exported API surfaces](https://jspecify.dev/docs/using/#gradle).
+
+## API changes
+
+### `Language.getFakeRootMethod` no longer takes `AnalysisOptions`
+
+`Language.getFakeRootMethod(IClassHierarchy, IAnalysisCacheView)` is now the
+implemented method. The previous
+`getFakeRootMethod(IClassHierarchy, AnalysisOptions, IAnalysisCacheView)`
+overload is retained as a `@Deprecated(forRemoval = true, since = "1.8.0")`
+default that delegates to it and ignores the unused `options` argument. The
+`AstCallGraph.ScriptFakeRoot` and `CrossLanguageCallGraph.CrossLanguageFakeRoot`
+constructors that take an unused `AnalysisOptions` are deprecated the same way.
+
+**Effect for third-party consumers:** Classes that implement `Language`
+directly must implement the new two-argument `getFakeRootMethod`; the
+three-argument form is no longer abstract. Callers of the deprecated overload,
+or of the deprecated fake-root constructors, should drop the `AnalysisOptions`
+argument before the deprecated members are removed in a future release.

--- a/cast/java/src/main/java/com/ibm/wala/cast/java/ipa/callgraph/AstJavaCFABuilder.java
+++ b/cast/java/src/main/java/com/ibm/wala/cast/java/ipa/callgraph/AstJavaCFABuilder.java
@@ -21,7 +21,7 @@ public class AstJavaCFABuilder extends AstJavaSSAPropagationCallGraphBuilder {
 
   public AstJavaCFABuilder(IClassHierarchy cha, AnalysisOptions options, IAnalysisCacheView cache) {
     super(
-        Language.JAVA.getFakeRootMethod(cha, options, cache),
+        Language.JAVA.getFakeRootMethod(cha, cache),
         options,
         cache,
         new DefaultPointerKeyFactory());

--- a/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/examples/hybrid/JavaJavaScriptHybridCallGraphBuilder.java
+++ b/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/examples/hybrid/JavaJavaScriptHybridCallGraphBuilder.java
@@ -123,7 +123,7 @@ public class JavaJavaScriptHybridCallGraphBuilder
         getOptions()
             .getAnalysisScope()
             .getLanguage(language)
-            .getFakeRootMethod(getClassHierarchy(), getOptions(), getAnalysisCache());
+            .getFakeRootMethod(getClassHierarchy(), getAnalysisCache());
   }
 
   @Override

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/FieldBasedCallGraphBuilder.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/FieldBasedCallGraphBuilder.java
@@ -188,7 +188,7 @@ public abstract class FieldBasedCallGraphBuilder {
       throws CancelException {
     // set up call graph
     final JSCallGraph cg =
-        new JSCallGraph(JavaScriptLoader.JS.getFakeRootMethod(cha, options, cache), options, cache);
+        new JSCallGraph(JavaScriptLoader.JS.getFakeRootMethod(cha, cache), options, cache);
     cg.init();
 
     // setup context interpreters

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/JSCFABuilder.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/JSCFABuilder.java
@@ -33,7 +33,7 @@ public abstract class JSCFABuilder extends JSSSAPropagationCallGraphBuilder {
 
   public JSCFABuilder(IClassHierarchy cha, AnalysisOptions options, IAnalysisCacheView cache) {
     super(
-        JavaScriptLoader.JS.getFakeRootMethod(cha, options, cache),
+        JavaScriptLoader.JS.getFakeRootMethod(cha, cache),
         options,
         cache,
         new AstCFAPointerKeys() {

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/JSCallGraph.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/JSCallGraph.java
@@ -74,8 +74,7 @@ public class JSCallGraph extends AstCallGraph {
 
   @Override
   protected CGNode makeFakeRootNode() throws com.ibm.wala.util.CancelException {
-    return findOrCreateNode(
-        new JSFakeRoot(cha, getAnalysisCache()), Everywhere.EVERYWHERE);
+    return findOrCreateNode(new JSFakeRoot(cha, getAnalysisCache()), Everywhere.EVERYWHERE);
   }
 
   @Override

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/JSCallGraph.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/JSCallGraph.java
@@ -43,8 +43,8 @@ public class JSCallGraph extends AstCallGraph {
 
   public static class JSFakeRoot extends ScriptFakeRoot {
 
-    public JSFakeRoot(IClassHierarchy cha, AnalysisOptions options, IAnalysisCacheView cache) {
-      super(fakeRoot, cha.lookupClass(JavaScriptTypes.FakeRoot), cha, options, cache);
+    public JSFakeRoot(IClassHierarchy cha, IAnalysisCacheView cache) {
+      super(fakeRoot, cha.lookupClass(JavaScriptTypes.FakeRoot), cha, cache);
     }
 
     @Override
@@ -75,7 +75,7 @@ public class JSCallGraph extends AstCallGraph {
   @Override
   protected CGNode makeFakeRootNode() throws com.ibm.wala.util.CancelException {
     return findOrCreateNode(
-        new JSFakeRoot(cha, options, getAnalysisCache()), Everywhere.EVERYWHERE);
+        new JSFakeRoot(cha, getAnalysisCache()), Everywhere.EVERYWHERE);
   }
 
   @Override

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/loader/JavaScriptLoader.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/loader/JavaScriptLoader.java
@@ -780,8 +780,7 @@ public class JavaScriptLoader extends CAstAbstractModuleLoader {
         }
 
         @Override
-        public AbstractRootMethod getFakeRootMethod(
-            IClassHierarchy cha, IAnalysisCacheView cache) {
+        public AbstractRootMethod getFakeRootMethod(IClassHierarchy cha, IAnalysisCacheView cache) {
           return new JSFakeRoot(cha, cache);
         }
 

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/loader/JavaScriptLoader.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/loader/JavaScriptLoader.java
@@ -65,7 +65,6 @@ import com.ibm.wala.classLoader.Module;
 import com.ibm.wala.classLoader.ModuleEntry;
 import com.ibm.wala.classLoader.NewSiteReference;
 import com.ibm.wala.core.util.strings.Atom;
-import com.ibm.wala.ipa.callgraph.AnalysisOptions;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.IAnalysisCacheView;
 import com.ibm.wala.ipa.callgraph.impl.AbstractRootMethod;
@@ -782,8 +781,8 @@ public class JavaScriptLoader extends CAstAbstractModuleLoader {
 
         @Override
         public AbstractRootMethod getFakeRootMethod(
-            IClassHierarchy cha, AnalysisOptions options, IAnalysisCacheView cache) {
-          return new JSFakeRoot(cha, options, cache);
+            IClassHierarchy cha, IAnalysisCacheView cache) {
+          return new JSFakeRoot(cha, cache);
         }
 
         @Override

--- a/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/AstCallGraph.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/AstCallGraph.java
@@ -100,9 +100,17 @@ public class AstCallGraph extends ExplicitCallGraph {
         MethodReference rootMethod,
         IClass declaringClass,
         IClassHierarchy cha,
-        @SuppressWarnings("unused") AnalysisOptions options,
         IAnalysisCacheView cache) {
       super(rootMethod, declaringClass, cha, cache);
+    }
+
+    public ScriptFakeRoot(
+        MethodReference rootMethod,
+        IClass declaringClass,
+        IClassHierarchy cha,
+        @SuppressWarnings("unused") AnalysisOptions options,
+        IAnalysisCacheView cache) {
+      this(rootMethod, declaringClass, cha, cache);
     }
 
     /**

--- a/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/AstCallGraph.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/AstCallGraph.java
@@ -104,6 +104,11 @@ public class AstCallGraph extends ExplicitCallGraph {
       super(rootMethod, declaringClass, cha, cache);
     }
 
+    /**
+     * @deprecated to remove unused {@code options} parameter
+     * @see #ScriptFakeRoot(MethodReference, IClass, IClassHierarchy, IAnalysisCacheView)
+     */
+    @Deprecated(forRemoval = true, since = "1.8.0")
     public ScriptFakeRoot(
         MethodReference rootMethod,
         IClass declaringClass,

--- a/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/CrossLanguageCallGraph.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/CrossLanguageCallGraph.java
@@ -106,12 +106,17 @@ public class CrossLanguageCallGraph extends AstCallGraph {
 
   public class CrossLanguageFakeRoot extends ScriptFakeRoot {
 
+    /**
+     * @deprecated to remove unused {@code options} parameter
+     * @see #CrossLanguageFakeRoot(IClassHierarchy, IAnalysisCacheView)
+     */
+    @Deprecated(forRemoval = true, since = "1.8.0")
     public CrossLanguageFakeRoot(
         IClass declaringClass,
         IClassHierarchy cha,
-        AnalysisOptions options,
+        @SuppressWarnings("unused") AnalysisOptions options,
         IAnalysisCacheView cache) {
-      super(rootMethod, declaringClass, cha, options, cache);
+      super(rootMethod, declaringClass, cha, cache);
     }
 
     /**

--- a/core/src/main/java/com/ibm/wala/classLoader/JavaLanguage.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/JavaLanguage.java
@@ -17,7 +17,6 @@ import com.ibm.wala.core.util.shrike.Exceptions.MethodResolutionFailure;
 import com.ibm.wala.core.util.shrike.ShrikeUtil;
 import com.ibm.wala.core.util.strings.Atom;
 import com.ibm.wala.core.util.warnings.Warnings;
-import com.ibm.wala.ipa.callgraph.AnalysisOptions;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.IAnalysisCacheView;
 import com.ibm.wala.ipa.callgraph.impl.AbstractRootMethod;
@@ -824,8 +823,7 @@ public class JavaLanguage extends LanguageImpl implements BytecodeLanguage, Cons
   }
 
   @Override
-  public AbstractRootMethod getFakeRootMethod(
-      IClassHierarchy cha, AnalysisOptions options, IAnalysisCacheView cache) {
+  public AbstractRootMethod getFakeRootMethod(IClassHierarchy cha, IAnalysisCacheView cache) {
     return new FakeRootMethod(new FakeRootClass(ClassLoaderReference.Primordial, cha), cache);
   }
 

--- a/core/src/main/java/com/ibm/wala/classLoader/Language.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/Language.java
@@ -131,8 +131,17 @@ public interface Language {
   /** do MethodReference objects have declared parameter types? */
   boolean methodsHaveDeclaredParameterTypes();
 
-  AbstractRootMethod getFakeRootMethod(
-      IClassHierarchy cha, AnalysisOptions options, IAnalysisCacheView cache);
+  AbstractRootMethod getFakeRootMethod(IClassHierarchy cha, IAnalysisCacheView cache);
+
+  /**
+   * @deprecated Use {@link #getFakeRootMethod(IClassHierarchy, IAnalysisCacheView)}; the {@code
+   *     options} parameter is unused.
+   */
+  @Deprecated(forRemoval = true, since = "1.8.0")
+  default AbstractRootMethod getFakeRootMethod(
+      IClassHierarchy cha, AnalysisOptions options, IAnalysisCacheView cache) {
+    return getFakeRootMethod(cha, cache);
+  }
 
   InducedCFG makeInducedCFG(SSAInstruction[] instructions, IMethod method, Context context);
 

--- a/core/src/main/java/com/ibm/wala/classLoader/Language.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/Language.java
@@ -139,7 +139,9 @@ public interface Language {
    */
   @Deprecated(forRemoval = true, since = "1.8.0")
   default AbstractRootMethod getFakeRootMethod(
-      IClassHierarchy cha, AnalysisOptions options, IAnalysisCacheView cache) {
+      IClassHierarchy cha,
+      @SuppressWarnings("unused") AnalysisOptions options,
+      IAnalysisCacheView cache) {
     return getFakeRootMethod(cha, cache);
   }
 

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/cha/CHACallGraph.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/cha/CHACallGraph.java
@@ -15,7 +15,6 @@ import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.classLoader.Language;
 import com.ibm.wala.classLoader.NewSiteReference;
 import com.ibm.wala.ipa.callgraph.AnalysisCacheImpl;
-import com.ibm.wala.ipa.callgraph.AnalysisOptions;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.Context;
 import com.ibm.wala.ipa.callgraph.Entrypoint;
@@ -54,7 +53,6 @@ import java.util.function.Predicate;
 /** Call graph in which call targets are determined entirely based on an {@link IClassHierarchy}. */
 public class CHACallGraph extends BasicCallGraph<CHAContextInterpreter> {
   private final IClassHierarchy cha;
-  private final AnalysisOptions options;
   private final IAnalysisCacheView cache;
 
   /**
@@ -125,7 +123,6 @@ public class CHACallGraph extends BasicCallGraph<CHAContextInterpreter> {
    */
   public CHACallGraph(IClassHierarchy cha, boolean applicationOnly) {
     this.cha = cha;
-    this.options = new AnalysisOptions();
     this.cache = new AnalysisCacheImpl();
     this.applicationOnly = applicationOnly;
     setInterpreter(new ContextInsensitiveCHAContextInterpreter());
@@ -300,14 +297,14 @@ public class CHACallGraph extends BasicCallGraph<CHAContextInterpreter> {
   @Override
   protected CGNode makeFakeRootNode() throws CancelException {
     return new CHARootNode(
-        Language.JAVA.getFakeRootMethod(cha, options, cache), Everywhere.EVERYWHERE);
+        Language.JAVA.getFakeRootMethod(cha, cache), Everywhere.EVERYWHERE);
   }
 
   @Override
   protected CGNode makeFakeWorldClinitNode() throws CancelException {
     return new CHARootNode(
         new FakeWorldClinitMethod(
-            Language.JAVA.getFakeRootMethod(cha, options, cache).getDeclaringClass(), cache),
+            Language.JAVA.getFakeRootMethod(cha, cache).getDeclaringClass(), cache),
         Everywhere.EVERYWHERE);
   }
 

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/cha/CHACallGraph.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/cha/CHACallGraph.java
@@ -19,6 +19,7 @@ import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.Context;
 import com.ibm.wala.ipa.callgraph.Entrypoint;
 import com.ibm.wala.ipa.callgraph.IAnalysisCacheView;
+import com.ibm.wala.ipa.callgraph.impl.AbstractRootMethod;
 import com.ibm.wala.ipa.callgraph.impl.BasicCallGraph;
 import com.ibm.wala.ipa.callgraph.impl.Everywhere;
 import com.ibm.wala.ipa.callgraph.impl.ExplicitPredecessorsEdgeManager;
@@ -66,6 +67,9 @@ public class CHACallGraph extends BasicCallGraph<CHAContextInterpreter> {
       new LambdaMethodTargetSelector((caller, site, receiver) -> null);
 
   private boolean isInitialized = false;
+
+  /** Lazily created via {@link #getOrCreateFakeRootMethod()}. */
+  private AbstractRootMethod fakeRootMethod;
 
   private class CHANode extends NodeImpl {
 
@@ -296,16 +300,27 @@ public class CHACallGraph extends BasicCallGraph<CHAContextInterpreter> {
 
   @Override
   protected CGNode makeFakeRootNode() throws CancelException {
-    return new CHARootNode(
-        Language.JAVA.getFakeRootMethod(cha, cache), Everywhere.EVERYWHERE);
+    return new CHARootNode(getOrCreateFakeRootMethod(), Everywhere.EVERYWHERE);
   }
 
   @Override
   protected CGNode makeFakeWorldClinitNode() throws CancelException {
     return new CHARootNode(
-        new FakeWorldClinitMethod(
-            Language.JAVA.getFakeRootMethod(cha, cache).getDeclaringClass(), cache),
+        new FakeWorldClinitMethod(getOrCreateFakeRootMethod().getDeclaringClass(), cache),
         Everywhere.EVERYWHERE);
+  }
+
+  /**
+   * Lazily creates the fake root method, caching it so that the fake-root and fake-world-clinit
+   * nodes share a single instance.
+   *
+   * @return the fake root method for this call graph.
+   */
+  private AbstractRootMethod getOrCreateFakeRootMethod() {
+    if (fakeRootMethod == null) {
+      fakeRootMethod = Language.JAVA.getFakeRootMethod(cha, cache);
+    }
+    return fakeRootMethod;
   }
 
   private int clinitPC = 0;

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/Util.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/Util.java
@@ -823,12 +823,7 @@ public class Util {
     SSAContextInterpreter appInterpreter = null;
     SSAPropagationCallGraphBuilder result =
         new nCFABuilder(
-            n,
-            l.getFakeRootMethod(cha, cache),
-            options,
-            cache,
-            appSelector,
-            appInterpreter);
+            n, l.getFakeRootMethod(cha, cache), options, cache, appSelector, appInterpreter);
     // nCFABuilder uses type-based heap abstraction by default, but we want allocation sites
     result.setInstanceKeys(
         new ZeroXInstanceKeys(

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/Util.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/Util.java
@@ -824,7 +824,7 @@ public class Util {
     SSAPropagationCallGraphBuilder result =
         new nCFABuilder(
             n,
-            l.getFakeRootMethod(cha, options, cache),
+            l.getFakeRootMethod(cha, cache),
             options,
             cache,
             appSelector,
@@ -955,7 +955,7 @@ public class Util {
     SSAPropagationCallGraphBuilder result =
         new nCFABuilder(
             n,
-            Language.JAVA.getFakeRootMethod(cha, options, cache),
+            Language.JAVA.getFakeRootMethod(cha, cache),
             options,
             cache,
             appSelector,

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/ZeroXCFABuilder.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/cfa/ZeroXCFABuilder.java
@@ -35,7 +35,7 @@ public class ZeroXCFABuilder extends SSAPropagationCallGraphBuilder {
       SSAContextInterpreter appContextInterpreter,
       int instancePolicy) {
 
-    super(l.getFakeRootMethod(cha, options, cache), options, cache, new DefaultPointerKeyFactory());
+    super(l.getFakeRootMethod(cha, cache), options, cache, new DefaultPointerKeyFactory());
 
     ContextSelector def = new DefaultContextSelector(options, cha);
     ContextSelector contextSelector =

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/AbstractRTABuilder.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/AbstractRTABuilder.java
@@ -102,7 +102,7 @@ public abstract class AbstractRTABuilder extends PropagationCallGraphBuilder {
       ContextSelector appContextSelector,
       SSAContextInterpreter appContextInterpreter) {
     super(
-        Language.JAVA.getFakeRootMethod(cha, options, cache),
+        Language.JAVA.getFakeRootMethod(cha, cache),
         options,
         cache,
         new DefaultPointerKeyFactory());

--- a/core/src/test/java/com/ibm/wala/core/tests/slicer/SlicerTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/slicer/SlicerTest.java
@@ -854,7 +854,7 @@ public class SlicerTest {
     SSAPropagationCallGraphBuilder builder =
         new nCFABuilder(
             1,
-            Language.JAVA.getFakeRootMethod(cha, options, cache),
+            Language.JAVA.getFakeRootMethod(cha, cache),
             options,
             cache,
             appSelector,


### PR DESCRIPTION
## Summary

Finishes the `options`-parameter removal that 1.7.2 began on `FakeRootMethod` (deprecating its 3-arg `(IClass, AnalysisOptions, IAnalysisCacheView)` constructor) by dropping the unused `options` from `Language.getFakeRootMethod`: a new `getFakeRootMethod(IClassHierarchy, IAnalysisCacheView)` becomes the implemented method, and the 3-arg overload is a `@Deprecated(forRemoval = true, since = "1.8.0")` default that delegates to it.

Two spots needed more than a mechanical edit: the JavaScript fake root (`JSFakeRoot`) needed a non-`options` `ScriptFakeRoot` constructor, which didn't exist yet, so it's added alongside the existing one; and `CHACallGraph`'s private `options` field became dead and is removed. Builds clean (`./gradlew compileJava compileTestJava`).

Closes #1906.

## Compatibility Note

This adds an abstract method to the `Language` interface, so external implementors must add the 2-arg override; the 3-arg `default` keeps existing *callers* source-compatible through the deprecation window. This matches the migration proposed in #1906. A non-breaking alternative (a 2-arg `default` delegating to the deprecated 3-arg) is possible but wouldn't let implementors drop the parameter, which is the goal here—glad to switch if you'd prefer it.
