### PR TITLE
Gate PropagationSystem's implicit-key debug dump under `DEBUG`

### DIFF
--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationSystem.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationSystem.java
@@ -245,11 +245,13 @@ public class PropagationSystem extends DefaultFixedPointSolver<PointsToSetVariab
     }
 
     if (pointsToMap.isImplicit(key)) {
-      System.err.println(
-          "Did not expect to findOrCreatePointsToSet for implicitly represented PointerKey");
-      System.err.println(key);
-      System.err.println(cg);
-      cg.forEach(n -> System.err.println(n.getIR()));
+      if (DEBUG) {
+        System.err.println(
+            "Did not expect to findOrCreatePointsToSet for implicitly represented PointerKey");
+        System.err.println(key);
+        System.err.println(cg);
+        cg.forEach(n -> System.err.println(n.getIR()));
+      }
       Assertions.UNREACHABLE();
     }
     PointsToSetVariable result = pointsToMap.getPointsToSet(key);

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationSystem.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationSystem.java
@@ -252,7 +252,8 @@ public class PropagationSystem extends DefaultFixedPointSolver<PointsToSetVariab
         System.err.println(cg);
         cg.forEach(n -> System.err.println(n.getIR()));
       }
-      Assertions.UNREACHABLE();
+      Assertions.UNREACHABLE(
+          "Did not expect to findOrCreatePointsToSet for implicitly represented PointerKey " + key);
     }
     PointsToSetVariable result = pointsToMap.getPointsToSet(key);
     if (result == null) {


### PR DESCRIPTION
## Summary

[`PropagationSystem.findOrCreatePointsToSet`](https://github.com/wala/WALA/blob/d40437a1db02d9c8fca10c8db0a5060b0a5a36d6/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationSystem.java#L247-L253) prints the entire call graph's IR to `System.err` when called on an implicitly-represented `PointerKey`, then calls [`Assertions.UNREACHABLE()`](https://github.com/wala/WALA/blob/d40437a1db02d9c8fca10c8db0a5060b0a5a36d6/util/src/main/java/com/ibm/wala/util/debug/Assertions.java#L45-L47). The dump runs unconditionally before the assertion. A downstream client (Ariadne) reaches this path during generator dispatch and [catches the resulting `UnimplementedError`](https://github.com/ponder-lab/ML/blob/51d93bb1eecbf79faf379daf65428279f7290637/com.ibm.wala.cast.python.ml/source/com/ibm/wala/cast/python/ml/client/TensorGeneratorFactory.java#L430-L433), so the analysis continues and re-triggers the path across many candidates—~900 times in a single test as its call graph grew under deeper context sensitivity—producing a ~32M-line CI log and roughly a 4.5x wall-time regression on the build step (tracked downstream at https://github.com/wala/ML/issues/573). The unconditional full-call-graph-IR dump is never appropriate, so gate it under the existing `DEBUG` flag: still available when debugging, silent by default.

## Note

A larger alternative would be to relax the `UNREACHABLE()` invariant so that reaching `findOrCreatePointsToSet` with an implicit key materializes the variable instead of throwing, but gating the dump is the minimal fix and keeps the invariant intact.
