### PR TITLE
Remove a redundant condition clause

### DIFF
--- a/cast/js/src/main/java/com/ibm/wala/cast/js/html/DefaultSourceExtractor.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/html/DefaultSourceExtractor.java
@@ -167,7 +167,7 @@ public class DefaultSourceExtractor extends DomLessSourceExtractor {
         ITag tag, String attr, String value, String varName, String varName2) {
       // There should probably be more checking to see what the attributes are since we allow things
       // like: ; to be used as attributes now.
-      if (attr.length() >= 2 && attr.startsWith("on")) {
+      if (attr.startsWith("on")) {
         printlnIndented(
             varName
                 + '.'


### PR DESCRIPTION
If `attr` starts with `"on"`, then it must be at least two characters long.  No need to check the latter if we're also going to check the former.