### PR TITLE
Modernize reporting by `CheckGitCleanlinessTask`

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/check-git-cleanliness.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/check-git-cleanliness.gradle.kts
@@ -2,6 +2,7 @@ package com.ibm.wala.gradle
 
 import kotlin.io.path.Path
 import org.eclipse.jgit.api.Git
+import org.gradle.api.tasks.VerificationException
 
 /**
  * Validate `.gitignore` patterns and strict source/build separation.
@@ -37,24 +38,27 @@ abstract class CheckGitCleanlinessTask : DefaultTask() {
     val status = Git.open(projectDirectory.asFile).use { it.status().call() }
     if (!status.isClean) {
       ids.run {
-        sequenceOf(
-                addedId to status.added,
-                changedId to status.changed,
-                removedId to status.removed,
-                missingId to status.missing,
-                modifiedId to status.modified,
-                untrackedId to status.untracked,
-                conflictingId to status.conflicting,
-            )
-            .forEach { (id, files) ->
-              if (files.isNotEmpty()) {
-                problems.reporter.report(id) {
-                  severity(Severity.ERROR)
-                  files.sortedBy(::Path).forEach(::fileLocation)
+        val dirtyProblems =
+            sequenceOf(
+                    addedId to status.added,
+                    changedId to status.changed,
+                    removedId to status.removed,
+                    missingId to status.missing,
+                    modifiedId to status.modified,
+                    untrackedId to status.untracked,
+                    conflictingId to status.conflicting,
+                )
+                .filter { (_, files) -> files.isNotEmpty() }
+                .map { (id, files) ->
+                  problems.reporter.create(id) { files.sortedBy(::Path).forEach(::fileLocation) }
                 }
-              }
-            }
-        throw GradleException(dirtyProblemGroup.displayName)
+                .toList()
+        if (dirtyProblems.isNotEmpty()) {
+          throw problems.reporter.throwing(
+              VerificationException(dirtyProblemGroup.displayName),
+              dirtyProblems,
+          )
+        }
       }
     }
     logger.info("Git working directory is clean")


### PR DESCRIPTION
Replace deprecated `severity(Severity.ERROR)` with modern `Problem`-reporting API:

1. Use `create(id) { ... }` to build `Problem` objects for each dirty category.

2. Use `throwing(throwable, problems)` to batch-report and fail the build.