### PR TITLE
Use `forEachRemaining` instead of explicit loops

### DIFF
--- a/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/AstSSAPropagationCallGraphBuilder.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/AstSSAPropagationCallGraphBuilder.java
@@ -683,10 +683,7 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
           for (InstanceKey functionKey : functionKeys) {
             system.findOrCreateIndexForInstanceKey(functionKey);
             ScopeMappingInstanceKey K = (ScopeMappingInstanceKey) functionKey;
-            Iterator<CGNode> x = K.getFunargNodes(definer);
-            while (x.hasNext()) {
-              result.add(x.next());
-            }
+            K.getFunargNodes(definer).forEachRemaining(result::add);
           }
         } else {
           PointsToSetVariable FV = system.findOrCreatePointsToSet(F);
@@ -696,10 +693,7 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
                     ptr -> {
                       InstanceKey iKey = system.getInstanceKey(ptr);
                       if (iKey instanceof ScopeMappingInstanceKey K) {
-                        Iterator<CGNode> x = K.getFunargNodes(definer);
-                        while (x.hasNext()) {
-                          result.add(x.next());
-                        }
+                        K.getFunargNodes(definer).forEachRemaining(result::add);
                       } else {
                         // Assertions.UNREACHABLE("unexpected instance key " + iKey);
                       }

--- a/core/src/main/java/com/ibm/wala/analysis/exceptionanalysis/IntraproceduralExceptionAnalysis.java
+++ b/core/src/main/java/com/ibm/wala/analysis/exceptionanalysis/IntraproceduralExceptionAnalysis.java
@@ -115,10 +115,7 @@ public class IntraproceduralExceptionAnalysis {
         }
 
         if (block.isCatchBlock()) {
-          Iterator<TypeReference> it = block.getCaughtExceptionTypes();
-          while (it.hasNext()) {
-            possiblyCaughtExceptions.add(it.next());
-          }
+          block.getCaughtExceptionTypes().forEachRemaining(possiblyCaughtExceptions::add);
         }
       }
     }
@@ -242,10 +239,7 @@ public class IntraproceduralExceptionAnalysis {
         ir.getControlFlowGraph().getExceptionalSuccessors(block);
     for (ISSABasicBlock succ : exceptionalSuccessors) {
       if (succ.isCatchBlock()) {
-        Iterator<TypeReference> it = succ.getCaughtExceptionTypes();
-        while (it.hasNext()) {
-          result.add(it.next());
-        }
+        succ.getCaughtExceptionTypes().forEachRemaining(result::add);
       }
     }
 

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/Util.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/Util.java
@@ -334,9 +334,7 @@ public class Util {
       throw new IllegalArgumentException("Null x");
     }
     Set<T> y = HashSetFactory.make();
-    while (x.hasNext()) {
-      y.add(x.next());
-    }
+    x.forEachRemaining(y::add);
     return y;
   }
 

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/pruned/CallGraphPruning.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/pruned/CallGraphPruning.java
@@ -118,10 +118,7 @@ public final class CallGraphPruning {
     while (i > 0) {
 
       for (CGNode n : A) {
-        Iterator<CGNode> it = cg.getSuccNodes(n);
-        while (it.hasNext()) {
-          B.add(it.next());
-        }
+        cg.getSuccNodes(n).forEachRemaining(B::add);
       }
 
       if (DEBUG) {

--- a/core/src/test/java/com/ibm/wala/core/tests/callGraph/ReflectionTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/callGraph/ReflectionTest.java
@@ -151,10 +151,7 @@ public class ReflectionTest extends WalaTestCase {
     Set<CGNode> newInstanceNodes = cg.getNodes(mr);
     Set<CGNode> succNodes = HashSetFactory.make();
     for (CGNode newInstanceNode : newInstanceNodes) {
-      Iterator<? extends CGNode> succNodesIter = cg.getSuccNodes(newInstanceNode);
-      while (succNodesIter.hasNext()) {
-        succNodes.add(succNodesIter.next());
-      }
+      cg.getSuccNodes(newInstanceNode).forEachRemaining(succNodes::add);
     }
     TypeReference extraneousTR =
         TypeReference.findOrCreate(ClassLoaderReference.Application, "Lreflection/Reflect3$Hash");
@@ -186,10 +183,7 @@ public class ReflectionTest extends WalaTestCase {
     Set<CGNode> newInstanceNodes = cg.getNodes(mr);
     Set<CGNode> succNodes = HashSetFactory.make();
     for (CGNode newInstanceNode : newInstanceNodes) {
-      Iterator<? extends CGNode> succNodesIter = cg.getSuccNodes(newInstanceNode);
-      while (succNodesIter.hasNext()) {
-        succNodes.add(succNodesIter.next());
-      }
+      cg.getSuccNodes(newInstanceNode).forEachRemaining(succNodes::add);
     }
     TypeReference extraneousTR =
         TypeReference.findOrCreate(ClassLoaderReference.Application, "Ljava/io/FilePermission");
@@ -220,10 +214,7 @@ public class ReflectionTest extends WalaTestCase {
     Set<CGNode> newInstanceNodes = cg.getNodes(mr);
     Set<CGNode> succNodes = HashSetFactory.make();
     for (CGNode newInstanceNode : newInstanceNodes) {
-      Iterator<? extends CGNode> succNodesIter = cg.getSuccNodes(newInstanceNode);
-      while (succNodesIter.hasNext()) {
-        succNodes.add(succNodesIter.next());
-      }
+      cg.getSuccNodes(newInstanceNode).forEachRemaining(succNodes::add);
     }
     TypeReference extraneousTR =
         TypeReference.findOrCreate(ClassLoaderReference.Application, "Lreflection/Reflect5$A");
@@ -252,10 +243,7 @@ public class ReflectionTest extends WalaTestCase {
     Set<CGNode> newInstanceNodes = cg.getNodes(mr);
     Set<CGNode> succNodes = HashSetFactory.make();
     for (CGNode newInstanceNode : newInstanceNodes) {
-      Iterator<? extends CGNode> succNodesIter = cg.getSuccNodes(newInstanceNode);
-      while (succNodesIter.hasNext()) {
-        succNodes.add(succNodesIter.next());
-      }
+      cg.getSuccNodes(newInstanceNode).forEachRemaining(succNodes::add);
     }
     TypeReference extraneousTR =
         TypeReference.findOrCreate(ClassLoaderReference.Application, "Lreflection/Reflect6$A");
@@ -341,10 +329,7 @@ public class ReflectionTest extends WalaTestCase {
   private static Collection<CGNode> getSuccNodes(CallGraph cg, Collection<CGNode> nodes) {
     Set<CGNode> succNodes = HashSetFactory.make();
     for (CGNode newInstanceNode : nodes) {
-      Iterator<? extends CGNode> succNodesIter = cg.getSuccNodes(newInstanceNode);
-      while (succNodesIter.hasNext()) {
-        succNodes.add(succNodesIter.next());
-      }
+      cg.getSuccNodes(newInstanceNode).forEachRemaining(succNodes::add);
     }
     return succNodes;
   }

--- a/scandroid/src/main/java/org/scandroid/prefixtransfer/BlockSearch.java
+++ b/scandroid/src/main/java/org/scandroid/prefixtransfer/BlockSearch.java
@@ -51,7 +51,6 @@ import com.ibm.wala.ssa.IR;
 import com.ibm.wala.ssa.ISSABasicBlock;
 import com.ibm.wala.ssa.SSACFG;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.Set;
 
 public class BlockSearch {
@@ -68,10 +67,7 @@ public class BlockSearch {
   public ISSABasicBlock searchFromBlock(ISSABasicBlock b, Set<ISSABasicBlock> targets) {
     blockQueue.clear();
     location = 0;
-    Iterator<ISSABasicBlock> startNodes = cfg.getPredNodes(b);
-    while (startNodes.hasNext()) {
-      blockQueue.add(startNodes.next());
-    }
+    cfg.getPredNodes(b).forEachRemaining(blockQueue::add);
 
     ISSABasicBlock candidate = null;
     while (location < blockQueue.size()) {
@@ -86,10 +82,7 @@ public class BlockSearch {
           return null;
         }
       } else {
-        Iterator<ISSABasicBlock> predNodes = cfg.getPredNodes(current);
-        while (predNodes.hasNext()) {
-          blockQueue.add(predNodes.next());
-        }
+        cfg.getPredNodes(current).forEachRemaining(blockQueue::add);
       }
     }
     return candidate;

--- a/util/src/main/java/com/ibm/wala/util/collections/Iterator2List.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/Iterator2List.java
@@ -25,9 +25,7 @@ public class Iterator2List<T> extends Iterator2Collection<T> implements Serializ
 
   public Iterator2List(Iterator<? extends T> i, List<T> delegate) {
     this.delegate = delegate;
-    while (i.hasNext()) {
-      delegate.add(i.next());
-    }
+    i.forEachRemaining(delegate::add);
   }
 
   @Override

--- a/util/src/main/java/com/ibm/wala/util/collections/Iterator2Set.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/Iterator2Set.java
@@ -24,9 +24,7 @@ public class Iterator2Set<T> extends Iterator2Collection<T> implements Serializa
 
   protected Iterator2Set(Iterator<? extends T> i, Set<T> delegate) {
     this.delegate = delegate;
-    while (i.hasNext()) {
-      delegate.add(i.next());
-    }
+    i.forEachRemaining(delegate::add);
   }
 
   @Override

--- a/util/src/main/java/com/ibm/wala/util/collections/ReverseIterator.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/ReverseIterator.java
@@ -29,9 +29,7 @@ public class ReverseIterator<T> implements Iterator<T> {
     if (other == null) {
       throw new IllegalArgumentException("other == null");
     }
-    while (other.hasNext()) {
-      list.add(other.next());
-    }
+    other.forEachRemaining(list::add);
     nextIndex = list.size() - 1;
   }
 

--- a/util/src/main/java/com/ibm/wala/util/graph/traverse/BFSPathFinder.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/traverse/BFSPathFinder.java
@@ -93,9 +93,7 @@ public class BFSPathFinder<T> {
       throw new IllegalArgumentException("targets is null");
     }
     final Set<T> ts = HashSetFactory.make();
-    while (targets.hasNext()) {
-      ts.add(targets.next());
-    }
+    targets.forEachRemaining(ts::add);
 
     this.G = G;
     this.roots = new NonNullSingletonIterator<>(src);

--- a/util/src/main/java/com/ibm/wala/util/graph/traverse/DFS.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/traverse/DFS.java
@@ -67,10 +67,7 @@ public class DFS {
       throw new IllegalArgumentException("C is null");
     }
     HashSet<T> result = HashSetFactory.make();
-    Iterator<T> dfs = iterateFinishTime(G, C.iterator());
-    while (dfs.hasNext()) {
-      result.add(dfs.next());
-    }
+    iterateFinishTime(G, C.iterator()).forEachRemaining(result::add);
     return result;
   }
 
@@ -86,10 +83,7 @@ public class DFS {
       throw new IllegalArgumentException("G == null");
     }
     HashSet<T> result = HashSetFactory.make();
-    Iterator<T> dfs = iterateFinishTime(G);
-    while (dfs.hasNext()) {
-      result.add(dfs.next());
-    }
+    iterateFinishTime(G).forEachRemaining(result::add);
     return result;
   }
 


### PR DESCRIPTION
When we need to do something for each item remaining in an `Iterator`, I prefer to use a high-level operation like `forEachRemaining` instead of the boilerplate `hasNext()`/`next()` loop.