### PR TITLE
Deprecate `Iterator2List` and `Iterator2Set`

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -62,7 +62,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="zulu-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="zulu-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
   <component name="TaskProjectConfiguration">

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -19,6 +19,31 @@ exported API surfaces](https://jspecify.dev/docs/using/#gradle).
 
 ## API changes
 
+### `Iterator2List` and `Iterator2Set` deprecated for removal
+
+The classes `Iterator2List` and `Iterator2Set`, along with all their methods
+and constructors, are deprecated for removal.
+
+The static methods `Iterator2Collection.toList(Iterator)` and
+`Iterator2Collection.toSet(Iterator)` are retained but now return plain
+`List<T>` and `Set<T>` respectively instead of `Iterator2List<T>` and
+`Iterator2Set<T>` wrappers.
+
+**Effect for third-party consumers:**
+
+- Code that uses `Iterator2List<T>` or `Iterator2Set<T>` as variable types,
+  method parameters, or return types should be migrated to `List<T>` or
+  `Set<T>` instead.
+
+- Code that calls `Iterator2Collection.toList(...)` or
+  `Iterator2Collection.toSet(...)` continues to work, but may need to
+  update type declarations if they were explicitly typed as
+  `Iterator2List<T>` or `Iterator2Set<T>`.
+
+- The `:util` module now declares Guava as an `implementation`-scope
+  dependency. This Guava dependency is the same one already used by the `:cast`,
+  `:dalvik`, and `:scandroid` modules.
+
 ### `Language.getFakeRootMethod` no longer takes `AnalysisOptions`
 
 `Language.getFakeRootMethod(IClassHierarchy, IAnalysisCacheView)` is now the

--- a/util/build.gradle.kts
+++ b/util/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
   api(libs.json)
   api(libs.jspecify)
   compileOnly(libs.jetbrains.annotations)
+  implementation(libs.guava)
   javadocClasspath(projects.core)
   testFixturesApi(libs.assertj.core)
   testFixturesApi(libs.jspecify)

--- a/util/src/main/java/com/ibm/wala/util/collections/Iterator2Collection.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/Iterator2Collection.java
@@ -10,10 +10,12 @@
  */
 package com.ibm.wala.util.collections;
 
-import java.util.ArrayList;
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -28,97 +30,110 @@ public abstract class Iterator2Collection<T> implements Collection<T> {
   protected abstract Collection<T> getDelegate();
 
   /** Returns a {@link Set} containing all elements in i. Note that duplicates will be removed. */
-  public static <T> Iterator2Set<T> toSet(Iterator<? extends T> i) throws IllegalArgumentException {
-    if (i == null) {
-      throw new IllegalArgumentException("i == null");
-    }
-    return new Iterator2Set<>(i, new LinkedHashSet<>(5));
+  public static <T> Set<T> toSet(Iterator<? extends T> i) throws IllegalArgumentException {
+    checkArgument(i != null, "i == null");
+    Set<T> result = Sets.newLinkedHashSet();
+    i.forEachRemaining(result::add);
+    return result;
   }
 
   /** Returns a {@link List} containing all elements in i, preserving duplicates. */
-  public static <T> Iterator2List<T> toList(Iterator<? extends T> i)
-      throws IllegalArgumentException {
-    if (i == null) {
-      throw new IllegalArgumentException("i == null");
-    }
-    return new Iterator2List<>(i, new ArrayList<>(5));
+  public static <T> List<T> toList(Iterator<? extends T> i) throws IllegalArgumentException {
+    checkArgument(i != null, "i == null");
+    return Lists.newArrayList(i);
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   public String toString() {
     return getDelegate().toString();
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   public int size() {
     return getDelegate().size();
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   public void clear() {
     getDelegate().clear();
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   public boolean isEmpty() {
     return getDelegate().isEmpty();
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   public Object[] toArray() {
     return getDelegate().toArray();
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   public boolean add(T arg0) {
     return getDelegate().add(arg0);
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   public boolean contains(Object arg0) {
     return getDelegate().contains(arg0);
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   public boolean remove(Object arg0) {
     return getDelegate().remove(arg0);
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   public boolean addAll(Collection<? extends T> arg0) {
     return getDelegate().addAll(arg0);
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   public boolean containsAll(Collection<?> arg0) {
     return getDelegate().containsAll(arg0);
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   public boolean removeAll(Collection<?> arg0) {
     return getDelegate().removeAll(arg0);
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   public boolean retainAll(Collection<?> arg0) {
     return getDelegate().retainAll(arg0);
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   public Iterator<T> iterator() {
     return getDelegate().iterator();
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   public <U> U[] toArray(U[] a) {
     return getDelegate().toArray(a);
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   public boolean equals(Object o) {
     return getDelegate().equals(o);
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   public int hashCode() {
     return getDelegate().hashCode();

--- a/util/src/main/java/com/ibm/wala/util/collections/Iterator2List.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/Iterator2List.java
@@ -17,67 +17,80 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 
+@Deprecated(forRemoval = true, since = "1.8.0")
 public class Iterator2List<T> extends Iterator2Collection<T> implements Serializable, List<T> {
 
   @Serial private static final long serialVersionUID = -4364941553982190713L;
 
   private final List<T> delegate;
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   public Iterator2List(Iterator<? extends T> i, List<T> delegate) {
     this.delegate = delegate;
     i.forEachRemaining(delegate::add);
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   public void add(int index, T element) {
     delegate.add(index, element);
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   public boolean addAll(int index, Collection<? extends T> c) {
     return delegate.addAll(index, c);
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   public T get(int index) {
     return delegate.get(index);
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   public int indexOf(Object o) {
     return delegate.indexOf(o);
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   public int lastIndexOf(Object o) {
     return delegate.lastIndexOf(o);
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   public ListIterator<T> listIterator() {
     return delegate.listIterator();
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   public ListIterator<T> listIterator(int index) {
     return delegate.listIterator(index);
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   public T remove(int index) {
     return delegate.remove(index);
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   public T set(int index, T element) {
     return delegate.set(index, element);
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   public List<T> subList(int fromIndex, int toIndex) {
     return delegate.subList(fromIndex, toIndex);
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   protected Collection<T> getDelegate() {
     return delegate;

--- a/util/src/main/java/com/ibm/wala/util/collections/Iterator2Set.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/Iterator2Set.java
@@ -16,17 +16,20 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
 
+@Deprecated(forRemoval = true, since = "1.8.0")
 public class Iterator2Set<T> extends Iterator2Collection<T> implements Serializable, Set<T> {
 
   @Serial private static final long serialVersionUID = 3771468677527694694L;
 
   private final Set<T> delegate;
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   protected Iterator2Set(Iterator<? extends T> i, Set<T> delegate) {
     this.delegate = delegate;
     i.forEachRemaining(delegate::add);
   }
 
+  @Deprecated(forRemoval = true, since = "1.8.0")
   @Override
   protected Collection<T> getDelegate() {
     return delegate;


### PR DESCRIPTION
We retain the static `Iterator2Collection.toList` and `Iterator2Collection.toSet` methods.  However, these now make weaker promises as to the types they return.  Internally, these are now implemented using existing Guava utility methods.  The collections that result are slightly more efficient than before, as they no longer route all `Collection` methods through an unnecessary proxy object.

That being said, the underlying `Collection` types are the same as before: `toList` continues to be based on `ArrayList`, and `toSet` continues to be based on `LinkedHashSet`.  But now we get there using less of our own code and fewer delegation layers.

Note that Guava is now an implementation dependency of our `utils` component.  Other parts of WALA were already using Guava, so this change should be easy for third-party code to handle.