### PR TITLE
Adapt two dataflow tests as dataflow macrobenchmarks

### DIFF
--- a/core/src/jmh/java/com/ibm/wala/benchmarks/dataflow/DataflowBenchmark.java
+++ b/core/src/jmh/java/com/ibm/wala/benchmarks/dataflow/DataflowBenchmark.java
@@ -1,0 +1,103 @@
+package com.ibm.wala.benchmarks.dataflow;
+
+import com.ibm.wala.examples.analysis.dataflow.DataflowTest;
+import com.ibm.wala.ipa.cha.ClassHierarchyException;
+import com.ibm.wala.util.CancelException;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * JMH macrobenchmarks for the interprocedural reaching-definitions analyses of {@link
+ * DataflowTest#testContextSensitive} and {@link DataflowTest#testContextInsensitive}.
+ *
+ * <p>{@link #analyzeTestContextSensitive()} times only the {@link
+ * com.ibm.wala.examples.analysis.dataflow.ContextSensitiveReachingDefs} construction and {@code
+ * analyze()} call for the {@code dataflow.StaticDataflow} test subject, while {@link
+ * #analyzeTestContextInsensitive()} times the equivalent context-insensitive work: the {@link
+ * com.ibm.wala.ipa.cfg.ExplodedInterproceduralCFG} construction, the {@link
+ * com.ibm.wala.examples.analysis.dataflow.ContextInsensitiveReachingDefs} construction, and the
+ * {@code analyze()} call. These are the parts of the two {@code DataflowTest} tests this benchmark
+ * cares about. All of the preceding analysis-pipeline work — analysis-scope construction,
+ * class-hierarchy construction, and call-graph construction (including pointer analysis) — is done
+ * once, in {@link #setup()}, before any timing begins, and the same call graphs are reused across
+ * every iteration.
+ *
+ * <p>Each measured invocation is one complete interprocedural reaching-definitions analysis, taking
+ * on the order of a quarter of a millisecond for the {@code dataflow.StaticDataflow} test subject
+ * (measured means of roughly {@code 0.25} and {@code 0.23} ms for the context-insensitive and
+ * context-sensitive analyses). Because a single invocation is a natural unit of work, this
+ * benchmark uses {@link Mode#SingleShotTime single-shot time mode}, in which each iteration is
+ * exactly one invocation, measured in {@link TimeUnit#MILLISECONDS milliseconds}.
+ *
+ * <p>These are sub-millisecond analyses, so a single invocation is noisy (allocation and GC jitter
+ * are on the same scale as the work itself). The {@code @Warmup} of 60 iterations covers the JIT
+ * ramp, which extends well past 30 iterations, and the {@code @Measurement} of 20 iterations across
+ * 4 forks averages the noise down to a per-run error of roughly {@code 5-9%}. Repeated runs agree
+ * with each other within that noise: e.g. the context-insensitive mean reproduced at {@code 0.255}
+ * and {@code 0.250} ms and the context-sensitive mean at {@code 0.236} and {@code 0.224} ms across
+ * two consecutive runs.
+ *
+ * <p>Run with {@code ./gradlew :core:jmh}.
+ */
+@BenchmarkMode(Mode.SingleShotTime)
+@Fork(4)
+@Measurement(iterations = 20)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 60)
+public class DataflowBenchmark {
+
+  /**
+   * The pre-analysis state for {@link #analyzeTestContextSensitive()}, built by {@link #setup()}.
+   */
+  private DataflowTest.TestContextSensitiveAnalysis contextSensitiveAnalysis;
+
+  /**
+   * The pre-analysis state for {@link #analyzeTestContextInsensitive()}, built by {@link #setup()}.
+   */
+  private DataflowTest.TestContextInsensitiveAnalysis contextInsensitiveAnalysis;
+
+  @Setup(Level.Trial)
+  public void setup()
+      throws CancelException, ClassHierarchyException, IllegalArgumentException, IOException {
+    contextSensitiveAnalysis = DataflowTest.prepareTestContextSensitive();
+    contextInsensitiveAnalysis = DataflowTest.prepareTestContextInsensitive();
+  }
+
+  /**
+   * Times only the context-sensitive reaching-definitions analysis that {@link
+   * DataflowTest#testContextSensitive} performs, using the same call graph that {@code
+   * testContextSensitive} uses.
+   *
+   * <p>The preceding pipeline work is done once, in {@link #setup()}, before any timing begins.
+   * Returning the analysis result prevents JMH and the JIT from eliminating the computation.
+   */
+  @Benchmark
+  public DataflowTest.TestContextSensitiveResult analyzeTestContextSensitive() {
+    return DataflowTest.computeTestContextSensitive(contextSensitiveAnalysis);
+  }
+
+  /**
+   * Times only the context-insensitive reaching-definitions analysis that {@link
+   * DataflowTest#testContextInsensitive} performs, using the same call graph and class hierarchy
+   * that {@code testContextInsensitive} uses.
+   *
+   * <p>The preceding pipeline work is done once, in {@link #setup()}, before any timing begins.
+   * Returning the analysis result prevents JMH and the JIT from eliminating the computation.
+   */
+  @Benchmark
+  public DataflowTest.TestContextInsensitiveResult analyzeTestContextInsensitive() {
+    return DataflowTest.computeTestContextInsensitive(contextInsensitiveAnalysis);
+  }
+}

--- a/core/src/main/java/com/ibm/wala/examples/analysis/dataflow/ContextInsensitiveReachingDefs.java
+++ b/core/src/main/java/com/ibm/wala/examples/analysis/dataflow/ContextInsensitiveReachingDefs.java
@@ -62,7 +62,7 @@ public class ContextInsensitiveReachingDefs {
    */
   private final Map<IField, BitVector> staticField2DefStatements = HashMapFactory.make();
 
-  private static final boolean VERBOSE = true;
+  private static final boolean VERBOSE = false;
 
   public ContextInsensitiveReachingDefs(ExplodedInterproceduralCFG icfg, IClassHierarchy cha) {
     this.icfg = icfg;

--- a/core/src/test/java/com/ibm/wala/examples/analysis/dataflow/DataflowTest.java
+++ b/core/src/test/java/com/ibm/wala/examples/analysis/dataflow/DataflowTest.java
@@ -28,7 +28,6 @@ import com.ibm.wala.ipa.callgraph.AnalysisScope;
 import com.ibm.wala.ipa.callgraph.CGNode;
 import com.ibm.wala.ipa.callgraph.CallGraph;
 import com.ibm.wala.ipa.callgraph.CallGraphBuilder;
-import com.ibm.wala.ipa.callgraph.CallGraphBuilderCancelException;
 import com.ibm.wala.ipa.callgraph.Entrypoint;
 import com.ibm.wala.ipa.callgraph.IAnalysisCacheView;
 import com.ibm.wala.ipa.callgraph.impl.Everywhere;
@@ -50,6 +49,7 @@ import com.ibm.wala.util.collections.Pair;
 import com.ibm.wala.util.config.PatternsFilter;
 import com.ibm.wala.util.intset.IntIterator;
 import com.ibm.wala.util.intset.IntSet;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -82,10 +82,9 @@ public class DataflowTest extends WalaTestCase {
     "sun/swing",
   };
 
-  @BeforeAll
-  public static void beforeClass() throws Exception {
-
-    scope =
+  /** Read the test analysis scope with the {@link #EXCLUSIONS} applied. */
+  private static AnalysisScope makeScope() throws IOException {
+    AnalysisScope scope =
         AnalysisScopeReader.instance.readJavaScope(
             TestConstants.WALA_TESTDATA, null, DataflowTest.class.getClassLoader());
 
@@ -95,6 +94,12 @@ public class DataflowTest extends WalaTestCase {
     scope.setExclusions(
         new PatternsFilter(
             Arrays.stream(EXCLUSIONS).map(exclusion -> Pattern.quote(exclusion) + "/.*")));
+    return scope;
+  }
+
+  @BeforeAll
+  public static void beforeClass() throws Exception {
+    scope = makeScope();
     try {
       cha = ClassHierarchyFactory.make(scope);
     } catch (ClassHierarchyException e) {
@@ -146,9 +151,27 @@ public class DataflowTest extends WalaTestCase {
     }
   }
 
-  @Test
-  public void testContextInsensitive()
-      throws IllegalArgumentException, CallGraphBuilderCancelException {
+  /**
+   * The analysis state that {@link #testContextInsensitive} builds before running the reaching
+   * definitions analysis, assembled by {@link #prepareTestContextInsensitive()}.
+   */
+  public record TestContextInsensitiveAnalysis(
+      CallGraph callGraph, IClassHierarchy classHierarchy) {}
+
+  /** The result of the {@link #computeTestContextInsensitive} analysis phase. */
+  public record TestContextInsensitiveResult(
+      ExplodedInterproceduralCFG icfg,
+      BitVectorSolver<BasicBlockInContext<IExplodedBasicBlock>> solver,
+      ContextInsensitiveReachingDefs reachingDefs) {}
+
+  /**
+   * Phase one of {@link #testContextInsensitive}: compute everything needed before running the
+   * analysis.
+   */
+  public static TestContextInsensitiveAnalysis prepareTestContextInsensitive()
+      throws IllegalArgumentException, ClassHierarchyException, CancelException, IOException {
+    AnalysisScope scope = makeScope();
+    IClassHierarchy cha = ClassHierarchyFactory.make(scope);
     Iterable<Entrypoint> entrypoints =
         com.ibm.wala.ipa.callgraph.impl.Util.makeMainEntrypoints(cha, "Ldataflow/StaticDataflow");
     AnalysisOptions options = CallGraphTestUtil.makeAnalysisOptions(scope, entrypoints);
@@ -156,10 +179,25 @@ public class DataflowTest extends WalaTestCase {
     CallGraphBuilder<InstanceKey> builder =
         Util.makeZeroOneCFABuilder(JavaLanguage.get(), options, new AnalysisCacheImpl(), cha);
     CallGraph cg = builder.makeCallGraph(options, null);
-    ExplodedInterproceduralCFG icfg = ExplodedInterproceduralCFG.make(cg);
-    ContextInsensitiveReachingDefs reachingDefs = new ContextInsensitiveReachingDefs(icfg, cha);
+    return new TestContextInsensitiveAnalysis(cg, cha);
+  }
+
+  /** Phase two of {@link #testContextInsensitive}: run the reaching definitions analysis. */
+  public static TestContextInsensitiveResult computeTestContextInsensitive(
+      TestContextInsensitiveAnalysis analysis) {
+    ExplodedInterproceduralCFG icfg = ExplodedInterproceduralCFG.make(analysis.callGraph());
+    ContextInsensitiveReachingDefs reachingDefs =
+        new ContextInsensitiveReachingDefs(icfg, analysis.classHierarchy());
     BitVectorSolver<BasicBlockInContext<IExplodedBasicBlock>> solver = reachingDefs.analyze();
-    assertThat(icfg)
+    return new TestContextInsensitiveResult(icfg, solver, reachingDefs);
+  }
+
+  @Test
+  public void testContextInsensitive()
+      throws IllegalArgumentException, ClassHierarchyException, CancelException, IOException {
+    TestContextInsensitiveAnalysis analysis = prepareTestContextInsensitive();
+    TestContextInsensitiveResult result = computeTestContextInsensitive(analysis);
+    assertThat(result.icfg())
         .filteredOn(
             bb ->
                 bb.getNode().toString().contains("testInterproc")
@@ -167,12 +205,13 @@ public class DataflowTest extends WalaTestCase {
         .singleElement()
         .satisfies(
             bb -> {
-              IntSet solution = solver.getOut(bb).getValue();
+              IntSet solution = result.solver().getOut(bb).getValue();
               IntIterator intIterator = solution.intIterator();
               List<Pair<CGNode, Integer>> applicationDefs = new ArrayList<>();
               while (intIterator.hasNext()) {
                 int next = intIterator.next();
-                final Pair<CGNode, Integer> def = reachingDefs.getNodeAndInstrForNumber(next);
+                final Pair<CGNode, Integer> def =
+                    result.reachingDefs().getNodeAndInstrForNumber(next);
                 if (def.fst
                     .getMethod()
                     .getDeclaringClass()
@@ -187,8 +226,26 @@ public class DataflowTest extends WalaTestCase {
             });
   }
 
-  @Test
-  public void testContextSensitive() throws IllegalArgumentException, CancelException {
+  /**
+   * The analysis state that {@link #testContextSensitive} builds before running the reaching
+   * definitions analysis, assembled by {@link #prepareTestContextSensitive()}.
+   */
+  public record TestContextSensitiveAnalysis(CallGraph callGraph) {}
+
+  /** The result of the {@link #computeTestContextSensitive} analysis phase. */
+  public record TestContextSensitiveResult(
+      TabulationResult<BasicBlockInContext<IExplodedBasicBlock>, CGNode, Pair<CGNode, Integer>>
+          result,
+      ContextSensitiveReachingDefs reachingDefs) {}
+
+  /**
+   * Phase one of {@link #testContextSensitive}: compute everything needed before running the
+   * analysis.
+   */
+  public static TestContextSensitiveAnalysis prepareTestContextSensitive()
+      throws IllegalArgumentException, ClassHierarchyException, CancelException, IOException {
+    AnalysisScope scope = makeScope();
+    IClassHierarchy cha = ClassHierarchyFactory.make(scope);
     Iterable<Entrypoint> entrypoints =
         com.ibm.wala.ipa.callgraph.impl.Util.makeMainEntrypoints(cha, "Ldataflow/StaticDataflow");
     AnalysisOptions options = CallGraphTestUtil.makeAnalysisOptions(scope, entrypoints);
@@ -196,11 +253,26 @@ public class DataflowTest extends WalaTestCase {
     CallGraphBuilder<InstanceKey> builder =
         Util.makeZeroOneCFABuilder(JavaLanguage.get(), options, new AnalysisCacheImpl(), cha);
     CallGraph cg = builder.makeCallGraph(options, null);
-    ContextSensitiveReachingDefs reachingDefs = new ContextSensitiveReachingDefs(cg);
+    return new TestContextSensitiveAnalysis(cg);
+  }
+
+  /** Phase two of {@link #testContextSensitive}: run the reaching definitions analysis. */
+  public static TestContextSensitiveResult computeTestContextSensitive(
+      TestContextSensitiveAnalysis analysis) {
+    ContextSensitiveReachingDefs reachingDefs =
+        new ContextSensitiveReachingDefs(analysis.callGraph());
     TabulationResult<BasicBlockInContext<IExplodedBasicBlock>, CGNode, Pair<CGNode, Integer>>
         result = reachingDefs.analyze();
+    return new TestContextSensitiveResult(result, reachingDefs);
+  }
+
+  @Test
+  public void testContextSensitive()
+      throws IllegalArgumentException, ClassHierarchyException, CancelException, IOException {
+    TestContextSensitiveAnalysis analysis = prepareTestContextSensitive();
+    TestContextSensitiveResult result = computeTestContextSensitive(analysis);
     ISupergraph<BasicBlockInContext<IExplodedBasicBlock>, CGNode> supergraph =
-        reachingDefs.getSupergraph();
+        result.reachingDefs().getSupergraph();
     assertThat(supergraph)
         .filteredOn(
             bb ->
@@ -209,12 +281,13 @@ public class DataflowTest extends WalaTestCase {
         .singleElement()
         .satisfies(
             bb -> {
-              IntSet solution = result.getResult(bb);
+              IntSet solution = result.result().getResult(bb);
               IntIterator intIterator = solution.intIterator();
               List<Pair<CGNode, Integer>> applicationDefs = new ArrayList<>();
               while (intIterator.hasNext()) {
                 int next = intIterator.next();
-                final Pair<CGNode, Integer> def = reachingDefs.getDomain().getMappedObject(next);
+                final Pair<CGNode, Integer> def =
+                    result.reachingDefs().getDomain().getMappedObject(next);
                 if (def.fst
                     .getMethod()
                     .getDeclaringClass()


### PR DESCRIPTION
Split `DataflowTest.testContextSensitive` and `DataflowTest.testContextInsensitive` into `prepare...` phases (analysis scope, class hierarchy, call graph, and pointer analysis) and `compute...` phases (the reaching-definitions analyses themselves), so that a new JMH benchmark can run all the setup once per fork and time only the analyses.  Set `ContextInsensitiveReachingDefs.VERBOSE` to `false` so the timed `analyze()` doesn't print to standard output on every invocation.

Each analysis takes roughly a quarter of a millisecond on the `dataflow.StaticDataflow` subject (measured means of about 0.25 ms for the context-insensitive analysis and 0.23 ms for the context-sensitive one).  These are sub-millisecond workloads, so single invocations are noisy:  allocation and GC jitter are on the same scale as the work itself, and the per-invocation time keeps dropping until about the sixtieth invocation as the JIT progressively compiles the analysis code. Benchmark accordingly:  single-shot time mode, sixty warmup invocations, twenty measured invocations, and four forks.  This reproduces the means to within about 5–9%, and repeated runs agree within that noise (e.g., 0.255 and 0.250 ms for the context-insensitive mean and 0.236 and 0.224 ms for the context-sensitive mean across two consecutive runs).