### PR TITLE
Stop testing on macOS 14 (Sonoma)

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,9 +17,6 @@ jobs:
         include:
           - os: macos-latest
             java: 17
-          # Apple Silicon M1 CPU according to <https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories>
-          - os: macos-14
-            java: 17
           - os: windows-latest
             java: 17
           - os: ubuntu-latest


### PR DESCRIPTION
macOS 14 (Sonoma) came out in September 2023. It's time to move on. GitHub has relatively few macOS runners, so these checks tend to bog down the merge queue.

I've already removed "JDK 17 on macos-14" as [a required status check when merging to WALA's `master`
branch](https://github.com/wala/WALA/settings/branch_protection_rules/21214944#require_status_checks_pass_desc).