### PR TITLE
Disable Minesweeper test

### DIFF
--- a/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/FieldBasedCGGamesTest.java
+++ b/cast/js/rhino/src/test/java/com/ibm/wala/cast/js/rhino/callgraph/fieldbased/test/FieldBasedCGGamesTest.java
@@ -66,6 +66,7 @@ public class FieldBasedCGGamesTest extends AbstractFieldBasedTest {
     runTest(url, List.of(), BuilderType.OPTIMISTIC);
   }
 
+  @Disabled("DNS fails to resolve `www.inmensia.com`")
   @Test
   public void testMinesweeper() throws IOException, WalaException, CancelException {
     URL url = getUrl("http://www.inmensia.com/files/minesweeper1.0.html");


### PR DESCRIPTION
DNS is failing to resolve `www.inmensia.com`.  Unfortunately, this test cannot run without fetching an HTML page from that site.

In general, it is a bad idea for tests to require online access to sites that we don't control.  But that's a bigger change, as WALA has *many* such dependencies.