### PR TITLE
Re-resolve lexical accesses when new closures reach a shared node

### DIFF
--- a/cast/js/src/test/resources/tests/closures_shared_node.js
+++ b/cast/js/src/test/resources/tests/closures_shared_node.js
@@ -1,0 +1,41 @@
+// Regression test for https://github.com/wala/WALA/issues/1990: `step`'s two closures
+// dispatch through the single call site in `invoke`, whose 1-CFA call string truncates the
+// callers apart, so one call graph node serves both closures. The identity chain delays the
+// second closure so it reaches that node only after its constraints were first generated;
+// without re-resolution, `late` never becomes a callee of `step`.
+function early() {
+  return 3;
+}
+
+function late() {
+  return 4;
+}
+
+function make(target) {
+  function step() {
+    return target();
+  }
+  return step;
+}
+
+function id1(f) {
+  return f;
+}
+
+function id2(f) {
+  return id1(f);
+}
+
+function id3(f) {
+  return id2(f);
+}
+
+function invoke(f) {
+  return f();
+}
+
+var a = make(early);
+invoke(a);
+
+var b = id3(make(late));
+invoke(b);

--- a/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestSimpleCallGraphShape.java
+++ b/cast/js/src/testFixtures/java/com/ibm/wala/cast/js/test/TestSimpleCallGraphShape.java
@@ -251,6 +251,28 @@ public abstract class TestSimpleCallGraphShape extends TestJSCallGraphShape {
     JSCallGraphBuilderUtil.makeScriptCG("tests", "recursive_lexical.js");
   }
 
+  private static final List<GraphAssertion> assertionsForClosuresSharedNode =
+      List.of(
+          new GraphAssertion("suffix:step", new String[] {"suffix:early"}),
+          new GraphAssertion("suffix:step", new String[] {"suffix:late"}));
+
+  /**
+   * Two closures of {@code step} whose captured {@code target}s differ must both wire their
+   * environments even when the second closure reaches the (shared) call graph node after its
+   * constraints were first generated; see https://github.com/wala/WALA/issues/1990.
+   */
+  @Test
+  public void testClosuresSharedNode()
+      throws IOException, IllegalArgumentException, CancelException, WalaException {
+    CallGraph CG =
+        JSCallGraphBuilderUtil.makeScriptCG(
+            "tests",
+            "closures_shared_node.js",
+            JSCallGraphBuilderUtil.CGBuilderType.ONE_CFA,
+            getClass().getClassLoader());
+    verifyGraphAssertions(CG, assertionsForClosuresSharedNode);
+  }
+
   private static final List<GraphAssertion> assertionsForLexicalMultiple =
       List.of(
           new GraphAssertion(ROOT, new String[] {"lexical_multiple_calls.js"}),

--- a/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/AstSSAPropagationCallGraphBuilder.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/AstSSAPropagationCallGraphBuilder.java
@@ -344,9 +344,7 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
       // single closure object is known statically) and its points-to set is implicitly
       // represented, so registering a side effect is both unnecessary and disallowed. See
       // https://github.com/wala/WALA/issues/1990.
-      SymbolTable symtab = node.getIR().getSymbolTable();
-      DefUse du = getBuilder().getCFAContextInterpreter().getDU(node);
-      if (!contentsAreInvariant(symtab, du, 1)) {
+      if (!contentsAreInvariant(ir.getSymbolTable(), du, 1)) {
         system.newSideEffect(op, getPointerKeyForLocal(1));
       }
     }

--- a/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/AstSSAPropagationCallGraphBuilder.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/AstSSAPropagationCallGraphBuilder.java
@@ -340,8 +340,15 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
       // node (e.g. under call-string context truncation), a closure arriving after the initial
       // resolution would otherwise never get its frame wired. The operator's constraint additions
       // are idempotent, and its equals()/hashCode() let the fixpoint system de-duplicate
-      // registrations. See https://github.com/wala/WALA/issues/1990.
-      system.newSideEffect(op, getPointerKeyForLocal(1));
+      // registrations. When v1's contents are invariant, the snapshot is already complete (the
+      // single closure object is known statically) and its points-to set is implicitly
+      // represented, so registering a side effect is both unnecessary and disallowed. See
+      // https://github.com/wala/WALA/issues/1990.
+      SymbolTable symtab = node.getIR().getSymbolTable();
+      DefUse du = getBuilder().getCFAContextInterpreter().getDU(node);
+      if (!contentsAreInvariant(symtab, du, 1)) {
+        system.newSideEffect(op, getPointerKeyForLocal(1));
+      }
     }
 
     @Override

--- a/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/AstSSAPropagationCallGraphBuilder.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/AstSSAPropagationCallGraphBuilder.java
@@ -332,13 +332,16 @@ public abstract class AstSSAPropagationCallGraphBuilder extends SSAPropagationCa
           .getPointerKeysForReflectedFieldWrite(I, F);
     }
 
-    private static void visitLexical(final LexicalOperator op) {
+    private void visitLexical(final LexicalOperator op) {
       op.doLexicalPointerKeys();
-      // I have no idea what the code below does, but commenting it out doesn't
-      // break any regression tests. --MS
-      // if (! checkLexicalInstruction(instruction)) {
-      // system.newSideEffect(op, getPointerKeyForLocal(1));
-      // }
+      // Re-resolve the lexical access whenever a new closure function object reaches this node's
+      // function value (v1): doLexicalPointerKeys() finds the access's defining frames from the
+      // current points-to set of v1, so when distinct closures of the same function share this
+      // node (e.g. under call-string context truncation), a closure arriving after the initial
+      // resolution would otherwise never get its frame wired. The operator's constraint additions
+      // are idempotent, and its equals()/hashCode() let the fixpoint system de-duplicate
+      // registrations. See https://github.com/wala/WALA/issues/1990.
+      system.newSideEffect(op, getPointerKeyForLocal(1));
     }
 
     @Override


### PR DESCRIPTION
## Problem

`AstConstraintVisitor.visitLexical` resolves a lexical access's defining frames from a one-time snapshot of the node's function-object (v1) points-to set; the re-evaluation side effect has been commented out since long ago ("I have no idea what the code below does, but commenting it out doesn't break any regression tests. --MS"). When two distinct closures of the same function share one call-graph node (e.g. under `nCFA(1)`, where the call string truncates to the immediate call site), a closure whose `ScopeMappingInstanceKey` flows into v1 after that snapshot never gets its captured environment wired: reads through it silently yield nothing and every dispatch downstream of the access is lost, first-wins by solver worklist order. Full diagnosis with a whole-project reproduction is in #1990.

## Fix

Make `visitLexical` an instance method and restore the side-effect registration on v1's points-to set, so growth re-runs `doLexicalPointerKeys()`. The `LexicalOperator`'s constraint additions are idempotent and its existing `equals`/`hashCode` let the fixpoint system de-duplicate registrations, so re-running is safe.

## Validation

The same restoration, applied in a downstream subclass ([wala/ML](https://github.com/ponder-lab/ML/pull/532), Python front end), fixes the whole-project node loss described in #1990 with no measurable test-suite slowdown there. Draft while this repository's cast and JS test suites are validated against the change.

Fixes #1990.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lk6J7cxYf5vsjm139L25pc