### PR TITLE
Avoid labeled break targets

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -92,14 +92,17 @@ tasks.withType<JavaCompile>().configureEach {
           "UnusedVariable",
           "UseEnumSwitch",
       )
+
       // checks we do not intend to try to fix in the near-term:
-      disable("LabelledBreakTarget")
+
       // Just too many of these; proper Javadoc would be a great long-term goal
       disable("MissingSummary")
+
       // WALA has many optimizations involving using == to check reference equality.  They
       // may be unnecessary on modern JITs, but fixing these issues requires subtle changes
       // that could introduce bugs
       disable("ReferenceEquality")
+
       // Example for running Error Prone's auto-patcher.  To run, uncomment and change the
       // check name to the one you want to patch, and also disable -Werror below
       //    		errorproneArgs.addAll(

--- a/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJJava17IRTest.java
+++ b/cast/java/ecj/src/test/java/com/ibm/wala/cast/java/test/ECJJava17IRTest.java
@@ -66,14 +66,15 @@ public class ECJJava17IRTest extends ECJIRTests {
                     (n) -> {
                       SymbolTable st = n.getIR().getSymbolTable();
                       for (int value : m.snd) {
-                        check:
-                        {
-                          for (int i = 1; i <= st.getMaxValueNumber(); i++) {
-                            if (st.isIntegerConstant(i) && st.getIntValue(i) == value) {
-                              System.err.println("found " + value + " in " + n);
-                              break check;
-                            }
+                        boolean found = false;
+                        for (int i = 1; i <= st.getMaxValueNumber(); i++) {
+                          if (st.isIntegerConstant(i) && st.getIntValue(i) == value) {
+                            System.err.println("found " + value + " in " + n);
+                            found = true;
+                            break;
                           }
+                        }
+                        if (!found) {
                           //noinspection ResultOfMethodCallIgnored
                           fail("cannot find %s in %s", value, n);
                         }

--- a/shrike/src/main/java/com/ibm/wala/shrike/cg/Runtime.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/cg/Runtime.java
@@ -130,39 +130,37 @@ public class Runtime {
       if (runtime.output != null) {
         String caller = runtime.callStacks.get().peek();
 
-        {
-          //
-          // check for expected caller
-          //
-          boolean handled = false;
-          if (runtime.handleCallback != null) {
-            StackTraceElement[] stack = new Throwable().getStackTrace();
-            if (stack.length > 2) {
-              // frames: Runtime.execution(0), callee(1), caller(2)
-              StackTraceElement callerFrame = stack[2];
-              if (!callerFrame.getMethodName().startsWith("$")) {
-                if (!caller.contains(callerFrame.getMethodName())
-                    || !caller.contains(bashToDescriptor(callerFrame.getClassName()))) {
-                  runtime.handleCallback.callback(stack, klass, method, receiver);
-                  handled = true;
-                }
+        //
+        // check for expected caller
+        //
+        boolean handled = false;
+        if (runtime.handleCallback != null) {
+          StackTraceElement[] stack = new Throwable().getStackTrace();
+          if (stack.length > 2) {
+            // frames: Runtime.execution(0), callee(1), caller(2)
+            StackTraceElement callerFrame = stack[2];
+            if (!callerFrame.getMethodName().startsWith("$")) {
+              if (!caller.contains(callerFrame.getMethodName())
+                  || !caller.contains(bashToDescriptor(callerFrame.getClassName()))) {
+                runtime.handleCallback.callback(stack, klass, method, receiver);
+                handled = true;
               }
             }
           }
+        }
 
-          if (!handled) {
-            String line =
-                (method.contains("<clinit>") ? "clinit" : String.valueOf(caller))
-                    + '\t'
-                    + bashToDescriptor(klass)
-                    + '\t'
-                    + String.valueOf(method)
-                    + '\n';
-            synchronized (runtime) {
-              if (runtime.output != null) {
-                runtime.output.printf(line);
-                runtime.output.flush();
-              }
+        if (!handled) {
+          String line =
+              (method.contains("<clinit>") ? "clinit" : String.valueOf(caller))
+                  + '\t'
+                  + bashToDescriptor(klass)
+                  + '\t'
+                  + String.valueOf(method)
+                  + '\n';
+          synchronized (runtime) {
+            if (runtime.output != null) {
+              runtime.output.printf(line);
+              runtime.output.flush();
             }
           }
         }

--- a/shrike/src/main/java/com/ibm/wala/shrike/cg/Runtime.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/cg/Runtime.java
@@ -130,11 +130,11 @@ public class Runtime {
       if (runtime.output != null) {
         String caller = runtime.callStacks.get().peek();
 
-        checkValid:
         {
           //
           // check for expected caller
           //
+          boolean handled = false;
           if (runtime.handleCallback != null) {
             StackTraceElement[] stack = new Throwable().getStackTrace();
             if (stack.length > 2) {
@@ -144,23 +144,25 @@ public class Runtime {
                 if (!caller.contains(callerFrame.getMethodName())
                     || !caller.contains(bashToDescriptor(callerFrame.getClassName()))) {
                   runtime.handleCallback.callback(stack, klass, method, receiver);
-                  break checkValid;
+                  handled = true;
                 }
               }
             }
           }
 
-          String line =
-              (method.contains("<clinit>") ? "clinit" : String.valueOf(caller))
-                  + '\t'
-                  + bashToDescriptor(klass)
-                  + '\t'
-                  + String.valueOf(method)
-                  + '\n';
-          synchronized (runtime) {
-            if (runtime.output != null) {
-              runtime.output.printf(line);
-              runtime.output.flush();
+          if (!handled) {
+            String line =
+                (method.contains("<clinit>") ? "clinit" : String.valueOf(caller))
+                    + '\t'
+                    + bashToDescriptor(klass)
+                    + '\t'
+                    + String.valueOf(method)
+                    + '\n';
+            synchronized (runtime) {
+              if (runtime.output != null) {
+                runtime.output.printf(line);
+                runtime.output.flush();
+              }
             }
           }
         }

--- a/util/src/main/java/com/ibm/wala/util/graph/traverse/WelshPowell.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/traverse/WelshPowell.java
@@ -108,20 +108,25 @@ public class WelshPowell<T> {
 
         for (T m : vertices) {
           if (colors[G.getNumber(m)] == -1) {
-            color_me:
-            {
-              for (T p : Iterator2Iterable.make(G.getPredNodes(m))) {
-                if (colors[G.getNumber(p)] == currentColor) {
-                  break color_me;
-                }
-              }
+            boolean canColor = true;
 
+            for (T p : Iterator2Iterable.make(G.getPredNodes(m))) {
+              if (colors[G.getNumber(p)] == currentColor) {
+                canColor = false;
+                break;
+              }
+            }
+
+            if (canColor) {
               for (T s : Iterator2Iterable.make(G.getSuccNodes(m))) {
                 if (colors[G.getNumber(s)] == currentColor) {
-                  break color_me;
+                  canColor = false;
+                  break;
                 }
               }
+            }
 
+            if (canColor) {
               colors[G.getNumber(m)] = currentColor;
               colored++;
 


### PR DESCRIPTION
[Error Prone's `LabelledBreakTarget` posits that "labels should only be used on loops."](https://errorprone.info/bugpattern/LabelledBreakTarget) Previously we disabled this check, but there aren't very many violations of it. We may as well restructure the few violators and let this check report errors per its default setting.

Also add a few line breaks in the build logic to make it easier to see which comments apply to which bits of Gradle/Kotlin code.