### PR TITLE
Make `DFSFinishTimeIterator` more `null`-strict

### DIFF
--- a/util/src/main/java/com/ibm/wala/util/graph/traverse/DFS.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/traverse/DFS.java
@@ -48,7 +48,7 @@ public class DFS {
         new SlowDFSFinishTimeIterator<>(G, C.iterator()) {
 
           @Override
-          protected Iterator<T> getConnected(@Nullable T n) {
+          protected Iterator<T> getConnected(T n) {
             return new FilterIterator<>(G.getSuccNodes(n), filter);
           }
         };

--- a/util/src/main/java/com/ibm/wala/util/graph/traverse/DFSFinishTimeIterator.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/traverse/DFSFinishTimeIterator.java
@@ -10,8 +10,11 @@
  */
 package com.ibm.wala.util.graph.traverse;
 
+import static java.util.Objects.requireNonNull;
+
 import com.ibm.wala.util.collections.EmptyIterator;
 import com.ibm.wala.util.collections.Iterator2Iterable;
+import com.ibm.wala.util.debug.Assertions;
 import com.ibm.wala.util.debug.UnimplementedError;
 import com.ibm.wala.util.graph.Graph;
 import com.uber.nullaway.annotations.Initializer;
@@ -62,11 +65,11 @@ public abstract class DFSFinishTimeIterator<T> extends ArrayList<T> implements I
     return (!empty() || (theNextElement != null && getPendingChildren(theNextElement) == null));
   }
 
-  abstract @Nullable Iterator<T> getPendingChildren(@Nullable T n);
+  abstract @Nullable Iterator<T> getPendingChildren(T n);
 
-  abstract void setPendingChildren(@Nullable T v, Iterator<T> iterator);
+  abstract void setPendingChildren(T v, Iterator<T> iterator);
 
-  private void push(@Nullable T elt) {
+  private void push(T elt) {
     add(elt);
   }
 
@@ -86,12 +89,12 @@ public abstract class DFSFinishTimeIterator<T> extends ArrayList<T> implements I
    * @return the next graph node in finishing time order.
    */
   @Override
-  public @Nullable T next() throws NoSuchElementException {
+  public T next() throws NoSuchElementException {
     if (!hasNext()) {
       throw new NoSuchElementException();
     }
     if (empty()) {
-      T v = theNextElement;
+      T v = requireNonNull(theNextElement);
       setPendingChildren(v, getConnected(v));
       push(v);
     }
@@ -113,13 +116,13 @@ public abstract class DFSFinishTimeIterator<T> extends ArrayList<T> implements I
       setPendingChildren(v, EmptyIterator.instance());
 
       // no more children to visit: finished this vertex
-      while (getPendingChildren(theNextElement) != null && roots.hasNext()) {
+      while (getPendingChildren(requireNonNull(theNextElement)) != null && roots.hasNext()) {
         theNextElement = roots.next();
       }
 
       return pop();
     }
-    return null;
+    return Assertions.UNREACHABLE();
   }
 
   /**
@@ -128,7 +131,7 @@ public abstract class DFSFinishTimeIterator<T> extends ArrayList<T> implements I
    * @param n the node of which to get the out edges
    * @return the out edges
    */
-  protected Iterator<T> getConnected(@Nullable T n) {
+  protected Iterator<T> getConnected(T n) {
     return G.getSuccNodes(n);
   }
 

--- a/util/src/main/java/com/ibm/wala/util/graph/traverse/DFSFinishTimeIterator.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/traverse/DFSFinishTimeIterator.java
@@ -94,6 +94,8 @@ public abstract class DFSFinishTimeIterator<T> extends ArrayList<T> implements I
       throw new NoSuchElementException();
     }
     if (empty()) {
+      // When the stack is empty, `hasNext()` can only return `true` if `theNextElement != null`,
+      // per the second disjunct of the `hasNext()` condition.
       T v = requireNonNull(theNextElement);
       setPendingChildren(v, getConnected(v));
       push(v);
@@ -115,7 +117,10 @@ public abstract class DFSFinishTimeIterator<T> extends ArrayList<T> implements I
       // the following saves space by allowing the original iterator to be GCed
       setPendingChildren(v, EmptyIterator.instance());
 
-      // no more children to visit: finished this vertex
+      // No more children to visit: finished this vertex. Since `hasNext()` was verified at entry
+      // and the stack is non-empty here, `theNextElement` must have been set by `init()` or by a
+      // prior iteration of this same `while` loop, where `roots.next()` returns non-`null` because
+      // `roots.hasNext()` was checked.
       while (getPendingChildren(requireNonNull(theNextElement)) != null && roots.hasNext()) {
         theNextElement = roots.next();
       }

--- a/util/src/main/java/com/ibm/wala/util/graph/traverse/NumberedDFSFinishTimeIterator.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/traverse/NumberedDFSFinishTimeIterator.java
@@ -64,7 +64,7 @@ public class NumberedDFSFinishTimeIterator<T> extends DFSFinishTimeIterator<T> {
   }
 
   @Override
-  @Nullable Iterator<T> getPendingChildren(@Nullable T n) {
+  @Nullable Iterator<T> getPendingChildren(T n) {
     int number = G.getNumber(n);
     if (number >= pendingChildren.length) {
       // the graph is probably growing as we traverse
@@ -79,7 +79,7 @@ public class NumberedDFSFinishTimeIterator<T> extends DFSFinishTimeIterator<T> {
 
   /** Method setPendingChildren. */
   @Override
-  void setPendingChildren(@Nullable T v, Iterator<T> iterator) {
+  void setPendingChildren(T v, Iterator<T> iterator) {
     pendingChildren[G.getNumber(v)] = iterator;
   }
 }

--- a/util/src/main/java/com/ibm/wala/util/graph/traverse/SlowDFSFinishTimeIterator.java
+++ b/util/src/main/java/com/ibm/wala/util/graph/traverse/SlowDFSFinishTimeIterator.java
@@ -70,12 +70,12 @@ public class SlowDFSFinishTimeIterator<T> extends DFSFinishTimeIterator<T> {
   }
 
   @Override
-  @Nullable Iterator<T> getPendingChildren(@Nullable T n) {
+  @Nullable Iterator<T> getPendingChildren(T n) {
     return pendingChildren.get(n);
   }
 
   @Override
-  void setPendingChildren(@Nullable T v, Iterator<T> iterator) {
+  void setPendingChildren(T v, Iterator<T> iterator) {
     pendingChildren.put(v, iterator);
   }
 }


### PR DESCRIPTION
Each `DFSFinishTimeIterator` is an `ArrayList`.  I'm trying to establish an invariant that the elements of that `ArrayList` are never `null`.  If we can convince ourselves that this is true, then that will help some other improvements I have pending.

This change adds two dynamic `requireNonNull(...)` checks in places where we cannot statically establish non-nullability.  With those two checks added, NullAway is satisfied that the rest of what we are doing here is valid.  But do we believe that each of those dynamic checks must always succeed?  They do always succeed in our tests, but perhaps our tests just don't cover some important cases.