### PR TITLE
Bump codecov/codecov-action to v7

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -78,7 +78,7 @@ jobs:
         run: ./gradlew testCodeCoverageReport "-Pcom.ibm.wala.jdk-version=${{ matrix.java }}"
         if: github.repository == 'wala/WALA'
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: ./code-coverage-report/build/reports/jacoco/testCodeCoverageReport/testCodeCoverageReport.xml
           token: ${{ secrets.WALA_MAIN_CODECOV_TOKEN }}


### PR DESCRIPTION
This should get rid of Node.js v20 deprecation messages on CI, e.g., see the annotations at the top of [this job](https://github.com/wala/WALA/actions/runs/28532905369/job/84586785338).

