### PR TITLE
Deprecate unused `Atom` methods

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -57,6 +57,33 @@ stack instead of the inherited `ArrayList` storage.
 * Code that only consumed these types via the `Iterator<T>` interface
   (`hasNext()`, `next()`, `forEachRemaining()`) is unaffected.
 
+#### Fourteen `Atom` methods deprecated
+
+The following methods of `com.ibm.wala.core.util.strings.Atom` are now
+deprecated (with `@Deprecated(since = "1.9.0")`). They are no longer used
+anywhere within WALA itself except by correctness tests, and we do not believe
+they are used anywhere outside WALA:
+
+* `arrayDescriptorFromElementDescriptor()`
+* `concat(byte, ImmutableByteArray)`
+* `contains(byte)`
+* `findOrCreate(ImmutableByteArray, int, int)`
+* `findOrCreateUtf8Atom(byte[])`
+* `isArrayDescriptor()`
+* `isArrayDescriptor(ImmutableByteArray)`
+* `isClassDescriptor()`
+* `isMethodDescriptor()`
+* `isReservedMemberName()`
+* `left(int)`
+* `parseForArrayDimensionality()`
+* `parseForArrayElementDescriptor()`
+* `parseForInnermostArrayElementDescriptor()`
+
+**Effect for third-party consumers:** if you do use any of these methods
+outside WALA, please [let the WALA maintainers
+know](https://github.com/wala/WALA/issues/new) so that we don't remove them in a
+future release.
+
 ## Version 1.8.0
 
 ### Functionality changes

--- a/core/src/jmh/java/com/ibm/wala/core/util/strings/AtomBenchmark.java
+++ b/core/src/jmh/java/com/ibm/wala/core/util/strings/AtomBenchmark.java
@@ -58,8 +58,7 @@ public class AtomBenchmark {
 
   /**
    * A representative mix of names and descriptors, pre-interned exactly once, plus the raw inputs
-   * used to create them and the atoms derived from them by slicing, concatenation, and descriptor
-   * parsing.
+   * used to create them and the atoms derived from them by slicing and concatenation.
    */
   @State(Scope.Thread)
   public static class AtomFixture {
@@ -67,10 +66,7 @@ public class AtomBenchmark {
     private Atom[] atoms;
     private byte[][] byteArrays;
     private String[] strings;
-    private ImmutableByteArray[] immutableByteArrays;
     private Atom[] prefixes;
-    private Atom[] arrayDescriptors;
-    private Atom[] elementDescriptors;
     private Atom[] leftConcats;
     private Atom[] rightConcats;
     private int next;
@@ -98,49 +94,27 @@ public class AtomBenchmark {
       atoms = new Atom[descriptors.size()];
       byteArrays = new byte[descriptors.size()][];
       strings = new String[descriptors.size()];
-      immutableByteArrays = new ImmutableByteArray[descriptors.size()];
       prefixes = new Atom[descriptors.size()];
       for (int i = 0; i < descriptors.size(); i++) {
         strings[i] = descriptors.get(i);
         byteArrays[i] = strings[i].getBytes(StandardCharsets.UTF_8);
-        immutableByteArrays[i] = ImmutableByteArray.make(strings[i]);
         atoms[i] = Atom.findOrCreate(byteArrays[i]);
-        prefixes[i] = atoms[i].left(Math.min(4, atoms[i].length()));
+        prefixes[i] = Atom.findOrCreate(byteArrays[i], 0, Math.min(4, atoms[i].length()));
       }
 
-      final List<Atom> arrays = new ArrayList<>();
-      final List<Atom> elements = new ArrayList<>();
       final List<Atom> concatLeft = new ArrayList<>();
       final List<Atom> concatRight = new ArrayList<>();
       for (int i = 0; i < atoms.length; i++) {
-        final Atom atom = atoms[i];
-        final Atom other = atoms[(i + 1) % atoms.length];
-        if (atom.isArrayDescriptor()) {
-          arrays.add(atom);
-        } else {
-          elements.add(atom);
-        }
-        concatLeft.add(atom);
-        concatRight.add(other);
+        concatLeft.add(atoms[i]);
+        concatRight.add(atoms[(i + 1) % atoms.length]);
       }
-      arrayDescriptors = arrays.toArray(new Atom[0]);
-      elementDescriptors = elements.toArray(new Atom[0]);
       leftConcats = concatLeft.toArray(new Atom[0]);
       rightConcats = concatRight.toArray(new Atom[0]);
 
-      // Pre-intern everything the concatenation and descriptor benchmarks derive, so that those
-      // benchmarks measure the steady-state "hit" path with a fixed-size dictionary.
+      // Pre-intern everything the concatenation benchmark derives, so that that benchmark measures
+      // the steady-state "hit" path with a fixed-size dictionary.
       for (int i = 0; i < atoms.length; i++) {
-        Atom.concat((byte) '(', immutableByteArrays[i]);
         Atom.concat(atoms[i], atoms[(i + 1) % atoms.length]);
-      }
-      for (final Atom element : elementDescriptors) {
-        element.arrayDescriptorFromElementDescriptor();
-      }
-      for (final Atom array : arrayDescriptors) {
-        array.parseForArrayElementDescriptor();
-        array.parseForInnermostArrayElementDescriptor();
-        array.parseForArrayDimensionality();
       }
     }
 
@@ -164,16 +138,6 @@ public class AtomBenchmark {
     /** Returns the next fixture string, cycling. */
     public String nextString() {
       return strings[nextIndex() % strings.length];
-    }
-
-    /** Returns the next fixture array descriptor, cycling. */
-    public Atom nextArrayDescriptor() {
-      return arrayDescriptors[nextIndex() % arrayDescriptors.length];
-    }
-
-    /** Returns the next fixture array-element descriptor, cycling. */
-    public Atom nextElementDescriptor() {
-      return elementDescriptors[nextIndex() % elementDescriptors.length];
     }
   }
 
@@ -242,13 +206,6 @@ public class AtomBenchmark {
     return Atom.findOrCreate(bytes, 0, bytes.length);
   }
 
-  /** Creates the leading half of an already-interned {@link Atom}. */
-  @Benchmark
-  public Atom left(AtomFixture fixture) {
-    final Atom atom = fixture.nextAtom();
-    return atom.left(atom.length() / 2);
-  }
-
   /** Creates the trailing half of an already-interned {@link Atom}. */
   @Benchmark
   public Atom right(AtomFixture fixture) {
@@ -270,14 +227,6 @@ public class AtomBenchmark {
     return Atom.concat(
         fixture.leftConcats[index % fixture.leftConcats.length],
         fixture.rightConcats[index % fixture.rightConcats.length]);
-  }
-
-  /** Prepends a byte to an {@link ImmutableByteArray} to form an already-interned {@link Atom}. */
-  @Benchmark
-  public Atom concatByteAndImmutableByteArray(AtomFixture fixture) {
-    final ImmutableByteArray bytes =
-        fixture.immutableByteArrays[fixture.nextIndex() % fixture.immutableByteArrays.length];
-    return Atom.concat((byte) '(', bytes);
   }
 
   /** Decodes an {@link Atom}'s bytes to a Unicode string. */
@@ -307,12 +256,6 @@ public class AtomBenchmark {
 
   /** Searches an {@link Atom} for a byte that is usually absent. */
   @Benchmark
-  public boolean contains(AtomFixture fixture) {
-    return fixture.nextAtom().contains((byte) 'a');
-  }
-
-  /** Searches an {@link Atom} for a byte that is usually absent. */
-  @Benchmark
   public int rIndex(AtomFixture fixture) {
     return fixture.nextAtom().rIndex((byte) 'a');
   }
@@ -321,40 +264,6 @@ public class AtomBenchmark {
   @Benchmark
   public int atomHashCode(AtomFixture fixture) {
     return fixture.nextAtom().hashCode();
-  }
-
-  /** Applies the single-byte descriptor predicates to an {@link Atom}. */
-  @Benchmark
-  public void descriptorPredicates(AtomFixture fixture, Blackhole blackhole) {
-    final Atom atom = fixture.nextAtom();
-    blackhole.consume(atom.isClassDescriptor());
-    blackhole.consume(atom.isArrayDescriptor());
-    blackhole.consume(atom.isMethodDescriptor());
-    blackhole.consume(atom.isReservedMemberName());
-  }
-
-  /** Strips one {@code [} from an already-interned array descriptor. */
-  @Benchmark
-  public Atom parseForArrayElementDescriptor(AtomFixture fixture) {
-    return fixture.nextArrayDescriptor().parseForArrayElementDescriptor();
-  }
-
-  /** Strips all {@code [}s from an already-interned array descriptor. */
-  @Benchmark
-  public Atom parseForInnermostArrayElementDescriptor(AtomFixture fixture) {
-    return fixture.nextArrayDescriptor().parseForInnermostArrayElementDescriptor();
-  }
-
-  /** Counts the leading {@code [}s of an already-interned array descriptor. */
-  @Benchmark
-  public int parseForArrayDimensionality(AtomFixture fixture) {
-    return fixture.nextArrayDescriptor().parseForArrayDimensionality();
-  }
-
-  /** Turns an already-interned element descriptor into its already-interned array descriptor. */
-  @Benchmark
-  public Atom arrayDescriptorFromElementDescriptor(AtomFixture fixture) {
-    return fixture.nextElementDescriptor().arrayDescriptorFromElementDescriptor();
   }
 
   /** Interns a fresh pool of genuinely new {@link Atom}s. */

--- a/core/src/main/java/com/ibm/wala/core/util/strings/Atom.java
+++ b/core/src/main/java/com/ibm/wala/core/util/strings/Atom.java
@@ -25,6 +25,11 @@ import org.jspecify.annotations.NonNull;
  *
  * <p>Atoms are used to represent names, descriptors, and string literals appearing in a class's
  * constant pool.
+ *
+ * <p>Some of {@link Atom}'s methods are deprecated. They are not used within WALA itself except by
+ * correctness tests, and we do not believe they are used anywhere outside of WALA. If you do use
+ * them outside of WALA, please <a href="https://github.com/wala/WALA/issues/new">let the WALA
+ * maintainers know</a> so that we don't remove them in the future.
  */
 public final class Atom implements Serializable {
 
@@ -76,7 +81,10 @@ public final class Atom implements Serializable {
    * @param utf8 atom value, as utf8 encoded bytes
    * @return atom
    * @throws IllegalArgumentException if utf8 is null
+   * @deprecated This method is used only by WALA's own unit tests. It may be removed in a future
+   *     release.
    */
+  @Deprecated(since = "1.9.0")
   public static Atom findOrCreateUtf8Atom(byte[] utf8) {
     if (utf8 == null) {
       throw new IllegalArgumentException("utf8 is null");
@@ -135,6 +143,17 @@ public final class Atom implements Serializable {
     return findOrCreate(b.b);
   }
 
+  /**
+   * Find or create an atom from {@code b[start]} of length {@code length}.
+   *
+   * @param b the immutable byte array
+   * @param start the offset of the first byte
+   * @param length the number of bytes
+   * @return atom
+   * @deprecated This method is used only by WALA's own unit tests. It may be removed in a future
+   *     release.
+   */
+  @Deprecated(since = "1.9.0")
   public static synchronized Atom findOrCreate(ImmutableByteArray b, int start, int length) {
     if (b == null) {
       throw new IllegalArgumentException("b is null");
@@ -171,7 +190,13 @@ public final class Atom implements Serializable {
     return UTF8Convert.fromUTF8(val);
   }
 
-  /** New Atom containing first count bytes */
+  /**
+   * New Atom containing first count bytes.
+   *
+   * @deprecated This method is used only by WALA's own unit tests. It may be removed in a future
+   *     release.
+   */
+  @Deprecated(since = "1.9.0")
   public Atom left(int count) {
     return findOrCreate(val, 0, count);
   }
@@ -200,7 +225,10 @@ public final class Atom implements Serializable {
    * descriptor - something like "I" or "Ljava/lang/Object;"
    *
    * @return array descriptor - something like "[I" or "[Ljava/lang/Object;"
+   * @deprecated This method is used only by WALA's own unit tests. It may be removed in a future
+   *     release.
    */
+  @Deprecated(since = "1.9.0")
   public Atom arrayDescriptorFromElementDescriptor() {
     byte[] sig = new byte[1 + val.length];
     sig[0] = (byte) '[';
@@ -211,7 +239,11 @@ public final class Atom implements Serializable {
   /**
    * Is "this" atom a reserved member name? Note: Sun has reserved all member names starting with
    * '&lt;' for future use. At present, only &lt;init&gt; and &lt;clinit&gt; are used.
+   *
+   * @deprecated This method is used only by WALA's own unit tests. It may be removed in a future
+   *     release.
    */
+  @Deprecated(since = "1.9.0")
   public boolean isReservedMemberName() {
     if (length() == 0) {
       return false;
@@ -219,7 +251,13 @@ public final class Atom implements Serializable {
     return val[0] == '<';
   }
 
-  /** Is "this" atom a class descriptor? */
+  /**
+   * Is "this" atom a class descriptor?
+   *
+   * @deprecated This method is used only by WALA's own unit tests. It may be removed in a future
+   *     release.
+   */
+  @Deprecated(since = "1.9.0")
   public boolean isClassDescriptor() {
     if (length() == 0) {
       return false;
@@ -227,7 +265,13 @@ public final class Atom implements Serializable {
     return val[0] == 'L';
   }
 
-  /** Is "this" atom an array descriptor? */
+  /**
+   * Is "this" atom an array descriptor?
+   *
+   * @deprecated This method is used only by WALA's own unit tests. It may be removed in a future
+   *     release.
+   */
+  @Deprecated(since = "1.9.0")
   public boolean isArrayDescriptor() {
     if (length() == 0) {
       return false;
@@ -235,7 +279,13 @@ public final class Atom implements Serializable {
     return val[0] == '[';
   }
 
-  /** Is "this" atom a method descriptor? */
+  /**
+   * Is "this" atom a method descriptor?
+   *
+   * @deprecated This method is used only by WALA's own unit tests. It may be removed in a future
+   *     release.
+   */
+  @Deprecated(since = "1.9.0")
   public boolean isMethodDescriptor() throws IllegalArgumentException {
     if (length() == 0) {
       return false;
@@ -258,7 +308,10 @@ public final class Atom implements Serializable {
    * descriptor - something like "[I"
    *
    * @return array element descriptor - something like "I"
+   * @deprecated This method is used only by WALA's own unit tests. It may be removed in a future
+   *     release.
    */
+  @Deprecated(since = "1.9.0")
   public Atom parseForArrayElementDescriptor() throws IllegalArgumentException {
     if (val.length == 0) {
       throw new IllegalArgumentException("empty atom is not an array");
@@ -272,7 +325,10 @@ public final class Atom implements Serializable {
    *
    * @return dimensionality - something like "1" or "2"
    * @throws IllegalStateException if this Atom does not represent an array
+   * @deprecated This method is used only by WALA's own unit tests. It may be removed in a future
+   *     release.
    */
+  @Deprecated(since = "1.9.0")
   public int parseForArrayDimensionality() throws IllegalArgumentException {
     if (val.length == 0) {
       throw new IllegalArgumentException("empty atom is not an array");
@@ -292,7 +348,10 @@ public final class Atom implements Serializable {
    * Return the innermost element type reference for an array
    *
    * @throws IllegalStateException if this Atom does not represent an array descriptor
+   * @deprecated This method is used only by WALA's own unit tests. It may be removed in a future
+   *     release.
    */
+  @Deprecated(since = "1.9.0")
   public Atom parseForInnermostArrayElementDescriptor() throws IllegalArgumentException {
     if (val.length == 0) {
       throw new IllegalArgumentException("empty atom is not an array");
@@ -384,7 +443,10 @@ public final class Atom implements Serializable {
 
   /**
    * @return true iff this atom contains the specified byte
+   * @deprecated This method is used only by WALA's own unit tests. It may be removed in a future
+   *     release.
    */
+  @Deprecated(since = "1.9.0")
   public boolean contains(byte b) {
     for (byte element : val) {
       if (element == b) {
@@ -410,6 +472,16 @@ public final class Atom implements Serializable {
     return findOrCreate(val);
   }
 
+  /**
+   * Concatenate a byte with an immutable byte array to form an atom.
+   *
+   * @param c the leading byte
+   * @param b the following bytes
+   * @return atom
+   * @deprecated This method is used only by WALA's own unit tests. It may be removed in a future
+   *     release.
+   */
+  @Deprecated(since = "1.9.0")
   public static Atom concat(byte c, ImmutableByteArray b) {
     if (b == null) {
       throw new IllegalArgumentException("b is null");
@@ -428,6 +500,15 @@ public final class Atom implements Serializable {
     return findOrCreate(val);
   }
 
+  /**
+   * Is the given immutable byte array an array descriptor?
+   *
+   * @param b the immutable byte array
+   * @return true iff the first byte is '['
+   * @deprecated This method is used only by WALA's own unit tests. It may be removed in a future
+   *     release.
+   */
+  @Deprecated(since = "1.9.0")
   public static boolean isArrayDescriptor(ImmutableByteArray b) {
     if (b == null) {
       throw new IllegalArgumentException("b is null");

--- a/core/src/test/java/com/ibm/wala/core/util/strings/AtomTest.java
+++ b/core/src/test/java/com/ibm/wala/core/util/strings/AtomTest.java
@@ -23,7 +23,7 @@ import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests of the {@link Atom} class. */
-@SuppressWarnings("UnnecessaryUnicodeEscape")
+@SuppressWarnings({"UnnecessaryUnicodeEscape", "deprecation"})
 public final class AtomTest {
 
   // --- Factories

--- a/core/src/testFixtures/java/com/ibm/wala/core/util/strings/AtomAssert.java
+++ b/core/src/testFixtures/java/com/ibm/wala/core/util/strings/AtomAssert.java
@@ -10,6 +10,7 @@ import org.assertj.core.api.AbstractObjectAssert;
  * Custom {@link org.assertj.core.api.Assertions} assertions for {@link Atom} instances, for use in
  * WALA's own tests.
  */
+@SuppressWarnings("deprecation")
 public class AtomAssert extends AbstractObjectAssert<AtomAssert, Atom> {
 
   public AtomAssert(final Atom actual) {


### PR DESCRIPTION
Fourteen `Atom` methods are no longer used by any WALA production code, only by WALA's own unit tests. We do not believe they are used outside WALA, so they are deprecated (`@Deprecated(since = "1.9.0")`, without `forRemoval`), and the `Atom` class Javadoc asks any external users to let us know before we remove them.

We keep exercising the deprecated methods in `AtomTest` and `AtomAssert` for correctness: as long as they remain in the public API, they must keep working, both to guard against regressions for any external users still relying on them and to keep their behavior stable until removal. The `-Werror` build treats deprecation warnings as errors, so the tests suppress them.

We remove the corresponding JMH benchmarks from `AtomBenchmark`: JMH exists to track the performance of code WALA actually runs, and no WALA production code calls these methods anymore. Their performance is therefore irrelevant, and the descriptor- and byte-array-slicing fixture machinery existed only to feed those dead benchmarks. Keeping tests while dropping benchmarks means we retain confidence in behavior but stop paying for measurements that no longer reflect any real workload.