### PR TITLE
Remove redundant guards, dead assertions, and tautologies

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -62,6 +62,7 @@ tasks.withType<JavaCompile>().configureEach {
       // warning-level checks upgraded to error, since we've fixed all the warnings
       error(
           "AddressSelection",
+          "AlreadyChecked",
           "AnnotateFormatMethod",
           "AnnotateFormatMethod",
           "AnnotationPosition",
@@ -376,7 +377,6 @@ tasks.withType<JavaCompile>().configureEach {
       // warning-level checks that are enabled by default, but which we violate one or more times
       disable(
           "AlmostJavadoc",
-          "AlreadyChecked",
           "AmbiguousMethodReference",
           "ArrayRecordComponent",
           "AssignmentExpression",

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PointerAnalysisImpl.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PointerAnalysisImpl.java
@@ -418,11 +418,10 @@ public class PointerAnalysisImpl extends AbstractPointerAnalysis {
     MutableSparseIntSet s = MutableSparseIntSet.makeEmpty();
     for (InstanceKey element : ik) {
       int index = instanceKeys.getMappedIndex(element);
-      if (index != -1) {
-        s.add(index);
-      } else {
-        assert index != -1 : "instance " + element + " not mapped!";
+      if (index == -1) {
+        throw new IllegalStateException("instance " + element + " not mapped!");
       }
+      s.add(index);
     }
     return new OrdinalSet<>(s, instanceKeys);
   }

--- a/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationSystem.java
+++ b/core/src/main/java/com/ibm/wala/ipa/callgraph/propagation/PropagationSystem.java
@@ -272,7 +272,6 @@ public class PropagationSystem extends DefaultFixedPointSolver<PointsToSetVariab
         }
         FilteredPointerKey fpk = (FilteredPointerKey) pk;
         assert fpk != null;
-        assert key != null;
         if (fpk.getTypeFilter() == null) {
           Assertions.UNREACHABLE("fpk.getTypeFilter() is null");
         }

--- a/core/src/main/java/com/ibm/wala/types/TypeName.java
+++ b/core/src/main/java/com/ibm/wala/types/TypeName.java
@@ -275,7 +275,7 @@ public final class TypeName implements Serializable {
       }
       if (!isPrimitive) {
         result.append('L');
-      } else if (packageName != null && isPrimitive) {
+      } else if (packageName != null) {
         result.append('P');
       }
     }

--- a/core/src/main/java/com/ibm/wala/types/generics/TypeSignature.java
+++ b/core/src/main/java/com/ibm/wala/types/generics/TypeSignature.java
@@ -40,7 +40,6 @@ public abstract class TypeSignature extends Signature {
     if (s.isEmpty()) {
       throw new IllegalArgumentException("illegal empty string s");
     }
-    assert !s.isEmpty();
     return switch (s.charAt(0)) {
       case TypeReference.VoidTypeCode -> BaseType.VOID;
       case TypeReference.BooleanTypeCode -> BaseType.BOOLEAN;

--- a/util/src/main/java/com/ibm/wala/util/intset/DebuggingMutableIntSet.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/DebuggingMutableIntSet.java
@@ -92,11 +92,9 @@ record DebuggingMutableIntSet(MutableIntSet primaryImpl, MutableIntSet secondary
     boolean pr = primaryImpl.add(i);
     boolean sr = secondaryImpl.add(i);
 
-    if (pr != sr) {
-      assert pr == sr
-          : "adding %d to %s returns %s, but adding %d to %s returns %s"
-              .formatted(i, primaryImpl, pr, i, secondaryImpl, sr);
-    }
+    assert pr == sr
+        : "adding %d to %s returns %s, but adding %d to %s returns %s"
+            .formatted(i, primaryImpl, pr, i, secondaryImpl, sr);
 
     return pr;
   }
@@ -119,9 +117,8 @@ record DebuggingMutableIntSet(MutableIntSet primaryImpl, MutableIntSet secondary
       boolean ppr = primaryImpl.containsAny(db.primaryImpl);
       boolean ssr = secondaryImpl.containsAny(db.secondaryImpl);
 
-      if (ppr != ssr) {
-        assert ppr == ssr : "containsAny " + this + ' ' + set + ' ' + ppr + ' ' + ssr;
-      }
+      assert ppr == ssr : "containsAny " + this + ' ' + set + ' ' + ppr + ' ' + ssr;
+
       return ppr;
     } else {
       return Assertions.UNREACHABLE();


### PR DESCRIPTION
Several code paths had assertions or conditional branches that were redundant with immediately preceding checks, unreachable logic, or conditions already guaranteed by enclosing context.