### PR TITLE
Update to NullAway 0.13.8 and address new warning

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -62,7 +62,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="zulu-25" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="zulu-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
   <component name="TaskProjectConfiguration">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -62,7 +62,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="zulu-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="zulu-25" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
   <component name="TaskProjectConfiguration">

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,6 +4,11 @@
 
 ### Functionality changes
 
+#### `MultiMap.removeAll` now returns an empty set when the key is not present
+
+Previously, `MultiMap.removeAll(k)` would return `null` when `k` was not a key in the multi-map.
+Now, it returns an empty set, which is more consistent and safer.
+
 #### `Assertions.UNREACHABLE` now returns a generic type
 
 The `Assertions.UNREACHABLE()`, `Assertions.UNREACHABLE(String)`, and

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -6,8 +6,9 @@
 
 #### `MultiMap.removeAll` now returns an empty set when the key is not present
 
-Previously, `MultiMap.removeAll(k)` would return `null` when `k` was not a key in the multi-map.
-Now, it returns an empty set, which is more consistent and safer.
+Previously, `MultiMap.removeAll(k)` would return `null` when `k` was not a key
+in the multi-map. Now, it returns an empty set, which is more consistent and
+safer.
 
 #### `Assertions.UNREACHABLE` now returns a generic type
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@ org.gradle.configureondemand=true
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
 org.gradle.parallel=true
 
-VERSION_NAME=1.8.1-SNAPSHOT
+VERSION_NAME=1.9.0-SNAPSHOT

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-com-uber-nullaway = "0.13.6"
+com-uber-nullaway = "0.13.8"
 #noinspection UnusedVersionCatalogEntry
 eclipse = "4.30.0"
 eclipse-wst-jsdt = "1.0.201.v2010012803"

--- a/util/src/main/java/com/ibm/wala/util/collections/AbstractMultiMap.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/AbstractMultiMap.java
@@ -110,7 +110,7 @@ abstract class AbstractMultiMap<K, V> implements Serializable, MultiMap<K, V> {
   }
 
   @Override
-  public Set<V> removeAll(K key) {
+  public @Nullable Set<V> removeAll(K key) {
     return map.remove(key);
   }
 

--- a/util/src/main/java/com/ibm/wala/util/collections/AbstractMultiMap.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/AbstractMultiMap.java
@@ -110,8 +110,9 @@ abstract class AbstractMultiMap<K, V> implements Serializable, MultiMap<K, V> {
   }
 
   @Override
-  public @Nullable Set<V> removeAll(K key) {
-    return map.remove(key);
+  public Set<V> removeAll(K key) {
+    Set<V> result = map.remove(key);
+    return result != null ? result : Collections.emptySet();
   }
 
   /*

--- a/util/src/main/java/com/ibm/wala/util/collections/MultiMap.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/MultiMap.java
@@ -59,6 +59,10 @@ public interface MultiMap<K, V> {
 
   boolean putAll(K key, Collection<? extends V> vals);
 
+  /**
+   * Returns the set associated with {@code key}, or an empty set if {@code key} is not a key in
+   * this multi-map.
+   */
   Set<V> removeAll(K key);
 
   void clear();

--- a/util/src/main/java/com/ibm/wala/util/collections/MultiMap.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/MultiMap.java
@@ -39,7 +39,6 @@ package com.ibm.wala.util.collections;
 
 import java.util.Collection;
 import java.util.Set;
-import org.jspecify.annotations.Nullable;
 
 public interface MultiMap<K, V> {
 
@@ -60,7 +59,7 @@ public interface MultiMap<K, V> {
 
   boolean putAll(K key, Collection<? extends V> vals);
 
-  @Nullable Set<V> removeAll(K key);
+  Set<V> removeAll(K key);
 
   void clear();
 

--- a/util/src/main/java/com/ibm/wala/util/collections/MultiMap.java
+++ b/util/src/main/java/com/ibm/wala/util/collections/MultiMap.java
@@ -39,6 +39,7 @@ package com.ibm.wala.util.collections;
 
 import java.util.Collection;
 import java.util.Set;
+import org.jspecify.annotations.Nullable;
 
 public interface MultiMap<K, V> {
 
@@ -59,7 +60,7 @@ public interface MultiMap<K, V> {
 
   boolean putAll(K key, Collection<? extends V> vals);
 
-  Set<V> removeAll(K key);
+  @Nullable Set<V> removeAll(K key);
 
   void clear();
 


### PR DESCRIPTION
`MultiMap.removeAll` now returns the empty set when a key is absent, a safer and more consistent behavior.