### PR TITLE
Expose a summary class shell's own methods (#1957 follow-up)

### DIFF
--- a/cast/src/main/java/com/ibm/wala/cast/loader/CAstAbstractModuleLoader.java
+++ b/cast/src/main/java/com/ibm/wala/cast/loader/CAstAbstractModuleLoader.java
@@ -34,6 +34,7 @@ import com.ibm.wala.classLoader.SourceFileModule;
 import com.ibm.wala.classLoader.SourceModule;
 import com.ibm.wala.core.util.warnings.Warning;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
+import com.ibm.wala.ipa.summaries.SummaryClassShellLoader;
 import com.ibm.wala.ssa.SSAInstruction;
 import com.ibm.wala.ssa.SymbolTable;
 import com.ibm.wala.types.MethodReference;
@@ -61,7 +62,8 @@ import java.util.Set;
  * abstract class loader that performs CAst and IR generation for relevant entities in a list of
  * {@link Module}s. Subclasses provide the CAst / IR translators appropriate for the language.
  */
-public abstract class CAstAbstractModuleLoader extends CAstAbstractLoader {
+public abstract class CAstAbstractModuleLoader extends CAstAbstractLoader
+    implements SummaryClassShellLoader {
 
   private static final boolean DEBUG = false;
 
@@ -392,6 +394,36 @@ public abstract class CAstAbstractModuleLoader extends CAstAbstractLoader {
         return getDeclaringClass().getClassLoader().getLanguage().getRootType();
       }
     }
+  }
+
+  /**
+   * Register a "shell" {@link IClass} for a summary-modeled type, so that source classes loaded by
+   * this loader can resolve it as a superclass at definition time.
+   *
+   * <p>A CAst class resolves its superclass through this loader's own type map ({@link
+   * #lookupClass(TypeName)}, {@link CoreClass#getSuperclass()}), which is loader-local and does not
+   * consult the {@link IClassHierarchy} or parent loaders. When a framework base type is modeled
+   * only by an XML method summary, the corresponding class is materialized into the {@link
+   * com.ibm.wala.ipa.summaries.BypassSyntheticClassLoader} only after the class hierarchy is built,
+   * which is too late, and in the wrong loader, for a source subclass to pick up the inheritance
+   * edge. Registering a shell here, before the hierarchy is built, closes that gap (see <a
+   * href="https://github.com/wala/WALA/issues/1957">#1957</a>).
+   *
+   * <p>Idempotent: if a class is already registered under {@code name}, it is returned unchanged.
+   *
+   * @param name the type to register a shell for
+   * @param superName the shell's superclass, or {@code null} for this loader's language root type
+   * @return the registered (or pre-existing) class
+   */
+  @Override
+  public IClass defineSummaryClassShell(TypeName name, TypeName superName) {
+    IClass existing = lookupClass(name);
+    if (existing != null) {
+      return existing;
+    }
+    TypeName actualSuperName =
+        superName == null ? getLanguage().getRootType().getName() : superName;
+    return new CoreClass(name, actualSuperName, this, null);
   }
 
   public class CoreClass extends AstDynamicPropertyClass {

--- a/cast/src/test/java/com/ibm/wala/cast/test/SummaryClassShellResolutionTest.java
+++ b/cast/src/test/java/com/ibm/wala/cast/test/SummaryClassShellResolutionTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2002 - 2006 IBM Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ */
+package com.ibm.wala.cast.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.wala.cast.ir.translator.TranslatorToCAst;
+import com.ibm.wala.cast.ir.translator.TranslatorToIR;
+import com.ibm.wala.cast.loader.CAstAbstractModuleLoader;
+import com.ibm.wala.cast.tree.CAst;
+import com.ibm.wala.cast.tree.CAstEntity;
+import com.ibm.wala.classLoader.IClass;
+import com.ibm.wala.classLoader.Language;
+import com.ibm.wala.classLoader.Module;
+import com.ibm.wala.classLoader.ModuleEntry;
+import com.ibm.wala.ssa.SSAInstructionFactory;
+import com.ibm.wala.types.ClassLoaderReference;
+import com.ibm.wala.types.TypeName;
+import com.ibm.wala.util.collections.Pair;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the loader-local resolution of summary-modeled class shells, the mechanism behind <a
+ * href="https://github.com/wala/WALA/issues/1957">#1957</a>.
+ *
+ * <p>A CAst class ({@code CoreClass}, the base of e.g. the Python front-end's {@code PythonClass})
+ * resolves its superclass through its own loader's type map only: {@code CoreClass.getSuperclass()}
+ * is a live, uncached {@code types.get(superName)} with no parent-loader or class-hierarchy
+ * fallback. So a source subclass can only inherit a summary-modeled base if a shell for that base
+ * has been registered <em>into the same loader</em> before the subclass is defined. Registering the
+ * shell into the {@code BypassSyntheticClassLoader} (where XML method summaries are otherwise
+ * materialized) would never be seen here.
+ */
+public class SummaryClassShellResolutionTest {
+
+  private static final TypeName BASE = TypeName.string2TypeName("Ltensorflow/keras/layers/Layer");
+  private static final TypeName SUB = TypeName.string2TypeName("Lmy/model/GCN");
+
+  /** The hook registers a resolvable shell and is idempotent. */
+  @Test
+  public void testShellIsRegisteredAndIdempotent() {
+    TestLoader loader = new TestLoader();
+
+    assertThat(loader.lookupClass(BASE)).isNull();
+
+    IClass shell = loader.defineSummaryClassShell(BASE, null);
+    assertThat(shell).isNotNull();
+    assertThat(loader.lookupClass(BASE)).isSameAs(shell);
+
+    // Idempotent: a second registration returns the same class rather than replacing it.
+    assertThat(loader.defineSummaryClassShell(BASE, null)).isSameAs(shell);
+  }
+
+  /** A subclass defined after its base shell resolves the inheritance edge. */
+  @Test
+  public void testSubclassResolvesRegisteredBase() {
+    TestLoader loader = new TestLoader();
+    IClass shell = loader.defineSummaryClassShell(BASE, null);
+    IClass sub = loader.new CoreClass(SUB, BASE, loader, null);
+    assertThat(sub.getSuperclass()).isSameAs(shell);
+  }
+
+  /**
+   * Without a shell, the base is invisible to loader-local resolution, exactly the #1957 symptom,
+   * since the summary-modeled base lives in a different loader (and is created only after the
+   * hierarchy is built).
+   */
+  @Test
+  public void testSubclassWithoutShellHasNoSuperclass() {
+    TestLoader loader = new TestLoader();
+
+    IClass sub = loader.new CoreClass(SUB, BASE, loader, null);
+
+    assertThat(sub.getSuperclass()).isNull();
+  }
+
+  /**
+   * A minimal concrete {@link CAstAbstractModuleLoader} sufficient to exercise shell resolution.
+   */
+  private static final class TestLoader extends CAstAbstractModuleLoader {
+
+    TestLoader() {
+      super(null, null);
+    }
+
+    @Override
+    public Language getLanguage() {
+      return Language.JAVA;
+    }
+
+    @Override
+    public ClassLoaderReference getReference() {
+      return ClassLoaderReference.Application;
+    }
+
+    @Override
+    public SSAInstructionFactory getInstructionFactory() {
+      return Language.JAVA.instructionFactory();
+    }
+
+    @Override
+    protected TranslatorToCAst getTranslatorToCAst(CAst ast, ModuleEntry m, List<Module> modules) {
+      throw new UnsupportedOperationException("not needed for this test");
+    }
+
+    @Override
+    protected boolean shouldTranslate(CAstEntity entity) {
+      return false;
+    }
+
+    @Override
+    protected TranslatorToIR initTranslator(Set<Pair<CAstEntity, ModuleEntry>> topLevelEntities) {
+      throw new UnsupportedOperationException("not needed for this test");
+    }
+  }
+}

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/Util.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/Util.java
@@ -11,6 +11,7 @@
 package com.ibm.wala.ipa.callgraph.impl;
 
 import com.ibm.wala.classLoader.IClass;
+import com.ibm.wala.classLoader.IClassLoader;
 import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.classLoader.Language;
 import com.ibm.wala.core.util.strings.Atom;
@@ -35,6 +36,7 @@ import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.ipa.summaries.BypassClassTargetSelector;
 import com.ibm.wala.ipa.summaries.BypassMethodTargetSelector;
 import com.ibm.wala.ipa.summaries.LambdaMethodTargetSelector;
+import com.ibm.wala.ipa.summaries.SummaryClassShellLoader;
 import com.ibm.wala.ipa.summaries.XMLMethodSummaryReader;
 import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.Descriptor;
@@ -52,6 +54,7 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 
 /** Call graph utilities */
@@ -180,6 +183,39 @@ public class Util {
             cha,
             cha.getLoader(cha.getScope().getLoader(Atom.findOrCreateUnicodeAtom("Synthetic"))));
     options.setSelector(cs);
+  }
+
+  /**
+   * Materialize class shells for the summary-modeled classes that opt in by declaring a superclass
+   * (see {@link XMLMethodSummaryReader#getClassSuperclasses()}), registering each into {@code
+   * loader} if it supports {@link SummaryClassShellLoader}. Only the classes whose declaring loader
+   * is {@code loader} are registered.
+   *
+   * <p>Call this before building the {@link IClassHierarchy} (and before translating source classes
+   * that subclass a summary-modeled type), so that those subclasses resolve their base at
+   * definition time rather than falling back to the language root. See <a
+   * href="https://github.com/wala/WALA/issues/1957">#1957</a>. Loaders that do not implement {@link
+   * SummaryClassShellLoader} are silently skipped.
+   *
+   * @throws IllegalArgumentException if {@code loader} or {@code summary} is null
+   */
+  public static void addSummaryClassShells(IClassLoader loader, XMLMethodSummaryReader summary) {
+    if (loader == null) {
+      throw new IllegalArgumentException("loader is null");
+    }
+    if (summary == null) {
+      throw new IllegalArgumentException("summary is null");
+    }
+    if (!(loader instanceof SummaryClassShellLoader registrar)) {
+      return;
+    }
+    for (Map.Entry<TypeReference, TypeReference> entry :
+        summary.getClassSuperclasses().entrySet()) {
+      TypeReference type = entry.getKey();
+      if (type.getClassLoader().equals(loader.getReference())) {
+        registrar.defineSummaryClassShell(type.getName(), entry.getValue().getName());
+      }
+    }
   }
 
   /**

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/Util.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/Util.java
@@ -36,6 +36,7 @@ import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.ipa.summaries.BypassClassTargetSelector;
 import com.ibm.wala.ipa.summaries.BypassMethodTargetSelector;
 import com.ibm.wala.ipa.summaries.LambdaMethodTargetSelector;
+import com.ibm.wala.ipa.summaries.MethodSummary;
 import com.ibm.wala.ipa.summaries.SummaryClassShellLoader;
 import com.ibm.wala.ipa.summaries.XMLMethodSummaryReader;
 import com.ibm.wala.types.ClassLoaderReference;
@@ -43,6 +44,7 @@ import com.ibm.wala.types.Descriptor;
 import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.types.TypeName;
 import com.ibm.wala.types.TypeReference;
+import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.collections.HashSetFactory;
 import com.ibm.wala.util.debug.Assertions;
 import com.ibm.wala.util.graph.Graph;
@@ -52,8 +54,11 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -209,11 +214,21 @@ public class Util {
     if (!(loader instanceof SummaryClassShellLoader registrar)) {
       return;
     }
+    // Group method summaries by declaring class, so each shell can expose its own methods.
+    Map<TypeReference, List<MethodSummary>> methodsByClass = HashMapFactory.make();
+    for (MethodSummary method : summary.getSummaries().values()) {
+      methodsByClass
+          .computeIfAbsent(method.getMethod().getDeclaringClass(), k -> new ArrayList<>())
+          .add(method);
+    }
     for (Map.Entry<TypeReference, TypeReference> entry :
         summary.getClassSuperclasses().entrySet()) {
       TypeReference type = entry.getKey();
       if (type.getClassLoader().equals(loader.getReference())) {
-        registrar.defineSummaryClassShell(type.getName(), entry.getValue().getName());
+        registrar.defineSummaryClassShell(
+            type.getName(),
+            entry.getValue().getName(),
+            methodsByClass.getOrDefault(type, Collections.emptyList()));
       }
     }
   }

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/BypassSyntheticClassLoader.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/BypassSyntheticClassLoader.java
@@ -26,6 +26,7 @@ import com.ibm.wala.util.config.StringFilter;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -106,13 +107,19 @@ public class BypassSyntheticClassLoader implements IClassLoader, SummaryClassShe
 
   @Override
   public IClass defineSummaryClassShell(TypeName name, TypeName superName) {
+    return defineSummaryClassShell(name, superName, Collections.emptyList());
+  }
+
+  @Override
+  public IClass defineSummaryClassShell(
+      TypeName name, TypeName superName, Collection<MethodSummary> methods) {
     IClass existing = lookupClass(name);
     if (existing != null) {
       return existing;
     }
     TypeReference type = TypeReference.findOrCreate(me, name);
     TypeReference superType = superName == null ? null : TypeReference.findOrCreate(me, superName);
-    IClass shell = new SummaryClassShell(type, cha, superType);
+    IClass shell = new SummaryClassShell(type, cha, superType, methods);
     registerClass(name, shell);
     return shell;
   }

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/BypassSyntheticClassLoader.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/BypassSyntheticClassLoader.java
@@ -20,6 +20,7 @@ import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.ssa.SSAInstructionFactory;
 import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.types.TypeName;
+import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.config.StringFilter;
 import java.io.IOException;
@@ -54,7 +55,7 @@ import java.util.List;
  *
  * @author Julian Dolby (dolby@us.ibm.com)
  */
-public class BypassSyntheticClassLoader implements IClassLoader {
+public class BypassSyntheticClassLoader implements IClassLoader, SummaryClassShellLoader {
 
   private final ClassLoaderReference me;
 
@@ -101,6 +102,19 @@ public class BypassSyntheticClassLoader implements IClassLoader {
   public void registerClass(TypeName className, IClass theClass) {
     cha.addClass(theClass);
     syntheticClasses.put(className, theClass);
+  }
+
+  @Override
+  public IClass defineSummaryClassShell(TypeName name, TypeName superName) {
+    IClass existing = lookupClass(name);
+    if (existing != null) {
+      return existing;
+    }
+    TypeReference type = TypeReference.findOrCreate(me, name);
+    TypeReference superType = superName == null ? null : TypeReference.findOrCreate(me, superName);
+    IClass shell = new SummaryClassShell(type, cha, superType);
+    registerClass(name, shell);
+    return shell;
   }
 
   /** Return the ClassLoaderReference for this class loader. */

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/SummaryClassShell.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/SummaryClassShell.java
@@ -18,20 +18,31 @@ import com.ibm.wala.core.util.strings.Atom;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
 import com.ibm.wala.types.Selector;
 import com.ibm.wala.types.TypeReference;
+import com.ibm.wala.util.collections.HashMapFactory;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 
 /**
  * A minimal standalone shell {@link IClass} for a type modeled only by a summary. Unlike {@link
  * BypassSyntheticClass}, which wraps an existing "real" type, a shell stands on its own and is
- * positioned in the hierarchy at an explicitly declared superclass. It carries no members; its
- * purpose is to occupy a place in the class hierarchy so that source subclasses resolve their base.
- * See <a href="https://github.com/wala/WALA/issues/1957">#1957</a>.
+ * positioned in the hierarchy at an explicitly declared superclass. Its purpose is to occupy a
+ * place in the class hierarchy so that source subclasses resolve their base. It carries no fields;
+ * it exposes only the methods given to it as {@link MethodSummary summaries} (typically the {@code
+ * <method>} children of the {@code <class>} it was materialized from), as {@link
+ * SummarizedMethod}s. See <a href="https://github.com/wala/WALA/issues/1957">#1957</a>.
  */
 public class SummaryClassShell extends SyntheticClass {
 
   /** The declared superclass, or {@code null} for the language root type. */
   private final TypeReference superReference;
+
+  /** The summaries for this shell's own declared methods, keyed by selector. */
+  private final Map<Selector, MethodSummary> methodSummaries = HashMapFactory.make();
+
+  /** Lazily materialized {@link SummarizedMethod}s, keyed by selector. */
+  private final Map<Selector, IMethod> resolvedMethods = HashMapFactory.make();
 
   /**
    * @param type the type this shell represents
@@ -39,8 +50,25 @@ public class SummaryClassShell extends SyntheticClass {
    * @param superReference the declared superclass, or {@code null} for the language root type
    */
   public SummaryClassShell(TypeReference type, IClassHierarchy cha, TypeReference superReference) {
+    this(type, cha, superReference, Collections.emptyList());
+  }
+
+  /**
+   * @param type the type this shell represents
+   * @param cha the governing class hierarchy
+   * @param superReference the declared superclass, or {@code null} for the language root type
+   * @param methods summaries for the shell's own declared methods
+   */
+  public SummaryClassShell(
+      TypeReference type,
+      IClassHierarchy cha,
+      TypeReference superReference,
+      Collection<MethodSummary> methods) {
     super(type, cha);
     this.superReference = superReference;
+    for (MethodSummary method : methods) {
+      methodSummaries.put(method.getMethod().getSelector(), method);
+    }
   }
 
   @Override
@@ -67,7 +95,17 @@ public class SummaryClassShell extends SyntheticClass {
 
   @Override
   public IMethod getMethod(Selector selector) {
-    return null;
+    IMethod cached = resolvedMethods.get(selector);
+    if (cached != null) {
+      return cached;
+    }
+    MethodSummary summary = methodSummaries.get(selector);
+    if (summary == null) {
+      return null;
+    }
+    IMethod method = new SummarizedMethod(summary.getMethod(), summary, this);
+    resolvedMethods.put(selector, method);
+    return method;
   }
 
   @Override
@@ -82,7 +120,11 @@ public class SummaryClassShell extends SyntheticClass {
 
   @Override
   public Collection<? extends IMethod> getDeclaredMethods() {
-    return Collections.emptySet();
+    Collection<IMethod> result = new ArrayList<>(methodSummaries.size());
+    for (Selector selector : methodSummaries.keySet()) {
+      result.add(getMethod(selector));
+    }
+    return result;
   }
 
   @Override
@@ -112,7 +154,9 @@ public class SummaryClassShell extends SyntheticClass {
 
   @Override
   public Collection<? extends IMethod> getAllMethods() {
-    return Collections.emptySet();
+    // The shell models only its own summarized members; inherited methods are resolved through the
+    // class hierarchy via getSuperclass().
+    return getDeclaredMethods();
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/SummaryClassShell.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/SummaryClassShell.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2002 - 2006 IBM Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ */
+package com.ibm.wala.ipa.summaries;
+
+import com.ibm.wala.classLoader.IClass;
+import com.ibm.wala.classLoader.IField;
+import com.ibm.wala.classLoader.IMethod;
+import com.ibm.wala.classLoader.SyntheticClass;
+import com.ibm.wala.core.util.strings.Atom;
+import com.ibm.wala.ipa.cha.IClassHierarchy;
+import com.ibm.wala.types.Selector;
+import com.ibm.wala.types.TypeReference;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * A minimal standalone shell {@link IClass} for a type modeled only by a summary. Unlike {@link
+ * BypassSyntheticClass}, which wraps an existing "real" type, a shell stands on its own and is
+ * positioned in the hierarchy at an explicitly declared superclass. It carries no members; its
+ * purpose is to occupy a place in the class hierarchy so that source subclasses resolve their base.
+ * See <a href="https://github.com/wala/WALA/issues/1957">#1957</a>.
+ */
+public class SummaryClassShell extends SyntheticClass {
+
+  /** The declared superclass, or {@code null} for the language root type. */
+  private final TypeReference superReference;
+
+  /**
+   * @param type the type this shell represents
+   * @param cha the governing class hierarchy
+   * @param superReference the declared superclass, or {@code null} for the language root type
+   */
+  public SummaryClassShell(TypeReference type, IClassHierarchy cha, TypeReference superReference) {
+    super(type, cha);
+    this.superReference = superReference;
+  }
+
+  @Override
+  public IClass getSuperclass() {
+    IClassHierarchy cha = getClassHierarchy();
+    if (superReference != null) {
+      IClass superClass = cha.lookupClass(superReference);
+      if (superClass != null) {
+        return superClass;
+      }
+    }
+    return cha.getRootClass();
+  }
+
+  @Override
+  public Collection<IClass> getDirectInterfaces() {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public Collection<IClass> getAllImplementedInterfaces() {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public IMethod getMethod(Selector selector) {
+    return null;
+  }
+
+  @Override
+  public IField getField(Atom name) {
+    return null;
+  }
+
+  @Override
+  public IMethod getClassInitializer() {
+    return null;
+  }
+
+  @Override
+  public Collection<? extends IMethod> getDeclaredMethods() {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public Collection<IField> getDeclaredInstanceFields() {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public Collection<IField> getDeclaredStaticFields() {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public Collection<IField> getAllInstanceFields() {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public Collection<IField> getAllStaticFields() {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public Collection<IField> getAllFields() {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public Collection<? extends IMethod> getAllMethods() {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public boolean isReferenceType() {
+    return getReference().isReferenceType();
+  }
+
+  @Override
+  public boolean isPublic() {
+    return true;
+  }
+
+  @Override
+  public boolean isPrivate() {
+    return false;
+  }
+
+  @Override
+  public int getModifiers() {
+    return 0;
+  }
+
+  @Override
+  public String toString() {
+    return "<SummaryShell " + getReference().getName() + '>';
+  }
+}

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/SummaryClassShellLoader.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/SummaryClassShellLoader.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2002 - 2006 IBM Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ */
+package com.ibm.wala.ipa.summaries;
+
+import com.ibm.wala.classLoader.IClass;
+import com.ibm.wala.classLoader.IClassLoader;
+import com.ibm.wala.types.TypeName;
+
+/**
+ * A capability, implemented by class loaders that can introduce "shell" classes for types modeled
+ * only by a summary, so that source classes subclassing such a type can resolve their base at
+ * definition time rather than falling back to the language root.
+ *
+ * <p>This exists because a class resolves its superclass through its own loader; a summary-modeled
+ * framework base materialized late (and in the {@link BypassSyntheticClassLoader}) is invisible to
+ * a source subclass at class-hierarchy-build time. Loaders that own a mutable set of classes (the
+ * {@link BypassSyntheticClassLoader} and the CAst module loaders) can instead register a shell
+ * eagerly, before the hierarchy is built. See <a
+ * href="https://github.com/wala/WALA/issues/1957">#1957</a>.
+ *
+ * @see com.ibm.wala.ipa.callgraph.impl.Util#addSummaryClassShells(IClassLoader,
+ *     XMLMethodSummaryReader)
+ */
+public interface SummaryClassShellLoader {
+
+  /**
+   * Register a shell {@link IClass} for a summary-modeled type, so that classes loaded by this
+   * loader can resolve it as a superclass.
+   *
+   * <p>Idempotent: if a class is already registered under {@code name}, it is returned unchanged.
+   *
+   * @param name the type to register a shell for
+   * @param superName the shell's superclass, or {@code null} for this loader's language root type
+   * @return the registered (or pre-existing) class
+   */
+  IClass defineSummaryClassShell(TypeName name, TypeName superName);
+}

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/SummaryClassShellLoader.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/SummaryClassShellLoader.java
@@ -13,6 +13,7 @@ package com.ibm.wala.ipa.summaries;
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IClassLoader;
 import com.ibm.wala.types.TypeName;
+import java.util.Collection;
 
 /**
  * A capability, implemented by class loaders that can introduce "shell" classes for types modeled
@@ -42,4 +43,24 @@ public interface SummaryClassShellLoader {
    * @return the registered (or pre-existing) class
    */
   IClass defineSummaryClassShell(TypeName name, TypeName superName);
+
+  /**
+   * Register a shell {@link IClass} that also exposes the given method summaries as its own
+   * declared methods, so that a walk of the shell (e.g. when resolving an inherited method on a
+   * subclass) finds them. The method bodies are still bound late by the usual bypass mechanism;
+   * only the declarations need to exist on the shell.
+   *
+   * <p>The default implementation ignores {@code methods} and delegates to {@link
+   * #defineSummaryClassShell(TypeName, TypeName)}; implementations whose shells can carry methods
+   * (such as the {@link BypassSyntheticClassLoader}) override this.
+   *
+   * @param name the type to register a shell for
+   * @param superName the shell's superclass, or {@code null} for this loader's language root type
+   * @param methods summaries for the methods the shell should declare
+   * @return the registered (or pre-existing) class
+   */
+  default IClass defineSummaryClassShell(
+      TypeName name, TypeName superName, Collection<MethodSummary> methods) {
+    return defineSummaryClassShell(name, superName);
+  }
 }

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/XMLMethodSummaryReader.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/XMLMethodSummaryReader.java
@@ -72,6 +72,25 @@ public class XMLMethodSummaryReader implements BytecodeConstants {
   /** Set of TypeReferences that are marked as "allocatable" */
   private final HashSet<TypeReference> allocatable = HashSetFactory.make();
 
+  /**
+   * Set of TypeReferences for classes declared via a {@code <class>} element. These are the classes
+   * the summary <em>models</em> (as opposed to the classes whose methods it merely overrides).
+   */
+  private final HashSet<TypeReference> classes = HashSetFactory.make();
+
+  /**
+   * Maps a class declared via {@code <class name="..." super="...">} to its declared superclass.
+   * Only classes that declare a {@code super} appear here: declaring a superclass opts the class in
+   * to being materialized as a standalone class shell, positioned in the hierarchy at the given
+   * superclass. A front-end (or {@link com.ibm.wala.ipa.callgraph.impl.Util#addSummaryClassShells})
+   * may register these shells into the corresponding scope loader before the {@link
+   * com.ibm.wala.ipa.cha.IClassHierarchy} is built, so that source classes subclassing a
+   * summary-modeled type can resolve their base at definition time (see <a
+   * href="https://github.com/wala/WALA/issues/1957">#1957</a>). Classes declared without a {@code
+   * super} stay method-summary-only, exactly as before.
+   */
+  private final HashMap<TypeReference, TypeReference> classSuperclasses = HashMapFactory.make();
+
   /** Set of Atoms that represent packages that can be ignored */
   private final HashSet<Atom> ignoredPackages = HashSetFactory.make();
 
@@ -164,6 +183,8 @@ public class XMLMethodSummaryReader implements BytecodeConstants {
 
   private static final String A_ALLOCATABLE = "allocatable";
 
+  private static final String A_SUPER = "super";
+
   private static final String A_REF = "ref";
 
   private static final String A_INDEX = "index";
@@ -223,6 +244,27 @@ public class XMLMethodSummaryReader implements BytecodeConstants {
    */
   public Set<TypeReference> getAllocatableClasses() {
     return allocatable;
+  }
+
+  /**
+   * @return Set of TypeReferences for classes declared via a {@code <class>} element, i.e. the
+   *     classes this summary models. The declaring class loader of each {@link TypeReference} is
+   *     the one named by the enclosing {@code <classloader>} element.
+   */
+  public Set<TypeReference> getClasses() {
+    return classes;
+  }
+
+  /**
+   * @return a map from each class declared via {@code <class name="..." super="...">} to its
+   *     declared superclass. Declaring a {@code super} opts the class in to being materialized as a
+   *     standalone class shell, positioned at that superclass; classes declared without a {@code
+   *     super} are method-summary-only and do not appear here. See {@link
+   *     com.ibm.wala.ipa.callgraph.impl.Util#addSummaryClassShells} and <a
+   *     href="https://github.com/wala/WALA/issues/1957">#1957</a>.
+   */
+  public Map<TypeReference, TypeReference> getClassSuperclasses() {
+    return classSuperclasses;
   }
 
   /**
@@ -312,6 +354,11 @@ public class XMLMethodSummaryReader implements BytecodeConstants {
     private void startClass(String cname, Attributes atts) {
       String clName = governingPackage == null ? 'L' + cname : "L" + governingPackage + '/' + cname;
       governingClass = className2Ref(clName);
+      classes.add(governingClass);
+      String superString = atts.getValue(A_SUPER);
+      if (superString != null) {
+        classSuperclasses.put(governingClass, className2Ref(superString));
+      }
       String allocString = atts.getValue(A_ALLOCATABLE);
       if (allocString != null) {
         Assertions.productionAssertion(allocString.equals("true"));

--- a/core/src/test/java/com/ibm/wala/core/tests/cha/SummaryClassShellTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/cha/SummaryClassShellTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2002 - 2006 IBM Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ */
+package com.ibm.wala.core.tests.cha;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.wala.classLoader.IClass;
+import com.ibm.wala.classLoader.IClassLoader;
+import com.ibm.wala.core.tests.callGraph.CallGraphTestUtil;
+import com.ibm.wala.core.tests.util.TestConstants;
+import com.ibm.wala.core.tests.util.WalaTestCase;
+import com.ibm.wala.ipa.callgraph.AnalysisScope;
+import com.ibm.wala.ipa.callgraph.impl.Util;
+import com.ibm.wala.ipa.cha.ClassHierarchy;
+import com.ibm.wala.ipa.cha.ClassHierarchyException;
+import com.ibm.wala.ipa.cha.ClassHierarchyFactory;
+import com.ibm.wala.ipa.summaries.SummaryClassShell;
+import com.ibm.wala.ipa.summaries.XMLMethodSummaryReader;
+import com.ibm.wala.types.TypeReference;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the generic, front-end-agnostic summary class-shell mechanism behind <a
+ * href="https://github.com/wala/WALA/issues/1957">#1957</a>: a summary {@code <class>} that
+ * declares a {@code super} opts in to being materialized as a standalone class shell positioned at
+ * that superclass, via {@link Util#addSummaryClassShells}; a {@code <class>} without a {@code
+ * super} stays method-summary-only.
+ */
+public class SummaryClassShellTest extends WalaTestCase {
+
+  /** A {@code <class super=...>} opts in as a shell; a plain {@code <class>} does not. */
+  private static final String XML =
+      """
+      <summary-spec>
+        <classloader name="Synthetic">
+          <class name="Base" super="Ljava/lang/Object"/>
+          <class name="NotAShell"/>
+        </classloader>
+      </summary-spec>
+      """;
+
+  private static XMLMethodSummaryReader read(AnalysisScope scope) {
+    return new XMLMethodSummaryReader(
+        new ByteArrayInputStream(XML.getBytes(StandardCharsets.UTF_8)), scope);
+  }
+
+  @Test
+  public void testReaderCapturesSuperAsShellOptIn() throws IOException {
+    AnalysisScope scope =
+        CallGraphTestUtil.makeJ2SEAnalysisScope(
+            TestConstants.WALA_TESTDATA, CallGraphTestUtil.REGRESSION_EXCLUSIONS);
+    XMLMethodSummaryReader reader = read(scope);
+
+    TypeReference base = TypeReference.findOrCreate(scope.getSyntheticLoader(), "LBase");
+    TypeReference notAShell = TypeReference.findOrCreate(scope.getSyntheticLoader(), "LNotAShell");
+
+    // Both are declared classes...
+    assertThat(reader.getClasses()).contains(base, notAShell);
+    // ...but only the one declaring a super opts in to being a shell.
+    assertThat(reader.getClassSuperclasses()).containsKey(base).doesNotContainKey(notAShell);
+    assertThat(reader.getClassSuperclasses().get(base))
+        .isEqualTo(TypeReference.findOrCreate(scope.getSyntheticLoader(), "Ljava/lang/Object"));
+  }
+
+  @Test
+  public void testDriverRegistersShellResolvingItsSuperclass()
+      throws ClassHierarchyException, IOException {
+    AnalysisScope scope =
+        CallGraphTestUtil.makeJ2SEAnalysisScope(
+            TestConstants.WALA_TESTDATA, CallGraphTestUtil.REGRESSION_EXCLUSIONS);
+    ClassHierarchy cha = ClassHierarchyFactory.make(scope);
+    XMLMethodSummaryReader reader = read(scope);
+    IClassLoader synthetic = cha.getLoader(scope.getSyntheticLoader());
+
+    Util.addSummaryClassShells(synthetic, reader);
+
+    TypeReference baseRef = TypeReference.findOrCreate(scope.getSyntheticLoader(), "LBase");
+    IClass base = cha.lookupClass(baseRef);
+    assertThat(base).isInstanceOf(SummaryClassShell.class);
+    assertThat(base.getSuperclass()).isSameAs(cha.lookupClass(TypeReference.JavaLangObject));
+
+    // The opt-out class did not get a shell.
+    TypeReference notAShell = TypeReference.findOrCreate(scope.getSyntheticLoader(), "LNotAShell");
+    assertThat(cha.lookupClass(notAShell)).isNull();
+  }
+}

--- a/core/src/test/java/com/ibm/wala/core/tests/cha/SummaryClassShellTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/cha/SummaryClassShellTest.java
@@ -11,19 +11,24 @@
 package com.ibm.wala.core.tests.cha;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IClassLoader;
 import com.ibm.wala.core.tests.callGraph.CallGraphTestUtil;
 import com.ibm.wala.core.tests.util.TestConstants;
 import com.ibm.wala.core.tests.util.WalaTestCase;
+import com.ibm.wala.core.util.strings.Atom;
 import com.ibm.wala.ipa.callgraph.AnalysisScope;
 import com.ibm.wala.ipa.callgraph.impl.Util;
 import com.ibm.wala.ipa.cha.ClassHierarchy;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.ipa.cha.ClassHierarchyFactory;
 import com.ibm.wala.ipa.summaries.SummaryClassShell;
+import com.ibm.wala.ipa.summaries.SummaryClassShellLoader;
 import com.ibm.wala.ipa.summaries.XMLMethodSummaryReader;
+import com.ibm.wala.types.Selector;
+import com.ibm.wala.types.TypeName;
 import com.ibm.wala.types.TypeReference;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -50,17 +55,30 @@ public class SummaryClassShellTest extends WalaTestCase {
       </summary-spec>
       """;
 
-  private static XMLMethodSummaryReader read(AnalysisScope scope) {
+  /** A shell declared in a loader other than the one the driver is asked to populate. */
+  private static final String XML_PRIMORDIAL =
+      """
+      <summary-spec>
+        <classloader name="Primordial">
+          <class name="Foreign" super="Ljava/lang/Object"/>
+        </classloader>
+      </summary-spec>
+      """;
+
+  private static AnalysisScope scope() throws IOException {
+    return CallGraphTestUtil.makeJ2SEAnalysisScope(
+        TestConstants.WALA_TESTDATA, CallGraphTestUtil.REGRESSION_EXCLUSIONS);
+  }
+
+  private static XMLMethodSummaryReader read(AnalysisScope scope, String xml) {
     return new XMLMethodSummaryReader(
-        new ByteArrayInputStream(XML.getBytes(StandardCharsets.UTF_8)), scope);
+        new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)), scope);
   }
 
   @Test
   public void testReaderCapturesSuperAsShellOptIn() throws IOException {
-    AnalysisScope scope =
-        CallGraphTestUtil.makeJ2SEAnalysisScope(
-            TestConstants.WALA_TESTDATA, CallGraphTestUtil.REGRESSION_EXCLUSIONS);
-    XMLMethodSummaryReader reader = read(scope);
+    AnalysisScope scope = scope();
+    XMLMethodSummaryReader reader = read(scope, XML);
 
     TypeReference base = TypeReference.findOrCreate(scope.getSyntheticLoader(), "LBase");
     TypeReference notAShell = TypeReference.findOrCreate(scope.getSyntheticLoader(), "LNotAShell");
@@ -76,11 +94,9 @@ public class SummaryClassShellTest extends WalaTestCase {
   @Test
   public void testDriverRegistersShellResolvingItsSuperclass()
       throws ClassHierarchyException, IOException {
-    AnalysisScope scope =
-        CallGraphTestUtil.makeJ2SEAnalysisScope(
-            TestConstants.WALA_TESTDATA, CallGraphTestUtil.REGRESSION_EXCLUSIONS);
+    AnalysisScope scope = scope();
     ClassHierarchy cha = ClassHierarchyFactory.make(scope);
-    XMLMethodSummaryReader reader = read(scope);
+    XMLMethodSummaryReader reader = read(scope, XML);
     IClassLoader synthetic = cha.getLoader(scope.getSyntheticLoader());
 
     Util.addSummaryClassShells(synthetic, reader);
@@ -93,5 +109,91 @@ public class SummaryClassShellTest extends WalaTestCase {
     // The opt-out class did not get a shell.
     TypeReference notAShell = TypeReference.findOrCreate(scope.getSyntheticLoader(), "LNotAShell");
     assertThat(cha.lookupClass(notAShell)).isNull();
+  }
+
+  /** A shell carries no members; its only role is to occupy a place in the hierarchy. */
+  @Test
+  public void testShellHasNoMembers() throws ClassHierarchyException, IOException {
+    AnalysisScope scope = scope();
+    ClassHierarchy cha = ClassHierarchyFactory.make(scope);
+    Util.addSummaryClassShells(cha.getLoader(scope.getSyntheticLoader()), read(scope, XML));
+
+    IClass base = cha.lookupClass(TypeReference.findOrCreate(scope.getSyntheticLoader(), "LBase"));
+    assertThat(base).isInstanceOf(SummaryClassShell.class);
+
+    assertThat(base.getDeclaredMethods()).isEmpty();
+    assertThat(base.getAllMethods()).isEmpty();
+    assertThat(base.getDeclaredInstanceFields()).isEmpty();
+    assertThat(base.getDeclaredStaticFields()).isEmpty();
+    assertThat(base.getAllInstanceFields()).isEmpty();
+    assertThat(base.getAllStaticFields()).isEmpty();
+    assertThat(base.getAllFields()).isEmpty();
+    assertThat(base.getDirectInterfaces()).isEmpty();
+    assertThat(base.getAllImplementedInterfaces()).isEmpty();
+    assertThat(base.getMethod(Selector.make("foo()V"))).isNull();
+    assertThat(base.getField(Atom.findOrCreateAsciiAtom("f"))).isNull();
+    assertThat(base.getClassInitializer()).isNull();
+    assertThat(base.isPublic()).isTrue();
+    assertThat(base.isPrivate()).isFalse();
+    assertThat(base.isReferenceType()).isTrue();
+    assertThat(base.getModifiers()).isZero();
+    assertThat(base.toString()).contains("Base");
+  }
+
+  /** Registering a shell twice returns the same class, and a null super defaults to the root. */
+  @Test
+  public void testShellRegistrationIsIdempotentAndDefaultsSuperToRoot()
+      throws ClassHierarchyException, IOException {
+    AnalysisScope scope = scope();
+    ClassHierarchy cha = ClassHierarchyFactory.make(scope);
+    SummaryClassShellLoader synthetic =
+        (SummaryClassShellLoader) cha.getLoader(scope.getSyntheticLoader());
+    TypeName name = TypeName.string2TypeName("LRootless");
+
+    IClass first = synthetic.defineSummaryClassShell(name, null);
+    assertThat(first.getSuperclass()).isSameAs(cha.getRootClass());
+    assertThat(synthetic.defineSummaryClassShell(name, null)).isSameAs(first);
+  }
+
+  /** The driver rejects null arguments. */
+  @Test
+  public void testDriverRejectsNullArguments() throws ClassHierarchyException, IOException {
+    AnalysisScope scope = scope();
+    ClassHierarchy cha = ClassHierarchyFactory.make(scope);
+    IClassLoader synthetic = cha.getLoader(scope.getSyntheticLoader());
+    XMLMethodSummaryReader reader = read(scope, XML);
+
+    assertThatThrownBy(() -> Util.addSummaryClassShells(null, reader))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Util.addSummaryClassShells(synthetic, null))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  /** A loader that cannot introduce shells is silently skipped. */
+  @Test
+  public void testDriverSkipsLoaderWithoutCapability() throws ClassHierarchyException, IOException {
+    AnalysisScope scope = scope();
+    ClassHierarchy cha = ClassHierarchyFactory.make(scope);
+    // The primordial loader is a bytecode loader and does not implement SummaryClassShellLoader.
+    IClassLoader primordial = cha.getLoader(scope.getPrimordialLoader());
+
+    Util.addSummaryClassShells(primordial, read(scope, XML));
+
+    assertThat(cha.lookupClass(TypeReference.findOrCreate(scope.getSyntheticLoader(), "LBase")))
+        .isNull();
+  }
+
+  /** Only classes whose declaring loader matches the target loader are registered. */
+  @Test
+  public void testDriverSkipsClassesFromOtherLoaders() throws ClassHierarchyException, IOException {
+    AnalysisScope scope = scope();
+    ClassHierarchy cha = ClassHierarchyFactory.make(scope);
+    IClassLoader synthetic = cha.getLoader(scope.getSyntheticLoader());
+
+    // The summary declares its shell under the Primordial loader, not the Synthetic one.
+    Util.addSummaryClassShells(synthetic, read(scope, XML_PRIMORDIAL));
+
+    assertThat(cha.lookupClass(TypeReference.findOrCreate(scope.getSyntheticLoader(), "LForeign")))
+        .isNull();
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/cha/SummaryClassShellTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/cha/SummaryClassShellTest.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.ibm.wala.classLoader.IClass;
 import com.ibm.wala.classLoader.IClassLoader;
+import com.ibm.wala.classLoader.IMethod;
 import com.ibm.wala.core.tests.callGraph.CallGraphTestUtil;
 import com.ibm.wala.core.tests.util.TestConstants;
 import com.ibm.wala.core.tests.util.WalaTestCase;
@@ -51,6 +52,18 @@ public class SummaryClassShellTest extends WalaTestCase {
         <classloader name="Synthetic">
           <class name="Base" super="Ljava/lang/Object"/>
           <class name="NotAShell"/>
+        </classloader>
+      </summary-spec>
+      """;
+
+  /** A shell whose {@code <class>} declares a method, which the shell should expose. */
+  private static final String XML_WITH_METHOD =
+      """
+      <summary-spec>
+        <classloader name="Synthetic">
+          <class name="WithMethod" super="Ljava/lang/Object">
+            <method name="foo" descriptor="()V"/>
+          </class>
         </classloader>
       </summary-spec>
       """;
@@ -138,6 +151,28 @@ public class SummaryClassShellTest extends WalaTestCase {
     assertThat(base.isReferenceType()).isTrue();
     assertThat(base.getModifiers()).isZero();
     assertThat(base.toString()).contains("Base");
+  }
+
+  /** A shell exposes the methods declared by its {@code <class>} as its own declared methods. */
+  @Test
+  public void testShellExposesItsSummaryMethods() throws ClassHierarchyException, IOException {
+    AnalysisScope scope = scope();
+    ClassHierarchy cha = ClassHierarchyFactory.make(scope);
+    Util.addSummaryClassShells(
+        cha.getLoader(scope.getSyntheticLoader()), read(scope, XML_WITH_METHOD));
+
+    IClass shell =
+        cha.lookupClass(TypeReference.findOrCreate(scope.getSyntheticLoader(), "LWithMethod"));
+    assertThat(shell).isInstanceOf(SummaryClassShell.class);
+
+    Selector foo = Selector.make("foo()V");
+    IMethod method = shell.getMethod(foo);
+    assertThat(method).isNotNull();
+    assertThat(method.getSelector()).isEqualTo(foo);
+    assertThat(method.getDeclaringClass()).isSameAs(shell);
+    assertThat(shell.getDeclaredMethods()).singleElement().isSameAs(method);
+    // The materialized method is cached.
+    assertThat(shell.getMethod(foo)).isSameAs(method);
   }
 
   /** Registering a shell twice returns the same class, and a null super defaults to the root. */

--- a/core/src/test/java/com/ibm/wala/core/tests/cha/SummaryClassSuperclassOrderingTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/cha/SummaryClassSuperclassOrderingTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2002 - 2006 IBM Corporation.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ */
+package com.ibm.wala.core.tests.cha;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ibm.wala.classLoader.IClass;
+import com.ibm.wala.classLoader.IClassLoader;
+import com.ibm.wala.classLoader.IField;
+import com.ibm.wala.classLoader.IMethod;
+import com.ibm.wala.classLoader.SyntheticClass;
+import com.ibm.wala.core.tests.callGraph.CallGraphTestUtil;
+import com.ibm.wala.core.tests.util.TestConstants;
+import com.ibm.wala.core.tests.util.WalaTestCase;
+import com.ibm.wala.core.util.strings.Atom;
+import com.ibm.wala.ipa.callgraph.AnalysisScope;
+import com.ibm.wala.ipa.cha.ClassHierarchy;
+import com.ibm.wala.ipa.cha.ClassHierarchyException;
+import com.ibm.wala.ipa.cha.ClassHierarchyFactory;
+import com.ibm.wala.ipa.summaries.BypassSyntheticClassLoader;
+import com.ibm.wala.types.Selector;
+import com.ibm.wala.types.TypeName;
+import com.ibm.wala.types.TypeReference;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Characterizes the class-hierarchy ordering invariant behind <a
+ * href="https://github.com/wala/WALA/issues/1957">#1957</a>: a source class that {@code extends} a
+ * type modeled only by an XML method summary keeps that inheritance edge only if the summary class
+ * exists <em>before</em> the subclass is added to the {@link ClassHierarchy}.
+ *
+ * <p>The {@link ClassHierarchy} snapshots each class's superclass at {@code addClass} time. So
+ * registering a summary-modeled base <em>after</em> the subclass (as happens today, since {@code
+ * Util.addBypassLogic(...)} materializes summary classes only after {@code buildClassHierarchy()})
+ * leaves the subclass parented at {@code Object}. Registering the base <em>before</em> the
+ * subclass, the remedy in #1957, preserves the edge. Both orderings are exercised below.
+ *
+ * <p>This models the class-hierarchy half of the bug. The loader-local <em>resolution</em> half,
+ * which is what bites the CAst/Python front-end in practice, is covered by {@code
+ * com.ibm.wala.cast.test.SummaryClassShellResolutionTest}.
+ */
+public class SummaryClassSuperclassOrderingTest extends WalaTestCase {
+
+  /** Registering the summary-modeled base before the subclass preserves the inheritance edge. */
+  @Test
+  public void testBaseRegisteredBeforeSubclass() throws ClassHierarchyException, IOException {
+    Fixture f = new Fixture();
+
+    f.registerBase();
+    f.registerSub();
+
+    assertThat(f.sub().getSuperclass()).isSameAs(f.base());
+    assertThat(f.cha.getImmediateSubclasses(f.base())).contains(f.sub());
+  }
+
+  /**
+   * Registering the summary-modeled base after the subclass (the current ordering) loses the
+   * inheritance edge: the subclass falls back to {@code Object}.
+   */
+  @Test
+  public void testBaseRegisteredAfterSubclass() throws ClassHierarchyException, IOException {
+    Fixture f = new Fixture();
+
+    f.registerSub();
+    f.registerBase();
+
+    assertThat(f.sub().getSuperclass()).isSameAs(f.cha.getRootClass());
+    assertThat(f.cha.getImmediateSubclasses(f.base())).doesNotContain(f.sub());
+  }
+
+  /**
+   * Holds a hierarchy plus a summary-modeled {@code Base} and a {@code Sub extends Base}, both as
+   * synthetic classes registered through the {@link BypassSyntheticClassLoader}. {@code Sub} caches
+   * its superclass on first resolution, mirroring {@link
+   * com.ibm.wala.classLoader.BytecodeClass#getSuperclass()}.
+   */
+  private static final class Fixture {
+    final ClassHierarchy cha;
+    private final BypassSyntheticClassLoader synthetic;
+    private final SummaryClass base;
+    private final SummaryClass sub;
+    private final TypeReference baseRef;
+    private final TypeReference subRef;
+
+    Fixture() throws ClassHierarchyException, IOException {
+      AnalysisScope scope =
+          CallGraphTestUtil.makeJ2SEAnalysisScope(
+              TestConstants.WALA_TESTDATA, CallGraphTestUtil.REGRESSION_EXCLUSIONS);
+      cha = ClassHierarchyFactory.make(scope);
+      synthetic = (BypassSyntheticClassLoader) cha.getLoader(scope.getSyntheticLoader());
+      baseRef =
+          TypeReference.findOrCreate(scope.getSyntheticLoader(), TypeName.string2TypeName("LBase"));
+      subRef =
+          TypeReference.findOrCreate(scope.getSyntheticLoader(), TypeName.string2TypeName("LSub"));
+      base = new SummaryClass(baseRef, cha, null);
+      sub = new SummaryClass(subRef, cha, baseRef.getName());
+    }
+
+    void registerBase() {
+      synthetic.registerClass(baseRef.getName(), base);
+    }
+
+    void registerSub() {
+      synthetic.registerClass(subRef.getName(), sub);
+    }
+
+    IClass base() {
+      return base;
+    }
+
+    IClass sub() {
+      return cha.lookupClass(subRef);
+    }
+  }
+
+  /**
+   * A minimal {@link SyntheticClass} that resolves its superclass through its class loader and
+   * caches the first resolution, mirroring the contract of {@link
+   * com.ibm.wala.classLoader.BytecodeClass#getSuperclass()}.
+   */
+  private static final class SummaryClass extends SyntheticClass {
+
+    private final TypeName superName;
+
+    private boolean superclassComputed;
+    private IClass superClass;
+
+    SummaryClass(TypeReference type, ClassHierarchy cha, TypeName superName) {
+      super(type, cha);
+      this.superName = superName;
+    }
+
+    @Override
+    public IClass getSuperclass() {
+      if (!superclassComputed) {
+        superclassComputed = true;
+        IClassLoader loader = getClassLoader();
+        if (superName != null) {
+          superClass = loader.lookupClass(superName);
+        }
+        if (superClass == null) {
+          superClass = loader.lookupClass(TypeReference.JavaLangObject.getName());
+        }
+      }
+      return superClass;
+    }
+
+    @Override
+    public Collection<IClass> getDirectInterfaces() {
+      return Collections.emptySet();
+    }
+
+    @Override
+    public Collection<IClass> getAllImplementedInterfaces() {
+      return Collections.emptySet();
+    }
+
+    @Override
+    public IMethod getMethod(Selector selector) {
+      return null;
+    }
+
+    @Override
+    public IField getField(Atom name) {
+      return null;
+    }
+
+    @Override
+    public IMethod getClassInitializer() {
+      return null;
+    }
+
+    @Override
+    public Collection<? extends IMethod> getDeclaredMethods() {
+      return Collections.emptySet();
+    }
+
+    @Override
+    public Collection<IField> getDeclaredInstanceFields() {
+      return Collections.emptySet();
+    }
+
+    @Override
+    public Collection<IField> getDeclaredStaticFields() {
+      return Collections.emptySet();
+    }
+
+    @Override
+    public Collection<IField> getAllInstanceFields() {
+      return Collections.emptySet();
+    }
+
+    @Override
+    public Collection<IField> getAllStaticFields() {
+      return Collections.emptySet();
+    }
+
+    @Override
+    public Collection<IField> getAllFields() {
+      return Collections.emptySet();
+    }
+
+    @Override
+    public Collection<? extends IMethod> getAllMethods() {
+      return Collections.emptySet();
+    }
+
+    @Override
+    public boolean isReferenceType() {
+      return getReference().isReferenceType();
+    }
+
+    @Override
+    public boolean isPublic() {
+      return true;
+    }
+
+    @Override
+    public boolean isPrivate() {
+      return false;
+    }
+
+    @Override
+    public int getModifiers() {
+      return 0;
+    }
+  }
+}


### PR DESCRIPTION
Depends on #1958 and is stacked on it. **Do not merge before #1958.** Until #1958 merges, the diff here also includes its commits; once #1958 lands, this reduces to the single follow-up commit. Toward #1957.

## What

#1958 registers a class shell before the CHA is built so a source subclass resolves its summary-modeled base. This follow-up lets that shell also carry the base's own methods, so a walk of the shell (for example, resolving an inherited method on the subclass) finds them. The method bodies are still bound late by the usual bypass mechanism; only the declarations need to exist on the shell.

## Change

- [`SummaryClassShell`](https://github.com/ponder-lab/WALA/blob/3cd29c2918b965892a9148a73bde7ab03e1c7b5e/core/src/main/java/com/ibm/wala/ipa/summaries/SummaryClassShell.java#L97) exposes the method summaries declared by its `<class>` (its `<method>` children) as its own declared methods, materialized lazily as `SummarizedMethod`s.
- [`SummaryClassShellLoader`](https://github.com/ponder-lab/WALA/blob/3cd29c2918b965892a9148a73bde7ab03e1c7b5e/core/src/main/java/com/ibm/wala/ipa/summaries/SummaryClassShellLoader.java#L63) gains a `defineSummaryClassShell(name, super, methods)` overload. It is a `default` that ignores `methods` and delegates to the no-methods version; the `BypassSyntheticClassLoader` overrides it. The no-methods 2-arg overload remains for a pure base shell.
- [`Util.addSummaryClassShells`](https://github.com/ponder-lab/WALA/blob/3cd29c2918b965892a9148a73bde7ab03e1c7b5e/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/Util.java#L218) groups the summary's methods by declaring class and hands each shell its own.

A loader whose shells cannot carry methods (the CAst module loaders' default) keeps the prior behavior; such a loader may override the hook to build a shell type that does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJxS9UvezNo842kqxmc1vS