### PR TITLE
Fix the `CAstBinaryOp` enum and address review feedback on #1798

### DIFF
--- a/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/ecj/util/SourceDirCallGraph.java
+++ b/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/ecj/util/SourceDirCallGraph.java
@@ -22,6 +22,7 @@ import com.ibm.wala.ipa.callgraph.impl.Util;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.ipa.cha.ClassHierarchyFactory;
 import com.ibm.wala.ipa.cha.IClassHierarchy;
+import com.ibm.wala.ssa.SSAOptions;
 import com.ibm.wala.ssa.SymbolTable;
 import com.ibm.wala.types.ClassLoaderReference;
 import com.ibm.wala.util.io.CommandLine;

--- a/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/examples/hybrid/HybridClassLoaderFactory.java
+++ b/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/examples/hybrid/HybridClassLoaderFactory.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 public class HybridClassLoaderFactory extends ClassLoaderFactoryImpl {
 
   private final JavaScriptTranslatorFactory jsTranslatorFactory;
-  private SSAOptions ssaOptions;
+  private final SSAOptions ssaOptions;
 
   public HybridClassLoaderFactory(
       JavaScriptTranslatorFactory jsTranslatorFactory,

--- a/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/vis/JsViewerDriver.java
+++ b/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/vis/JsViewerDriver.java
@@ -30,6 +30,7 @@ import com.ibm.wala.classLoader.SourceModule;
 import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.ibm.wala.ipa.callgraph.propagation.InstanceKey;
 import com.ibm.wala.ipa.callgraph.propagation.PointerAnalysis;
+import com.ibm.wala.ssa.SSAOptions;
 import com.ibm.wala.util.CancelException;
 import com.ibm.wala.util.WalaException;
 import java.io.IOException;

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/summaries/JavaScriptConstructorFunctions.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/summaries/JavaScriptConstructorFunctions.java
@@ -59,7 +59,7 @@ public class JavaScriptConstructorFunctions {
 
   private final IClassHierarchy cha;
 
-  private SSAOptions ssaOptions;
+  private final SSAOptions ssaOptions;
 
   public JavaScriptConstructorFunctions(IClassHierarchy cha, SSAOptions ssaOptions) {
     this.cha = cha;

--- a/cast/src/main/java/com/ibm/wala/cast/ir/ssa/CAstBinaryOp.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/ssa/CAstBinaryOp.java
@@ -22,7 +22,7 @@ public enum CAstBinaryOp implements IBinaryOpInstruction.IOperator {
   LE,
   STRICT_EQ,
   STRICT_NE,
-  INSTANCE_OF;
+  INSTANCE_OF,
   POW;
 
   @Override

--- a/core/src/main/java/com/ibm/wala/ssa/InstanceOfPiPolicy.java
+++ b/core/src/main/java/com/ibm/wala/ssa/InstanceOfPiPolicy.java
@@ -44,12 +44,12 @@ public class InstanceOfPiPolicy implements SSAPiNodePolicy {
       SSAInstruction def1,
       SSAInstruction def2,
       SymbolTable symbolTable) {
-    if (isInstanceOf(def1)) {
+    if (isInstanceOfInstruction(def1)) {
       if (symbolTable.isBooleanOrZeroOneConstant(cond.getUse(1))) {
         return Pair.make(def1.getUse(0), def1);
       }
     }
-    if (isInstanceOf(def2)) {
+    if (isInstanceOfInstruction(def2)) {
       if (symbolTable.isBooleanOrZeroOneConstant(cond.getUse(0))) {
         return Pair.make(def2.getUse(0), def2);
       }
@@ -57,7 +57,7 @@ public class InstanceOfPiPolicy implements SSAPiNodePolicy {
     return null;
   }
 
-  protected boolean isInstanceOf(SSAInstruction def) {
+  protected boolean isInstanceOfInstruction(SSAInstruction def) {
     return def instanceof SSAInstanceofInstruction;
   }
 


### PR DESCRIPTION
@juliandolby, this is an optional suggested completion for #1798; take it or leave it.

Motivation: this work is relevant to https://github.com/wala/ML, whose Python front end extends `AstTranslator` and will need the new `SSAOptions` constructor plumbing, so I wanted to help get #1798 over the line.

Branching off `ssa_options_analysis_engine`, this gets the branch compiling and addresses the review feedback:

- Fixes three latent compile errors, all masked because `cast:spotlessJavaCheck` failed first and aborted the build before `compileJava` ran:
  - `CAstBinaryOp`: the new `INSTANCE_OF` constant ended the enum constant list with `;`, orphaning `POW;` into an uncompilable statement (this is what google-java-format could not parse).
  - `SourceDirCallGraph`: uses `SSAOptions.defaultOptions()` without importing `SSAOptions`.
  - `JsViewerDriver`: same missing `SSAOptions` import in test code.
- Makes the `ssaOptions` fields `final` per @liblit and @msridhar.
- Renames the predicate to `isInstanceOfInstruction` per @msridhar.

Verified locally that `compileJava`, `compileTestJava`, and `compileTestFixturesJava` all pass across every subproject.

I left the question of whether to split the `instanceof`-operator changes into a separate PR for you to decide. Merge this into your branch if it's useful; otherwise feel free to ignore it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
