### PR TITLE
Refine some calls to string formatters

### DIFF
--- a/.idea/inspectionProfiles/No_Back_Sliding.xml
+++ b/.idea/inspectionProfiles/No_Back_Sliding.xml
@@ -645,9 +645,11 @@
       <scope name="Java Sources as Test Subjects" level="WARNING" enabled="false" />
     </inspection_tool>
     <inspection_tool class="StringBufferToStringInConcatenation" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="StringConcatenationInFormatCall" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="StringConcatenationInLoops" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Java Sources as Test Subjects" level="WARNING" enabled="false" />
     </inspection_tool>
+    <inspection_tool class="StringConcatenationInMessageFormatCall" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="StringEquality" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="StringOperationCanBeSimplified" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Java Sources as Test Subjects" level="WARNING" enabled="false" />

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -67,6 +67,7 @@ tasks.withType<JavaCompile>().configureEach {
           "AssertEqualsArgumentOrderChecker",
           "BadInstanceof",
           "FallThrough",
+          "FormatStringShouldUsePlaceholders",
           "FunctionalInterfaceClash",
           "IfChainToSwitch",
           "InstanceOfAndCastMatchWrongType",

--- a/shrike/src/main/java/com/ibm/wala/shrike/cg/Runtime.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/cg/Runtime.java
@@ -179,7 +179,7 @@ public class Runtime {
     if (runtime.currentSite.get() != null) {
       synchronized (runtime) {
         if (runtime.output != null) {
-          runtime.output.printf("return from " + runtime.currentSite.get() + '\n');
+          runtime.output.printf("return from %s%n", runtime.currentSite.get());
           runtime.output.flush();
         }
       }
@@ -202,7 +202,7 @@ public class Runtime {
     //	  runtime.currentSite = klass + "\t" + method + "\t" + receiver;
     synchronized (runtime) {
       if (runtime.output != null) {
-        runtime.output.printf("call to " + runtime.currentSite.get() + '\n');
+        runtime.output.printf("call to %s%n", runtime.currentSite.get());
         runtime.output.flush();
       }
     }

--- a/shrike/src/main/java/com/ibm/wala/shrike/sourcepos/Debug.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/sourcepos/Debug.java
@@ -173,7 +173,7 @@ public final class Debug {
 
   private static void log(LogLevel level, String str, Object... obj) {
     if (OUT_STREAM != null && allowed.contains(level)) {
-      OUT_STREAM.format("[" + level + "] " + str, obj);
+      OUT_STREAM.format("[%s] %s".formatted(level, str), obj);
     }
   }
 


### PR DESCRIPTION
Passing a string concatenation in a call to a string-formatting method is silly.  If we're going to invoke a formatting engine, then we may as well have it handle the concatenation too.