### PR TITLE
Use different site for Kawa 3.0 download

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -88,7 +88,7 @@ interface GenerateHelloHashServices {
 //  download and extract kawa 3.0 "kawa.jar"
 //
 
-val kawa = adHocDownload(uri("https://ftpmirror.gnu.org/gnu/kawa"), "kawa", "zip", "3.0")
+val kawa = adHocDownload(uri("https://ftp.gnu.org/pub/gnu/kawa"), "kawa", "zip", "3.0")
 
 val extractKawa =
     tasks.register<Sync>("extractKawa") {


### PR DESCRIPTION
`ftpmirror.gnu.org` has been failing with HTTP error 502 (Bad Gateway) for the last few days.  Download the artifact we need from a different site that still works.