### PR TITLE
Detect invalid type before constructing instance

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -341,6 +341,7 @@ tasks.withType<JavaCompile>().configureEach {
           "UnnecessaryStringBuilder",
           "UnrecognisedJavadocTag",
           "UnsafeFinalization",
+          "UnsafeReflectiveConstructionCast",
           "UnsynchronizedOverridesSynchronized",
           "UnusedLabel",
           "UnusedNestedClass",
@@ -402,7 +403,6 @@ tasks.withType<JavaCompile>().configureEach {
           "StringCaseLocaleUsage",
           "StringSplitter",
           "SuperCallToObjectMethod",
-          "UnsafeReflectiveConstructionCast",
           "UnusedMethod",
           "VariableNameSameAsType",
       )

--- a/shrike/src/main/java/com/ibm/wala/shrike/cg/Runtime.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/cg/Runtime.java
@@ -83,7 +83,10 @@ public class Runtime {
 
     try {
       handleCallback =
-          (Policy) Class.forName(policyClassName).getDeclaredConstructor().newInstance();
+          Class.forName(policyClassName)
+              .asSubclass(Policy.class)
+              .getDeclaredConstructor()
+              .newInstance();
     } catch (InstantiationException
         | IllegalAccessException
         | ClassNotFoundException


### PR DESCRIPTION
If `policyClassName` names a class that does not implement `Policy`, then previously we would only discover that mistake _after_ constructing an instance.  Now we detect the mistake earlier, _before_ invoking the constructor.