### PR TITLE
Correct many invalid format strings

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -61,6 +61,7 @@ tasks.withType<JavaCompile>().configureEach {
       disableAllWarnings = true
       // warning-level checks upgraded to error, since we've fixed all the warnings
       error(
+          "AnnotateFormatMethod",
           "AnnotationPosition",
           "ArgumentSelectionDefectChecker",
           "AssertEqualsArgumentOrderChecker",

--- a/core/src/main/java/com/ibm/wala/core/util/ssa/ParameterAccessor.java
+++ b/core/src/main/java/com/ibm/wala/core/util/ssa/ParameterAccessor.java
@@ -42,6 +42,7 @@
 */
 package com.ibm.wala.core.util.ssa;
 
+import com.google.errorprone.annotations.FormatMethod;
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IClassLoader;
 import com.ibm.wala.classLoader.IMethod;
@@ -367,7 +368,7 @@ public class ParameterAccessor {
     final boolean hasImplicitThis;
     Set<IMethod> targets = cha.getPossibleTargets(mRef);
     if (targets.isEmpty()) {
-      warn("Unable to look up the method {} starting extensive search...", mRef);
+      warn("Unable to look up the method %s starting extensive search...", mRef);
 
       targets = new HashSet<>();
       final TypeReference mClass = mRef.getDeclaringClass();
@@ -391,7 +392,7 @@ public class ParameterAccessor {
         testClasses.add(lookedUp);
       }
 
-      info("Searching the classes {} for the method", testClasses);
+      info("Searching the classes %s for the method", testClasses);
 
       for (IClass testClass : testClasses) {
         final IMethod cand = testClass.getMethod(mSel);
@@ -408,10 +409,10 @@ public class ParameterAccessor {
 
         { // DEBUG
           for (IClass testClass : testClasses) {
-            info("Known Methods in " + testClass);
+            info("Known Methods in %s", testClass);
             for (IMethod contained : testClass.getAllMethods()) {
               System.out.println(contained);
-              info("\t" + contained);
+              info("\t%s", contained);
             }
           }
         } // */
@@ -438,11 +439,11 @@ public class ParameterAccessor {
     }
 
     if (hasImplicitThis) {
-      info("The method {} has an implicit this pointer", mRef);
+      info("The method %s has an implicit this pointer", mRef);
       this.implicitThis = 1;
       this.descriptorOffset = -1;
     } else {
-      info("The method {} has no implicit this pointer", mRef);
+      info("The method %s has no implicit this pointer", mRef);
       this.implicitThis = -1;
       this.descriptorOffset = 0;
     }
@@ -469,11 +470,11 @@ public class ParameterAccessor {
     this.numberOfParameters = mRef.getNumberOfParameters();
 
     if (hasImplicitThis) {
-      info("The method {} has an implicit this pointer", mRef);
+      info("The method %s has an implicit this pointer", mRef);
       this.implicitThis = 1;
       this.descriptorOffset = -1;
     } else {
-      info("The method {} has no implicit this pointer", mRef);
+      info("The method %s has no implicit this pointer", mRef);
       this.implicitThis = -1;
       this.descriptorOffset = 0;
     }
@@ -616,7 +617,7 @@ public class ParameterAccessor {
           // final int firstInSelector = firstInSelector();
           for (int i = (hasImplicitThis() ? 1 : 0); i < this.method.getNumberOfParameters(); ++i) {
             debug(
-                "all() adding: Parameter({}, {}, {}, {}, {})",
+                "all() adding: Parameter(%s, %s, %s, %s, %s)",
                 (i + 1),
                 this.method.getParameterType(i),
                 this.base,
@@ -830,14 +831,12 @@ public class ParameterAccessor {
       case IMETHOD -> {
         if (this.hasImplicitThis()) { // XXX TODO BUG!
           debug(
-              "This IMethod {} has an implicit this pointer at {}, so firstInSelector is accessible using SSA-Value {}",
-              this.method,
-              this.implicitThis,
-              (this.implicitThis + 1));
+              "This IMethod %s has an implicit this pointer at %s, so firstInSelector is accessible using SSA-Value %s",
+              this.method, this.implicitThis, (this.implicitThis + 1));
           return this.implicitThis + 1;
         } else {
           debug(
-              "This IMethod {} has no implicit this pointer, so firstInSelector is accessible using SSA-Value 1",
+              "This IMethod %s has no implicit this pointer, so firstInSelector is accessible using SSA-Value 1",
               this.method);
           return 1;
         }
@@ -845,14 +844,12 @@ public class ParameterAccessor {
       case METHOD_REFERENCE -> {
         if (this.hasImplicitThis()) {
           debug(
-              "This IMethod {} has an implicit this pointer at {}, so firstInSelector is accessible using SSA-Value {}",
-              this.mRef,
-              this.implicitThis,
-              (this.implicitThis + 1));
+              "This IMethod %s has an implicit this pointer at %s, so firstInSelector is accessible using SSA-Value %s",
+              this.mRef, this.implicitThis, (this.implicitThis + 1));
           return this.implicitThis + 1;
         } else {
           debug(
-              "This mRef {} has no implicit this pointer, so firstInSelector is accessible using SSA-Value 1",
+              "This mRef %s has no implicit this pointer, so firstInSelector is accessible using SSA-Value 1",
               this.mRef);
           return 1;
         }
@@ -978,7 +975,7 @@ public class ParameterAccessor {
     if (searchType == null) {
       throw new IllegalStateException("Could not find " + tName + " in any loader!");
     } else {
-      debug("Retrieved {} as {}", tName, searchType);
+      debug("Retrieved %s as %s", tName, searchType);
     }
 
     for (final Parameter cand : all) {
@@ -992,7 +989,7 @@ public class ParameterAccessor {
         for (final IClassLoader loader : cha.getLoaders()) {
           final IClass c = loader.lookupClass(cand.getType().getName());
           if (c != null) {
-            info("Using alternative for from: {}", cand);
+            info("Using alternative for from: %s", cand);
             if (cha.isSubclassOf(c, searchType)) {
               allExtends.add(cand);
             }
@@ -1000,7 +997,7 @@ public class ParameterAccessor {
         }
 
         // TODO: That's true for base-type too
-        warn("Unable to look up IClass of {}", cand);
+        warn("Unable to look up IClass of %s", cand);
       }
     }
 
@@ -1034,7 +1031,7 @@ public class ParameterAccessor {
     if (searchType == null) {
       throw new IllegalStateException("Could not find the IClass of " + tRef);
     } else {
-      debug("Retrieved {} as {}", tRef, searchType);
+      debug("Retrieved %s as %s", tRef, searchType);
     }
 
     for (final Parameter cand : all) {
@@ -1046,7 +1043,7 @@ public class ParameterAccessor {
         }
       } else {
         // TODO: That's true for base-type too
-        warn("Unable to look up IClass of {}", cand);
+        warn("Unable to look up IClass of %s", cand);
       }
     }
 
@@ -1093,7 +1090,7 @@ public class ParameterAccessor {
     if (searchType == null) {
       throw new IllegalStateException("Could not find " + tName + " in any loader!");
     } else {
-      debug("Retrieved {} as {}", tName, searchType);
+      debug("Retrieved %s as %s", tName, searchType);
     }
 
     for (final Parameter cand : all) {
@@ -1107,7 +1104,7 @@ public class ParameterAccessor {
         for (final IClassLoader loader : cha.getLoaders()) {
           final IClass c = loader.lookupClass(cand.getType().getName());
           if (c != null) {
-            info("Using alternative for from: {}", cand);
+            info("Using alternative for from: %s", cand);
             if (cha.isSubclassOf(c, searchType)) {
               return cand;
             }
@@ -1115,7 +1112,7 @@ public class ParameterAccessor {
         }
 
         // TODO: That's true for primitive-type too
-        warn("Unable to look up IClass of {}", cand);
+        warn("Unable to look up IClass of %s", cand);
       }
     }
 
@@ -1149,7 +1146,7 @@ public class ParameterAccessor {
     if (searchType == null) {
       throw new IllegalStateException("Could not find the IClass of " + tRef);
     } else {
-      debug("Retrieved {} as {}", tRef, searchType);
+      debug("Retrieved %s as %s", tRef, searchType);
     }
 
     for (final Parameter cand : all) {
@@ -1161,7 +1158,7 @@ public class ParameterAccessor {
         }
       } else {
         // TODO: That's true for base-type too
-        warn("Unable to look up IClass of {}", cand);
+        warn("Unable to look up IClass of %s", cand);
       }
     }
 
@@ -1194,7 +1191,7 @@ public class ParameterAccessor {
 
     if ((args.get(1) instanceof Parameter)
         && (((Parameter) args.get(1)).getDisposition() == ParameterDisposition.THIS)) {
-      warn("The first argument is an implicit this: {} this may be ok however.", args.get(1));
+      warn("The first argument is an implicit this: %s this may be ok however.", args.get(1));
     }
 
     // ****
@@ -1252,7 +1249,7 @@ public class ParameterAccessor {
 
     if ((args.get(1) instanceof Parameter)
         && (((Parameter) args.get(1)).getDisposition() == ParameterDisposition.THIS)) {
-      warn("The first argument is an implicit this: {} this may be ok however.", args.get(1));
+      warn("The first argument is an implicit this: %s this may be ok however.", args.get(1));
     }
 
     // ****
@@ -1322,7 +1319,7 @@ public class ParameterAccessor {
     if ((params.length > 1)
         && (args.get(1) instanceof Parameter)
         && (((Parameter) args.get(1)).getDisposition() == ParameterDisposition.THIS)) {
-      warn("The first argument is an implicit this: {} this may be ok however.", args.get(1));
+      warn("The first argument is an implicit this: %s this may be ok however.", args.get(1));
     }
 
     // ****
@@ -1389,7 +1386,7 @@ public class ParameterAccessor {
     if ((params.length > 1)
         && (args.get(1) instanceof Parameter)
         && (((Parameter) args.get(1)).getDisposition() == ParameterDisposition.THIS)) {
-      warn("The first argument is an implicit this: {} this may be ok however.", args.get(1));
+      warn("The first argument is an implicit this: %s this may be ok however.", args.get(1));
     }
 
     // ****
@@ -1487,22 +1484,22 @@ public class ParameterAccessor {
     // ****
     // Implementation starts here
     debug(
-        "Collecting parameters for callee {}",
+        "Collecting parameters for callee %s",
         ((callee.mRef != null) ? callee.mRef : callee.method));
-    debug("\tThe calling function is {}", ((this.mRef != null) ? this.mRef : this.method));
+    debug("\tThe calling function is %s", ((this.mRef != null) ? this.mRef : this.method));
     forEachParameter:
     for (final Parameter param : calleeParams) {
-      debug("\tSearching candidate for {}", param);
+      debug("\tSearching candidate for %s", param);
       final TypeReference paramType = param.getType();
 
       { // Exact match in overrides
         for (final SSAValue cand : overrides) {
           if (cand.getType().getName().equals(paramType.getName())) { // XXX: What about the loader?
             assigned.add(cand);
-            debug("\t\tAssigning: {} from the overrides (eq)", cand);
+            debug("\t\tAssigning: %s from the overrides (eq)", cand);
             continue forEachParameter;
           } else {
-            debug("\t\tSkipping: {} of the overrides (eq)", cand);
+            debug("\t\tSkipping: %s of the overrides (eq)", cand);
           }
         }
       }
@@ -1511,10 +1508,10 @@ public class ParameterAccessor {
         for (final Parameter cand : thisParams) {
           if (cand.getType().getName().equals(paramType.getName())) {
             assigned.add(cand);
-            debug("\t\tAssigning: {} from callers params (eq)", cand);
+            debug("\t\tAssigning: %s from callers params (eq)", cand);
             continue forEachParameter;
           } else {
-            debug("\t\tSkipping: {} of the callers params (eq)", cand);
+            debug("\t\tSkipping: %s of the callers params (eq)", cand);
           }
         }
       }
@@ -1523,7 +1520,7 @@ public class ParameterAccessor {
         for (final SSAValue cand : defaults) {
           if (cand.getType().getName().equals(paramType.getName())) {
             assigned.add(cand);
-            debug("\t\tAssigning: {} from the defaults (eq)", cand);
+            debug("\t\tAssigning: %s from the defaults (eq)", cand);
             continue forEachParameter;
           }
         }
@@ -1538,7 +1535,7 @@ public class ParameterAccessor {
             for (final SSAValue cand : overrides) {
               if (isAssignable(cand, param, cha)) {
                 assigned.add(cand);
-                debug("\t\tAssigning: {} from the overrides (ass)", cand);
+                debug("\t\tAssigning: %s from the overrides (ass)", cand);
                 continue forEachParameter;
               }
             }
@@ -1551,7 +1548,7 @@ public class ParameterAccessor {
             try {
               if (isAssignable(cand, param, cha)) {
                 assigned.add(cand);
-                debug("\t\tAssigning: {} from the caller's params (ass)", cand);
+                debug("\t\tAssigning: %s from the caller's params (ass)", cand);
                 continue forEachParameter;
               }
             } catch (ClassLookupException e) {
@@ -1563,14 +1560,14 @@ public class ParameterAccessor {
           for (final SSAValue cand : defaults) {
             if (isAssignable(cand, param, cha)) {
               assigned.add(cand);
-              debug("\t\tAssigning: {} from the defaults (ass)", cand);
+              debug("\t\tAssigning: %s from the defaults (ass)", cand);
               continue forEachParameter;
             }
           }
         }
 
         if (instantiator != null) {
-          info("Creating new instance of: {} in call to {}", param, callee);
+          info("Creating new instance of: %s in call to %s", param, callee);
           /*{ // DEBUG
               System.out.println("Creating new instance of: " + param);
               System.out.println("in connectThrough");
@@ -1582,7 +1579,7 @@ public class ParameterAccessor {
           final int inst = instantiator.createInstance(param.getType(), instantiatorArgs);
           if (inst < 0) {
             warn(
-                "No type was assignable and the instantiator returned an invalid one! Using null for {}",
+                "No type was assignable and the instantiator returned an invalid one! Using null for %s",
                 param);
             assigned.add(null);
           } else {
@@ -1673,13 +1670,12 @@ public class ParameterAccessor {
 
     if (fromClass == null) {
       debug(
-          "Unable to look up the type of from="
-              + from
-              + " in the ClassHierarchy - tying other loaders...");
+          "Unable to look up the type of from=%s in the ClassHierarchy - tying other loaders...",
+          from);
       for (final IClassLoader loader : cha.getLoaders()) {
         final IClass cand = loader.lookupClass(from.getName());
         if (cand != null) {
-          debug("Using alternative for from: {}", cand);
+          debug("Using alternative for from: %s", cand);
           fromClass = cand;
           break;
         }
@@ -1694,20 +1690,18 @@ public class ParameterAccessor {
 
     if (toClass == null) {
       debug(
-          "Unable to look up the type of to="
-              + to
-              + " in the ClassHierarchy - tying other loaders...");
+          "Unable to look up the type of to=%s in the ClassHierarchy - tying other loaders...", to);
       for (final IClassLoader loader : cha.getLoaders()) {
         final IClass cand = loader.lookupClass(to.getName());
         if (cand != null) {
-          debug("Using alternative for to: {}", cand);
+          debug("Using alternative for to: %s", cand);
           toClass = cand;
           break;
         }
       }
 
       if (toClass == null) {
-        error("Unable to look up the type of to={} in the ClassHierarchy", to);
+        error("Unable to look up the type of to=%s in the ClassHierarchy", to);
         return false;
         // throw new ClassLookupException("Unable to look up the type of to=" + to +
         //        " in the ClassHierarchy");
@@ -1718,10 +1712,8 @@ public class ParameterAccessor {
     //  Does an expression c1 x := c2 y typecheck?
 
     trace(
-        "isAssignableFrom({}, {}) = {}",
-        toClass,
-        fromClass,
-        cha.isAssignableFrom(toClass, fromClass));
+        "isAssignableFrom(%s, %s) = %s",
+        toClass, fromClass, cha.isAssignableFrom(toClass, fromClass));
     return cha.isAssignableFrom(toClass, fromClass);
   }
 
@@ -1744,13 +1736,12 @@ public class ParameterAccessor {
 
     if (subClass == null) {
       debug(
-          "Unable to look up the type of from="
-              + sub
-              + " in the ClassHierarchy - tying other loaders...");
+          "Unable to look up the type of from=%s in the ClassHierarchy - tying other loaders...",
+          sub);
       for (final IClassLoader loader : cha.getLoaders()) {
         final IClass cand = loader.lookupClass(sub.getName());
         if (cand != null) {
-          debug("Using alternative for from: {}", cand);
+          debug("Using alternative for from: %s", cand);
           subClass = cand;
           break;
         }
@@ -1764,20 +1755,19 @@ public class ParameterAccessor {
 
     if (superClass == null) {
       debug(
-          "Unable to look up the type of to="
-              + superC
-              + " in the ClassHierarchy - tying other loaders...");
+          "Unable to look up the type of to=%s in the ClassHierarchy - tying other loaders...",
+          superC);
       for (final IClassLoader loader : cha.getLoaders()) {
         final IClass cand = loader.lookupClass(superC.getName());
         if (cand != null) {
-          debug("Using alternative for to: {}", cand);
+          debug("Using alternative for to: %s", cand);
           superClass = cand;
           break;
         }
       }
 
       if (superClass == null) {
-        error("Unable to look up the type of to={} in the ClassHierarchy", superC);
+        error("Unable to look up the type of to=%s in the ClassHierarchy", superC);
         throw new ClassLookupException(
             "Unable to look up the type of to=" + superC + " in the ClassHierarchy");
       }
@@ -1910,30 +1900,35 @@ public class ParameterAccessor {
     return "<ParamAccessor forMethod=" + this.forMethod() + " />";
   }
 
+  @FormatMethod
   private static void debug(String s, Object... args) {
     if (DEBUG) {
       System.err.printf(s, args);
     }
   }
 
+  @FormatMethod
   private static void info(String s, Object... args) {
     if (DEBUG) {
       System.err.printf(s, args);
     }
   }
 
+  @FormatMethod
   private static void warn(String s, Object... args) {
     if (DEBUG) {
       System.err.printf(s, args);
     }
   }
 
+  @FormatMethod
   private static void trace(String s, Object... args) {
     if (DEBUG) {
       System.err.printf(s, args);
     }
   }
 
+  @FormatMethod
   private static void error(String s, Object... args) {
     if (DEBUG) {
       System.err.printf(s, args);

--- a/core/src/main/java/com/ibm/wala/core/util/ssa/SSAValueManager.java
+++ b/core/src/main/java/com/ibm/wala/core/util/ssa/SSAValueManager.java
@@ -42,6 +42,7 @@
 */
 package com.ibm.wala.core.util.ssa;
 
+import com.google.errorprone.annotations.FormatMethod;
 import com.ibm.wala.core.util.ssa.SSAValue.NamedKey;
 import com.ibm.wala.core.util.ssa.SSAValue.VariableKey;
 import com.ibm.wala.core.util.strings.Atom;
@@ -185,7 +186,7 @@ public class SSAValueManager {
                   nextLocal = param.value.getNumber() + 1;
                 }
 
-                debug("reSetting SSA {} to allocated", value);
+                debug("reSetting SSA %s to allocated", value);
                 param.status = ValueStatus.ALLOCATED;
                 param.setInScope = currentScope;
                 param.setBy = setBy;
@@ -202,7 +203,7 @@ public class SSAValueManager {
             throw new IllegalStateException(
                 "The parameter " + value + " using Key " + key + " has already been allocated");
           } else {
-            info("New variable in management: {}", value);
+            info("New variable in management: %s", value);
             final Managed<SSAValue> param = new Managed<>(value, key);
             param.status = ValueStatus.ALLOCATED;
             param.setInScope = currentScope;
@@ -256,15 +257,15 @@ public class SSAValueManager {
           param.setInScope = currentScope;
           param.setBy = setBy;
 
-          info("Setting SSA {} to phi! now {}", value, param.status);
+          info("Setting SSA %s to phi! now %s", value, param.status);
           didPhi = true;
         } else if (param.setInScope == currentScope) {
           if (param.status == ValueStatus.INVALIDATED) {
-            info("Closing SSA Value {} in scope {}", param.value, param.setInScope);
+            info("Closing SSA Value %s in scope %s", param.value, param.setInScope);
             param.status = ValueStatus.CLOSED;
           }
           // TODO: FREE CLOSED
-          // info("Closing free SSA Value {} in scope {}", param.value, param.setInScope);
+          // info("Closing free SSA Value %s in scope %s", param.value, param.setInScope);
           // param.status = ValueStatus.FREE_CLOSED;
         }
         //        else if (param.setInScope < currentScope) {
@@ -308,7 +309,7 @@ public class SSAValueManager {
 
     seenTypes.computeIfAbsent(key, absent -> new ArrayList<>()).add(param);
 
-    debug("Returning as Free SSA: {}", param);
+    debug("Returning as Free SSA: %s", param);
     return var;
   }
 
@@ -354,7 +355,7 @@ public class SSAValueManager {
       seenTypes.put(key, aParam);
     }
 
-    debug("Returning as Unallocated SSA: {}", param);
+    debug("Returning as Unallocated SSA: %s", param);
     return var;
   }
 
@@ -397,9 +398,9 @@ public class SSAValueManager {
         if ((param.status == ValueStatus.FREE) || (param.status == ValueStatus.ALLOCATED)) {
           // assert (param.value.getType().equals(type)) : "Unequal types";
           if (param.setInScope > currentScope) {
-            debug("SSA Value {} is out of scope {}", param, currentScope);
+            debug("SSA Value %s is out of scope %s", param, currentScope);
           } else if (param.setInScope == currentScope) {
-            debug("Returning SSA Value {} is {}", param.value, param.status);
+            debug("Returning SSA Value %s is %s", param.value, param.status);
             return param.value;
           } else {
             if ((candidate == null) || (param.setInScope > candidate.setInScope)) {
@@ -407,7 +408,7 @@ public class SSAValueManager {
             }
           }
         } else {
-          debug("SSA Value {} is {}", param, param.status);
+          debug("SSA Value %s is %s", param, param.status);
         }
       }
     } else {
@@ -416,7 +417,7 @@ public class SSAValueManager {
     }
 
     if (candidate != null) {
-      debug("Returning inherited (from {}) SSA Value {}", candidate.setInScope, candidate);
+      debug("Returning inherited (from %s) SSA Value %s", candidate.setInScope, candidate);
       return candidate.value;
     } else {
       throw new IllegalStateException("No suitable candidate has been found for Key " + key);
@@ -602,7 +603,7 @@ public class SSAValueManager {
           } else {
             param.status = ValueStatus.INVALIDATED;
           }
-          info("Invalidated SSA {} for key {}", param, key);
+          info("Invalidated SSA %s for key %s", param, key);
         }
       }
     }
@@ -733,12 +734,14 @@ public class SSAValueManager {
     return names;
   }
 
+  @FormatMethod
   private static void debug(String s, Object... args) {
     if (DEBUG) {
       System.err.printf(s, args);
     }
   }
 
+  @FormatMethod
   private static void info(String s, Object... args) {
     if (DEBUG) {
       System.err.printf(s, args);

--- a/core/src/main/java/com/ibm/wala/core/util/ssa/TypeSafeInstructionFactory.java
+++ b/core/src/main/java/com/ibm/wala/core/util/ssa/TypeSafeInstructionFactory.java
@@ -42,6 +42,7 @@
 */
 package com.ibm.wala.core.util.ssa;
 
+import com.google.errorprone.annotations.FormatMethod;
 import com.ibm.wala.classLoader.CallSiteReference;
 import com.ibm.wala.classLoader.JavaLanguage.JavaInstructionFactory;
 import com.ibm.wala.classLoader.NewSiteReference;
@@ -115,7 +116,7 @@ public class TypeSafeInstructionFactory {
       List<? extends SSAValue> params,
       final SSAValue exception,
       final CallSiteReference site) {
-    info("Now: InvokeInstruction to {} using {}", site, params);
+    info("Now: InvokeInstruction to %s using %s", site, params);
     if (iindex < 0) {
       throw new IllegalArgumentException("The iIndex may not be negative");
     }
@@ -265,7 +266,7 @@ public class TypeSafeInstructionFactory {
       List<? extends SSAValue> params,
       final SSAValue exception,
       final CallSiteReference site) {
-    info("Now: InvokeInstruction to {} using {}", site, params);
+    info("Now: InvokeInstruction to %s using %s", site, params);
     if (iindex < 0) {
       throw new IllegalArgumentException("The iIndex may not be negative");
     }
@@ -394,7 +395,7 @@ public class TypeSafeInstructionFactory {
    * @throws IllegalArgumentException if result has no validIn set
    */
   public SSAReturnInstruction ReturnInstruction(final int iindex, final SSAValue result) {
-    info("Now: ReturnInstruction using {}", result);
+    info("Now: ReturnInstruction using %s", result);
 
     if (iindex < 0) {
       throw new IllegalArgumentException("iIndex may not be negative");
@@ -428,7 +429,7 @@ public class TypeSafeInstructionFactory {
       final SSAValue targetValue,
       final SSAValue containingInstance,
       FieldReference field) {
-    info("Now: Get {} from {} into {}", field, containingInstance, targetValue);
+    info("Now: Get %s from %s into %s", field, containingInstance, targetValue);
 
     if (iindex < 0) {
       throw new IllegalArgumentException("iIndex may not be negative");
@@ -488,7 +489,7 @@ public class TypeSafeInstructionFactory {
    */
   public SSAGetInstruction GetInstruction(
       final int iindex, final SSAValue targetValue, FieldReference field) {
-    info("Now: Get {} into {}", field, targetValue);
+    info("Now: Get %s into %s", field, targetValue);
 
     if (iindex < 0) {
       throw new IllegalArgumentException("iIndex may not be negative");
@@ -526,7 +527,7 @@ public class TypeSafeInstructionFactory {
       final SSAValue targetInstance,
       final SSAValue newValue,
       FieldReference field) {
-    info("Now: Put {} to {}", newValue, field);
+    info("Now: Put %s to %s", newValue, field);
 
     if (iindex < 0) {
       throw new IllegalArgumentException("iIndex may not be negative");
@@ -584,7 +585,7 @@ public class TypeSafeInstructionFactory {
    */
   public SSAPutInstruction PutInstruction(
       final int iindex, final SSAValue newValue, FieldReference field) {
-    info("Now: Put {} to {}", newValue, field);
+    info("Now: Put %s to %s", newValue, field);
 
     if (iindex < 0) {
       throw new IllegalArgumentException("iIndex may not be negative");
@@ -606,7 +607,7 @@ public class TypeSafeInstructionFactory {
   }
 
   public SSANewInstruction NewInstruction(int iindex, SSAValue result, NewSiteReference site) {
-    info("Now: New {}", result);
+    info("Now: New %s", result);
 
     if (iindex < 0) {
       throw new IllegalArgumentException("iIndex may not be negative");
@@ -626,7 +627,7 @@ public class TypeSafeInstructionFactory {
 
   public SSANewInstruction NewInstruction(
       int iindex, SSAValue result, NewSiteReference site, Collection<? extends SSAValue> params) {
-    info("Now: New {}", result);
+    info("Now: New %s", result);
 
     if (iindex < 0) {
       throw new IllegalArgumentException("iIndex may not be negative");
@@ -676,7 +677,7 @@ public class TypeSafeInstructionFactory {
    */
   public SSAPhiInstruction PhiInstruction(
       int iindex, SSAValue result, Collection<? extends SSAValue> params) {
-    info("Now: Phi into {} from {}", result, params);
+    info("Now: Phi into %s from %s", result, params);
 
     if (iindex < 0) {
       throw new IllegalArgumentException("iIndex may not be negative");
@@ -866,6 +867,7 @@ public class TypeSafeInstructionFactory {
         iindex, array.getNumber(), index, value.getNumber(), innerType);
   }
 
+  @FormatMethod
   private static void info(String s, Object... args) {
     if (DEBUG) {
       System.err.printf(s, args);


### PR DESCRIPTION
Several existing logging methods expect their first argument to be a `"%s"`-style format string.  However, these methods were nearly always being called with `"{}"`-style format strings.  The latter are hereby corrected.  We're also enabling an Error Prone check to catch future mistakes like these.

These logging methods were being called incorrectly more often than correctly.  Therefore, the total amount of code change would have been smaller if we changed the logging methods to use the `"{}"`-style format strings that most callers assumed.  However, we don't have a good way to statically annotate `"{}"`-style formatters.  We do have a way to annotate and statically check `"%s"`-style formatters, so let's standardize on the latter.