### PR TITLE
Stop using third-party XVFB GitHub Action

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -55,14 +55,16 @@ jobs:
       - name: Choose extra Linux-only Gradle tasks
         run: echo OS_SPECIFIC_GRADLE_TASKS='publishAllPublicationsToFakeRemoteRepository shellcheck' >> $GITHUB_ENV
         if: runner.os == 'Linux'
+      - name: Prepare to run under XVFB
+        run: echo XVFB_RUN=xvfb-run >> $GITHUB_ENV
+        if: runner.os == 'Linux'
       - name: Build and test using Gradle
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: >-
-            ./gradlew
-            --scan
-            --console=colored "-Pcom.ibm.wala.jdk-version=${{ matrix.java }}"
-            aggregatedJavadocs javadoc build ${{ env.OS_SPECIFIC_GRADLE_TASKS }} checkGitCleanliness
+        run: >-
+          ${{ env.XVFB_RUN }}
+          ./gradlew
+          --scan
+          --console=colored "-Pcom.ibm.wala.jdk-version=${{ matrix.java }}"
+          aggregatedJavadocs javadoc build ${{ env.OS_SPECIFIC_GRADLE_TASKS }} checkGitCleanliness
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
I am aware of two third-party GitHub Actions helpers for running job steps under XVFB:

* [setup-xvfb](https://github.com/coactions/setup-xvfb). Not updated since 2024.  Apparently uses Node 16.

* [xvfb-action](https://github.com/GabrielBB/xvfb-action). Not updated since 2024.  Uses Node 20.

Neither of the above are satisfactory.  GitHub now warns about actions that don't use at least Node 24, and will stop supporting them entirely starting June 16, 2026.

Fortunately, it's pretty easy to handle the "run under XVFB if Linux" logic ourselves.