### PR TITLE
ECJ-compile all source sets, no matter when they appear

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/java.gradle.kts
@@ -487,10 +487,15 @@ if (providers.gradleProperty("excludeSlowTests").isPresent) {
   tasks.named<Test>("test") { useJUnitPlatform { excludeTags("slow") } }
 }
 
-val ecjCompileTaskProviders =
-    sourceSets.map { sourceSet -> JavaCompileUsingEcj.withSourceSet(project, sourceSet) }
+private val ecjCompileTasksProvider = objects.listProperty<JavaCompileUsingEcj>()
 
-tasks.named("check") { dependsOn(ecjCompileTaskProviders) }
+sourceSets.configureEach {
+  // Register ECJ compilation for every source set, including those created after this plugin
+  // applies (e.g., `jmh` and `testSubjects`).
+  ecjCompileTasksProvider.add(JavaCompileUsingEcj.withSourceSet(project, this))
+}
+
+tasks.named("check") { dependsOn(ecjCompileTasksProvider) }
 
 tasks.withType<JavaCompile>().configureEach {
   options.run {

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/test-subjects.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/test-subjects.gradle.kts
@@ -1,6 +1,8 @@
 /**
- * Configures a `testSubjects` source set for Java code that will be analyzed by WALA tests. Sets up
- * both standard Java compilation and ECJ-based compilation for these test subjects.
+ * Configures a `testSubjects` source set for Java code that will be analyzed by WALA tests.
+ * Standard and ECJ-based compilation for the new source set are both registered automatically by
+ * the `com.ibm.wala.gradle.java` plugin; this plugin only disables Error Prone for the test
+ * subjects.
  */
 package com.ibm.wala.gradle
 
@@ -10,13 +12,9 @@ plugins { id("com.ibm.wala.gradle.java") }
 
 val testSubjects = sourceSets.create("testSubjects")
 
-val compileTestSubjectsJavaUsingEcj = JavaCompileUsingEcj.withSourceSet(project, testSubjects)
-
 tasks {
   named<JavaCompile>("compileTestSubjectsJava") {
     // No need to run Error Prone on our analysis test inputs
     options.errorprone.enabled = false
   }
-
-  named("check") { dependsOn(compileTestSubjectsJavaUsingEcj) }
 }


### PR DESCRIPTION
Previously, the `com.ibm.wala.gradle.java` plugin registered an ECJ compilation task only for source sets that already existed when the plugin applied.  Source sets created later, such as `jmh` and `testSubjects`, were skipped.  For example, `:core:check` never ECJ-compiled the JMH benchmark sources.

Now `com.ibm.wala.gradle.java` uses `sourceSets.configureEach` to register an ECJ compilation task for each source set as it is created, including those that will be created in the future.  With that hook in place, the `com.ibm.wala.gradle.test-subjects` plugin no longer needs to register its own copy of the same task.