### PR TITLE
Optionally include Git hash in JMH results file name

### DIFF
--- a/README-Gradle.md
+++ b/README-Gradle.md
@@ -238,10 +238,14 @@ code, run the `jmh` task, change the code under test, then run it again
 and compare.  The `jmh` task prints human-readable results to the
 console and writes machine-readable results to
 `<subproject>/build/results/jmh/results.json` for a given `<subproject>`.
-Results can be unstable on noisy machines, so consider running a single
-benchmark with more forks and iterations for more trustworthy comparisons,
-e.g. by editing the `@Fork`, `@Warmup`, and `@Measurement` annotations in
-the benchmark source.
+Setting the `jmhResultsFileNameIncludesGitHash` Gradle property (e.g., with
+`-PjmhResultsFileNameIncludesGitHash`) appends the current Git commit hash
+to the results file name, writing to
+`<subproject>/build/results/jmh/results-<git-hash>.json`.  Results can be
+unstable on noisy machines, so consider running a single benchmark with
+more forks and iterations for more trustworthy comparisons, e.g. by
+editing the `@Fork`, `@Warmup`, and `@Measurement` annotations in the
+benchmark source.
 
 #### JMH Macrobenchmarks
 
@@ -308,4 +312,5 @@ other.
 <!--
 LocalWords:  processTestResources pre classpath gradlew mvn
 LocalWords:  javadoc buildship issuecomment
+LocalWords:  jmhResultsFileNameIncludesGitHash
 -->

--- a/build-logic/src/main/kotlin/com/ibm/wala/gradle/jmh.gradle.kts
+++ b/build-logic/src/main/kotlin/com/ibm/wala/gradle/jmh.gradle.kts
@@ -1,7 +1,14 @@
 package com.ibm.wala.gradle
 
-// Build configuration for subprojects that include JMH benchmarks.
-
+/**
+ * Build configuration for subprojects that include JMH benchmarks.
+ *
+ * Applies JMH and WALA Java plugins, then configures benchmark result output to a JSON file in the
+ * build directory. Optionally appends the current Git commit hash to the result file name when the
+ * project property `jmhResultsFileNameIncludesGitHash` is enabled. Disables compiler
+ * warnings-as-errors and Error Prone for JMH-generated classes to accommodate auto-generated
+ * benchmark code.
+ */
 import net.ltgt.gradle.errorprone.errorprone
 
 plugins {
@@ -9,9 +16,44 @@ plugins {
   id("com.ibm.wala.gradle.java")
 }
 
+/**
+ * Indicates whether the Git commit hash should be included in the benchmark results file name.
+ *
+ * Evaluates the `jmhResultsFileNameIncludesGitHash` Gradle property, defaulting to `false` if not
+ * set.
+ */
+private val includeGitHash =
+    providers
+        .gradleProperty("jmhResultsFileNameIncludesGitHash")
+        .map { it.isEmpty() || it.toBooleanStrictOrNull() != false }
+        .orElse(false)
+
+/**
+ * Suffix to append to the benchmark results file name.
+ *
+ * When [includeGitHash] is enabled, this is `"-"` followed by the Git commit description;
+ * otherwise, it is an empty string.
+ */
+private val resultsFileSuffix =
+    includeGitHash.flatMap { enabled ->
+      if (enabled) {
+        providers
+            .exec {
+              commandLine("git", "describe", "--abbrev=0", "--always", "--dirty", "--match=")
+            }
+            .standardOutput
+            .asText
+            .map { "-${it.trim()}" }
+      } else {
+        providers.provider { "" }
+      }
+    }
+
 jmh {
   jmhVersion = catalogVersion("jmh")
   resultFormat = "JSON"
+  resultsFile =
+      resultsFileSuffix.flatMap { layout.buildDirectory.file("results/jmh/results$it.json") }
 }
 
 tasks {


### PR DESCRIPTION
Add the `jmhResultsFileNameIncludesGitHash` property to optionally append the current Git commit hash to the JMH results file name. Document this feature in `jmh.gradle.kts` and `README-Gradle.md`.

The high-level intent of this feature is to make performance _comparisons_ more convenient.  By enabling this property, one can store JHM data from multiple Git revisions (e.g., multiple branches) without each revision's results overwriting the others.