### PR TITLE
Use lazy file property variants on built-in tasks

### DIFF
--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/publishing.gradle.kts
@@ -11,15 +11,13 @@ val isSnapshot = "SNAPSHOT" in version as String
 val java = extensions.getByType<JavaPluginExtension>()
 
 val testFixturesJavadoc =
-    tasks.named<Javadoc>("testFixturesJavadoc") {
-      destinationDir = java.docsDir.get().dir(name).asFile
-    }
+    tasks.named<Javadoc>("testFixturesJavadoc") { destinationDirectory = java.docsDir.dir(name) }
 
 val testFixturesJavadocJar =
     tasks.register<Jar>("testFixturesJavadocJar") {
       description = "Assemble Javadoc JAR for test fixtures"
       archiveClassifier = "test-fixtures-javadoc"
-      from(testFixturesJavadoc.map { it.destinationDir!! })
+      from(testFixturesJavadoc)
     }
 
 mavenPublishing {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,7 +77,7 @@ dependencies {
 tasks.register<Javadoc>("aggregatedJavadocs") {
   description = "Generate javadocs from all child projects as if they were a single project"
   group = "Documentation"
-  destinationDir = layout.buildDirectory.dir("docs/javadoc").get().asFile
+  destinationDirectory = layout.buildDirectory.dir("docs/javadoc")
   title = "${project.name} $version API"
   (options as StandardJavadocDocletOptions).author(true)
   classpath = files(aggregatedJavadocClasspathExtras, aggregatedJavadocRuntimeElements)

--- a/cast/java/test/data/build.gradle.kts
+++ b/cast/java/test/data/build.gradle.kts
@@ -62,7 +62,7 @@ val downloadJLex =
       into(layout.buildDirectory.dir(name))
     }
 
-testSubjects { java.srcDir(downloadJLex.map { it.destinationDir }) }
+testSubjects { java.srcDir(downloadJLex) }
 
 ////////////////////////////////////////////////////////////////////////
 //

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -248,7 +248,7 @@ val unpackOcamlJava =
         )
       }
       val outputDir = layout.buildDirectory.dir(name)
-      workingDir(outputDir)
+      workingDirectory = outputDir
       outputs.dir(outputDir)
     }
 
@@ -275,8 +275,8 @@ val generateHelloHashJar =
       // `ocamljava` script to compile OCaml to Java bytecode
       executable(
           unpackOcamlJava
-              .map {
-                it.workingDir.resolve(
+              .flatMap {
+                it.workingDirectory.file(
                     "ocamljava-$ocamlJavaVersion/bin/ocamljava${if (isWindows) ".bat" else ""}"
                 )
               }


### PR DESCRIPTION
One of these changes uses a lazy API that has been around for a while. The others use [new lazy APIs that were added in Gradle 9.7.0](https://docs.gradle.org/current/release-notes.html#lazy-variants-of-common-filedir-properties-on-built-in-tasks).