### PR TITLE
Allow scope files to reference classes and sources in JARs

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -84,6 +84,18 @@ outside WALA, please [let the WALA maintainers
 know](https://github.com/wala/WALA/issues/new) so that we don't remove them in a
 future release.
 
+#### Analysis scope files may reference classes and sources packaged in JARs
+
+In an analysis scope file, `classFile` and `sourceFile` entries previously
+could only name files that exist on the filesystem.  They now also work when
+the named class or source file is a classpath resource, including a resource
+packaged inside a JAR.  For example, an entry such as
+`Application,Java,classFile,hello/Hello.class` now resolves
+`hello/Hello.class` via the classloader, whether it is an unpacked file or an
+entry of `hello.jar`.  This is particularly useful when running an analysis
+from a single executable JAR whose supporting classes and sources are
+included as entries.
+
 ## Version 1.8.0
 
 ### Functionality changes

--- a/core/src/main/java/com/ibm/wala/classLoader/SourceURLModule.java
+++ b/core/src/main/java/com/ibm/wala/classLoader/SourceURLModule.java
@@ -10,6 +10,8 @@
  */
 package com.ibm.wala.classLoader;
 
+import com.ibm.wala.core.util.io.FileSuffixes;
+import java.io.File;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URL;
@@ -23,6 +25,13 @@ public class SourceURLModule extends AbstractURLModule implements SourceModule {
   @Override
   public boolean isClassFile() {
     return false;
+  }
+
+  @Override
+  public String getClassName() {
+    // For a JAR resource, the entry name is the logical name of the source file, e.g.
+    // `hello/Hello.java`.  For any other URL it is a pathname, possibly absolute.
+    return FileSuffixes.stripSuffix(getName()).replace(File.separator.charAt(0), '/');
   }
 
   @Override

--- a/core/src/main/java/com/ibm/wala/core/util/config/AnalysisScopeReader.java
+++ b/core/src/main/java/com/ibm/wala/core/util/config/AnalysisScopeReader.java
@@ -14,6 +14,7 @@ import com.ibm.wala.classLoader.BinaryDirectoryTreeModule;
 import com.ibm.wala.classLoader.ClassFileURLModule;
 import com.ibm.wala.classLoader.Module;
 import com.ibm.wala.classLoader.SourceDirectoryTreeModule;
+import com.ibm.wala.classLoader.SourceURLModule;
 import com.ibm.wala.core.util.io.FileProvider;
 import com.ibm.wala.core.util.strings.Atom;
 import com.ibm.wala.ipa.callgraph.AnalysisScope;
@@ -196,9 +197,9 @@ public class AnalysisScopeReader {
     String entryPathname = tokens.nextToken();
     FileProvider fp = new FileProvider();
     if ("classFile".equals(entryType)) {
-      File cf = fp.getFile(entryPathname, javaLoader);
+      URL cf = fp.getURLFromClassLoader(entryPathname, javaLoader);
       try {
-        scope.addClassFileToScope(walaLoader, cf);
+        scope.addToScope(walaLoader, new ClassFileURLModule(cf));
       } catch (InvalidClassFileException e) {
         Assertions.UNREACHABLE(e.toString());
       }
@@ -211,8 +212,8 @@ public class AnalysisScopeReader {
         Assertions.UNREACHABLE(e.toString());
       }
     } else if ("sourceFile".equals(entryType)) {
-      File sf = fp.getFile(entryPathname, javaLoader);
-      scope.addSourceFileToScope(walaLoader, sf, entryPathname);
+      URL sf = fp.getURLFromClassLoader(entryPathname, javaLoader);
+      scope.addToScope(walaLoader, new SourceURLModule(sf));
     } else if ("binaryDir".equals(entryType)) {
       File bd = fp.getFile(entryPathname, javaLoader);
       assert bd.isDirectory();

--- a/core/src/main/java/com/ibm/wala/core/util/io/FileProvider.java
+++ b/core/src/main/java/com/ibm/wala/core/util/io/FileProvider.java
@@ -21,6 +21,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.JarURLConnection;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
@@ -74,6 +75,40 @@ public class FileProvider {
 
   public File getFile(String fileName, ClassLoader loader) throws IOException {
     return getFileFromClassLoader(fileName, loader);
+  }
+
+  /**
+   * Returns the URL of the given file name, which may be either a classpath resource or a plain
+   * filesystem path.
+   *
+   * <p>The {@link ClassLoader} is searched first, so that a resource packaged inside a JAR is found
+   * even though it has no real filesystem path. If no such resource exists, {@code fileName} is
+   * instead treated as a pathname relative to the current working directory.
+   *
+   * @return the URL of the given file name
+   * @throws FileNotFoundException if {@code fileName} is neither a classpath resource nor an
+   *     existing filesystem path
+   */
+  public URL getURLFromClassLoader(String fileName, ClassLoader loader)
+      throws FileNotFoundException, MalformedURLException {
+    if (fileName == null) {
+      throw new IllegalArgumentException("null fileName");
+    }
+    if (loader == null) {
+      throw new IllegalArgumentException("null loader");
+    }
+    URL url = loader.getResource(fileName);
+    if (DEBUG_LEVEL > 0) {
+      System.err.println("FileProvider got url: " + url + " for " + fileName);
+    }
+    if (url != null) {
+      return url;
+    }
+    File f = new File(fileName);
+    if (f.exists()) {
+      return f.toURI().toURL();
+    }
+    throw new FileNotFoundException(fileName);
   }
 
   public File getFileFromClassLoader(String fileName, ClassLoader loader)

--- a/core/src/test/java/com/ibm/wala/core/tests/cha/SourceMapTest.java
+++ b/core/src/test/java/com/ibm/wala/core/tests/cha/SourceMapTest.java
@@ -23,7 +23,14 @@ import com.ibm.wala.ipa.cha.ClassHierarchy;
 import com.ibm.wala.ipa.cha.ClassHierarchyException;
 import com.ibm.wala.ipa.cha.ClassHierarchyFactory;
 import com.ibm.wala.types.TypeReference;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 import org.junit.jupiter.api.Test;
 
 /** A test of support for source file mapping */
@@ -47,6 +54,44 @@ public class SourceMapTest extends WalaTestCase {
     String sourceFile = klass.getSourceFileName();
     System.err.println("Source file: " + sourceFile);
     assertThat(sourceFile).isNotNull();
+  }
+
+  @Test
+  public void testHelloFromJar() throws ClassHierarchyException, IOException {
+
+    // Copy the `hello` test subject into a temporary JAR, so that the scope file's `classFile` and
+    // `sourceFile` entries must resolve `hello/Hello.class` and `hello/Hello.java` as entries of
+    // that JAR rather than as unpacked files on the filesystem.
+    File jar = createJarContaining("hello/Hello.class", "hello/Hello.java");
+    try (URLClassLoader jarLoader =
+        new URLClassLoader(new URL[] {jar.toURI().toURL()}, MY_CLASSLOADER)) {
+      AnalysisScope scope =
+          AnalysisScopeReader.instance.readJavaScope(TestConstants.HELLO, null, jarLoader);
+      ClassHierarchy cha = ClassHierarchyFactory.make(scope);
+      TypeReference t =
+          TypeReference.findOrCreate(scope.getApplicationLoader(), TestConstants.HELLO_MAIN);
+      IClass klass = cha.lookupClass(t);
+      assertThat(klass).isNotNull();
+      String sourceFile = klass.getSourceFileName();
+      System.err.println("Source file: " + sourceFile);
+      assertThat(sourceFile).isNotNull();
+    }
+  }
+
+  private static File createJarContaining(String... entries) throws IOException {
+    File jar = File.createTempFile("wala-source-map-test", ".jar");
+    jar.deleteOnExit();
+    try (JarOutputStream out = new JarOutputStream(new FileOutputStream(jar))) {
+      for (String entry : entries) {
+        try (InputStream in = MY_CLASSLOADER.getResourceAsStream(entry)) {
+          assertThat(in).as("classpath resource %s", entry).isNotNull();
+          out.putNextEntry(new JarEntry(entry));
+          in.transferTo(out);
+          out.closeEntry();
+        }
+      }
+    }
+    return jar;
   }
 
   @Test


### PR DESCRIPTION
In an analysis scope file, 'classFile' and 'sourceFile' entries previously could only name files that exist on the filesystem.  They now also work when the named class or source file is a classpath resource, including a resource packaged inside a JAR.

The broader context here is that we plan to add JMH macrobenchmarks that directly call existing test methods. Previously these tests ran with their test resources available on the classpath as unpacked directories. However, when JMH runs those benchmarks, everything (including the test resources) is bundled up into one or more JAR archives. This change lets those tests find and use their resources using the standard JMH classpath without messy Gradle gymnastics.

`FileProvider.getURLFromClassLoader()` resolves a scope-file pathname to a URL, searching the classloader first and then falling back to the filesystem. `AnalysisScopeReader` now uses `ClassFileURLModule` and `SourceURLModule` for 'classFile' and 'sourceFile' entries, respectively, reading the class or source bytes from the resolved URL instead of requiring a real file. `SourceURLModule` gains a `getClassName()` derived from the URL's entry name or pathname, as `ClassLoaderImpl.loadAllSources` needs it.

Adds `SourceMapTest.testHelloFromJar`, which loads the 'hello' test subject only from a JAR.