### PR TITLE
Fix `SparseLongSet` cloning fast path

### DIFF
--- a/util/src/main/java/com/ibm/wala/util/intset/SparseLongSet.java
+++ b/util/src/main/java/com/ibm/wala/util/intset/SparseLongSet.java
@@ -83,17 +83,34 @@ public class SparseLongSet implements LongSet {
     if (S == null) {
       throw new IllegalArgumentException("S == null");
     }
+    elements = new long[S.size()];
+    size = S.size();
+    S.foreach(
+        new IntSetAction() {
+          private int index = 0;
+
+          @Override
+          public void act(int i) {
+            elements[index++] = i;
+          }
+        });
+  }
+
+  public SparseLongSet(LongSet S) throws IllegalArgumentException {
+    if (S == null) {
+      throw new IllegalArgumentException("S == null");
+    }
     if (S instanceof SparseLongSet sparseLongSet) {
       cloneState(sparseLongSet);
     } else {
       elements = new long[S.size()];
       size = S.size();
       S.foreach(
-          new IntSetAction() {
+          new LongSetAction() {
             private int index = 0;
 
             @Override
-            public void act(int i) {
+            public void act(long i) {
               elements[index++] = i;
             }
           });


### PR DESCRIPTION
The existing `SparseLongSet(IntSet S)` had a cloning-based fast path for the special case of `S instanceof SparseLongSet`.  However, that is unlikely to ever happen.  Technically, yes, one could create a `SparseLongSet` subclass that also implements the `IntSet` interface. But why would someone ever do such a thing?

As revised in this commit, we retain the `SparseLongSet(IntSet S)` constructor but without a cloning-based fast path.  We also add a new `SparseLongSet(LongSet S)` constructor.  The latter _does_ have a cloning-based fast path for the special case of `S instanceof SparseLongSet`.