### PR TITLE
Read `StringBuilder` instead of short-lived `String`

### DIFF
--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/summaries/JavaScriptConstructorFunctions.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/summaries/JavaScriptConstructorFunctions.java
@@ -519,7 +519,9 @@ public class JavaScriptConstructorFunctions {
                 @Override
                 @SuppressWarnings("resource")
                 public InputStream getInputStream() {
-                  // No leak here: `ReaderInputStream.close()` closes the underlying `Reader`.
+                  // `ReaderInputStream` takes ownership of the underlying `Reader`.  Therefore, if
+                  // whoever called `getInputStream()` eventually closes the returned `InputStream`,
+                  // then that will also close the `Reader` that `getInputReader()` provided.
                   return ReaderInputStream.builder().setReader(getInputReader()).getUnchecked();
                 }
 

--- a/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/summaries/JavaScriptConstructorFunctions.java
+++ b/cast/js/src/main/java/com/ibm/wala/cast/js/ipa/summaries/JavaScriptConstructorFunctions.java
@@ -41,18 +41,17 @@ import com.ibm.wala.types.TypeReference;
 import com.ibm.wala.util.collections.HashMapFactory;
 import com.ibm.wala.util.collections.NonNullSingletonIterator;
 import com.ibm.wala.util.collections.Pair;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
-import java.io.StringReader;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import org.apache.commons.io.input.CharSequenceReader;
+import org.apache.commons.io.input.ReaderInputStream;
 import org.jspecify.annotations.NonNull;
 
 public class JavaScriptConstructorFunctions {
@@ -518,8 +517,10 @@ public class JavaScriptConstructorFunctions {
                 }
 
                 @Override
+                @SuppressWarnings("resource")
                 public InputStream getInputStream() {
-                  return new ByteArrayInputStream(fun.toString().getBytes(StandardCharsets.UTF_8));
+                  // No leak here: `ReaderInputStream.close()` closes the underlying `Reader`.
+                  return ReaderInputStream.builder().setReader(getInputReader()).getUnchecked();
                 }
 
                 @Override
@@ -549,7 +550,7 @@ public class JavaScriptConstructorFunctions {
 
                 @Override
                 public Reader getInputReader() {
-                  return new StringReader(fun.toString());
+                  return new CharSequenceReader(fun);
                 }
 
                 @Override


### PR DESCRIPTION
Replace `StringReader` and `ByteArrayInputStream` wrappers in `JavaScriptConstructorFunctions` with `CharSequenceReader` and `ReaderInputStream` from `commons-io`.  This change lets us read directly from the `StringBuilder` without creating an intermediate `String`.

Note that `commons-io` is already a dependency here, so this change does not affect dependencies in any way that third-party WALA users would notice.