### PR TITLE
Restructure list of Error Prone checks

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -60,23 +60,25 @@ tasks.withType<JavaCompile>().configureEach {
       // don't run warning-level checks by default as they add too much noise to build output
       disableAllWarnings = true
       // warning-level checks upgraded to error, since we've fixed all the warnings
-      error("UnnecessaryParentheses")
-      error("UnusedVariable")
-      error("JdkObsolete")
-      error("AnnotationPosition")
-      error("AssertEqualsArgumentOrderChecker")
-      error("ArgumentSelectionDefectChecker")
-      error("ArrayRecordComponent")
-      error("FallThrough")
-      error("IfChainToSwitch")
-      error("ProtectedMembersInFinalClass")
-      error("RefactorSwitch")
-      error("StringConcatToTextBlock")
-      error("StatementSwitchToExpressionSwitch")
-      error("TraditionalSwitchExpression")
-      error("UnnecessaryBreakInSwitch")
-      error("UnnecessaryDefaultInEnumSwitch")
-      error("UseEnumSwitch")
+      error(
+          "AnnotationPosition",
+          "ArgumentSelectionDefectChecker",
+          "ArrayRecordComponent",
+          "AssertEqualsArgumentOrderChecker",
+          "FallThrough",
+          "IfChainToSwitch",
+          "JdkObsolete",
+          "ProtectedMembersInFinalClass",
+          "RefactorSwitch",
+          "StatementSwitchToExpressionSwitch",
+          "StringConcatToTextBlock",
+          "TraditionalSwitchExpression",
+          "UnnecessaryBreakInSwitch",
+          "UnnecessaryDefaultInEnumSwitch",
+          "UnnecessaryParentheses",
+          "UnusedVariable",
+          "UseEnumSwitch",
+      )
       // checks we do not intend to try to fix in the near-term:
       disable("LabelledBreakTarget")
       // Just too many of these; proper Javadoc would be a great long-term goal


### PR DESCRIPTION
The order in which we list these checks is arbitrary.  Sorting them alphabetically makes it easier to scan for existing items or to find duplicates.  This ordering also reduces the risk of Git merge conflicts that would arise if always appending to the end.

Also, since Error Prone's `error` method is variadic, use one call for all of them just to reduce visual noise.

Note that this commit does not add or remove any checks.  It just restructures what was already here.