### PR TITLE
Allow `Assertions.UNREACHABLE(...)` in expressions

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -2,3 +2,6 @@ $schema: https://raw.githubusercontent.com/DavidAnson/markdownlint-cli2/main/sch
 noBanner: true
 noProgress: true
 showFound: false
+config:
+  no-duplicate-heading:
+    siblings_only: true

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,36 @@
 # WALA Release Notes
 
+## Version 1.9.0
+
+### Functionality changes
+
+#### `Assertions.UNREACHABLE` now returns a generic type
+
+The `Assertions.UNREACHABLE()`, `Assertions.UNREACHABLE(String)`, and
+`Assertions.UNREACHABLE(Object)` methods now return a generic type `<T>`
+instead of `void`. This allows callers to write `return Assertions.UNREACHABLE(…)`
+in methods that return a value, eliminating the previously required pattern of
+calling `Assertions.UNREACHABLE()` followed by a separate `return null;` (or
+similar unreachable-`return` statement).
+
+**Effect for third-party consumers:**
+
+* Existing call sites that previously wrote:
+
+  ```java
+  Assertions.UNREACHABLE("message");
+  return null;
+  ```
+
+  can now be simplified to:
+
+  ```java
+  return Assertions.UNREACHABLE("message");
+  ```
+
+* Existing call sites that just call `Assertions.UNREACHABLE()` as a
+  statement without a following `return` continue to work unchanged.
+
 ## Version 1.8.0
 
 ### Functionality changes

--- a/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/FakeExceptionTypeBinding.java
+++ b/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/FakeExceptionTypeBinding.java
@@ -82,8 +82,7 @@ public class FakeExceptionTypeBinding implements ITypeBinding {
 
   @Override
   public boolean isAssignmentCompatible(ITypeBinding variableType) {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return false;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
@@ -103,189 +102,158 @@ public class FakeExceptionTypeBinding implements ITypeBinding {
 
   @Override
   public ITypeBinding createArrayType(int dimension) {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding createArrayType");
-    return null;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding createArrayType");
   }
 
   @Override
   public String getBinaryName() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return null;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public ITypeBinding getBound() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return null;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public ITypeBinding getComponentType() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return null;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public IVariableBinding[] getDeclaredFields() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return null;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public IMethodBinding[] getDeclaredMethods() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return null;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @SuppressWarnings("deprecation")
   @Override
   public int getDeclaredModifiers() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return 0;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public ITypeBinding[] getDeclaredTypes() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return null;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public ITypeBinding getDeclaringClass() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return null;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public IMethodBinding getDeclaringMethod() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return null;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public int getDimensions() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return 0;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public ITypeBinding getElementType() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return null;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public ITypeBinding getErasure() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return null;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public ITypeBinding[] getInterfaces() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return null;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public int getModifiers() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return 0;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public String getName() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return null;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public IPackageBinding getPackage() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return null;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public String getQualifiedName() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return null;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public ITypeBinding getSuperclass() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return null;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public ITypeBinding[] getTypeArguments() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return null;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public ITypeBinding[] getTypeBounds() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return null;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public ITypeBinding getTypeDeclaration() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return null;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public ITypeBinding[] getTypeParameters() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return null;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public ITypeBinding getWildcard() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return null;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public boolean isAnnotation() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return false;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public boolean isAnonymous() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return false;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public boolean isArray() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return false;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public boolean isCapture() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return false;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public boolean isCastCompatible(ITypeBinding type) {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return false;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public boolean isClass() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return false;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public boolean isEnum() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return false;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   /**
@@ -300,68 +268,57 @@ public class FakeExceptionTypeBinding implements ITypeBinding {
 
   @Override
   public boolean isFromSource() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return false;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public boolean isGenericType() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return false;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public boolean isInterface() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return false;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   // add @Override here once Eclipse Mars is no longer supported
   public boolean isIntersectionType() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return false;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public boolean isLocal() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return false;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public boolean isMember() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return false;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public boolean isNested() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return false;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public boolean isNullType() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return false;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public boolean isParameterizedType() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return false;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public boolean isPrimitive() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return false;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public boolean isRawType() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return false;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
@@ -384,56 +341,47 @@ public class FakeExceptionTypeBinding implements ITypeBinding {
 
   @Override
   public boolean isTopLevel() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return false;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public boolean isTypeVariable() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return false;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public boolean isUpperbound() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return false;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public boolean isWildcardType() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return false;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public IAnnotationBinding[] getAnnotations() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return null;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public IJavaElement getJavaElement() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return null;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public String getKey() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return null;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public int getKind() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return 0;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public boolean isDeprecated() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return false;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
@@ -443,40 +391,34 @@ public class FakeExceptionTypeBinding implements ITypeBinding {
 
   @Override
   public boolean isRecovered() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return false;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public boolean isSynthetic() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return false;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public ITypeBinding getGenericTypeOfWildcardType() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return null;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   @Override
   public int getRank() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return 0;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   // do not put @Override here, to avoid breaking compilation on Juno
   @Override
   public IMethodBinding getFunctionalInterfaceMethod() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return null;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   // do not put @Override here, to avoid breaking compilation on Juno
   @Override
   public IAnnotationBinding[] getTypeAnnotations() {
-    Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
-    return null;
+    return Assertions.UNREACHABLE("FakeExceptionTypeBinding ");
   }
 
   // do not put @Override here, to avoid breaking compilation on older Eclipse versions

--- a/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDT2CAstUtils.java
+++ b/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDT2CAstUtils.java
@@ -85,19 +85,18 @@ public class JDT2CAstUtils {
   }
 
   public static CAstOperator mapAssignOperator(Operator op) {
-    if (op == Assignment.Operator.PLUS_ASSIGN) return CAstOperator.OP_ADD;
-    else if (op == Assignment.Operator.BIT_AND_ASSIGN) return CAstOperator.OP_BIT_AND;
-    else if (op == Assignment.Operator.BIT_OR_ASSIGN) return CAstOperator.OP_BIT_OR;
-    else if (op == Assignment.Operator.BIT_XOR_ASSIGN) return CAstOperator.OP_BIT_XOR;
-    else if (op == Assignment.Operator.DIVIDE_ASSIGN) return CAstOperator.OP_DIV;
-    else if (op == Assignment.Operator.REMAINDER_ASSIGN) return CAstOperator.OP_MOD;
-    else if (op == Assignment.Operator.TIMES_ASSIGN) return CAstOperator.OP_MUL;
-    else if (op == Assignment.Operator.LEFT_SHIFT_ASSIGN) return CAstOperator.OP_LSH;
-    else if (op == Assignment.Operator.RIGHT_SHIFT_SIGNED_ASSIGN) return CAstOperator.OP_RSH;
-    else if (op == Assignment.Operator.MINUS_ASSIGN) return CAstOperator.OP_SUB;
-    else if (op == Assignment.Operator.RIGHT_SHIFT_UNSIGNED_ASSIGN) return CAstOperator.OP_URSH;
-    Assertions.UNREACHABLE("Unknown assignment operator");
-    return null;
+    if (op == Operator.PLUS_ASSIGN) return CAstOperator.OP_ADD;
+    else if (op == Operator.BIT_AND_ASSIGN) return CAstOperator.OP_BIT_AND;
+    else if (op == Operator.BIT_OR_ASSIGN) return CAstOperator.OP_BIT_OR;
+    else if (op == Operator.BIT_XOR_ASSIGN) return CAstOperator.OP_BIT_XOR;
+    else if (op == Operator.DIVIDE_ASSIGN) return CAstOperator.OP_DIV;
+    else if (op == Operator.REMAINDER_ASSIGN) return CAstOperator.OP_MOD;
+    else if (op == Operator.TIMES_ASSIGN) return CAstOperator.OP_MUL;
+    else if (op == Operator.LEFT_SHIFT_ASSIGN) return CAstOperator.OP_LSH;
+    else if (op == Operator.RIGHT_SHIFT_SIGNED_ASSIGN) return CAstOperator.OP_RSH;
+    else if (op == Operator.MINUS_ASSIGN) return CAstOperator.OP_SUB;
+    else if (op == Operator.RIGHT_SHIFT_UNSIGNED_ASSIGN) return CAstOperator.OP_URSH;
+    return Assertions.UNREACHABLE("Unknown assignment operator");
   }
 
   protected static CAstOperator mapBinaryOpcode(InfixExpression.Operator operator) {
@@ -125,9 +124,8 @@ public class JDT2CAstUtils {
     if (operator == InfixExpression.Operator.RIGHT_SHIFT_SIGNED) return CAstOperator.OP_RSH;
     if (operator == InfixExpression.Operator.MINUS) return CAstOperator.OP_SUB;
     if (operator == InfixExpression.Operator.RIGHT_SHIFT_UNSIGNED) return CAstOperator.OP_URSH;
-    Assertions.UNREACHABLE(
+    return Assertions.UNREACHABLE(
         "Java2CAstTranslator.JavaTranslatingVisitorImpl.mapBinaryOpcode(): unrecognized binary operator.");
-    return null;
   }
 
   /**
@@ -171,8 +169,7 @@ public class JDT2CAstUtils {
         return enumDeclaration.resolveBinding();
       current = current.getParent();
     }
-    Assertions.UNREACHABLE("Couldn't find declaring class of node");
-    return null;
+    return Assertions.UNREACHABLE("Couldn't find declaring class of node");
   }
 
   private static final IdentityHashMap<ITypeBinding, @NonNull Integer> ids =
@@ -214,22 +211,20 @@ public class JDT2CAstUtils {
   }
 
   public static InfixExpression.Operator mapAssignOperatorToInfixOperator(Assignment.Operator op) {
-    if (op == Assignment.Operator.PLUS_ASSIGN) return InfixExpression.Operator.PLUS;
-    else if (op == Assignment.Operator.BIT_AND_ASSIGN) return InfixExpression.Operator.AND;
-    else if (op == Assignment.Operator.BIT_OR_ASSIGN) return InfixExpression.Operator.OR;
-    else if (op == Assignment.Operator.BIT_XOR_ASSIGN) return InfixExpression.Operator.XOR;
-    else if (op == Assignment.Operator.DIVIDE_ASSIGN) return InfixExpression.Operator.DIVIDE;
-    else if (op == Assignment.Operator.REMAINDER_ASSIGN) return InfixExpression.Operator.REMAINDER;
-    else if (op == Assignment.Operator.TIMES_ASSIGN) return InfixExpression.Operator.TIMES;
-    else if (op == Assignment.Operator.LEFT_SHIFT_ASSIGN)
-      return InfixExpression.Operator.LEFT_SHIFT;
-    else if (op == Assignment.Operator.RIGHT_SHIFT_SIGNED_ASSIGN)
+    if (op == Operator.PLUS_ASSIGN) return InfixExpression.Operator.PLUS;
+    else if (op == Operator.BIT_AND_ASSIGN) return InfixExpression.Operator.AND;
+    else if (op == Operator.BIT_OR_ASSIGN) return InfixExpression.Operator.OR;
+    else if (op == Operator.BIT_XOR_ASSIGN) return InfixExpression.Operator.XOR;
+    else if (op == Operator.DIVIDE_ASSIGN) return InfixExpression.Operator.DIVIDE;
+    else if (op == Operator.REMAINDER_ASSIGN) return InfixExpression.Operator.REMAINDER;
+    else if (op == Operator.TIMES_ASSIGN) return InfixExpression.Operator.TIMES;
+    else if (op == Operator.LEFT_SHIFT_ASSIGN) return InfixExpression.Operator.LEFT_SHIFT;
+    else if (op == Operator.RIGHT_SHIFT_SIGNED_ASSIGN)
       return InfixExpression.Operator.RIGHT_SHIFT_SIGNED;
-    else if (op == Assignment.Operator.MINUS_ASSIGN) return InfixExpression.Operator.MINUS;
-    else if (op == Assignment.Operator.RIGHT_SHIFT_UNSIGNED_ASSIGN)
+    else if (op == Operator.MINUS_ASSIGN) return InfixExpression.Operator.MINUS;
+    else if (op == Operator.RIGHT_SHIFT_UNSIGNED_ASSIGN)
       return InfixExpression.Operator.RIGHT_SHIFT_UNSIGNED;
-    Assertions.UNREACHABLE("Unknown assignment operator");
-    return null;
+    return Assertions.UNREACHABLE("Unknown assignment operator");
   }
 
   private static void getMethodInClassOrSuperclass(

--- a/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTIdentityMapper.java
+++ b/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTIdentityMapper.java
@@ -114,11 +114,10 @@ public class JDTIdentityMapper {
     else if (type.isTypeVariable()) {
       return typeToTypeID(JDT2CAstUtils.getTypesVariablesBase(type, fAst));
     }
-    Assertions.UNREACHABLE(
+    return Assertions.UNREACHABLE(
         "typeToTypeID() encountered the type "
             + type
             + " that is neither primitive, array, nor class!");
-    return null;
   }
 
   public String anonLocalTypeToTypeID(ITypeBinding type) {

--- a/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
+++ b/cast/java/ecj/src/main/java/com/ibm/wala/cast/java/translator/jdt/JDTJava2CAstTranslator.java
@@ -374,9 +374,8 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
 
     @Override
     public Iterator<CAstEntity> getScopedEntities(CAstNode construct) {
-      Assertions.UNREACHABLE(
+      return Assertions.UNREACHABLE(
           "Non-AST-bearing entity (ClassEntity) asked for scoped entities related to a given AST node");
-      return null;
     }
 
     @Override
@@ -720,8 +719,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
     for (IMethodBinding met : superClass.getDeclaredMethods()) {
       if (met.isConstructor() && met.getParameterTypes().length == 0) return met;
     }
-    Assertions.UNREACHABLE("Couldn't find default ctor");
-    return null;
+    return Assertions.UNREACHABLE("Couldn't find default ctor");
   }
 
   /**
@@ -1453,8 +1451,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
     } else if (node instanceof EnumConstantDeclaration enumConstantDeclaration) {
       return createEnumConstantDeclarationInit(enumConstantDeclaration, context);
     } else {
-      Assertions.UNREACHABLE("invalid init node gathered by createClassDeclaration");
-      return null;
+      return Assertions.UNREACHABLE("invalid init node gathered by createClassDeclaration");
     }
   }
 
@@ -2395,9 +2392,8 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
       current = current.getDeclaringClass();
     }
 
-    Assertions.UNREACHABLE(
+    return Assertions.UNREACHABLE(
         "Couldn't find field in class or enclosing class or superclasses of these");
-    return null;
   }
 
   /**
@@ -3107,8 +3103,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
       // enum constant
       return visit(simpleName, context);
     } else {
-      Assertions.UNREACHABLE("null constant for non-enum switch case!");
-      return null;
+      return Assertions.UNREACHABLE("null constant for non-enum switch case!");
     }
   }
 
@@ -3911,8 +3906,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
     } else if (n instanceof AnnotationTypeDeclaration) {
       return visitTypeDecl(n, context);
     } else {
-      Assertions.UNREACHABLE("Unhandled type declaration type");
-      return null;
+      return Assertions.UNREACHABLE("Unhandled type declaration type");
     }
   }
 
@@ -4024,9 +4018,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
 
     // VariableDeclarationStatement handled as special case (returns multiple statements)
 
-    Assertions.UNREACHABLE("Unhandled JDT node type " + n.getClass().getCanonicalName());
-
-    return null;
+    return Assertions.UNREACHABLE("Unhandled JDT node type " + n.getClass().getCanonicalName());
   }
 
   private void visitNodeOrNodes(ASTNode n, WalkContext context, Collection<CAstNode> coll) {
@@ -4070,8 +4062,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
 
     @Override
     public String getSignature() {
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
 
     @Override
@@ -4096,9 +4087,8 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
 
     @Override
     public Iterator<CAstEntity> getScopedEntities(CAstNode construct) {
-      Assertions.UNREACHABLE(
+      return Assertions.UNREACHABLE(
           "CompilationUnitEntity asked for AST-related entities, but it has no AST.");
-      return null;
     }
 
     @Override
@@ -4108,14 +4098,12 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
 
     @Override
     public CAstControlFlowMap getControlFlow() {
-      Assertions.UNREACHABLE("CompilationUnitEntity.getControlFlow()");
-      return null;
+      return Assertions.UNREACHABLE("CompilationUnitEntity.getControlFlow()");
     }
 
     @Override
     public CAstSourcePositionMap getSourceMap() {
-      Assertions.UNREACHABLE("CompilationUnitEntity.getSourceMap()");
-      return null;
+      return Assertions.UNREACHABLE("CompilationUnitEntity.getSourceMap()");
     }
 
     @Override
@@ -4125,8 +4113,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
 
     @Override
     public CAstNodeTypeMap getNodeTypeMap() {
-      Assertions.UNREACHABLE("CompilationUnitEntity.getNodeTypeMap()");
-      return null;
+      return Assertions.UNREACHABLE("CompilationUnitEntity.getNodeTypeMap()");
     }
 
     @Override
@@ -4136,8 +4123,7 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
 
     @Override
     public CAstType getType() {
-      Assertions.UNREACHABLE("CompilationUnitEntity.getType()");
-      return null;
+      return Assertions.UNREACHABLE("CompilationUnitEntity.getType()");
     }
 
     @Override
@@ -4204,20 +4190,17 @@ public abstract class JDTJava2CAstTranslator<T extends Position> {
       implements WalkContext {
     @Override
     public Collection<Pair<ITypeBinding, Object>> getCatchTargets(ITypeBinding type) {
-      Assertions.UNREACHABLE("RootContext.getCatchTargets()");
-      return null;
+      return Assertions.UNREACHABLE("RootContext.getCatchTargets()");
     }
 
     @Override
     public Map<ASTNode, String> getLabelMap() {
-      Assertions.UNREACHABLE("RootContext.getLabelMap()");
-      return null;
+      return Assertions.UNREACHABLE("RootContext.getLabelMap()");
     }
 
     @Override
     public boolean needLValue() {
-      Assertions.UNREACHABLE("Rootcontext.needLValue()");
-      return false;
+      return Assertions.UNREACHABLE("Rootcontext.needLValue()");
     }
   }
 

--- a/cast/java/src/main/java/com/ibm/wala/cast/java/ipa/callgraph/AstJavaSSAPropagationCallGraphBuilder.java
+++ b/cast/java/src/main/java/com/ibm/wala/cast/java/ipa/callgraph/AstJavaSSAPropagationCallGraphBuilder.java
@@ -325,7 +325,6 @@ public class AstJavaSSAPropagationCallGraphBuilder extends AstSSAPropagationCall
 
   @Override
   public GlobalObjectKey getGlobalObject(Atom language) {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 }

--- a/cast/java/src/main/java/com/ibm/wala/cast/java/loader/JavaSourceLoaderImpl.java
+++ b/cast/java/src/main/java/com/ibm/wala/cast/java/loader/JavaSourceLoaderImpl.java
@@ -339,13 +339,11 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
     }
 
     public int getMaxLocals() {
-      Assertions.UNREACHABLE("AbstractJavaMethod.getMaxLocals() called");
-      return 0;
+      return Assertions.UNREACHABLE("AbstractJavaMethod.getMaxLocals() called");
     }
 
     public int getMaxStackHeight() {
-      Assertions.UNREACHABLE("AbstractJavaMethod.getMaxStackHeight() called");
-      return 0;
+      return Assertions.UNREACHABLE("AbstractJavaMethod.getMaxStackHeight() called");
     }
 
     @Override
@@ -418,14 +416,12 @@ public abstract class JavaSourceLoaderImpl extends ClassLoaderImpl {
 
     @Override
     public String getLocalVariableName(int bcIndex, int localNumber) {
-      Assertions.UNREACHABLE("AbstractJavaMethod.getLocalVariableName() called");
-      return null;
+      return Assertions.UNREACHABLE("AbstractJavaMethod.getLocalVariableName() called");
     }
 
     @Override
     public boolean hasLocalVariableTable() {
-      Assertions.UNREACHABLE("AbstractJavaMethod.hasLocalVariableTable() called");
-      return false;
+      return Assertions.UNREACHABLE("AbstractJavaMethod.hasLocalVariableTable() called");
     }
 
     @Override

--- a/cast/java/src/main/java/com/ibm/wala/cast/java/translator/JavaCAst2IRTranslator.java
+++ b/cast/java/src/main/java/com/ibm/wala/cast/java/translator/JavaCAst2IRTranslator.java
@@ -104,8 +104,7 @@ public class JavaCAst2IRTranslator extends AstTranslator {
   // ask this question when parsing Java code
   @Override
   protected boolean treatGlobalsAsLexicallyScoped() {
-    Assertions.UNREACHABLE();
-    return false;
+    return Assertions.UNREACHABLE();
   }
 
   @Override

--- a/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
+++ b/cast/js/rhino/src/main/java/com/ibm/wala/cast/js/translator/RhinoToAstTranslator.java
@@ -428,8 +428,7 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
 
     @Override
     public String getSignature() {
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
 
     @Override
@@ -495,8 +494,7 @@ public class RhinoToAstTranslator implements TranslatorToCAst {
 
     @Override
     public Collection<CAstQualifier> getQualifiers() {
-      Assertions.UNREACHABLE("JuliansUnnamedCAstEntity$2.getQualifiers()");
-      return null;
+      return Assertions.UNREACHABLE("JuliansUnnamedCAstEntity$2.getQualifiers()");
     }
 
     @Override

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/client/JavaScriptAnalysisEngine.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/client/JavaScriptAnalysisEngine.java
@@ -68,8 +68,7 @@ public abstract class JavaScriptAnalysisEngine<I extends InstanceKey>
       return setClassHierarchy(
           SeqClassHierarchyFactory.make(getScope(), loaderFactory, JavaScriptLoader.JS));
     } catch (ClassHierarchyException e) {
-      Assertions.UNREACHABLE(e.toString());
-      return null;
+      return Assertions.UNREACHABLE(e.toString());
     }
   }
 

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/CAstRewriterExt.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/callgraph/correlations/extraction/CAstRewriterExt.java
@@ -160,8 +160,7 @@ public abstract class CAstRewriterExt extends CAstRewriter<NodePos, NoKey> {
       CAstControlFlowMap orig,
       CAstSourcePositionMap src) {
     if (oldTarget == CAstControlFlowMap.EXCEPTION_TO_EXIT) return oldTarget;
-    Assertions.UNREACHABLE();
-    return super.flowOutTo(nodeMap, oldSource, label, oldTarget, orig, src);
+    return Assertions.UNREACHABLE();
   }
 
   @Override

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/translator/JSAstTranslator.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/translator/JSAstTranslator.java
@@ -144,9 +144,8 @@ public class JSAstTranslator extends AstTranslator {
 
   @Override
   protected boolean defineType(CAstEntity type, WalkContext wc) {
-    Assertions.UNREACHABLE(
+    return Assertions.UNREACHABLE(
         "JavaScript doesn't have types. I suggest you look elsewhere for your amusement.");
-    return false;
   }
 
   @Override

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/translator/JavaScriptTranslatorToCAst.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/translator/JavaScriptTranslatorToCAst.java
@@ -59,8 +59,7 @@ public interface JavaScriptTranslatorToCAst extends TranslatorToCAst {
 
     @Override
     public T top() {
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
 
     @Override
@@ -70,14 +69,12 @@ public interface JavaScriptTranslatorToCAst extends TranslatorToCAst {
 
     @Override
     public List<CAstNode> getNameDecls() {
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
 
     @Override
     public CAstNode getCatchTarget() {
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
 
     @Override

--- a/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/CAstAnalysisScope.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ipa/callgraph/CAstAnalysisScope.java
@@ -53,8 +53,7 @@ public class CAstAnalysisScope extends AnalysisScope {
    */
   @Override
   public ClassLoaderReference getPrimordialLoader() {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   /**
@@ -64,8 +63,7 @@ public class CAstAnalysisScope extends AnalysisScope {
    */
   @Override
   public ClassLoaderReference getExtensionLoader() {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   /**
@@ -75,8 +73,7 @@ public class CAstAnalysisScope extends AnalysisScope {
    */
   @Override
   public ClassLoaderReference getApplicationLoader() {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   /**
@@ -84,8 +81,7 @@ public class CAstAnalysisScope extends AnalysisScope {
    */
   @Override
   public ArrayClassLoader getArrayClassLoader() {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   /**

--- a/cast/src/main/java/com/ibm/wala/cast/ipa/cha/CrossLanguageClassHierarchy.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ipa/cha/CrossLanguageClassHierarchy.java
@@ -132,8 +132,7 @@ public class CrossLanguageClassHierarchy implements IClassHierarchy {
 
   @Override
   public IClass getRootClass() {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   @Override

--- a/cast/src/main/java/com/ibm/wala/cast/ir/cfg/Util.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/cfg/Util.java
@@ -24,7 +24,6 @@ public class Util {
       ++i;
     }
 
-    Assertions.UNREACHABLE();
-    return -1;
+    return Assertions.UNREACHABLE();
   }
 }

--- a/cast/src/main/java/com/ibm/wala/cast/ir/ssa/AstConsumeInstruction.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/ssa/AstConsumeInstruction.java
@@ -26,8 +26,7 @@ public abstract class AstConsumeInstruction extends SSAInstruction {
 
   @Override
   public int getDef(int i) {
-    Assertions.UNREACHABLE();
-    return -1;
+    return Assertions.UNREACHABLE();
   }
 
   @Override

--- a/cast/src/main/java/com/ibm/wala/cast/ir/ssa/AstIsDefinedInstruction.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/ssa/AstIsDefinedInstruction.java
@@ -108,8 +108,7 @@ public class AstIsDefinedInstruction extends SSAInstruction {
           + getValueString(symbolTable, fieldVal)
           + ')';
     } else {
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
   }
 
@@ -157,8 +156,7 @@ public class AstIsDefinedInstruction extends SSAInstruction {
     } else if (j == 1 && fieldVal != -1) {
       return fieldVal;
     } else {
-      Assertions.UNREACHABLE();
-      return -1;
+      return Assertions.UNREACHABLE();
     }
   }
 

--- a/cast/src/main/java/com/ibm/wala/cast/ir/ssa/analysis/LiveAnalysis.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/ssa/analysis/LiveAnalysis.java
@@ -234,8 +234,7 @@ public class LiveAnalysis {
                   @Override
                   public UnaryOperator<BitVectorVariable> getEdgeTransferFunction(
                       ISSABasicBlock s, ISSABasicBlock d) {
-                    Assertions.UNREACHABLE();
-                    return null;
+                    return Assertions.UNREACHABLE();
                   }
 
                   /** Live analysis uses 'union' as 'meet operator' */

--- a/cast/src/main/java/com/ibm/wala/cast/ir/translator/AbstractEntity.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/translator/AbstractEntity.java
@@ -37,8 +37,7 @@ public abstract class AbstractEntity implements CAstEntity {
 
   @Override
   public String getSignature() {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   @Override

--- a/cast/src/main/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
+++ b/cast/src/main/java/com/ibm/wala/cast/ir/translator/AstTranslator.java
@@ -2960,20 +2960,17 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
 
     @Override
     public CAstControlFlowMap getControlFlow() {
-      Assertions.UNREACHABLE("TypeContext.getControlFlow()");
-      return null;
+      return Assertions.UNREACHABLE("TypeContext.getControlFlow()");
     }
 
     @Override
     public IncipientCFG cfg() {
-      Assertions.UNREACHABLE("TypeContext.cfg()");
-      return null;
+      return Assertions.UNREACHABLE("TypeContext.cfg()");
     }
 
     @Override
     public UnwindState getUnwindState() {
-      Assertions.UNREACHABLE("TypeContext.getUnwindState()");
-      return null;
+      return Assertions.UNREACHABLE("TypeContext.getUnwindState()");
     }
   }
 
@@ -3341,8 +3338,7 @@ public abstract class AstTranslator extends CAstVisitor<AstTranslator.WalkContex
     else if (op == CAstOperator.OP_INSTANCE_OF) return CAstBinaryOp.INSTANCE_OF;
     else if (op == CAstOperator.OP_POW) return CAstBinaryOp.POW;
     else {
-      Assertions.UNREACHABLE("cannot translate " + CAstPrinter.print(op));
-      return null;
+      return Assertions.UNREACHABLE("cannot translate " + CAstPrinter.print(op));
     }
   }
 

--- a/cast/src/main/java/com/ibm/wala/cast/loader/CAstAbstractModuleLoader.java
+++ b/cast/src/main/java/com/ibm/wala/cast/loader/CAstAbstractModuleLoader.java
@@ -377,13 +377,11 @@ public abstract class CAstAbstractModuleLoader extends CAstAbstractLoader
     }
 
     public int getMaxLocals() {
-      Assertions.UNREACHABLE();
-      return -1;
+      return Assertions.UNREACHABLE();
     }
 
     public int getMaxStackHeight() {
-      Assertions.UNREACHABLE();
-      return -1;
+      return Assertions.UNREACHABLE();
     }
 
     @Override

--- a/cast/src/main/java/com/ibm/wala/cast/util/CAstPattern.java
+++ b/cast/src/main/java/com/ibm/wala/cast/util/CAstPattern.java
@@ -371,11 +371,9 @@ public class CAstPattern {
     try {
       return new Parser(patternString).parse();
     } catch (NoSuchFieldException e) {
-      Assertions.UNREACHABLE("no such kind in pattern: " + e.getMessage());
-      return null;
+      return Assertions.UNREACHABLE("no such kind in pattern: " + e.getMessage());
     } catch (IllegalAccessException e) {
-      Assertions.UNREACHABLE("internal error in CAstPattern" + e);
-      return null;
+      return Assertions.UNREACHABLE("internal error in CAstPattern" + e);
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/analysis/pointers/BasicHeapGraph.java
+++ b/core/src/main/java/com/ibm/wala/analysis/pointers/BasicHeapGraph.java
@@ -225,8 +225,7 @@ public class BasicHeapGraph<T extends InstanceKey> extends HeapGraphImpl<T> {
 
                 @Override
                 public boolean hasEdge(Object src, Object dst) {
-                  Assertions.UNREACHABLE();
-                  return false;
+                  return Assertions.UNREACHABLE();
                 }
               };
 
@@ -287,8 +286,7 @@ public class BasicHeapGraph<T extends InstanceKey> extends HeapGraphImpl<T> {
         return result.toIntArray();
       }
     } else {
-      Assertions.UNREACHABLE("Unexpected type: " + N.getClass());
-      return null;
+      return Assertions.UNREACHABLE("Unexpected type: " + N.getClass());
     }
   }
 
@@ -484,8 +482,7 @@ public class BasicHeapGraph<T extends InstanceKey> extends HeapGraphImpl<T> {
 
   @Override
   public boolean hasEdge(Object from, Object to) throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return false;
+    return Assertions.UNREACHABLE();
   }
 
   @Override
@@ -538,13 +535,11 @@ public class BasicHeapGraph<T extends InstanceKey> extends HeapGraphImpl<T> {
 
   @Override
   public IntSet getSuccNodeNumbers(Object node) throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   @Override
   public IntSet getPredNodeNumbers(Object node) throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 }

--- a/core/src/main/java/com/ibm/wala/analysis/reflection/AbstractReflectionInterpreter.java
+++ b/core/src/main/java/com/ibm/wala/analysis/reflection/AbstractReflectionInterpreter.java
@@ -93,8 +93,7 @@ public abstract class AbstractReflectionInterpreter implements SSAContextInterpr
     if (klass != null) {
       return new ConeType(klass);
     }
-    Assertions.UNREACHABLE(type.toString());
-    return null;
+    return Assertions.UNREACHABLE(type.toString());
   }
 
   /** A warning when we expect excessive pollution from a factory method */

--- a/core/src/main/java/com/ibm/wala/analysis/reflection/FactoryBypassInterpreter.java
+++ b/core/src/main/java/com/ibm/wala/analysis/reflection/FactoryBypassInterpreter.java
@@ -237,8 +237,7 @@ public class FactoryBypassInterpreter extends AbstractReflectionInterpreter {
       return CodeScanner.getFieldsRead(m).iterator();
     } catch (InvalidClassFileException e) {
       e.printStackTrace();
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
   }
 
@@ -252,8 +251,7 @@ public class FactoryBypassInterpreter extends AbstractReflectionInterpreter {
       return CodeScanner.getFieldsWritten(m).iterator();
     } catch (InvalidClassFileException e) {
       e.printStackTrace();
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
   }
 
@@ -278,8 +276,7 @@ public class FactoryBypassInterpreter extends AbstractReflectionInterpreter {
       return CodeScanner.getCaughtExceptions(m);
     } catch (InvalidClassFileException e) {
       e.printStackTrace();
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
   }
 
@@ -292,8 +289,7 @@ public class FactoryBypassInterpreter extends AbstractReflectionInterpreter {
       return CodeScanner.hasObjectArrayLoad(m);
     } catch (InvalidClassFileException e) {
       e.printStackTrace();
-      Assertions.UNREACHABLE();
-      return false;
+      return Assertions.UNREACHABLE();
     }
   }
 
@@ -306,8 +302,7 @@ public class FactoryBypassInterpreter extends AbstractReflectionInterpreter {
       return CodeScanner.hasObjectArrayStore(m);
     } catch (InvalidClassFileException e) {
       e.printStackTrace();
-      Assertions.UNREACHABLE();
-      return false;
+      return Assertions.UNREACHABLE();
     }
   }
 
@@ -320,8 +315,7 @@ public class FactoryBypassInterpreter extends AbstractReflectionInterpreter {
       return CodeScanner.iterateCastTypes(m);
     } catch (InvalidClassFileException e) {
       e.printStackTrace();
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/analysis/reflection/GetMethodContextInterpreter.java
+++ b/core/src/main/java/com/ibm/wala/analysis/reflection/GetMethodContextInterpreter.java
@@ -104,8 +104,7 @@ public class GetMethodContextInterpreter implements SSAContextInterpreter {
           SSAOptions.defaultOptions(),
           constants);
     }
-    Assertions.UNREACHABLE("Unexpected method " + node);
-    return null;
+    return Assertions.UNREACHABLE("Unexpected method " + node);
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/analysis/reflection/JavaLangClassContextInterpreter.java
+++ b/core/src/main/java/com/ibm/wala/analysis/reflection/JavaLangClassContextInterpreter.java
@@ -227,8 +227,7 @@ public class JavaLangClassContextInterpreter implements SSAContextInterpreter {
           SSAOptions.defaultOptions(),
           constants);
     }
-    Assertions.UNREACHABLE("Unexpected method " + method);
-    return null;
+    return Assertions.UNREACHABLE("Unexpected method " + method);
   }
 
   /* END Custom change: caching */

--- a/core/src/main/java/com/ibm/wala/analysis/typeInference/ConeType.java
+++ b/core/src/main/java/com/ibm/wala/analysis/typeInference/ConeType.java
@@ -51,8 +51,7 @@ public class ConeType extends TypeAbstraction {
     } else if (rhs instanceof PrimitiveType) {
       return TOP;
     } else {
-      Assertions.UNREACHABLE("unexpected type " + rhs.getClass());
-      return null;
+      return Assertions.UNREACHABLE("unexpected type " + rhs.getClass());
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/analysis/typeInference/PointType.java
+++ b/core/src/main/java/com/ibm/wala/analysis/typeInference/PointType.java
@@ -67,8 +67,7 @@ public class PointType extends TypeAbstraction {
         // TODO: avoid the allocation
         return other.meet(new ConeType(this.getType()));
       } else {
-        Assertions.UNREACHABLE("Unexpected type: " + rhs.getClass());
-        return null;
+        return Assertions.UNREACHABLE("Unexpected type: " + rhs.getClass());
       }
     }
   }

--- a/core/src/main/java/com/ibm/wala/cfg/AbstractCFG.java
+++ b/core/src/main/java/com/ibm/wala/cfg/AbstractCFG.java
@@ -635,8 +635,7 @@ public abstract class AbstractCFG<I, T extends IBasicBlock<I>>
 
   @Override
   public IntSet getPredNodeNumbers(T node) throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   /*

--- a/core/src/main/java/com/ibm/wala/cfg/ShrikeCFG.java
+++ b/core/src/main/java/com/ibm/wala/cfg/ShrikeCFG.java
@@ -95,8 +95,7 @@ public class ShrikeCFG extends AbstractCFG<IInstruction, ShrikeCFG.BasicBlock>
       return method.getInstructions();
     } catch (InvalidClassFileException e) {
       e.printStackTrace();
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
   }
 
@@ -531,8 +530,7 @@ public class ShrikeCFG extends AbstractCFG<IInstruction, ShrikeCFG.BasicBlock>
       return method.getBytecodeIndex(index);
     } catch (InvalidClassFileException e) {
       e.printStackTrace();
-      Assertions.UNREACHABLE();
-      return -1;
+      return Assertions.UNREACHABLE();
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/cfg/Util.java
+++ b/core/src/main/java/com/ibm/wala/cfg/Util.java
@@ -143,8 +143,7 @@ public class Util {
       }
     }
 
-    Assertions.UNREACHABLE();
-    return -1;
+    return Assertions.UNREACHABLE();
   }
 
   /**
@@ -195,7 +194,6 @@ public class Util {
       }
       i++;
     }
-    Assertions.UNREACHABLE("Invalid: a must be a predecessor of b! " + a + ' ' + b);
-    return -1;
+    return Assertions.UNREACHABLE("Invalid: a must be a predecessor of b! " + a + ' ' + b);
   }
 }

--- a/core/src/main/java/com/ibm/wala/classLoader/AbstractNestedJarFileModule.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/AbstractNestedJarFileModule.java
@@ -169,8 +169,7 @@ public abstract class AbstractNestedJarFileModule implements Module {
 
     @Override
     public Module asModule() {
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
 
     @Override

--- a/core/src/main/java/com/ibm/wala/classLoader/AbstractURLModule.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/AbstractURLModule.java
@@ -41,8 +41,7 @@ public abstract class AbstractURLModule implements Module, ModuleEntry {
       if (con instanceof JarURLConnection jarURLConnection) return jarURLConnection.getEntryName();
       else return new FileProvider().filePathFromURL(url);
     } catch (IOException e) {
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
   }
 
@@ -63,8 +62,7 @@ public abstract class AbstractURLModule implements Module, ModuleEntry {
 
   @Override
   public Module asModule() throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/classLoader/ArrayClass.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/ArrayClass.java
@@ -189,8 +189,7 @@ public class ArrayClass implements IClass, Constants {
 
   @Override
   public Collection<IField> getDeclaredStaticFields() throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   @Override
@@ -255,8 +254,7 @@ public class ArrayClass implements IClass, Constants {
   @Override
   public Collection<IClass> getDirectInterfaces() throws UnimplementedError {
     // TODO Auto-generated method stub
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   @Override
@@ -270,14 +268,12 @@ public class ArrayClass implements IClass, Constants {
 
   @Override
   public Collection<IField> getAllInstanceFields() {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   @Override
   public Collection<IField> getAllStaticFields() {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   @Override
@@ -289,8 +285,7 @@ public class ArrayClass implements IClass, Constants {
 
   @Override
   public Collection<IField> getAllFields() {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/classLoader/CallSiteReference.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/CallSiteReference.java
@@ -14,6 +14,7 @@ import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.ContextItem;
 import com.ibm.wala.shrike.shrikeBT.BytecodeConstants;
 import com.ibm.wala.shrike.shrikeBT.IInvokeInstruction;
+import com.ibm.wala.shrike.shrikeBT.IInvokeInstruction.Dispatch;
 import com.ibm.wala.ssa.IR;
 import com.ibm.wala.types.MethodReference;
 import com.ibm.wala.util.debug.Assertions;
@@ -152,13 +153,12 @@ public abstract class CallSiteReference extends ProgramCounter
   }
 
   protected String getInvocationString(IInvokeInstruction.IDispatch invocationCode) {
-    if (invocationCode == IInvokeInstruction.Dispatch.STATIC) return "static";
-    if (invocationCode == IInvokeInstruction.Dispatch.SPECIAL) return "special";
-    if (invocationCode == IInvokeInstruction.Dispatch.VIRTUAL) return "virtual";
-    if (invocationCode == IInvokeInstruction.Dispatch.INTERFACE) return "interface";
+    if (invocationCode == Dispatch.STATIC) return "static";
+    if (invocationCode == Dispatch.SPECIAL) return "special";
+    if (invocationCode == Dispatch.VIRTUAL) return "virtual";
+    if (invocationCode == Dispatch.INTERFACE) return "interface";
 
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   public String getInvocationString() {

--- a/core/src/main/java/com/ibm/wala/classLoader/FileModule.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/FileModule.java
@@ -78,8 +78,7 @@ public abstract class FileModule implements Module, ModuleEntry {
       return new FileInputStream(file);
     } catch (FileNotFoundException e) {
       e.printStackTrace();
-      Assertions.UNREACHABLE("could not read " + file);
-      return null;
+      return Assertions.UNREACHABLE("could not read " + file);
     }
   }
 
@@ -97,8 +96,7 @@ public abstract class FileModule implements Module, ModuleEntry {
 
   @Override
   public Module asModule() throws UnimplementedError {
-    Assertions.UNREACHABLE("implement me");
-    return null;
+    return Assertions.UNREACHABLE("implement me");
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/classLoader/JarFileEntry.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/JarFileEntry.java
@@ -46,8 +46,7 @@ public class JarFileEntry implements ModuleEntry {
     } catch (Exception e) {
       // TODO Auto-generated catch block
       e.printStackTrace();
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/classLoader/JarFileModule.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/JarFileModule.java
@@ -105,8 +105,7 @@ public class JarFileModule implements Module {
       return bb;
     } catch (IOException e) {
       e.printStackTrace();
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/classLoader/JarStreamModule.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/JarStreamModule.java
@@ -165,8 +165,7 @@ public class JarStreamModule extends JarInputStream implements Module {
 
     @Override
     public Module asModule() {
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
 
     @Override

--- a/core/src/main/java/com/ibm/wala/classLoader/ShrikeBTMethod.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/ShrikeBTMethod.java
@@ -331,8 +331,7 @@ public abstract class ShrikeBTMethod implements IMethod, BytecodeConstants {
       Descriptor D = Descriptor.findOrCreate(declaringClass.getClassLoader().getLanguage(), desc);
       return MethodReference.findOrCreate(declaringClass.getReference(), name, D);
     } catch (InvalidClassFileException e) {
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
   }
 
@@ -761,8 +760,7 @@ public abstract class ShrikeBTMethod implements IMethod, BytecodeConstants {
                   loader, TypeName.findOrCreate(ImmutableByteArray.make('L' + strings[i]))));
       return result;
     } catch (InvalidClassFileException e) {
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/classLoader/ShrikeCTMethod.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/ShrikeCTMethod.java
@@ -305,8 +305,7 @@ public final class ShrikeCTMethod extends ShrikeBTMethod implements IBytecodeMet
           return getClassReader().getCP().getCPUtf8(nameIndex);
         } catch (InvalidClassFileException e) {
           e.printStackTrace();
-          Assertions.UNREACHABLE();
-          return null;
+          return Assertions.UNREACHABLE();
         }
       }
     }
@@ -330,8 +329,7 @@ public final class ShrikeCTMethod extends ShrikeBTMethod implements IBytecodeMet
       return false;
     } catch (InvalidClassFileException e) {
       e.printStackTrace();
-      Assertions.UNREACHABLE();
-      return false;
+      return Assertions.UNREACHABLE();
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/classLoader/ShrikeClass.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/ShrikeClass.java
@@ -198,8 +198,7 @@ public final class ShrikeClass extends JVMClass<IClassLoader> {
       return reader.get();
     } catch (InvalidClassFileException e) {
       e.printStackTrace();
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/core/util/strings/UTF8Convert.java
+++ b/core/src/main/java/com/ibm/wala/core/util/strings/UTF8Convert.java
@@ -205,8 +205,7 @@ public abstract class UTF8Convert {
       return fromUTF8(s.b);
     } catch (UTFDataFormatException e) {
       e.printStackTrace();
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
   }
 }

--- a/core/src/main/java/com/ibm/wala/dataflow/IFDS/BackwardsSupergraph.java
+++ b/core/src/main/java/com/ibm/wala/dataflow/IFDS/BackwardsSupergraph.java
@@ -319,8 +319,7 @@ public class BackwardsSupergraph<T, P> implements ISupergraph<T, P> {
 
   @Override
   public Iterator<T> iterateNodes(IntSet s) throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   @Override
@@ -330,7 +329,6 @@ public class BackwardsSupergraph<T, P> implements ISupergraph<T, P> {
 
   @Override
   public IntSet getPredNodeNumbers(Object node) throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 }

--- a/core/src/main/java/com/ibm/wala/dataflow/IFDS/ICFGSupergraph.java
+++ b/core/src/main/java/com/ibm/wala/dataflow/IFDS/ICFGSupergraph.java
@@ -122,8 +122,7 @@ public class ICFGSupergraph
   }
 
   public BasicBlockInContext<IExplodedBasicBlock> getMainEntry() {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   @Override
@@ -134,8 +133,7 @@ public class ICFGSupergraph
 
   @Override
   public int getNumberOfBlocks(CGNode procedure) {
-    Assertions.UNREACHABLE();
-    return 0;
+    return Assertions.UNREACHABLE();
   }
 
   @Override
@@ -281,8 +279,7 @@ public class ICFGSupergraph
 
   @Override
   public Iterator<BasicBlockInContext<IExplodedBasicBlock>> iterateNodes(IntSet s) {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/demandpa/flowgraph/SimpleDemandPointerFlowGraph.java
+++ b/core/src/main/java/com/ibm/wala/demandpa/flowgraph/SimpleDemandPointerFlowGraph.java
@@ -186,8 +186,7 @@ public class SimpleDemandPointerFlowGraph extends SlowSparseNumberedGraph<Object
   @Override
   public IntSet getPredNodeNumbers(Object node) throws UnimplementedError {
     if (node instanceof StaticFieldKey) {
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     } else {
       return super.getPredNodeNumbers(node);
     }
@@ -211,8 +210,7 @@ public class SimpleDemandPointerFlowGraph extends SlowSparseNumberedGraph<Object
   @Override
   public int getPredNodeCount(Object N) throws UnimplementedError {
     if (N instanceof StaticFieldKey) {
-      Assertions.UNREACHABLE();
-      return -1;
+      return Assertions.UNREACHABLE();
     } else {
       return super.getPredNodeCount(N);
     }
@@ -236,8 +234,7 @@ public class SimpleDemandPointerFlowGraph extends SlowSparseNumberedGraph<Object
   @Override
   public int getSuccNodeCount(Object N) throws UnimplementedError {
     if (N instanceof StaticFieldKey) {
-      Assertions.UNREACHABLE();
-      return -1;
+      return Assertions.UNREACHABLE();
     } else {
       return super.getSuccNodeCount(N);
     }

--- a/core/src/main/java/com/ibm/wala/demandpa/util/ArrayContents.java
+++ b/core/src/main/java/com/ibm/wala/demandpa/util/ArrayContents.java
@@ -67,38 +67,32 @@ public class ArrayContents implements IField {
 
   @Override
   public TypeReference getFieldTypeReference() throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   @Override
   public boolean isFinal() throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return false;
+    return Assertions.UNREACHABLE();
   }
 
   @Override
   public boolean isPrivate() throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return false;
+    return Assertions.UNREACHABLE();
   }
 
   @Override
   public boolean isProtected() throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return false;
+    return Assertions.UNREACHABLE();
   }
 
   @Override
   public boolean isPublic() throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return false;
+    return Assertions.UNREACHABLE();
   }
 
   @Override
   public boolean isStatic() throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return false;
+    return Assertions.UNREACHABLE();
   }
 
   @Override
@@ -108,8 +102,7 @@ public class ArrayContents implements IField {
 
   @Override
   public Atom getName() throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   @Override
@@ -124,8 +117,7 @@ public class ArrayContents implements IField {
 
   @Override
   public ClassHierarchy getClassHierarchy() throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/escape/LocalLiveRangeAnalysis.java
+++ b/core/src/main/java/com/ibm/wala/escape/LocalLiveRangeAnalysis.java
@@ -120,15 +120,14 @@ public class LocalLiveRangeAnalysis {
       Assertions.UNREACHABLE();
     }
     for (ISSABasicBlock issaBasicBlock : ir.getControlFlowGraph()) {
-      SSACFG.BasicBlock b = (SSACFG.BasicBlock) issaBasicBlock;
+      BasicBlock b = (BasicBlock) issaBasicBlock;
       for (SSAInstruction x : b) {
         if (s.equals(x)) {
           return b;
         }
       }
     }
-    Assertions.UNREACHABLE("no block for " + s + " in IR " + ir);
-    return null;
+    return Assertions.UNREACHABLE("no block for " + s + " in IR " + ir);
   }
 
   /**
@@ -138,12 +137,11 @@ public class LocalLiveRangeAnalysis {
    */
   private static ISSABasicBlock findBlock(IR ir, int i) {
     for (ISSABasicBlock issaBasicBlock : ir.getControlFlowGraph()) {
-      SSACFG.BasicBlock b = (SSACFG.BasicBlock) issaBasicBlock;
+      BasicBlock b = (BasicBlock) issaBasicBlock;
       if (i >= b.getFirstInstructionIndex() && i <= b.getLastInstructionIndex()) {
         return b;
       }
     }
-    Assertions.UNREACHABLE("no block for " + i + " in IR " + ir);
-    return null;
+    return Assertions.UNREACHABLE("no block for " + i + " in IR " + ir);
   }
 }

--- a/core/src/main/java/com/ibm/wala/examples/drivers/PDFSDG.java
+++ b/core/src/main/java/com/ibm/wala/examples/drivers/PDFSDG.java
@@ -88,8 +88,7 @@ public class PDFSDG {
         return result;
       }
     }
-    Assertions.UNREACHABLE("unknown data datapendence option: " + d);
-    return null;
+    return Assertions.UNREACHABLE("unknown data datapendence option: " + d);
   }
 
   public static ControlDependenceOptions getControlDependenceOptions(Properties p) {
@@ -99,8 +98,7 @@ public class PDFSDG {
         return result;
       }
     }
-    Assertions.UNREACHABLE("unknown control datapendence option: " + d);
-    return null;
+    return Assertions.UNREACHABLE("unknown control datapendence option: " + d);
   }
 
   /**

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/AnalysisScope.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/AnalysisScope.java
@@ -467,8 +467,7 @@ public class AnalysisScope {
       }
       return result;
     } catch (java.io.IOException e) {
-      Assertions.UNREACHABLE("error getting rt.jar manifest!");
-      return null;
+      return Assertions.UNREACHABLE("error getting rt.jar manifest!");
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/ContextUtil.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/ContextUtil.java
@@ -37,8 +37,7 @@ public class ContextUtil {
       } else if (item instanceof InstanceKey instanceKey) {
         return instanceKey.concreteType();
       } else {
-        Assertions.UNREACHABLE("Unexpected: " + item.getClass());
-        return null;
+        return Assertions.UNREACHABLE("Unexpected: " + item.getClass());
       }
     }
   }

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/cha/ContextInsensitiveCHAContextInterpreter.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/cha/ContextInsensitiveCHAContextInterpreter.java
@@ -34,8 +34,7 @@ public class ContextInsensitiveCHAContextInterpreter implements CHAContextInterp
       return CodeScanner.getCallSites(node.getMethod()).iterator();
     } catch (InvalidClassFileException e) {
       e.printStackTrace();
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/FakeRootClass.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/impl/FakeRootClass.java
@@ -190,8 +190,7 @@ public class FakeRootClass extends SyntheticClass {
    */
   @Override
   public IMethod getClassInitializer() throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   /**

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PointerAnalysisImpl.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PointerAnalysisImpl.java
@@ -225,17 +225,16 @@ public class PointerAnalysisImpl extends AbstractPointerAnalysis {
           if (v.pointsToSet != null) {
             return v.pointsToSet;
           } else {
-            Assertions.UNREACHABLE("saw " + key + ": time to implement for " + def.getClass());
-            return null;
+            return Assertions.UNREACHABLE(
+                "saw " + key + ": time to implement for " + def.getClass());
           }
         } else {
-          Assertions.UNREACHABLE("unexpected null def for " + key);
-          return null;
+          return Assertions.UNREACHABLE("unexpected null def for " + key);
         }
       }
     } else {
-      Assertions.UNREACHABLE("unexpected implicit key " + key + " that's not a local pointer key");
-      return null;
+      return Assertions.UNREACHABLE(
+          "unexpected implicit key " + key + " that's not a local pointer key");
     }
   }
 
@@ -411,8 +410,7 @@ public class PointerAnalysisImpl extends AbstractPointerAnalysis {
     if (lpk.getValueNumber() == exc) {
       return computeImplicitExceptionsForCall(node, call);
     } else {
-      Assertions.UNREACHABLE("time to implement me.");
-      return null;
+      return Assertions.UNREACHABLE("time to implement me.");
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PointerKeyComparator.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PointerKeyComparator.java
@@ -199,8 +199,7 @@ public class PointerKeyComparator implements Comparator<PointerKey> {
 
   protected int compareOtherKeys(Object key1, Object key2) {
     System.err.println("Cannot compare " + key1 + " and " + key2);
-    Assertions.UNREACHABLE();
-    return 0;
+    return Assertions.UNREACHABLE();
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationGraph.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationGraph.java
@@ -917,8 +917,7 @@ public class PropagationGraph implements IFixedPointSystem<PointsToSetVariable> 
      */
     @Override
     public boolean containsNode(PointsToSetVariable N) {
-      Assertions.UNREACHABLE();
-      return false;
+      return Assertions.UNREACHABLE();
     }
 
     /**
@@ -1064,8 +1063,7 @@ public class PropagationGraph implements IFixedPointSystem<PointsToSetVariable> 
      */
     @Override
     protected NumberedEdgeManager<PointsToSetVariable> getEdgeManager() {
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/ContextInsensitiveRTAInterpreter.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/ContextInsensitiveRTAInterpreter.java
@@ -47,8 +47,7 @@ public abstract class ContextInsensitiveRTAInterpreter
       return CodeScanner.getNewSites(node.getMethod()).iterator();
     } catch (InvalidClassFileException e) {
       e.printStackTrace();
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
   }
 
@@ -61,8 +60,7 @@ public abstract class ContextInsensitiveRTAInterpreter
       return CodeScanner.getFieldsRead(node.getMethod()).iterator();
     } catch (InvalidClassFileException e) {
       e.printStackTrace();
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
   }
 
@@ -75,8 +73,7 @@ public abstract class ContextInsensitiveRTAInterpreter
       return CodeScanner.getFieldsWritten(node.getMethod()).iterator();
     } catch (InvalidClassFileException e) {
       e.printStackTrace();
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/RTASelectorKey.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/RTASelectorKey.java
@@ -53,7 +53,6 @@ public class RTASelectorKey implements PointerKey {
    * @see com.ibm.wala.ipa.callgraph.propagation.FilteredPointerKey#getTypeFilter()
    */
   public IClass getTypeFilter() throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 }

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/TypeBasedHeapModel.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/TypeBasedHeapModel.java
@@ -207,22 +207,19 @@ public class TypeBasedHeapModel implements HeapModel {
   }
 
   public String getStringConstantForInstanceKey() throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   @Override
   public InstanceKey getInstanceKeyForPEI(CGNode node, ProgramCounter instr, TypeReference type)
       throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   @Override
   public InstanceKey getInstanceKeyForMetadataObject(Object obj, TypeReference objType)
       throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   /**
@@ -247,12 +244,10 @@ public class TypeBasedHeapModel implements HeapModel {
           return pointerKeys.getFilteredPointerKeyForLocal(
               node, valueNumber, new FilteredPointerKey.SingleClassFilter(c.concreteType()));
         } else {
-          Assertions.UNREACHABLE("need to handle " + result.getClass());
-          return null;
+          return Assertions.UNREACHABLE("need to handle " + result.getClass());
         }
       } else {
-        Assertions.UNREACHABLE("need to handle " + result.getClass());
-        return null;
+        return Assertions.UNREACHABLE("need to handle " + result.getClass());
       }
     }
   }
@@ -261,8 +256,7 @@ public class TypeBasedHeapModel implements HeapModel {
   public FilteredPointerKey getFilteredPointerKeyForLocal(
       CGNode node, int valueNumber, FilteredPointerKey.TypeFilter filter)
       throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/TypeBasedPointerAnalysis.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/rta/TypeBasedPointerAnalysis.java
@@ -165,8 +165,7 @@ public class TypeBasedPointerAnalysis extends AbstractPointerAnalysis {
           .getClassHierarchy()
           .lookupClass(r.getNode().getMethod().getReturnType());
     } else {
-      Assertions.UNREACHABLE("inferType " + key.getClass());
-      return null;
+      return Assertions.UNREACHABLE("inferType " + key.getClass());
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/util/CallGraphSearchUtil.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/util/CallGraphSearchUtil.java
@@ -50,8 +50,7 @@ public class CallGraphSearchUtil {
         return n;
       }
     }
-    Assertions.UNREACHABLE("failed to find method " + name);
-    return null;
+    return Assertions.UNREACHABLE("failed to find method " + name);
   }
 
   /**
@@ -70,7 +69,6 @@ public class CallGraphSearchUtil {
       }
     }
     System.err.println("call graph " + cg);
-    Assertions.UNREACHABLE("failed to find method " + name);
-    return null;
+    return Assertions.UNREACHABLE("failed to find method " + name);
   }
 }

--- a/core/src/main/java/com/ibm/wala/ipa/cfg/AbstractInterproceduralCFG.java
+++ b/core/src/main/java/com/ibm/wala/ipa/cfg/AbstractInterproceduralCFG.java
@@ -783,8 +783,7 @@ public abstract class AbstractInterproceduralCFG<T extends ISSABasicBlock>
 
   @Override
   public Iterator<BasicBlockInContext<T>> iterateNodes(IntSet s) throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/ipa/cha/ClassHierarchy.java
+++ b/core/src/main/java/com/ibm/wala/ipa/cha/ClassHierarchy.java
@@ -822,9 +822,8 @@ public class ClassHierarchy implements IClassHierarchy {
       }
       Set<IClass> superA;
       superA = getSuperclasses(a);
-      Assertions.UNREACHABLE(
+      return Assertions.UNREACHABLE(
           "getLeastCommonSuperclass " + tempA + ' ' + b + ": " + superA + ", " + superB);
-      return null;
     }
   }
 
@@ -1161,8 +1160,7 @@ public class ClassHierarchy implements IClassHierarchy {
         return loader;
       }
     }
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/ipa/modref/GenReach.java
+++ b/core/src/main/java/com/ibm/wala/ipa/modref/GenReach.java
@@ -94,8 +94,7 @@ public class GenReach<T, L> extends BitVectorFramework<T, L> {
 
     @Override
     public UnaryOperator<BitVectorVariable> getEdgeTransferFunction(T src, T dst) {
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
   }
 }

--- a/core/src/main/java/com/ibm/wala/ipa/slicer/HeapReachingDefs.java
+++ b/core/src/main/java/com/ibm/wala/ipa/slicer/HeapReachingDefs.java
@@ -255,14 +255,12 @@ public class HeapReachingDefs<T extends InstanceKey> {
 
     @Override
     public boolean containsKey(Object key) {
-      Assertions.UNREACHABLE();
-      return delegate.containsKey(key);
+      return Assertions.UNREACHABLE();
     }
 
     @Override
     public boolean containsValue(Object value) {
-      Assertions.UNREACHABLE();
-      return delegate.containsValue(value);
+      return Assertions.UNREACHABLE();
     }
 
     @Override
@@ -272,8 +270,7 @@ public class HeapReachingDefs<T extends InstanceKey> {
 
     @Override
     public boolean equals(Object o) {
-      Assertions.UNREACHABLE();
-      return delegate.equals(o);
+      return Assertions.UNREACHABLE();
     }
 
     @Override
@@ -283,14 +280,12 @@ public class HeapReachingDefs<T extends InstanceKey> {
 
     @Override
     public int hashCode() {
-      Assertions.UNREACHABLE();
-      return delegate.hashCode();
+      return Assertions.UNREACHABLE();
     }
 
     @Override
     public boolean isEmpty() {
-      Assertions.UNREACHABLE();
-      return delegate.isEmpty();
+      return Assertions.UNREACHABLE();
     }
 
     @Override
@@ -300,8 +295,7 @@ public class HeapReachingDefs<T extends InstanceKey> {
 
     @Override
     public OrdinalSet<Statement> put(Statement key, OrdinalSet<Statement> value) {
-      Assertions.UNREACHABLE();
-      return delegate.put(key, value);
+      return Assertions.UNREACHABLE();
     }
 
     @Override
@@ -312,20 +306,17 @@ public class HeapReachingDefs<T extends InstanceKey> {
 
     @Override
     public OrdinalSet<Statement> remove(Object key) {
-      Assertions.UNREACHABLE();
-      return delegate.remove(key);
+      return Assertions.UNREACHABLE();
     }
 
     @Override
     public int size() {
-      Assertions.UNREACHABLE();
-      return delegate.size();
+      return Assertions.UNREACHABLE();
     }
 
     @Override
     public Collection<OrdinalSet<Statement>> values() {
-      Assertions.UNREACHABLE();
-      return delegate.values();
+      return Assertions.UNREACHABLE();
     }
 
     /** For a statement s, compute the set of statements that may def the heap value read by s. */
@@ -425,8 +416,7 @@ public class HeapReachingDefs<T extends InstanceKey> {
           return OrdinalSet.empty();
         }
         default -> {
-          Assertions.UNREACHABLE(s.getKind().toString());
-          return null;
+          return Assertions.UNREACHABLE(s.getKind().toString());
         }
       }
     }

--- a/core/src/main/java/com/ibm/wala/ipa/slicer/PDG.java
+++ b/core/src/main/java/com/ibm/wala/ipa/slicer/PDG.java
@@ -725,8 +725,7 @@ public class PDG<T extends InstanceKey> implements NumberedLabeledGraph<Statemen
     } else if (use instanceof SSAArrayLengthInstruction s) {
       return s.getArrayRef();
     } else {
-      Assertions.UNREACHABLE("BOOM");
-      return -1;
+      return Assertions.UNREACHABLE("BOOM");
     }
   }
 
@@ -1046,8 +1045,7 @@ public class PDG<T extends InstanceKey> implements NumberedLabeledGraph<Statemen
   @Override
   public int getPredNodeCount(Statement N) throws UnimplementedError {
     populate();
-    Assertions.UNREACHABLE();
-    return delegate.getPredNodeCount(N);
+    return Assertions.UNREACHABLE();
   }
 
   @Override
@@ -1106,8 +1104,7 @@ public class PDG<T extends InstanceKey> implements NumberedLabeledGraph<Statemen
   @Override
   public int getSuccNodeCount(Statement N) throws UnimplementedError {
     populate();
-    Assertions.UNREACHABLE();
-    return delegate.getSuccNodeCount(N);
+    return Assertions.UNREACHABLE();
   }
 
   @Override
@@ -1209,20 +1206,17 @@ public class PDG<T extends InstanceKey> implements NumberedLabeledGraph<Statemen
 
   @Override
   public Iterator<Statement> iterateNodes(IntSet s) {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   @Override
   public IntSet getPredNodeNumbers(Statement node) {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   @Override
   public IntSet getSuccNodeNumbers(Statement node) {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/ipa/slicer/SDG.java
+++ b/core/src/main/java/com/ibm/wala/ipa/slicer/SDG.java
@@ -240,8 +240,7 @@ public class SDG<T extends InstanceKey> extends AbstractNumberedGraph<Statement>
 
     @Override
     public Iterator<Statement> iterateNodes(IntSet s) {
-      Assertions.UNREACHABLE();
-      return super.iterateNodes(s);
+      return Assertions.UNREACHABLE();
     }
 
     @Override
@@ -438,8 +437,7 @@ public class SDG<T extends InstanceKey> extends AbstractNumberedGraph<Statement>
           return result.iterator();
         }
         default -> {
-          Assertions.UNREACHABLE(N.getKind().toString());
-          return null;
+          return Assertions.UNREACHABLE(N.getKind().toString());
         }
       }
     }
@@ -598,8 +596,7 @@ public class SDG<T extends InstanceKey> extends AbstractNumberedGraph<Statement>
           return result.iterator();
         }
         default -> {
-          Assertions.UNREACHABLE(N.getKind().toString());
-          return null;
+          return Assertions.UNREACHABLE(N.getKind().toString());
         }
       }
     }
@@ -771,8 +768,7 @@ public class SDG<T extends InstanceKey> extends AbstractNumberedGraph<Statement>
           }
         }
         default -> {
-          Assertions.UNREACHABLE(src.getKind());
-          return Collections.emptySet();
+          return Assertions.UNREACHABLE(src.getKind());
         }
       }
     }

--- a/core/src/main/java/com/ibm/wala/ipa/slicer/SDGSupergraph.java
+++ b/core/src/main/java/com/ibm/wala/ipa/slicer/SDGSupergraph.java
@@ -37,19 +37,16 @@ class SDGSupergraph implements ISupergraph<Statement, PDG<? extends InstanceKey>
 
   @Override
   public Graph<PDG<? extends InstanceKey>> getProcedureGraph() {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   public Object[] getEntry() {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   @Override
   public byte classifyEdge(Statement src, Statement dest) {
-    Assertions.UNREACHABLE();
-    return 0;
+    return Assertions.UNREACHABLE();
   }
 
   @Override
@@ -75,8 +72,7 @@ class SDGSupergraph implements ISupergraph<Statement, PDG<? extends InstanceKey>
         return pdg.getCallStatements(call).iterator();
       }
       default -> {
-        Assertions.UNREACHABLE(r.getKind().toString());
-        return null;
+        return Assertions.UNREACHABLE(r.getKind().toString());
       }
     }
   }
@@ -127,15 +123,13 @@ class SDGSupergraph implements ISupergraph<Statement, PDG<? extends InstanceKey>
     if (!backward) {
       return EmptyIterator.instance();
     } else {
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
   }
 
   @Override
   public int getNumberOfBlocks(PDG<? extends InstanceKey> procedure) {
-    Assertions.UNREACHABLE();
-    return 0;
+    return Assertions.UNREACHABLE();
   }
 
   @Override
@@ -171,8 +165,7 @@ class SDGSupergraph implements ISupergraph<Statement, PDG<? extends InstanceKey>
         return pdg.getCallerReturnStatements(st).iterator();
       }
       default -> {
-        Assertions.UNREACHABLE(call.getKind().toString());
-        return null;
+        return Assertions.UNREACHABLE(call.getKind().toString());
       }
     }
   }
@@ -207,8 +200,7 @@ class SDGSupergraph implements ISupergraph<Statement, PDG<? extends InstanceKey>
         }
       }
       default -> {
-        Assertions.UNREACHABLE(n.getKind() + " " + n);
-        return false;
+        return Assertions.UNREACHABLE(n.getKind() + " " + n);
       }
     }
   }
@@ -298,8 +290,7 @@ class SDGSupergraph implements ISupergraph<Statement, PDG<? extends InstanceKey>
 
   @Override
   public int getNumberOfNodes() {
-    Assertions.UNREACHABLE();
-    return 0;
+    return Assertions.UNREACHABLE();
   }
 
   @Override
@@ -324,8 +315,7 @@ class SDGSupergraph implements ISupergraph<Statement, PDG<? extends InstanceKey>
 
   @Override
   public int getPredNodeCount(Statement N) {
-    Assertions.UNREACHABLE();
-    return 0;
+    return Assertions.UNREACHABLE();
   }
 
   @Override
@@ -335,8 +325,7 @@ class SDGSupergraph implements ISupergraph<Statement, PDG<? extends InstanceKey>
 
   @Override
   public int getSuccNodeCount(Statement N) {
-    Assertions.UNREACHABLE();
-    return 0;
+    return Assertions.UNREACHABLE();
   }
 
   @Override
@@ -386,8 +375,7 @@ class SDGSupergraph implements ISupergraph<Statement, PDG<? extends InstanceKey>
 
   @Override
   public Iterator<Statement> iterateNodes(IntSet s) {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/ipa/slicer/SliceFunctions.java
+++ b/core/src/main/java/com/ibm/wala/ipa/slicer/SliceFunctions.java
@@ -51,8 +51,7 @@ public class SliceFunctions implements IPartiallyBalancedFlowFunctions<Statement
         }
       }
       default -> {
-        Assertions.UNREACHABLE(src.getKind().toString());
-        return null;
+        return Assertions.UNREACHABLE(src.getKind().toString());
       }
     }
   }

--- a/core/src/main/java/com/ibm/wala/ipa/slicer/SlicerUtil.java
+++ b/core/src/main/java/com/ibm/wala/ipa/slicer/SlicerUtil.java
@@ -46,8 +46,7 @@ public class SlicerUtil {
         }
       }
     }
-    Assertions.UNREACHABLE("failed to find call to " + methodName + " in " + n);
-    return null;
+    return Assertions.UNREACHABLE("failed to find call to " + methodName + " in " + n);
   }
 
   /**
@@ -65,8 +64,7 @@ public class SlicerUtil {
         return new NormalStatement(n, i);
       }
     }
-    Assertions.UNREACHABLE("failed to find allocation in " + n);
-    return null;
+    return Assertions.UNREACHABLE("failed to find allocation in " + n);
   }
 
   public static void dumpSlice(Collection<Statement> slice) {

--- a/core/src/main/java/com/ibm/wala/ipa/slicer/thin/CISDG.java
+++ b/core/src/main/java/com/ibm/wala/ipa/slicer/thin/CISDG.java
@@ -85,14 +85,12 @@ public class CISDG implements ISDG {
 
   @Override
   public boolean equals(Object obj) {
-    Assertions.UNREACHABLE();
-    return noHeap.equals(obj);
+    return Assertions.UNREACHABLE();
   }
 
   @Override
   public ControlDependenceOptions getCOptions() {
-    Assertions.UNREACHABLE();
-    return noHeap.getCOptions();
+    return Assertions.UNREACHABLE();
   }
 
   @Override
@@ -102,8 +100,7 @@ public class CISDG implements ISDG {
 
   @Override
   public Statement getNode(int number) {
-    Assertions.UNREACHABLE();
-    return noHeap.getNode(number);
+    return Assertions.UNREACHABLE();
   }
 
   @Override
@@ -118,8 +115,7 @@ public class CISDG implements ISDG {
 
   @Override
   public PDG<InstanceKey> getPDG(CGNode node) {
-    Assertions.UNREACHABLE();
-    return noHeap.getPDG(node);
+    return Assertions.UNREACHABLE();
   }
 
   @Override
@@ -129,8 +125,7 @@ public class CISDG implements ISDG {
 
   @Override
   public IntSet getPredNodeNumbers(Statement node) {
-    Assertions.UNREACHABLE();
-    return noHeap.getPredNodeNumbers(node);
+    return Assertions.UNREACHABLE();
   }
 
   @Override
@@ -159,8 +154,7 @@ public class CISDG implements ISDG {
 
   @Override
   public IntSet getSuccNodeNumbers(Statement node) {
-    Assertions.UNREACHABLE();
-    return noHeap.getSuccNodeNumbers(node);
+    return Assertions.UNREACHABLE();
   }
 
   @Override
@@ -184,20 +178,17 @@ public class CISDG implements ISDG {
 
   @Override
   public boolean hasEdge(Statement src, Statement dst) {
-    Assertions.UNREACHABLE();
-    return noHeap.hasEdge(src, dst);
+    return Assertions.UNREACHABLE();
   }
 
   @Override
   public int hashCode() {
-    Assertions.UNREACHABLE();
-    return noHeap.hashCode();
+    return Assertions.UNREACHABLE();
   }
 
   @Override
   public Iterator<? extends Statement> iterateLazyNodes() {
-    Assertions.UNREACHABLE();
-    return noHeap.iterateLazyNodes();
+    return Assertions.UNREACHABLE();
   }
 
   @Override
@@ -212,8 +203,7 @@ public class CISDG implements ISDG {
 
   @Override
   public Iterator<Statement> iterateNodes(IntSet s) {
-    Assertions.UNREACHABLE();
-    return noHeap.iterateNodes(s);
+    return Assertions.UNREACHABLE();
   }
 
   @Override
@@ -254,8 +244,7 @@ public class CISDG implements ISDG {
 
   @Override
   public String toString() {
-    Assertions.UNREACHABLE();
-    return noHeap.toString();
+    return Assertions.UNREACHABLE();
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/ipa/summaries/BypassSyntheticClass.java
+++ b/core/src/main/java/com/ibm/wala/ipa/summaries/BypassSyntheticClass.java
@@ -190,8 +190,7 @@ public class BypassSyntheticClass extends SyntheticClass {
    */
   @Override
   public int getModifiers() throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return 0;
+    return Assertions.UNREACHABLE();
   }
 
   /**
@@ -207,8 +206,7 @@ public class BypassSyntheticClass extends SyntheticClass {
    */
   @Override
   public Collection<IClass> getDirectInterfaces() throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   /**

--- a/core/src/main/java/com/ibm/wala/ssa/DefaultIRFactory.java
+++ b/core/src/main/java/com/ibm/wala/ssa/DefaultIRFactory.java
@@ -44,8 +44,7 @@ public class DefaultIRFactory implements IRFactory<IMethod> {
       final IBytecodeMethod<IInstruction> castMethod = (IBytecodeMethod<IInstruction>) method;
       return shrikeFactory.makeCFG(castMethod);
     } else {
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
   }
 
@@ -61,8 +60,7 @@ public class DefaultIRFactory implements IRFactory<IMethod> {
       final IBytecodeMethod<IInstruction> castMethod = (IBytecodeMethod<IInstruction>) method;
       return shrikeFactory.makeIR(castMethod, c, options);
     } else {
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
   }
 

--- a/core/src/main/java/com/ibm/wala/ssa/SSAAddressOfInstruction.java
+++ b/core/src/main/java/com/ibm/wala/ssa/SSAAddressOfInstruction.java
@@ -91,8 +91,7 @@ public class SSAAddressOfInstruction extends SSAInstruction {
 
   @Override
   public SSAInstruction copyForSSA(SSAInstructionFactory insts, int[] defs, int[] uses) {
-    Assertions.UNREACHABLE("not yet implemented.  to be nuked");
-    return null;
+    return Assertions.UNREACHABLE("not yet implemented.  to be nuked");
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/ssa/SSABuilder.java
+++ b/core/src/main/java/com/ibm/wala/ssa/SSABuilder.java
@@ -984,8 +984,7 @@ public class SSABuilder extends AbstractIntStackMachine {
         return shrikeCFG.getMethod().getInstructions();
       } catch (InvalidClassFileException e) {
         e.printStackTrace();
-        Assertions.UNREACHABLE();
-        return null;
+        return Assertions.UNREACHABLE();
       }
     }
   }
@@ -1068,8 +1067,7 @@ public class SSABuilder extends AbstractIntStackMachine {
         }
       } catch (Exception e) {
         e.printStackTrace();
-        Assertions.UNREACHABLE();
-        return null;
+        return Assertions.UNREACHABLE();
       }
     }
 

--- a/core/src/main/java/com/ibm/wala/ssa/SSACFG.java
+++ b/core/src/main/java/com/ibm/wala/ssa/SSACFG.java
@@ -1085,8 +1085,7 @@ public class SSACFG
 
   @Override
   public IntSet getPredNodeNumbers(ISSABasicBlock node) throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   /** A warning for when we fail to resolve the type for a checkcast */

--- a/core/src/main/java/com/ibm/wala/ssa/SSALoadIndirectInstruction.java
+++ b/core/src/main/java/com/ibm/wala/ssa/SSALoadIndirectInstruction.java
@@ -37,8 +37,7 @@ public class SSALoadIndirectInstruction extends SSAAbstractUnaryInstruction {
 
   @Override
   public SSAInstruction copyForSSA(SSAInstructionFactory insts, int[] defs, int[] uses) {
-    Assertions.UNREACHABLE("not implemented");
-    return null;
+    return Assertions.UNREACHABLE("not implemented");
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/ssa/SSAStoreIndirectInstruction.java
+++ b/core/src/main/java/com/ibm/wala/ssa/SSAStoreIndirectInstruction.java
@@ -44,8 +44,7 @@ public class SSAStoreIndirectInstruction extends SSAInstruction {
 
   @Override
   public SSAInstruction copyForSSA(SSAInstructionFactory insts, int[] defs, int[] uses) {
-    Assertions.UNREACHABLE("unimplemented");
-    return null;
+    return Assertions.UNREACHABLE("unimplemented");
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/ssa/SymbolTable.java
+++ b/core/src/main/java/com/ibm/wala/ssa/SymbolTable.java
@@ -458,8 +458,7 @@ public class SymbolTable implements Cloneable {
       nt.copy = true;
       return nt;
     } catch (CloneNotSupportedException e) {
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
   }
 }

--- a/core/src/main/java/com/ibm/wala/ssa/analysis/ExplodedControlFlowGraph.java
+++ b/core/src/main/java/com/ibm/wala/ssa/analysis/ExplodedControlFlowGraph.java
@@ -443,8 +443,7 @@ public class ExplodedControlFlowGraph
 
   @Override
   public Iterator<IExplodedBasicBlock> iterateNodes(IntSet s) throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   @Override
@@ -458,8 +457,7 @@ public class ExplodedControlFlowGraph
 
   @Override
   public IntSet getSuccNodeNumbers(IExplodedBasicBlock node) throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   /**

--- a/core/src/main/java/com/ibm/wala/types/TypeName.java
+++ b/core/src/main/java/com/ibm/wala/types/TypeName.java
@@ -294,8 +294,7 @@ public final class TypeName implements Serializable {
         return result.toString();
       } catch (UTFDataFormatException e) {
         e.printStackTrace();
-        Assertions.UNREACHABLE();
-        return null;
+        return Assertions.UNREACHABLE();
       }
     }
   }

--- a/core/src/main/java/com/ibm/wala/types/generics/TypeVariableSignature.java
+++ b/core/src/main/java/com/ibm/wala/types/generics/TypeVariableSignature.java
@@ -95,8 +95,7 @@ public class TypeVariableSignature extends TypeSignature {
       return -1;
     } catch (InvalidClassFileException e) {
       e.printStackTrace();
-      Assertions.UNREACHABLE();
-      return -1;
+      return Assertions.UNREACHABLE();
     }
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/basic/GraphDataflowTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/basic/GraphDataflowTest.java
@@ -140,8 +140,7 @@ public class GraphDataflowTest extends WalaTestCase {
 
           @Override
           public UnaryOperator<BitVectorVariable> getEdgeTransferFunction(String from, String to) {
-            Assertions.UNREACHABLE();
-            return null;
+            return Assertions.UNREACHABLE();
           }
 
           @Override

--- a/core/src/test/java/com/ibm/wala/core/tests/demandpa/AbstractPtrTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/demandpa/AbstractPtrTest.java
@@ -108,8 +108,7 @@ public abstract class AbstractPtrTest {
         return n;
       }
     }
-    Assertions.UNREACHABLE("failed to find method");
-    return null;
+    return Assertions.UNREACHABLE("failed to find method");
   }
 
   public static CGNode findStaticMethod(CallGraph cg, Atom name, Descriptor args) {
@@ -120,8 +119,7 @@ public abstract class AbstractPtrTest {
         return n;
       }
     }
-    Assertions.UNREACHABLE("failed to find method");
-    return null;
+    return Assertions.UNREACHABLE("failed to find method");
   }
 
   public static CGNode findInstanceMethod(
@@ -135,8 +133,7 @@ public abstract class AbstractPtrTest {
         return n;
       }
     }
-    Assertions.UNREACHABLE("failed to find method");
-    return null;
+    return Assertions.UNREACHABLE("failed to find method");
   }
 
   public static PointerKey getParam(CGNode n, String methodName, HeapModel heapModel) {
@@ -154,8 +151,7 @@ public abstract class AbstractPtrTest {
         }
       }
     }
-    Assertions.UNREACHABLE("failed to find call to " + methodName + " in " + n);
-    return null;
+    return Assertions.UNREACHABLE("failed to find call to " + methodName + " in " + n);
   }
 
   protected void doFlowsToSizeTest(String mainClass, int size)

--- a/core/src/test/java/com/ibm/wala/core/tests/ptrs/MultiDimArrayTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/ptrs/MultiDimArrayTest.java
@@ -76,7 +76,6 @@ public class MultiDimArrayTest extends WalaTestCase {
         return n;
       }
     }
-    Assertions.UNREACHABLE("Unexpected: failed to find doNothing node");
-    return null;
+    return Assertions.UNREACHABLE("Unexpected: failed to find doNothing node");
   }
 }

--- a/core/src/test/java/com/ibm/wala/core/tests/ptrs/TypeBasedArrayAliasTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/ptrs/TypeBasedArrayAliasTest.java
@@ -78,8 +78,7 @@ public class TypeBasedArrayAliasTest extends WalaTestCase {
         return n;
       }
     }
-    Assertions.UNREACHABLE("Unexpected: failed to find " + methodName + " node");
-    return null;
+    return Assertions.UNREACHABLE("Unexpected: failed to find " + methodName + " node");
   }
 
   private static Condition<PointerAnalysis<InstanceKey>> mayAliased(

--- a/dalvik/src/main/java/com/ibm/wala/dalvik/ssa/DexSSABuilder.java
+++ b/dalvik/src/main/java/com/ibm/wala/dalvik/ssa/DexSSABuilder.java
@@ -1494,8 +1494,7 @@ public class DexSSABuilder extends AbstractIntRegisterMachine {
         }
       } catch (Exception e) {
         e.printStackTrace();
-        Assertions.UNREACHABLE();
-        return null;
+        return Assertions.UNREACHABLE();
       }
     }
 

--- a/ide/jdt/src/main/java/com/ibm/wala/ide/util/JdtPosition.java
+++ b/ide/jdt/src/main/java/com/ibm/wala/ide/util/JdtPosition.java
@@ -71,8 +71,7 @@ public final class JdtPosition implements Position {
     try {
       return URI.create("file:" + path).toURL();
     } catch (MalformedURLException e) {
-      Assertions.UNREACHABLE(e.toString());
-      return null;
+      return Assertions.UNREACHABLE(e.toString());
     }
   }
 

--- a/ide/src/main/java/com/ibm/wala/ide/ui/SWTTreeViewer.java
+++ b/ide/src/main/java/com/ibm/wala/ide/ui/SWTTreeViewer.java
@@ -240,8 +240,7 @@ public class SWTTreeViewer<T> extends AbstractJFaceRunner {
       @Override
       public Object getParent(Object element) {
         // TODO Auto-generated method stub
-        Assertions.UNREACHABLE();
-        return null;
+        return Assertions.UNREACHABLE();
       }
 
       /*
@@ -275,8 +274,7 @@ public class SWTTreeViewer<T> extends AbstractJFaceRunner {
           return (d == null) ? super.getText(element) : d.getLabel(element);
         } catch (WalaException e) {
           e.printStackTrace();
-          Assertions.UNREACHABLE();
-          return null;
+          return Assertions.UNREACHABLE();
         }
       }
     }

--- a/ide/src/main/java/com/ibm/wala/ide/util/HeadlessUtil.java
+++ b/ide/src/main/java/com/ibm/wala/ide/util/HeadlessUtil.java
@@ -68,8 +68,7 @@ public class HeadlessUtil {
         return result;
       }
     }
-    Assertions.UNREACHABLE();
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   public interface EclipseCompiler<Unit> {

--- a/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/TypeAnnotationsReader.java
+++ b/shrike/src/main/java/com/ibm/wala/shrike/shrikeCT/TypeAnnotationsReader.java
@@ -295,8 +295,7 @@ public class TypeAnnotationsReader extends AnnotationsReader {
         return Pair.make(new TypeArgumentTarget(offset, type_argument_index), 3);
       }
       default -> {
-        Assertions.UNREACHABLE();
-        return null;
+        return Assertions.UNREACHABLE();
       }
     }
   }

--- a/util/src/main/java/com/ibm/wala/fixpoint/UnaryOperator.java
+++ b/util/src/main/java/com/ibm/wala/fixpoint/UnaryOperator.java
@@ -37,7 +37,6 @@ public abstract class UnaryOperator<T extends IVariable<T>> extends AbstractOper
   @Override
   public byte evaluate(T lhs, T[] rhs) throws UnimplementedError {
     // this should never be called. Use the other, more efficient form.
-    Assertions.UNREACHABLE();
-    return 0;
+    return Assertions.UNREACHABLE();
   }
 }

--- a/util/src/main/java/com/ibm/wala/util/collections/CompoundIntIterator.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/CompoundIntIterator.java
@@ -52,7 +52,6 @@ public class CompoundIntIterator implements IntIterator {
 
   @Override
   public int hashCode() throws UnimplementedError {
-    Assertions.UNREACHABLE("define a custom hash code to avoid non-determinism");
-    return 0;
+    return Assertions.UNREACHABLE("define a custom hash code to avoid non-determinism");
   }
 }

--- a/util/src/main/java/com/ibm/wala/util/collections/ObjectArrayMapping.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/ObjectArrayMapping.java
@@ -74,8 +74,7 @@ public class ObjectArrayMapping<T> implements OrdinalSetMapping<T> {
 
   @Override
   public int add(Object o) throws UnimplementedError {
-    Assertions.UNREACHABLE();
-    return 0;
+    return Assertions.UNREACHABLE();
   }
 
   @Override

--- a/util/src/main/java/com/ibm/wala/util/debug/Assertions.java
+++ b/util/src/main/java/com/ibm/wala/util/debug/Assertions.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.util.debug;
 
+import org.jetbrains.annotations.Contract;
+
 /**
  * WALA-specific assertion checking.
  *
@@ -42,7 +44,9 @@ public class Assertions {
    *
    * @throws UnimplementedError unconditionally
    */
-  public static void UNREACHABLE() {
+  @Contract(" -> fail")
+  @SuppressWarnings("TypeParameterUnusedInFormals")
+  public static <T> T UNREACHABLE() {
     throw new UnimplementedError();
   }
 
@@ -51,7 +55,9 @@ public class Assertions {
    *
    * @throws UnimplementedError unconditionally
    */
-  public static void UNREACHABLE(String string) {
+  @Contract("_ -> fail")
+  @SuppressWarnings("TypeParameterUnusedInFormals")
+  public static <T> T UNREACHABLE(String string) {
     throw new UnimplementedError(string);
   }
 
@@ -60,7 +66,9 @@ public class Assertions {
    *
    * @throws UnimplementedError unconditionally
    */
-  public static void UNREACHABLE(Object o) {
-    throw new UnimplementedError(o == null ? "" : o.toString());
+  @Contract("_ -> fail")
+  @SuppressWarnings("TypeParameterUnusedInFormals")
+  public static <T> T UNREACHABLE(Object o) {
+    return UNREACHABLE(o == null ? "" : o.toString());
   }
 }

--- a/util/src/main/java/com/ibm/wala/util/graph/GraphReachability.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/GraphReachability.java
@@ -115,8 +115,7 @@ public class GraphReachability<T, S> {
           @Override
           public @Nullable UnaryOperator<BitVectorVariable> getEdgeTransferFunction(
               Object from, Object to) {
-            Assertions.UNREACHABLE();
-            return null;
+            return Assertions.UNREACHABLE();
           }
 
           /*

--- a/util/src/main/java/com/ibm/wala/util/graph/dominators/Dominators.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/dominators/Dominators.java
@@ -199,8 +199,7 @@ public abstract class Dominators<T> {
             @Override
             public boolean hasEdge(@Nullable Object src, @Nullable Object dst) {
               // TODO Auto-generated method stub
-              Assertions.UNREACHABLE();
-              return false;
+              return Assertions.UNREACHABLE();
             }
           };
     };

--- a/util/src/main/java/com/ibm/wala/util/intset/BimodalMutableIntSet.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/BimodalMutableIntSet.java
@@ -163,8 +163,7 @@ public class BimodalMutableIntSet implements MutableIntSet {
     } else if (that instanceof BitVectorIntSet) {
       return impl.intersection(that);
     } else {
-      Assertions.UNREACHABLE("Unexpected: " + that);
-      return null;
+      return Assertions.UNREACHABLE("Unexpected: " + that);
     }
   }
 
@@ -326,8 +325,7 @@ public class BimodalMutableIntSet implements MutableIntSet {
     } else if (that instanceof BitVectorIntSet) {
       return impl.containsAny(that);
     } else {
-      Assertions.UNREACHABLE("unsupported " + that.getClass());
-      return false;
+      return Assertions.UNREACHABLE("unsupported " + that.getClass());
     }
   }
 

--- a/util/src/main/java/com/ibm/wala/util/intset/BitVectorIntSet.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/BitVectorIntSet.java
@@ -352,8 +352,7 @@ public final class BitVectorIntSet implements MutableIntSet {
     } else if (that instanceof MutableSharedBitVectorIntSet mutableSharedBitVectorIntSet) {
       return sameValue(mutableSharedBitVectorIntSet.makeDenseCopy());
     } else {
-      Assertions.UNREACHABLE("unexpected argument type " + that.getClass());
-      return false;
+      return Assertions.UNREACHABLE("unexpected argument type " + that.getClass());
     }
   }
 

--- a/util/src/main/java/com/ibm/wala/util/intset/DebuggingMutableIntSet.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/DebuggingMutableIntSet.java
@@ -124,8 +124,7 @@ record DebuggingMutableIntSet(MutableIntSet primaryImpl, MutableIntSet secondary
       }
       return ppr;
     } else {
-      Assertions.UNREACHABLE();
-      return false;
+      return Assertions.UNREACHABLE();
     }
   }
 
@@ -145,8 +144,7 @@ record DebuggingMutableIntSet(MutableIntSet primaryImpl, MutableIntSet secondary
 
       return ppr;
     } else {
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
   }
 
@@ -175,8 +173,7 @@ record DebuggingMutableIntSet(MutableIntSet primaryImpl, MutableIntSet secondary
 
       return ppr;
     } else {
-      Assertions.UNREACHABLE();
-      return false;
+      return Assertions.UNREACHABLE();
     }
   }
 
@@ -193,8 +190,7 @@ record DebuggingMutableIntSet(MutableIntSet primaryImpl, MutableIntSet secondary
 
       return ppr;
     } else {
-      Assertions.UNREACHABLE();
-      return false;
+      return Assertions.UNREACHABLE();
     }
   }
 
@@ -234,8 +230,7 @@ record DebuggingMutableIntSet(MutableIntSet primaryImpl, MutableIntSet secondary
 
       return ppr;
     } else {
-      Assertions.UNREACHABLE();
-      return false;
+      return Assertions.UNREACHABLE();
     }
   }
 
@@ -271,8 +266,7 @@ record DebuggingMutableIntSet(MutableIntSet primaryImpl, MutableIntSet secondary
 
       return pr;
     } else {
-      Assertions.UNREACHABLE();
-      return false;
+      return Assertions.UNREACHABLE();
     }
   }
 

--- a/util/src/main/java/com/ibm/wala/util/intset/DebuggingMutableIntSetFactory.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/DebuggingMutableIntSetFactory.java
@@ -70,8 +70,7 @@ public class DebuggingMutableIntSetFactory implements MutableIntSetFactory<Debug
 
       return new DebuggingMutableIntSet(pr, sr);
     } else {
-      Assertions.UNREACHABLE();
-      return null;
+      return Assertions.UNREACHABLE();
     }
   }
 

--- a/util/src/main/java/com/ibm/wala/util/intset/IntSetUtil.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/IntSetUtil.java
@@ -94,8 +94,7 @@ public class IntSetUtil {
     } else if (set instanceof EmptyIntSet) {
       return IntSetUtil.make();
     } else {
-      Assertions.UNREACHABLE(set.getClass().toString());
-      return null;
+      return Assertions.UNREACHABLE(set.getClass().toString());
     }
   }
 

--- a/util/src/main/java/com/ibm/wala/util/intset/LongSetUtil.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/LongSetUtil.java
@@ -71,8 +71,7 @@ public class LongSetUtil {
     if (set instanceof SparseLongSet) {
       return MutableSparseLongSet.make(set);
     } else {
-      Assertions.UNREACHABLE(set.getClass().toString());
-      return null;
+      return Assertions.UNREACHABLE(set.getClass().toString());
     }
   }
 

--- a/util/src/main/java/com/ibm/wala/util/intset/MutableSharedBitVectorIntSet.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/MutableSharedBitVectorIntSet.java
@@ -345,8 +345,7 @@ public class MutableSharedBitVectorIntSet implements MutableIntSet {
     } else if (that instanceof SemiSparseMutableIntSet) {
       return that.sameValue(this);
     } else {
-      Assertions.UNREACHABLE("unexpected class " + that.getClass());
-      return false;
+      return Assertions.UNREACHABLE("unexpected class " + that.getClass());
     }
   }
 
@@ -434,8 +433,7 @@ public class MutableSharedBitVectorIntSet implements MutableIntSet {
       } else {
         /* sharedPart != null , privatePart != null */
         if (that.sharedPart == null) {
-          Assertions.UNREACHABLE();
-          return false;
+          return Assertions.UNREACHABLE();
         } else {
           /* that.sharedPart != null */
           if (that.privatePart == null) {

--- a/util/src/main/java/com/ibm/wala/util/intset/MutableSparseLongSet.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/MutableSparseLongSet.java
@@ -253,8 +253,7 @@ public final class MutableSparseLongSet extends SparseLongSet implements Mutable
     if (set instanceof SparseLongSet sparseLongSet) {
       return addAll(sparseLongSet);
     } else {
-      Assertions.UNREACHABLE();
-      return false;
+      return Assertions.UNREACHABLE();
     }
   }
 

--- a/util/src/main/java/com/ibm/wala/util/intset/SparseIntSet.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/SparseIntSet.java
@@ -168,8 +168,7 @@ public class SparseIntSet implements IntSet {
     } else if (that instanceof MutableSharedBitVectorIntSet mutableSharedBitVectorIntSet) {
       return sameValue(mutableSharedBitVectorIntSet.makeSparseCopy());
     } else {
-      Assertions.UNREACHABLE(that.getClass().toString());
-      return false;
+      return Assertions.UNREACHABLE(that.getClass().toString());
     }
   }
 

--- a/util/src/main/java/com/ibm/wala/util/intset/SparseLongSet.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/SparseLongSet.java
@@ -161,8 +161,7 @@ public class SparseLongSet implements LongSet {
     if (that instanceof SparseLongSet sparseLongSet) {
       return sameValueInternal(sparseLongSet);
     } else {
-      Assertions.UNREACHABLE(that.getClass().toString());
-      return false;
+      return Assertions.UNREACHABLE(that.getClass().toString());
     }
   }
 
@@ -344,8 +343,7 @@ public class SparseLongSet implements LongSet {
       temp.intersectWith(sparseLongSet);
       return temp;
     } else {
-      Assertions.UNREACHABLE("Unexpected: " + that.getClass());
-      return null;
+      return Assertions.UNREACHABLE("Unexpected: " + that.getClass());
     }
   }
 
@@ -445,8 +443,7 @@ public class SparseLongSet implements LongSet {
     if (that instanceof SparseLongSet sparseLongSet) {
       return isSubsetInternal(sparseLongSet);
     } else {
-      Assertions.UNREACHABLE("Unexpected type " + that.getClass());
-      return false;
+      return Assertions.UNREACHABLE("Unexpected type " + that.getClass());
     }
   }
 

--- a/util/src/main/java/com/ibm/wala/util/math/Logs.java
+++ b/util/src/main/java/com/ibm/wala/util/math/Logs.java
@@ -71,8 +71,7 @@ public class Logs {
       }
       test <<= 1;
     }
-    Assertions.UNREACHABLE();
-    return -1;
+    return Assertions.UNREACHABLE();
   }
 
   /** Binary log: finds the smallest power k such that 2^k &gt;= n */


### PR DESCRIPTION
Previously, the various overloads of `Assertions.UNREACHABLE(...)` returned `void`.  Therefore, calls to these methods could be used as statements but not expressions.  That restriction led to many code fragments like the following:

```java
Assertions.UNREACHABLE();
return null;
```

An unfortunate side effect of that style was to make many methods appear to return nullable values even though the `return null` statement could never be reached.

Now the `Asserions.UNREACHABLE(...)` methods statically claim to return a value of any arbitrary type.  In reality, they will never return at all; each such method always throws an exception.  However, by _pretending_ to return an arbitrarily typed value, we can now replace the above code pattern with:

```java
return Assertions.UNREACHABLE();
```

This change should help us recognize that some methods can never return `null`, even though they contain unreachable code.

This change was inspired by several standard Kotlin features.  The `TODO()`, `TODO(String)`, and `error(Any)` functions all return type `Nothing`, which is a subtype of every other type.  Kotlin's `throw ...` construct is also an expression (not a statement) with static type `Nothing`.

Also add JetBrains `@Contract` annotations to `Asserions.UNREACHABLE(...)` methods declaring that they always "fail" (i.e., throw exceptions) regardless of the arguments passed to them. Some static analysis tools may benefit from this information.