### PR TITLE
Add JMH macrobenchmarks that reuse `core` tests

### DIFF
--- a/.idea/dictionaries/project.xml
+++ b/.idea/dictionaries/project.xml
@@ -210,6 +210,8 @@
       <w>lushr</w>
       <w>lval</w>
       <w>lxor</w>
+      <w>macrobenchmark</w>
+      <w>macrobenchmarks</w>
       <w>markdownlint</w>
       <w>mavencentral</w>
       <w>meeted</w>

--- a/README-Gradle.md
+++ b/README-Gradle.md
@@ -253,18 +253,11 @@ WALA user or a unit test would.  For example,
 `core/src/jmh/java/com/ibm/wala/benchmarks/callgraph/CallGraphBenchmark.java`
 reuses `CallGraphTest.testHelloAllEntrypoints()` verbatim as its workload.
 Because these tasks take seconds rather than microseconds, they use JMH’s
-single-shot time mode, in which each iteration is a single invocation.
-
-Run all `core` benchmarks (micro and macro) with the `jmh` task:
-
-```shell
-./gradlew :core:jmh
-```
-
-As with the microbenchmarks, results are printed to the console and written
-to `core/build/results/jmh/results.json`.  Expect the macrobenchmarks to
-take several seconds per iteration, so consider limiting the warmup and
-measurement iteration counts while developing a new benchmark.
+single-shot time mode, in which each iteration is a single invocation.  The
+`jmh` task described above runs these macrobenchmarks alongside the
+microbenchmarks.  Expect them to take several seconds per iteration, so
+consider limiting the warmup and measurement iteration counts while
+developing a new benchmark.
 
 #### Useful Command-Line Flags
 

--- a/README-Gradle.md
+++ b/README-Gradle.md
@@ -243,6 +243,29 @@ benchmark with more forks and iterations for more trustworthy comparisons,
 e.g. by editing the `@Fork`, `@Warmup`, and `@Measurement` annotations in
 the benchmark source.
 
+#### JMH Macrobenchmarks
+
+A few larger-scale, end-to-end tasks live alongside the microbenchmarks in
+`core/src/jmh/java`, under the `com.ibm.wala.benchmarks` package.  Unlike
+the microbenchmarks above, which measure tightly-scoped operations in
+isolation, each macrobenchmark runs a complete analysis task just as a real
+WALA user or a unit test would.  For example,
+`core/src/jmh/java/com/ibm/wala/benchmarks/callgraph/CallGraphBenchmark.java`
+reuses `CallGraphTest.testHelloAllEntrypoints()` verbatim as its workload.
+Because these tasks take seconds rather than microseconds, they use JMH’s
+single-shot time mode, in which each iteration is a single invocation.
+
+Run all `core` benchmarks (micro and macro) with the `jmh` task:
+
+```shell
+./gradlew :core:jmh
+```
+
+As with the microbenchmarks, results are printed to the console and written
+to `core/build/results/jmh/results.json`.  Expect the macrobenchmarks to
+take several seconds per iteration, so consider limiting the warmup and
+measurement iteration counts while developing a new benchmark.
+
 #### Useful Command-Line Flags
 
 Among Gradle’s command-line flags, I have found the following

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/jmh.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/jmh.gradle.kts
@@ -1,6 +1,6 @@
 package com.ibm.wala.gradle
 
-// Build configuration for subprojects that include JMH microbenchmarks.
+// Build configuration for subprojects that include JMH benchmarks.
 
 import net.ltgt.gradle.errorprone.errorprone
 
@@ -10,7 +10,6 @@ plugins {
 }
 
 jmh {
-  includeTests = false
   jmhVersion = catalogVersion("jmh")
   resultFormat = "JSON"
 }

--- a/core/src/jmh/java/com/ibm/wala/benchmarks/callgraph/CallGraphBenchmark.java
+++ b/core/src/jmh/java/com/ibm/wala/benchmarks/callgraph/CallGraphBenchmark.java
@@ -16,10 +16,10 @@ import org.openjdk.jmh.annotations.Warmup;
 /**
  * JMH macrobenchmarks that perform large-scale, end-to-end WALA analyses.
  *
- * <p>Unlike the microbenchmarks under {@code core/src/jmh/java}, which measure tightly-scoped
- * operations in isolation, each macrobenchmark here runs a complete analysis task just as a real
- * WALA user or a unit test would. The first such task, {@link #testHelloAllEntrypoints()}, is
- * exactly the work of {@link CallGraphTest#testHelloAllEntrypoints}.
+ * <p>Unlike the microbenchmarks, which measure tightly-scoped operations in isolation, each
+ * macrobenchmark here runs a complete analysis task just as a real WALA user or a unit test would.
+ * The first such task, {@link #testHelloAllEntrypoints()}, is exactly the work of {@link
+ * CallGraphTest#testHelloAllEntrypoints}.
  *
  * <p>Because these tasks take seconds rather than microseconds, they use the {@link
  * Mode#SingleShotTime single-shot time mode}, in which each iteration is a single invocation. Run

--- a/core/src/jmh/java/com/ibm/wala/benchmarks/callgraph/CallGraphBenchmark.java
+++ b/core/src/jmh/java/com/ibm/wala/benchmarks/callgraph/CallGraphBenchmark.java
@@ -1,0 +1,54 @@
+package com.ibm.wala.benchmarks.callgraph;
+
+import com.ibm.wala.core.tests.callGraph.CallGraphTest;
+import com.ibm.wala.ipa.cha.ClassHierarchyException;
+import com.ibm.wala.util.CancelException;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * JMH macrobenchmarks that perform large-scale, end-to-end WALA analyses.
+ *
+ * <p>Unlike the microbenchmarks under {@code core/src/jmh/java}, which measure tightly-scoped
+ * operations in isolation, each macrobenchmark here runs a complete analysis task just as a real
+ * WALA user or a unit test would. The first such task, {@link #testHelloAllEntrypoints()}, is
+ * exactly the work of {@link CallGraphTest#testHelloAllEntrypoints}.
+ *
+ * <p>Because these tasks take seconds rather than microseconds, they use the {@link
+ * Mode#SingleShotTime single-shot time mode}, in which each iteration is a single invocation. Run
+ * with {@code ./gradlew :core:jmh}.
+ *
+ * <p>The benchmark is stable to roughly one percent across forks, but with only a single fork and a
+ * handful of iterations JMH reports a wildly inflated error: its printed margin is {@code t(n-1,
+ * 99.9%) x} the standard error, and with {@code n = 3} that t-multiplier is about 32. Each fork is
+ * therefore treated as one independent sample, and four forks (with two measured invocations each)
+ * give a printed error that is small enough to track relative changes in runtime.
+ */
+@BenchmarkMode(Mode.SingleShotTime)
+@Fork(4)
+@Measurement(iterations = 2)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 1)
+public class CallGraphBenchmark {
+
+  /**
+   * Builds call graphs from all application entrypoints of the {@code hello} test subject.
+   *
+   * <p>We intentionally reuse {@link CallGraphTest#testHelloAllEntrypoints} verbatim, as a
+   * large-scale benchmark workload. Error Prone's {@code JUnitMethodInvoked} check dislikes this,
+   * but the benchmark is exactly a stand-in for the JUnit runner.
+   */
+  @Benchmark
+  @SuppressWarnings("JUnitMethodInvoked")
+  public void testHelloAllEntrypoints()
+      throws CancelException, ClassHierarchyException, IllegalArgumentException, IOException {
+    new CallGraphTest().testHelloAllEntrypoints();
+  }
+}


### PR DESCRIPTION
Add a first JMH macrobenchmark, `CallGraphBenchmark`, which reuses `CallGraphTest.testHelloAllEntrypoints()` verbatim as an end-to-end analysis workload.  It lives in `core/src/jmh/java` alongside the microbenchmarks.