### PR TITLE
Use format strings for better readability

### DIFF
--- a/cast/java/test/data/src/testSubjects/java/javaonepointseven/TryWithResourcesStatement.java
+++ b/cast/java/test/data/src/testSubjects/java/javaonepointseven/TryWithResourcesStatement.java
@@ -37,8 +37,7 @@ public class TryWithResourcesStatement {
         float price = rs.getFloat("PRICE");
         int sales = rs.getInt("SALES");
         int total = rs.getInt("TOTAL");
-        System.out.println(
-            coffeeName + ", " + supplierID + ", " + price + ", " + sales + ", " + total);
+        System.out.printf("%s, %d, %s, %d, %d%n", coffeeName, supplierID, price, sales, total);
       }
 
       rs.close();

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/FuncVertex.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/callgraph/fieldbased/flowgraph/vertices/FuncVertex.java
@@ -82,7 +82,7 @@ public class FuncVertex extends Vertex implements ObjectVertex {
     Iterator<CallSiteReference> sites = CG.getPossibleSites(caller, ctor);
     CallSiteReference site = sites.next();
     assert !sites.hasNext()
-        : caller + " --> " + ctor + " @ " + site + " and " + sites.next() + '\n' + caller.getIR();
+        : "%s --> %s @ %s and %s\n%s".formatted(caller, ctor, site, sites.next(), caller.getIR());
 
     return NonNullSingletonIterator.make(
         Pair.make(caller, NewSiteReference.make(site.getProgramCounter(), klass.getReference())));

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/html/DefaultSourceExtractor.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/html/DefaultSourceExtractor.java
@@ -169,16 +169,8 @@ public class DefaultSourceExtractor extends DomLessSourceExtractor {
       // like: ; to be used as attributes now.
       if (attr.length() >= 2 && attr.startsWith("on")) {
         printlnIndented(
-            varName
-                + '.'
-                + attr
-                + " = function "
-                + tag.getName().toLowerCase()
-                + '_'
-                + attr
-                + "(event) {"
-                + value
-                + "};",
+            "%s.%s = function %s_%s(event) {%s};"
+                .formatted(varName, attr, tag.getName().toLowerCase(), attr, value),
             tag);
         writeEntrypoint(
             varName2 + '.' + attr + "(null);", tag.getElementPosition(), entrypointUrl, false);
@@ -192,7 +184,7 @@ public class DefaultSourceExtractor extends DomLessSourceExtractor {
           attr = attr.toLowerCase();
         }
 
-        printlnIndented(varName + "['" + attr + "'] = " + quote + value + quote + ';', tag);
+        printlnIndented("%s['%s'] = %s%s%s;".formatted(varName, attr, quote, value, quote), tag);
       }
     }
 

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/EscapeCorrelation.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/EscapeCorrelation.java
@@ -56,15 +56,9 @@ public class EscapeCorrelation extends Correlation {
 
   @Override
   public String pp(SSASourcePositionMap positions) {
-    return get
-        + "@"
-        + positions.getPosition(get)
-        + " ["
-        + getIndexName()
-        + "] ->? "
-        + invoke
-        + '@'
-        + positions.getPosition(invoke);
+    return "%s@%s [%s] ->? %s@%s"
+        .formatted(
+            get, positions.getPosition(get), getIndexName(), invoke, positions.getPosition(invoke));
   }
 
   @Override

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/ReadWriteCorrelation.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/ReadWriteCorrelation.java
@@ -48,15 +48,9 @@ public class ReadWriteCorrelation extends Correlation {
 
   @Override
   public String pp(SSASourcePositionMap positions) {
-    return get
-        + "@"
-        + positions.getPosition(get)
-        + " ["
-        + getIndexName()
-        + "]-> "
-        + put
-        + '@'
-        + positions.getPosition(put);
+    return "%s@%s [%s]-> %s@%s"
+        .formatted(
+            get, positions.getPosition(get), getIndexName(), put, positions.getPosition(put));
   }
 
   @Override

--- a/cast/src/main/java/com/ibm/wala/cast/ir/ssa/SSAConversion.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/ssa/SSAConversion.java
@@ -198,38 +198,25 @@ public class SSAConversion extends AbstractSSAConversion {
 
     private CopyPropagationRecord(int instructionIndex, int rhs) {
       if (DEBUG_UNDO)
-        System.err.println(
-            ("new copy record for instruction #" + instructionIndex + ", rhs value is " + rhs));
+        System.err.printf(
+            "new copy record for instruction #%d, rhs value is %d%n", instructionIndex, rhs);
       this.rhs = rhs;
       this.instructionIndex = instructionIndex;
     }
 
     private void addChild(CopyPropagationRecord rec) {
       if (DEBUG_UNDO)
-        System.err.println(
-            ("("
-                + rec.instructionIndex
-                + ','
-                + rec.rhs
-                + ") is a child of ("
-                + instructionIndex
-                + ','
-                + rhs
-                + ')'));
+        System.err.printf(
+            "(%d,%d) is a child of (%d,%d)%n",
+            rec.instructionIndex, rec.rhs, instructionIndex, rhs);
       childRecords.add(rec);
     }
 
     private void addUse(int instructionIndex, int use) {
       if (DEBUG_UNDO)
-        System.err.println(
-            ("propagated use of ("
-                + this.instructionIndex
-                + ','
-                + this.rhs
-                + ") at use #"
-                + use
-                + " of instruction #"
-                + instructionIndex));
+        System.err.printf(
+            "propagated use of (%d,%d) at use #%d of instruction #%d%n",
+            this.instructionIndex, this.rhs, use, instructionIndex);
       UseRecord rec = new UseRecord(instructionIndex, use);
       copyPropagationMap.put(rec, this);
       renamedUses.add(rec);
@@ -261,8 +248,7 @@ public class SSAConversion extends AbstractSSAConversion {
       instructions[instructionIndex] = new AssignInstruction(instructionIndex, lhs, rhs);
 
       if (DEBUG_UNDO)
-        System.err.println(
-            ("recreating assignment at " + instructionIndex + " as " + lhs + " = " + rhs));
+        System.err.printf("recreating assignment at %d as %d = %d%n", instructionIndex, lhs, rhs);
 
       for (Object x : renamedUses) {
         if (x instanceof UseRecord use) {
@@ -270,8 +256,7 @@ public class SSAConversion extends AbstractSSAConversion {
           SSAInstruction inst = instructions[idx];
 
           if (DEBUG_UNDO)
-            System.err.println(
-                ("Changing use #" + use.useNumber + " of inst #" + idx + " to val " + lhs));
+            System.err.printf("Changing use #%d of inst #%d to val %d%n", use.useNumber, idx, lhs);
 
           if (use.useNumber >= 0) {
             instructions[idx] = undo(inst, use.useNumber, lhs);
@@ -347,7 +332,7 @@ public class SSAConversion extends AbstractSSAConversion {
     private void undoCopyPropagation(int instructionIndex, int useNumber) {
 
       if (DEBUG_UNDO)
-        System.err.println(("undoing for use #" + useNumber + " of inst #" + instructionIndex));
+        System.err.printf("undoing for use #%d of inst #%d%n", useNumber, instructionIndex);
 
       UseRecord use = new UseRecord(instructionIndex, useNumber);
       CopyPropagationRecord copyPropagationRecord = copyPropagationMap.get(use);
@@ -457,7 +442,7 @@ public class SSAConversion extends AbstractSSAConversion {
 
     SSAPhiInstruction phi = new SSAPhiInstruction(SSAInstruction.NO_INDEX, value, params);
 
-    if (DEBUG) System.err.println(("Placing " + phi + " at " + Y));
+    if (DEBUG) System.err.printf("Placing %s at %s%n", phi, Y);
 
     addPhi(Y, phi);
   }
@@ -725,10 +710,10 @@ public class SSAConversion extends AbstractSSAConversion {
   public static SSAInformation convert(
       AstMethod M, final AstIRFactory.AstIR ir, SSAOptions options, final IntSet values) {
     if (DEBUG) {
-      System.err.println(("starting conversion for " + values));
+      System.err.printf("starting conversion for %s%n", values);
       System.err.println(ir);
     }
-    if (DEBUG_UNDO) System.err.println((">>> starting " + ir.getMethod()));
+    if (DEBUG_UNDO) System.err.printf(">>> starting %s%n", ir.getMethod());
     SSAConversion ssa =
         new SSAConversion(M, ir, options) {
           final int limit = ir.getSymbolTable().getMaxValueNumber();
@@ -739,7 +724,7 @@ public class SSAConversion extends AbstractSSAConversion {
           }
         };
     ssa.perform();
-    if (DEBUG_UNDO) System.err.println(("<<< done " + ir.getMethod()));
+    if (DEBUG_UNDO) System.err.printf("<<< done %s%n", ir.getMethod());
     return ssa.getComputedLocalMap();
   }
 }

--- a/cast/src/main/java/com/ibm/wala/cast/ir/translator/NativeTranslatorToCAst.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/translator/NativeTranslatorToCAst.java
@@ -78,18 +78,11 @@ public abstract class NativeTranslatorToCAst extends NativeBridge implements Tra
       public String toString() {
         String urlString = sourceURL.toString();
         if (urlString.lastIndexOf(File.separator) == -1)
-          return "[" + fl + ':' + fc + "]->[" + ll + ':' + lc + ']';
+          return "[%d:%d]->[%d:%d]".formatted(fl, fc, ll, lc);
         else
-          return urlString.substring(urlString.lastIndexOf(File.separator) + 1)
-              + "@["
-              + fl
-              + ':'
-              + fc
-              + "]->["
-              + ll
-              + ':'
-              + lc
-              + ']';
+          return "%s@[%d:%d]->[%d:%d]"
+              .formatted(
+                  urlString.substring(urlString.lastIndexOf(File.separator) + 1), fl, fc, ll, lc);
       }
 
       @Override

--- a/cast/src/main/java/com/ibm/wala/cast/tree/impl/AbstractSourcePosition.java
+++ b/cast/src/main/java/com/ibm/wala/cast/tree/impl/AbstractSourcePosition.java
@@ -65,15 +65,8 @@ public abstract class AbstractSourcePosition implements Position {
     String pos;
     if (getFirstCol() != -1) {
       pos =
-          "["
-              + getFirstLine()
-              + ':'
-              + getFirstCol()
-              + "] -> ["
-              + getLastLine()
-              + ':'
-              + getLastCol()
-              + ']';
+          "[%d:%d] -> [%d:%d]"
+              .formatted(getFirstLine(), getFirstCol(), getLastLine(), getLastCol());
     } else if (getFirstOffset() != -1) {
       pos = "[" + getFirstOffset() + "->" + getLastOffset() + "] (line " + getFirstLine() + ')';
     } else {

--- a/cast/src/main/java/com/ibm/wala/cast/tree/impl/CAstSourcePositionRecorder.java
+++ b/cast/src/main/java/com/ibm/wala/cast/tree/impl/CAstSourcePositionRecorder.java
@@ -108,7 +108,7 @@ public class CAstSourcePositionRecorder implements CAstSourcePositionMap {
 
           @Override
           public String toString() {
-            return "[" + fl + ':' + fc + "]->[" + ll + ':' + lc + ']';
+            return "[%d:%d]->[%d:%d]".formatted(fl, fc, ll, lc);
           }
         });
   }

--- a/core/src/main/java/com/ibm/wala/classLoader/ShrikeCTMethod.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/ShrikeCTMethod.java
@@ -212,7 +212,7 @@ public final class ShrikeCTMethod extends ShrikeBTMethod implements IBytecodeMet
 
     @Override
     public String toString() {
-      return fileName + '(' + firstLine + ',' + firstCol + '-' + lastLine + ',' + lastCol + ')';
+      return "%s(%d,%d-%d,%d)".formatted(fileName, firstLine, firstCol, lastLine, lastCol);
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/core/util/ssa/ParameterAccessor.java
+++ b/core/src/main/java/com/ibm/wala/core/util/ssa/ParameterAccessor.java
@@ -130,13 +130,8 @@ public class ParameterAccessor {
 
     @Override
     public String toString() {
-      return "<ParameterKey no="
-          + this.paramNo
-          + " type="
-          + this.type
-          + " name=\""
-          + this.name
-          + "\" />";
+      return "<ParameterKey no=%d type=%s name=\"%s\" />"
+          .formatted(this.paramNo, this.type, this.name);
     }
   }
 
@@ -191,49 +186,41 @@ public class ParameterAccessor {
       // If type was null the call to super failed
       if ((number < 1) && (basedOn == BasedOn.METHOD_REFERENCE)) {
         throw new IllegalArgumentException(
-            "The first accessible SSA-Value of a MethodReference is 1 but the "
-                + "Value-Number given is "
-                + number);
+            "The first accessible SSA-Value of a MethodReference is 1 but the Value-Number given is %d"
+                .formatted(number));
       }
       if ((number < 0) && (basedOn == BasedOn.IMETHOD)) {
         throw new IllegalArgumentException(
-            "The first accessible SSA-Value of an IMethod is 0 but the "
-                + "Value-Number given is "
-                + number);
+            "The first accessible SSA-Value of an IMethod is 0 but the Value-Number given is %d"
+                .formatted(number));
       }
       if ((disp == ParameterDisposition.PARAM)
           && (number + descriptorOffset > mRef.getNumberOfParameters())) {
         throw new IllegalArgumentException(
-            "The SSA-Value "
-                + number
-                + " (with added offset "
-                + descriptorOffset
-                + ") is beyond the number of Arguments ("
-                + mRef.getNumberOfParameters()
-                + ") of the Method "
-                + mRef.getName()
-                + '\n'
-                + mRef.getSignature());
+            "The SSA-Value %d (with added offset %d) is beyond the number of Arguments (%d) of the Method %s\n%s"
+                .formatted(
+                    number,
+                    descriptorOffset,
+                    mRef.getNumberOfParameters(),
+                    mRef.getName(),
+                    mRef.getSignature()));
       }
       if ((disp == ParameterDisposition.THIS)
           && (basedOn == BasedOn.METHOD_REFERENCE)
           && (number != 1)) {
         throw new IllegalArgumentException(
-            "The implicit this-pointer of a MethodReference is located at SSA-Value 1. "
-                + "The SSA-Value given is "
-                + number);
+            "The implicit this-pointer of a MethodReference is located at SSA-Value 1. The SSA-Value given is %d"
+                .formatted(number));
       }
       if ((disp == ParameterDisposition.THIS) && (basedOn == BasedOn.IMETHOD) && (number != 0)) {
         throw new IllegalArgumentException(
-            "The implicit this-pointer of an IMethod is located at SSA-Value 0. "
-                + "The SSA-Value given is "
-                + number);
+            "The implicit this-pointer of an IMethod is located at SSA-Value 0. The SSA-Value given is %d"
+                .formatted(number));
       }
       if ((descriptorOffset < -2) || (descriptorOffset > 1)) {
         throw new IllegalArgumentException(
-            "The descriptor-offset given is not within its expected bounds: "
-                + "-1 (for a method without implicit this-pointer) to 1. The given offset is "
-                + descriptorOffset);
+            "The descriptor-offset given is not within its expected bounds: -1 (for a method without implicit this-pointer) to 1. The given offset is %d"
+                .formatted(descriptorOffset));
       }
 
       this.disp = disp;
@@ -279,47 +266,26 @@ public class ParameterAccessor {
     public String toString() {
       return switch (this.disp) {
         case THIS ->
-            "Implicit this-parameter of "
-                + this.mRef.getName()
-                + " as "
-                + this.type
-                + " accessible using "
-                + "SSA-Value "
-                + this.number;
+            "Implicit this-parameter of %s as %s accessible using SSA-Value %d"
+                .formatted(this.mRef.getName(), this.type, this.number);
         case PARAM ->
             this.key instanceof NamedKey
-                ? "Parameter "
-                    + getNumberInDescriptor()
-                    + " \""
-                    + getVariableName()
-                    + "\" of "
-                    + this.mRef.getName()
-                    + " is "
-                    + this.type
-                    + " accessible using SSA-Value "
-                    + this.number
-                : "Parameter "
-                    + getNumberInDescriptor()
-                    + " of "
-                    + this.mRef.getName()
-                    + " is "
-                    + this.type
-                    + " accessible using SSA-Value "
-                    + this.number;
+                ? "Parameter %d \"%s\" of %s is %s accessible using SSA-Value %d"
+                    .formatted(
+                        getNumberInDescriptor(),
+                        getVariableName(),
+                        this.mRef.getName(),
+                        this.type,
+                        this.number)
+                : "Parameter %d of %s is %s accessible using SSA-Value %d"
+                    .formatted(
+                        getNumberInDescriptor(), this.mRef.getName(), this.type, this.number);
         case RETURN ->
-            "Return Value of "
-                + this.mRef.getName()
-                + " as "
-                + this.type
-                + " accessible using SSA-Value "
-                + this.number;
+            "Return Value of %s as %s accessible using SSA-Value %d"
+                .formatted(this.mRef.getName(), this.type, this.number);
         case NEW ->
-            "New instance of "
-                + this.type
-                + " accessible in "
-                + this.mRef.getName()
-                + " using number "
-                + this.number;
+            "New instance of %s accessible in %s using number %d"
+                .formatted(this.type, this.mRef.getName(), this.number);
       };
     }
   }
@@ -428,11 +394,8 @@ public class ParameterAccessor {
         final boolean tmpStatic = it.next().isStatic();
         if (testStatic != tmpStatic) {
           throw new IllegalStateException(
-              "The ClassHierarchy knows multiple ("
-                  + targets.size()
-                  + ") targets for "
-                  + mRef
-                  + ". The targets contradict themselves if they have an implicit this!");
+              "The ClassHierarchy knows multiple (%d) targets for %s. The targets contradict themselves if they have an implicit this!"
+                  .formatted(targets.size(), mRef));
         }
       }
       hasImplicitThis = !testStatic;
@@ -571,12 +534,8 @@ public class ParameterAccessor {
     }
     if ((no < 0) || (no > this.numberOfParameters)) {
       throw new ArrayIndexOutOfBoundsException(
-          "The given number ("
-              + no
-              + ") was not within bounds (1 to "
-              + this.numberOfParameters
-              + ") when accessing a parameter of "
-              + this);
+          "The given number (%d) was not within bounds (1 to %d) when accessing a parameter of %s"
+              .formatted(no, this.numberOfParameters, this));
     }
 
     return switch (this.base) {
@@ -689,10 +648,8 @@ public class ParameterAccessor {
         try {
           if (!isSubclassOf(this.method.getParameterType(self), asType, cha)) {
             throw new IllegalArgumentException(
-                "Class "
-                    + asType
-                    + " is not a super-class of "
-                    + this.method.getParameterType(self));
+                "Class %s is not a super-class of %s"
+                    .formatted(asType, this.method.getParameterType(self)));
           }
         } catch (ClassLookupException e) {
           // Can't test assume all fits
@@ -817,14 +774,13 @@ public class ParameterAccessor {
   public int firstInSelector() {
     if (this.numberOfParameters == 0) {
       throw new IllegalArgumentException(
-          "The method "
-              + Objects.requireNonNullElseGet(method, mRef::toString)
-              + " has no explicit parameters.");
+          "The method %s has no explicit parameters."
+              .formatted(Objects.requireNonNullElseGet(method, mRef::toString)));
     }
     if (this.implicitThis > 1) {
       throw new IllegalStateException(
-          "An internal error in ParameterAccessor locating the implicit this pointer occurred! Invalid: "
-              + this.implicitThis);
+          "An internal error in ParameterAccessor locating the implicit this pointer occurred! Invalid: %d"
+              .formatted(this.implicitThis));
     }
 
     switch (this.base) {
@@ -1230,16 +1186,8 @@ public class ParameterAccessor {
     }
     if (target.getNumberOfParameters() != args.size()) {
       throw new IllegalArgumentException(
-          "Number of arguments mismatch: "
-              + args.size()
-              + " given on a method that "
-              + "needs "
-              + target.getNumberOfParameters()
-              + " arguments. Arguments given were "
-              + args
-              + " for a static "
-              + "call to "
-              + target);
+          "Number of arguments mismatch: %d given on a method that needs %d arguments. Arguments given were %s for a static call to %s"
+              .formatted(args.size(), target.getNumberOfParameters(), args, target));
     }
 
     int[] params = new int[args.size()];
@@ -1262,33 +1210,14 @@ public class ParameterAccessor {
       } else {
         if (cha == null) {
           throw new IllegalArgumentException(
-              "Parameter "
-                  + i
-                  + " ("
-                  + param
-                  + ") of the Arguments list "
-                  + "is not equal to param "
-                  + i
-                  + " ( "
-                  + target.getParameter(i)
-                  + ") of "
-                  + target
-                  + "and no ClassHierarchy was given to test assignability");
+              "Parameter %d (%s) of the Arguments list is not equal to param %d ( %s) of %sand no ClassHierarchy was given to test assignability"
+                  .formatted(i, param, i, target.getParameter(i), target));
         } else if (isAssignable(param, target.getParameter(i), cha)) {
           params[i] = param.getNumber();
         } else {
           throw new IllegalArgumentException(
-              "Parameter "
-                  + i
-                  + " ("
-                  + param
-                  + ") of the Arguments list "
-                  + "is not assignable to param "
-                  + i
-                  + " ( "
-                  + target.getParameter(i)
-                  + ") of "
-                  + target);
+              "Parameter %d (%s) of the Arguments list is not assignable to param %d ( %s) of %s"
+                  .formatted(i, param, i, target.getParameter(i), target));
         }
       }
     }
@@ -1370,16 +1299,8 @@ public class ParameterAccessor {
     }
     if (target.getNumberOfParameters() != args.size() + 1) { // TODO: Verify
       throw new IllegalArgumentException(
-          "Number of arguments mismatch: "
-              + args.size()
-              + " given on a method that "
-              + "needs "
-              + target.getNumberOfParameters()
-              + " arguments. Arguments given were "
-              + args
-              + " for a static "
-              + "call to "
-              + target);
+          "Number of arguments mismatch: %d given on a method that needs %d arguments. Arguments given were %s for a static call to %s"
+              .formatted(args.size(), target.getNumberOfParameters(), args, target));
     }
 
     int[] params = new int[args.size() + 1];
@@ -1400,33 +1321,14 @@ public class ParameterAccessor {
       } else {
         if (cha == null) {
           throw new IllegalArgumentException(
-              "Parameter "
-                  + i
-                  + " ("
-                  + param
-                  + ") of the Arguments list "
-                  + "is not equal to param "
-                  + i
-                  + " ( "
-                  + target.getParameter(i)
-                  + ") of "
-                  + target
-                  + "and no ClassHierarchy was given to test assignability");
+              "Parameter %d (%s) of the Arguments list is not equal to param %d ( %s) of %sand no ClassHierarchy was given to test assignability"
+                  .formatted(i, param, i, target.getParameter(i), target));
         } else if (isAssignable(param, target.getParameter(i), cha)) {
           params[i] = param.getNumber();
         } else {
           throw new IllegalArgumentException(
-              "Parameter "
-                  + i
-                  + " ("
-                  + param
-                  + ") of the Arguments list "
-                  + "is not assignable to param "
-                  + i
-                  + " ( "
-                  + target.getParameter(i)
-                  + ") of "
-                  + target);
+              "Parameter %d (%s) of the Arguments list is not assignable to param %d ( %s) of %s"
+                  .formatted(i, param, i, target.getParameter(i), target));
         }
       }
     }
@@ -1623,12 +1525,9 @@ public class ParameterAccessor {
     } // of final Parameter param : calleeParams
 
     if (assigned.size() != calleeParams.size()) {
-      System.err.println(
-          "Assigned "
-              + assigned.size()
-              + " params to a method taking "
-              + calleeParams.size()
-              + " params!");
+      System.err.printf(
+          "Assigned %d params to a method taking %d params!%n",
+          assigned.size(), calleeParams.size());
       System.err.println("The call takes the parameters");
       for (Parameter param : calleeParams) {
         System.err.println("\t" + param);

--- a/core/src/main/java/com/ibm/wala/core/util/ssa/SSAValueManager.java
+++ b/core/src/main/java/com/ibm/wala/core/util/ssa/SSAValueManager.java
@@ -116,17 +116,8 @@ public class SSAValueManager {
 
     @Override
     public String toString() {
-      return "<Managed "
-          + this.value
-          + " key=\""
-          + this.key
-          + "\" status=\""
-          + this.status
-          + " setIn=\""
-          + this.setInScope
-          + "\" setBy=\""
-          + this.setBy
-          + "\" />";
+      return "<Managed %s key=\"%s\" status=\"%s setIn=\"%d\" setBy=\"%s\" />"
+          .formatted(this.value, this.key, this.status, this.setInScope, this.setBy);
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/core/util/ssa/TypeSafeInstructionFactory.java
+++ b/core/src/main/java/com/ibm/wala/core/util/ssa/TypeSafeInstructionFactory.java
@@ -347,15 +347,8 @@ public class TypeSafeInstructionFactory {
         aParams[i] = givenParam.getNumber();
         if (!isAssignableFrom(givenParam.getType(), targetParam.getType())) {
           throw new IllegalArgumentException(
-              "Parameter "
-                  + i
-                  + " is not assignable from\n\t"
-                  + givenParam
-                  + " to\n\t"
-                  + targetParam
-                  + "\nin call "
-                  + site
-                  + "\n---------");
+              "Parameter %d is not assignable from\n\t%s to\n\t%s\nin call %s\n---------"
+                  .formatted(i, givenParam, targetParam, site));
         }
       }
     } else {

--- a/core/src/main/java/com/ibm/wala/dataflow/IFDS/PathEdge.java
+++ b/core/src/main/java/com/ibm/wala/dataflow/IFDS/PathEdge.java
@@ -43,7 +43,7 @@ public final class PathEdge<T> {
 
   @Override
   public String toString() {
-    return '<' + entry.toString() + ',' + d1 + "> -> <" + target + ',' + d2 + '>';
+    return "<%s,%d> -> <%s,%d>".formatted(entry.toString(), d1, target, d2);
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/CallGraphStats.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/CallGraphStats.java
@@ -81,15 +81,8 @@ public class CallGraphStats {
 
     @Override
     public String toString() {
-      return "Call graph stats:\n  Nodes: "
-          + nNodes
-          + "\n  Edges: "
-          + nEdges
-          + "\n  Methods: "
-          + nMethods
-          + "\n  Bytecode Bytes: "
-          + bytecodeBytes
-          + '\n';
+      return "Call graph stats:\n  Nodes: %d\n  Edges: %d\n  Methods: %d\n  Bytecode Bytes: %d\n"
+          .formatted(nNodes, nEdges, nMethods, bytecodeBytes);
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/AllocationSiteInNode.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/AllocationSiteInNode.java
@@ -35,15 +35,12 @@ public abstract class AllocationSiteInNode extends AbstractTypeInNode {
 
   @Override
   public String toString() {
-    return "SITE_IN_NODE{"
-        + getNode().getMethod()
-        + ':'
-        + concreteType().getName().toUnicodeString()
-        + ':'
-        + this.getSite()
-        + " in "
-        + getNode().getContext()
-        + '}';
+    return "SITE_IN_NODE{%s:%s:%s in %s}"
+        .formatted(
+            getNode().getMethod(),
+            concreteType().getName().toUnicodeString(),
+            this.getSite(),
+            getNode().getContext());
   }
 
   /**

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationCallGraphBuilder.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationCallGraphBuilder.java
@@ -938,15 +938,13 @@ public abstract class PropagationCallGraphBuilder implements CallGraphBuilder<In
     public byte evaluate(PointsToSetVariable ref) {
       if (DEBUG_GET) {
         String S =
-            "EVAL GetField "
-                + getField()
-                + ' '
-                + getFixedSet().getPointerKey()
-                + ' '
-                + ref.getPointerKey()
-                + getFixedSet()
-                + ' '
-                + ref;
+            "EVAL GetField %s %s %s%s %s"
+                .formatted(
+                    getField(),
+                    getFixedSet().getPointerKey(),
+                    ref.getPointerKey(),
+                    getFixedSet(),
+                    ref);
         System.err.println(S);
       }
 
@@ -1050,15 +1048,13 @@ public abstract class PropagationCallGraphBuilder implements CallGraphBuilder<In
     public byte evaluate(PointsToSetVariable rhs) {
       if (DEBUG_PUT) {
         String S =
-            "EVAL PutField "
-                + getField()
-                + ' '
-                + getFixedSet().getPointerKey()
-                + ' '
-                + rhs.getPointerKey()
-                + getFixedSet()
-                + ' '
-                + rhs;
+            "EVAL PutField %s %s %s%s %s"
+                .formatted(
+                    getField(),
+                    getFixedSet().getPointerKey(),
+                    rhs.getPointerKey(),
+                    getFixedSet(),
+                    rhs);
         System.err.println(S);
       }
 

--- a/core/src/main/java/com/ibm/wala/types/FieldReference.java
+++ b/core/src/main/java/com/ibm/wala/types/FieldReference.java
@@ -85,15 +85,12 @@ public final class FieldReference extends MemberReference {
 
   @Override
   public String toString() {
-    return "< "
-        + getDeclaringClass().getClassLoader().name()
-        + ", "
-        + getDeclaringClass().getName()
-        + ", "
-        + getName()
-        + ", "
-        + fieldType
-        + " >";
+    return "< %s, %s, %s, %s >"
+        .formatted(
+            getDeclaringClass().getClassLoader().name(),
+            getDeclaringClass().getName(),
+            getName(),
+            fieldType);
   }
 
   /** An identifier/selector for fields. */

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/dex/instructions/Invoke.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/dex/instructions/Invoke.java
@@ -106,16 +106,8 @@ public abstract class Invoke extends Instruction {
         sep = ",";
       }
       argString.append(')');
-      return "InvokeVirtual "
-          + clazzName
-          + ' '
-          + methodName
-          + ' '
-          + descriptor
-          + ' '
-          + argString
-          + ' '
-          + pc;
+      return "InvokeVirtual %s %s %s %s %d"
+          .formatted(clazzName, methodName, descriptor, argString, pc);
     }
   }
 
@@ -149,16 +141,8 @@ public abstract class Invoke extends Instruction {
         sep = ",";
       }
       argString.append(')');
-      return "InvokeSuper "
-          + clazzName
-          + ' '
-          + methodName
-          + ' '
-          + descriptor
-          + ' '
-          + argString
-          + ' '
-          + pc;
+      return "InvokeSuper %s %s %s %s %d"
+          .formatted(clazzName, methodName, descriptor, argString, pc);
     }
   }
 
@@ -190,16 +174,8 @@ public abstract class Invoke extends Instruction {
         sep = ",";
       }
       argString.append(')');
-      return "InvokeDirect "
-          + clazzName
-          + ' '
-          + methodName
-          + ' '
-          + descriptor
-          + ' '
-          + argString
-          + ' '
-          + pc;
+      return "InvokeDirect %s %s %s %s %d"
+          .formatted(clazzName, methodName, descriptor, argString, pc);
     }
   }
 
@@ -231,16 +207,8 @@ public abstract class Invoke extends Instruction {
         sep = ",";
       }
       argString.append(')');
-      return "InvokeStatic "
-          + clazzName
-          + ' '
-          + methodName
-          + ' '
-          + descriptor
-          + ' '
-          + argString
-          + ' '
-          + pc;
+      return "InvokeStatic %s %s %s %s %d"
+          .formatted(clazzName, methodName, descriptor, argString, pc);
     }
   }
 
@@ -272,16 +240,8 @@ public abstract class Invoke extends Instruction {
         sep = ",";
       }
       argString.append(')');
-      return "InvokeInterface "
-          + clazzName
-          + ' '
-          + methodName
-          + ' '
-          + descriptor
-          + ' '
-          + argString
-          + ' '
-          + pc;
+      return "InvokeInterface %s %s %s %s %d"
+          .formatted(clazzName, methodName, descriptor, argString, pc);
     }
   }
 

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidEntryPointManager.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidEntryPointManager.java
@@ -444,24 +444,12 @@ public final /* singleton */ class AndroidEntryPointManager implements Serializa
       if ((newType == Intent.IntentType.UNKNOWN_TARGET)
           && (oriType != Intent.IntentType.UNKNOWN_TARGET)) {
         throw new IllegalArgumentException(
-            "You are lowering information on the Intent-Target of the "
-                + "Intent "
-                + original
-                + " from "
-                + oriType
-                + " to "
-                + newType
-                + ". Use registerIntentForce()"
-                + "If you are sure you want to do this!");
+            "You are lowering information on the Intent-Target of the Intent %s from %s to %s. Use registerIntentForce()If you are sure you want to do this!"
+                .formatted(original, oriType, newType));
       } else if (oriType != newType) {
         throw new IllegalArgumentException(
-            "You are changing the Intents target to a contradicting one! "
-                + newType
-                + "(new) is incompatible to "
-                + oriType
-                + "(before). On Intent "
-                + intent
-                + ". Use registerIntentForce() if you are sure you want to do this!");
+            "You are changing the Intents target to a contradicting one! %s(new) is incompatible to %s(before). On Intent %s. Use registerIntentForce() if you are sure you want to do this!"
+                .formatted(newType, oriType, intent));
       }
 
       // TODO: Add actual target to the Intent and compare these?
@@ -547,24 +535,12 @@ public final /* singleton */ class AndroidEntryPointManager implements Serializa
       if ((newType == Intent.IntentType.UNKNOWN_TARGET)
           && (oriType != Intent.IntentType.UNKNOWN_TARGET)) {
         throw new IllegalArgumentException(
-            "You are lowering information on the Intent-Target of the "
-                + "Intent "
-                + original
-                + " from "
-                + oriType
-                + " to "
-                + newType
-                + ". Use setOverrideForce()"
-                + "If you are sure you want to do this!");
+            "You are lowering information on the Intent-Target of the Intent %s from %s to %s. Use setOverrideForce()If you are sure you want to do this!"
+                .formatted(original, oriType, newType));
       } else if (oriType != newType) {
         throw new IllegalArgumentException(
-            "You are changing the Intents target to a contradicting one! "
-                + newType
-                + "(new) is incompatible to "
-                + oriType
-                + "(before). On Intent "
-                + to
-                + ". Use setOverrideForce() if you are sure you want to do this!");
+            "You are changing the Intents target to a contradicting one! %s(new) is incompatible to %s(before). On Intent %s. Use setOverrideForce() if you are sure you want to do this!"
+                .formatted(newType, oriType, to));
       }
 
       // TODO: Check resolvable Target is not overridden with unresolvable one

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/util/AndroidManifestXMLReader.java
@@ -680,15 +680,8 @@ public class AndroidManifestXMLReader {
           current.getHandler().popAttributes();
         } else {
           throw new IllegalStateException(
-              "In "
-                  + self
-                  + ": Tag "
-                  + current
-                  + " not allowed in Context "
-                  + parserStack
-                  + "\n\t"
-                  + "Allowed Tags: "
-                  + allowedTags);
+              "In %s: Tag %s not allowed in Context %s\n\tAllowed Tags: %s"
+                  .formatted(self, current, parserStack, allowedTags));
         }
       }
 

--- a/ide/src/main/java/com/ibm/wala/ide/ui/SWTTreeViewer.java
+++ b/ide/src/main/java/com/ibm/wala/ide/ui/SWTTreeViewer.java
@@ -74,16 +74,8 @@ public class SWTTreeViewer<T> extends AbstractJFaceRunner {
 
   @Override
   public String toString() {
-    return super.toString()
-        + ", graphInput: "
-        + graphInput
-        + ", rootsInput: "
-        + rootsInput
-        + ", NodeDecoratorInput: "
-        + nodeDecoratorInput
-        + ", popUpActions: "
-        + popUpActions
-        + ')';
+    return "%s, graphInput: %s, rootsInput: %s, NodeDecoratorInput: %s, popUpActions: %s)"
+        .formatted(super.toString(), graphInput, rootsInput, nodeDecoratorInput, popUpActions);
   }
 
   public void run() throws WalaException {

--- a/shrike/src/main/java/com/ibm/wala/shrike/bench/InterfaceAnalyzer.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/bench/InterfaceAnalyzer.java
@@ -58,16 +58,13 @@ public class InterfaceAnalyzer {
     for (Map.Entry<String, TypeStats> entry : typeStats.entrySet()) {
       TypeStats t = entry.getValue();
       w.write(
-          entry.getKey()
-              + '\t'
-              + t.totalOccurrences
-              + '\t'
-              + t.methodOccurrences
-              + '\t'
-              + t.publicMethodOccurrences
-              + '\t'
-              + t.foreignPublicMethodOccurrences
-              + '\n');
+          "%s\t%d\t%d\t%d\t%d\n"
+              .formatted(
+                  entry.getKey(),
+                  t.totalOccurrences,
+                  t.methodOccurrences,
+                  t.publicMethodOccurrences,
+                  t.foreignPublicMethodOccurrences));
     }
 
     w.flush();

--- a/shrike/src/main/java/com/ibm/wala/shrike/cg/Runtime.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/cg/Runtime.java
@@ -201,7 +201,7 @@ public class Runtime {
             ? "BLOB"
             : runtime.callStacks.get().peek().split("\t")[1];
     runtime.currentSite.set(
-        callerClass + '\t' + callerMethod + '\t' + klass + '\t' + method + '\t' + receiver);
+        "%s\t%s\t%s\t%s\t%s".formatted(callerClass, callerMethod, klass, method, receiver));
     //	  runtime.currentSite = klass + "\t" + method + "\t" + receiver;
     synchronized (runtime) {
       if (runtime.output != null) {

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/GetInstruction.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/GetInstruction.java
@@ -149,15 +149,9 @@ public class GetInstruction extends Instruction implements IGetInstruction {
 
   @Override
   public String toString() {
-    return "Get("
-        + getFieldType()
-        + ','
-        + (isStatic() ? "STATIC" : "NONSTATIC")
-        + ','
-        + getClassType()
-        + ','
-        + getFieldName()
-        + ')';
+    return "Get(%s,%s,%s,%s)"
+        .formatted(
+            getFieldType(), isStatic() ? "STATIC" : "NONSTATIC", getClassType(), getFieldName());
   }
 
   @Override

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/InvokeInstruction.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/InvokeInstruction.java
@@ -184,15 +184,9 @@ public class InvokeInstruction extends Instruction implements IInvokeInstruction
 
   @Override
   public final String toString() {
-    return "Invoke("
-        + getInvocationModeString()
-        + ','
-        + getClassType()
-        + ','
-        + getMethodName()
-        + ','
-        + getMethodSignature()
-        + ')';
+    return "Invoke(%s,%s,%s,%s)"
+        .formatted(
+            getInvocationModeString(), getClassType(), getMethodName(), getMethodSignature());
   }
 
   @Override

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/PutInstruction.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/PutInstruction.java
@@ -139,15 +139,9 @@ public class PutInstruction extends Instruction implements IPutInstruction {
 
   @Override
   public final String toString() {
-    return "Put("
-        + getFieldType()
-        + ','
-        + (isStatic() ? "STATIC" : "NONSTATIC")
-        + ','
-        + getClassType()
-        + ','
-        + getFieldName()
-        + ')';
+    return "Put(%s,%s,%s,%s)"
+        .formatted(
+            getFieldType(), isStatic() ? "STATIC" : "NONSTATIC", getClassType(), getFieldName());
   }
 
   @Override

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/shrikeCT/tools/ClassPrinter.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/shrikeCT/tools/ClassPrinter.java
@@ -174,15 +174,12 @@ public class ClassPrinter {
         w.write("    exception handlers:\n");
         for (int e = 0; e < rawHandlers.length; e += 4) {
           w.write(
-              "      "
-                  + rawHandlers[e]
-                  + " to "
-                  + rawHandlers[e + 1]
-                  + " catch "
-                  + getClassName(cr, rawHandlers[e + 3])
-                  + " at "
-                  + rawHandlers[e + 2]
-                  + '\n');
+              "      %d to %d catch %s at %d\n"
+                  .formatted(
+                      rawHandlers[e],
+                      rawHandlers[e + 1],
+                      getClassName(cr, rawHandlers[e + 3]),
+                      rawHandlers[e + 2]));
         }
 
         ClassReader.AttrIterator codeAttrs = new ClassReader.AttrIterator();

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/shrikeCT/tools/MethodTracer.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeBT/shrikeCT/tools/MethodTracer.java
@@ -126,16 +126,13 @@ public class MethodTracer {
           for (int k = 0; k < ins.length; k++) {
             if (ins[k] instanceof InvokeInstruction instr) {
               final String msg =
-                  "Call from "
-                      + Util.makeClass('L' + ci.getReader().getName() + ';')
-                      + '.'
-                      + ci.getReader().getMethodName(i)
-                      + ':'
-                      + k
-                      + " to target "
-                      + Util.makeClass(instr.getClassType())
-                      + '.'
-                      + instr.getMethodName();
+                  "Call from %s.%s:%d to target %s.%s"
+                      .formatted(
+                          Util.makeClass('L' + ci.getReader().getName() + ';'),
+                          ci.getReader().getMethodName(i),
+                          k,
+                          Util.makeClass(instr.getClassType()),
+                          instr.getMethodName());
               me.insertBefore(
                   k,
                   new MethodEditor.Patch() {

--- a/util/src/main/java/com/ibm/wala/util/intset/DebuggingMutableIntSet.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/DebuggingMutableIntSet.java
@@ -69,15 +69,8 @@ record DebuggingMutableIntSet(MutableIntSet primaryImpl, MutableIntSet secondary
   public int size() {
     if (primaryImpl.size() != secondaryImpl.size()) {
       assert primaryImpl.size() == secondaryImpl.size()
-          : "size "
-              + primaryImpl.size()
-              + " of "
-              + primaryImpl
-              + " differs from "
-              + "size "
-              + secondaryImpl.size()
-              + " of "
-              + secondaryImpl;
+          : "size %d of %s differs from size %d of %s"
+              .formatted(primaryImpl.size(), primaryImpl, secondaryImpl.size(), secondaryImpl);
     }
 
     return primaryImpl.size();
@@ -101,18 +94,8 @@ record DebuggingMutableIntSet(MutableIntSet primaryImpl, MutableIntSet secondary
 
     if (pr != sr) {
       assert pr == sr
-          : "adding "
-              + i
-              + " to "
-              + primaryImpl
-              + " returns "
-              + pr
-              + ", but adding "
-              + i
-              + " to "
-              + secondaryImpl
-              + " returns "
-              + sr;
+          : "adding %d to %s returns %s, but adding %d to %s returns %s"
+              .formatted(i, primaryImpl, pr, i, secondaryImpl, sr);
     }
 
     return pr;
@@ -242,16 +225,9 @@ record DebuggingMutableIntSet(MutableIntSet primaryImpl, MutableIntSet secondary
       boolean ssr = secondaryImpl.addAll(db.secondaryImpl);
 
       if (ppr != ssr) {
-        System.err.println(
-            "ppr was "
-                + ppr
-                + " (should be "
-                + (ps != primaryImpl.size())
-                + ") but ssr was "
-                + ssr
-                + " (should be "
-                + (ss != secondaryImpl.size())
-                + ')');
+        System.err.printf(
+            "ppr was %s (should be %s) but ssr was %s (should be %s)%n",
+            ppr, ps != primaryImpl.size(), ssr, ss != secondaryImpl.size());
         System.err.println("adding " + set + " to " + this + " failed");
         Assertions.UNREACHABLE();
       }

--- a/util/src/main/java/com/ibm/wala/util/intset/SemiSparseMutableIntSet.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/SemiSparseMutableIntSet.java
@@ -227,17 +227,8 @@ public class SemiSparseMutableIntSet implements MutableIntSet {
         }
 
         assert assertDisjoint()
-            : this
-                + ", densePart.length()="
-                + densePart.length()
-                + ", newOffset="
-                + newOffset
-                + ", newLength="
-                + newLength
-                + ", newCount="
-                + newCount
-                + ", moveCount="
-                + moveCount;
+            : "%s, densePart.length()=%d, newOffset=%d, newLength=%d, newCount=%d, moveCount=%d"
+                .formatted(this, densePart.length(), newOffset, newLength, newCount, moveCount);
       }
     }
   }

--- a/util/src/main/java/com/ibm/wala/util/tables/StringTable.java
+++ b/util/src/main/java/com/ibm/wala/util/tables/StringTable.java
@@ -148,16 +148,8 @@ public class StringTable extends Table<String> implements Cloneable {
     int nColumns = st.countTokens();
     Assertions.productionAssertion(
         nColumns == getNumberOfColumns(),
-        "expected "
-            + getNumberOfColumns()
-            + " got "
-            + nColumns
-            + " row "
-            + row
-            + ' '
-            + line.length()
-            + ' '
-            + line);
+        "expected %d got %d row %d %d %s"
+            .formatted(getNumberOfColumns(), nColumns, row, line.length(), line));
     SimpleVector<String> r = new SimpleVector<>();
     rows.add(row, r);
     for (int i = 0; i < nColumns; i++) {


### PR DESCRIPTION
Long string concatenations spread over multiple lines obfuscate the overall form of the result.  IMHO, format strings make these complex text layouts more readable.